### PR TITLE
fix(install): skip setup.sh inside Docker, print manual instructions

### DIFF
--- a/benchpress/install.py
+++ b/benchpress/install.py
@@ -13,22 +13,26 @@ def after_install():
 	print("  BenchPress — Running post-install setup")
 	print("=" * 60 + "\n")
 
-	if not os.path.exists(script):
+	# setup.sh requires host-level access (docker group, sysctl, sudoers,
+	# wireguard). Skip it when running inside a container.
+	if os.path.exists("/.dockerenv"):
+		print("[!] Running inside Docker — skipping host setup script.")
 		_print_manual_instructions(site)
-		return
-
-	try:
-		result = subprocess.run(
-			["bash", script, site],
-			cwd=bench_dir,
-			check=False,
-		)
-		if result.returncode != 0:
-			print(f"\n[!] setup.sh exited with code {result.returncode}")
+	elif not os.path.exists(script):
+		_print_manual_instructions(site)
+	else:
+		try:
+			result = subprocess.run(
+				["bash", script, site],
+				cwd=bench_dir,
+				check=False,
+			)
+			if result.returncode != 0:
+				print(f"\n[!] setup.sh exited with code {result.returncode}")
+				_print_manual_instructions(site)
+		except Exception as e:
+			print(f"\n[!] Could not run setup.sh: {e}")
 			_print_manual_instructions(site)
-	except Exception as e:
-		print(f"\n[!] Could not run setup.sh: {e}")
-		_print_manual_instructions(site)
 
 	# Create test users in developer mode
 	if frappe.conf.get("developer_mode"):

--- a/setup.sh
+++ b/setup.sh
@@ -36,6 +36,14 @@ if [ -z "$SITE_NAME" ]; then
     error "Site name required. Usage: bash apps/benchpress/setup.sh <site-name>"
 fi
 
+# Every step needs host-level access (docker group, sysctl, sudoers,
+# wireguard kernel module) — none of it works inside a container.
+if [ -f "/.dockerenv" ]; then
+    warn "Running inside a Docker container — host setup must be run on the host."
+    warn "  bash apps/benchpress/setup.sh $SITE_NAME"
+    exit 0
+fi
+
 # apps/frappe exists in every valid bench (dev or Docker); Procfile is
 # dev-mode only and never written in containerised installs.
 if [ ! -d "$BENCH_DIR/apps/frappe" ]; then


### PR DESCRIPTION
## Summary

Fixes #50.

`after_install()` ran `setup.sh` via `subprocess.run` inside the backend container, where every step requires host privileges (docker group, `sysctl`, sudoers, WireGuard kernel module). Step 1 immediately blocked on a `sudo` password prompt for the `frappe` user, which has no sudo in-container.

## Changes

- **`benchpress/install.py`** — `after_install()` checks for `/.dockerenv` and, when inside a container, skips the script and prints the manual host instructions instead. Unlike the snippet in the issue, this is structured without an early `return`, so `create_test_users()` still runs in developer mode inside Docker — the benchpress_devops environment relies on that.
- **`setup.sh`** — same `/.dockerenv` guard at the top: warns that host setup must run on the host and exits 0 cleanly. Covers the case where someone shells into the container and runs the script manually (the printed manual instructions are otherwise easy to follow in the wrong place).

The issue offered the two guards as alternatives; this PR includes both since they protect different entry points (automatic install hook vs. manual invocation).

## Testing

- `python3 -m py_compile benchpress/install.py` and `bash -n setup.sh` pass.
- On a host (no `/.dockerenv`), both code paths are unchanged.

Related: #40 (Procfile guard, merged in #42)