### PR TITLE
fix(setup): replace Procfile check with apps/frappe for bench detection

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -36,7 +36,9 @@ if [ -z "$SITE_NAME" ]; then
     error "Site name required. Usage: bash apps/benchpress/setup.sh <site-name>"
 fi
 
-if [ ! -f "$BENCH_DIR/Procfile" ]; then
+# apps/frappe exists in every valid bench (dev or Docker); Procfile is
+# dev-mode only and never written in containerised installs.
+if [ ! -d "$BENCH_DIR/apps/frappe" ]; then
     error "Run this script from inside your frappe-bench directory. Found: $BENCH_DIR"
 fi
 


### PR DESCRIPTION
## Summary

Fixes #40 — `setup.sh` always exited with *"Run this script from inside your frappe-bench directory"* in Docker installs, even when run from the correct bench root.

## Root cause

The bench-directory guard required `$BENCH_DIR/Procfile`, which `bench init` only writes in **development mode** (`bench start`). Docker-based installs (benchpress_devops) manage processes via supervisord/gunicorn and never create a Procfile, so the guard failed unconditionally — including when invoked by `after_install()` during `bench install-app benchpress`.

## Fix

Check for `$BENCH_DIR/apps/frappe` instead. Frappe is mandatory in every valid bench, so the directory exists in both dev and containerised installs.

```bash
# Before
if [ ! -f "$BENCH_DIR/Procfile" ]; then

# After
if [ ! -d "$BENCH_DIR/apps/frappe" ]; then
```

This is the only `Procfile` reference in the repo — no other dev-mode assumptions found.

## Testing

- `bash -n setup.sh` — syntax OK
- Simulated a Docker bench layout (`apps/frappe/` + `sites/`, no Procfile): guard now passes and the script proceeds.
- Simulated a non-bench directory (no `apps/frappe`): guard still rejects with the same error message.