### PR TITLE
refactor: consolidate duplicated logic and remove self-fix residue

### DIFF
--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -6,7 +6,6 @@ from frappe import _
 
 from benchpress.permissions import (
 	get_bench_owner_filter,
-	has_app_permission,
 	is_admin,
 	require_admin,
 	require_bench_access,
@@ -131,39 +130,31 @@ def create_bench(data: str) -> dict:
 		doc.status = "Deploying"
 		doc.save(ignore_permissions=True)
 		frappe.db.commit()
-
-		frappe.enqueue(
-			"benchpress.deploy_manager.deploy_bench",
-			bench_name=doc.name,
-			queue="long",
-			timeout=3600,
-		)
-		return {"name": doc.name, "status": "Deploying"}
-
-	doc = frappe.get_doc(
-		{
-			"doctype": "Bench Instance",
-			"bench_name": data.get("bench_name"),
-			"lab": lab_name,
-			"frappe_version": lab.frappe_version,
-			"domain": data.get("domain"),
-			"status": "Draft",
-		}
-	)
-
-	for app in lab.apps:
-		doc.append(
-			"apps",
+	else:
+		doc = frappe.get_doc(
 			{
-				"app_name": app.app_name,
-				"app_label": app.app_label,
-				"git_url": app.git_url,
-				"branch": app.branch,
-			},
+				"doctype": "Bench Instance",
+				"bench_name": data.get("bench_name"),
+				"lab": lab_name,
+				"frappe_version": lab.frappe_version,
+				"domain": data.get("domain"),
+				"status": "Draft",
+			}
 		)
 
-	doc.insert()
-	frappe.db.commit()
+		for app in lab.apps:
+			doc.append(
+				"apps",
+				{
+					"app_name": app.app_name,
+					"app_label": app.app_label,
+					"git_url": app.git_url,
+					"branch": app.branch,
+				},
+			)
+
+		doc.insert()
+		frappe.db.commit()
 
 	frappe.enqueue(
 		"benchpress.deploy_manager.deploy_bench",
@@ -219,26 +210,13 @@ def bench_action(bench_name: str, action: str) -> dict:
 			try:
 				stop_container(bench.container_id)
 			except Exception:
-				pass
+				pass  # best-effort
 			remove_container(bench.container_id)
 
-		from benchpress.docker_manager import get_client
+		from benchpress.deploy_manager import remove_bench_volume
 
-		client = get_client()
-		try:
-			client.volumes.get(f"benchpress-{bench.bench_name}-data").remove(force=True)
-		except Exception:
-			pass
+		remove_bench_volume(bench.bench_name)
 
-		if bench.wg_public_key:
-			from benchpress.wg_manager import remove_peer_from_server
-
-			try:
-				remove_peer_from_server(bench.wg_public_key)
-			except Exception:
-				pass
-		bench.status = "Stopped"
-		bench.save(ignore_permissions=True)
 		frappe.delete_doc("Bench Instance", bench_name, force=True)
 		frappe.db.commit()
 		return {"status": "deleted"}
@@ -330,36 +308,22 @@ def create_site(data: str) -> dict:
 
 
 def _create_site_on_bench(site_doc_name: str) -> None:
-	from benchpress.docker_manager import exec_in_container
-	from benchpress.mariadb_manager import create_mariadb_user, drop_mariadb_user
+	from benchpress.deploy_manager import create_site_in_container
 
 	site = frappe.get_doc("Bench Site", site_doc_name)
 	bench = frappe.get_doc("Bench Instance", site.bench)
 	db_server = frappe.get_doc("Database Server", bench.database_server)
+	lab = frappe.get_cached_doc("Lab", bench.lab)
 
 	try:
-		admin_password = "admin"
+		admin_password = bench.get_password("admin_password")
 		site.admin_password = admin_password
 		site_name = site.full_domain or site.site_name
 		apps_csv = ",".join(a.app_name for a in site.apps_installed if a.app_name.lower() != "frappe")
 
-		db_name, temp_user, temp_password = create_mariadb_user(db_server.name, site_name)
-		try:
-			exit_code, output = exec_in_container(
-				bench.container_id,
-				"bash /opt/benchpress/scripts/setup-site.sh",
-				environment={
-					"SITE_NAME": site_name,
-					"ADMIN_PASSWORD": admin_password,
-					"APPS": apps_csv,
-					"DB_HOST": db_server.container_name,
-					"DB_NAME": db_name,
-					"MARIADB_ROOT_USERNAME": temp_user,
-					"MARIADB_ROOT_PASSWORD": temp_password,
-				},
-			)
-		finally:
-			drop_mariadb_user(db_server.name, site_name, db_name)
+		exit_code, output = create_site_in_container(
+			bench.container_id, db_server, lab, site_name, admin_password, apps_csv
+		)
 
 		if exit_code != 0:
 			site.status = "Error"

--- a/benchpress/benchpress/doctype/bench_instance/bench_instance.js
+++ b/benchpress/benchpress/doctype/bench_instance/bench_instance.js
@@ -57,39 +57,13 @@ frappe.ui.form.on("Bench Instance", {
 			);
 		}
 
-		if (frm.doc.wg_config && frm.doc.status === "Running") {
-			frm.add_custom_button(
-				__("Download VPN Config"),
-				() => {
-					const blob = new Blob([frm.doc.wg_config], { type: "text/plain" });
-					const url = URL.createObjectURL(blob);
-					const a = document.createElement("a");
-					a.href = url;
-					a.download = `${frm.doc.bench_name || frm.doc.name}.conf`;
-					a.click();
-					URL.revokeObjectURL(url);
-				},
-				__("VPN")
-			);
-
-			frm.add_custom_button(
-				__("Copy VPN Config"),
-				() => {
-					navigator.clipboard.writeText(frm.doc.wg_config).then(() => {
-						frappe.show_alert({
-							message: __("WireGuard config copied to clipboard"),
-							indicator: "green",
-						});
-					});
-				},
-				__("VPN")
-			);
+		if (!frm._realtime_bound) {
+			frm._realtime_bound = true;
+			frappe.realtime.on("bench_deploy_log", (data) => {
+				if (data.bench === frm.doc.name) {
+					frm.reload_doc();
+				}
+			});
 		}
-
-		frappe.realtime.on("bench_deploy_log", (data) => {
-			if (data.bench === frm.doc.name) {
-				frm.reload_doc();
-			}
-		});
 	},
 });

--- a/benchpress/benchpress/doctype/bench_instance/bench_instance.py
+++ b/benchpress/benchpress/doctype/bench_instance/bench_instance.py
@@ -4,6 +4,7 @@
 import re
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 from benchpress.benchpress.doctype.bench_instance import get_instance_id
@@ -19,13 +20,13 @@ class BenchInstance(Document):
 	def autoname(self):
 		self.name = self.bench_name
 
-	def _derive_username(self):
+	def _derive_username(self, email: str | None = None):
 		"""Derive a valid Linux username from the Frappe user email.
 
 		Takes the part before @, lowercases, strips invalid chars, caps at 32 chars.
 		e.g., John.Doe@example.com -> johndoe
 		"""
-		email = frappe.session.user
+		email = email or frappe.session.user
 		username = email.split("@")[0].lower()
 		# Keep only valid Linux username characters
 		username = re.sub(r"[^a-z0-9_.-]", "", username)
@@ -54,14 +55,14 @@ class BenchInstance(Document):
 			queue="long",
 			timeout=1800,
 		)
-		frappe.msgprint("Deploy started. Watch the Deploy Log for progress.")
+		frappe.msgprint(_("Deploy started. Watch the Deploy Log for progress."))
 
 	@frappe.whitelist()
 	def enqueue_stop(self):
 		from benchpress.deploy_manager import stop_bench
 
 		stop_bench(self.name)
-		frappe.msgprint("Bench stopped.")
+		frappe.msgprint(_("Bench stopped."))
 
 	@frappe.whitelist()
 	def enqueue_redeploy(self):
@@ -71,16 +72,16 @@ class BenchInstance(Document):
 			queue="long",
 			timeout=1800,
 		)
-		frappe.msgprint("Redeploy started. Watch the Deploy Log for progress.")
+		frappe.msgprint(_("Redeploy started. Watch the Deploy Log for progress."))
 
 	@frappe.whitelist()
 	def enqueue_start(self):
 		from benchpress.docker_manager import start_container
 
 		if not self.container_id:
-			frappe.throw("No container to start.")
+			frappe.throw(_("No container to start."))
 		start_container(self.container_id)
 		self.status = "Running"
 		self.save(ignore_permissions=True)
 		frappe.db.commit()  # nosemgrep: intentional commit to persist status before response
-		frappe.msgprint("Bench started.")
+		frappe.msgprint(_("Bench started."))

--- a/benchpress/benchpress/doctype/bench_instance/test_bench_instance.py
+++ b/benchpress/benchpress/doctype/bench_instance/test_bench_instance.py
@@ -37,11 +37,6 @@ class IntegrationTestBenchInstance(IntegrationTestCase):
 	@classmethod
 	def tearDownClass(cls):
 		frappe.set_user("Administrator")
-		frappe.get_all(
-			"Bench Instance",
-			filters={"lab": cls.lab_name},
-			pluck="name",
-		)
 		for name in frappe.get_all("Bench Instance", filters={"lab": cls.lab_name}, pluck="name"):
 			frappe.delete_doc("Bench Instance", name, force=True, ignore_permissions=True)
 		cls.lab.delete(ignore_permissions=True)

--- a/benchpress/benchpress/doctype/build_log/build_log.js
+++ b/benchpress/benchpress/doctype/build_log/build_log.js
@@ -40,8 +40,8 @@ frappe.ui.form.on("Build Log", {
 					step_count++;
 					let [, current, total] = is_step;
 					return (
-						'<div style="margin-top: 12px; padding: 8px 12px; background: #161b22; border-left: 3px solid #3b82f6; border-radius: 0 6px 6px 0; font-weight: 600; color: #58a6ff; font-size: 13px;">' +
-						'<span style="color: #8b949e; margin-right: 8px;">' +
+						'<div style="margin-top: 12px; padding: 8px 12px; background: var(--subtle-fg); border-left: 3px solid var(--blue-500); border-radius: 0 6px 6px 0; font-weight: 600; color: var(--blue-400); font-size: 13px;">' +
+						'<span style="color: var(--text-muted); margin-right: 8px;">' +
 						current +
 						"/" +
 						total +
@@ -53,7 +53,7 @@ frappe.ui.form.on("Build Log", {
 
 				if (is_success) {
 					return (
-						'<div style="margin-top: 16px; padding: 12px 16px; background: #0d1f0d; border: 1px solid #238636; border-radius: 6px; color: #3fb950; font-weight: 600; font-size: 13px;">' +
+						'<div style="margin-top: 16px; padding: 12px 16px; background: var(--bg-green); border: 1px solid var(--green-600); border-radius: 6px; color: var(--green-500); font-weight: 600; font-size: 13px;">' +
 						'<span style="margin-right: 8px;">✓</span>' +
 						frappe.utils.escape_html(line) +
 						"</div>"
@@ -62,7 +62,7 @@ frappe.ui.form.on("Build Log", {
 
 				if (is_error) {
 					return (
-						'<div style="margin-top: 16px; padding: 12px 16px; background: #2d0a0a; border: 1px solid #da3633; border-radius: 6px; color: #f85149; font-weight: 600; font-size: 13px;">' +
+						'<div style="margin-top: 16px; padding: 12px 16px; background: var(--bg-red); border: 1px solid var(--red-600); border-radius: 6px; color: var(--red-500); font-weight: 600; font-size: 13px;">' +
 						'<span style="margin-right: 8px;">✗</span>' +
 						frappe.utils.escape_html(line) +
 						"</div>"
@@ -71,7 +71,7 @@ frappe.ui.form.on("Build Log", {
 
 				if (is_header) {
 					return (
-						'<div style="padding: 6px 12px; color: #d2a8ff; font-weight: 600; font-size: 13px;">' +
+						'<div style="padding: 6px 12px; color: var(--purple-400); font-weight: 600; font-size: 13px;">' +
 						frappe.utils.escape_html(line) +
 						"</div>"
 					);
@@ -79,20 +79,20 @@ frappe.ui.form.on("Build Log", {
 
 				if (is_cached) {
 					return (
-						'<div style="padding: 2px 12px 2px 24px; color: #3fb950; font-size: 12px;">' +
+						'<div style="padding: 2px 12px 2px 24px; color: var(--green-500); font-size: 12px;">' +
 						'<span style="margin-right: 6px;">●</span>cached</div>'
 					);
 				}
 
 				if (is_arrow) {
 					return (
-						'<div style="padding: 2px 12px 2px 24px; color: #8b949e; font-size: 12px;">' +
+						'<div style="padding: 2px 12px 2px 24px; color: var(--text-muted); font-size: 12px;">' +
 						frappe.utils.escape_html(line) +
 						"</div>"
 					);
 				}
 
-				let color = "#c9d1d9";
+				let color = "var(--text-color)";
 				return (
 					'<div style="padding: 2px 12px 2px 24px; color: ' +
 					color +
@@ -103,39 +103,56 @@ frappe.ui.form.on("Build Log", {
 			})
 			.join("");
 
+		let make_status_bar = function (bg, border, icon_html, label, label_color) {
+			return (
+				'<div style="padding: 10px 16px; background: ' +
+				bg +
+				"; border-bottom: 1px solid " +
+				border +
+				'; border-radius: 6px 6px 0 0; display: flex; align-items: center; gap: 8px;">' +
+				icon_html +
+				'<span style="color: ' +
+				label_color +
+				'; font-weight: 600; font-size: 13px;">' +
+				label +
+				"</span>" +
+				'<span style="color: var(--text-muted); font-size: 12px; margin-left: auto;">' +
+				(frm.doc.lab || "") +
+				"</span>" +
+				"</div>"
+			);
+		};
+
 		let status_bar = "";
 		if (frm.doc.log_type === "info") {
-			status_bar =
-				'<div style="padding: 10px 16px; background: #161b22; border-bottom: 1px solid #30363d; border-radius: 6px 6px 0 0; display: flex; align-items: center; gap: 8px;">' +
-				'<div style="width: 10px; height: 10px; border-radius: 50%; background: #d29922; animation: pulse 1.5s infinite;"></div>' +
-				'<span style="color: #d29922; font-weight: 600; font-size: 13px;">Building...</span>' +
-				'<span style="color: #8b949e; font-size: 12px; margin-left: auto;">' +
-				(frm.doc.lab || "") +
-				"</span>" +
-				"</div>";
+			status_bar = make_status_bar(
+				"var(--subtle-fg)",
+				"var(--border-color)",
+				'<div style="width: 10px; height: 10px; border-radius: 50%; background: var(--yellow-500); animation: pulse 1.5s infinite;"></div>',
+				"Building...",
+				"var(--yellow-500)"
+			);
 		} else if (frm.doc.log_type === "success") {
-			status_bar =
-				'<div style="padding: 10px 16px; background: #0d1f0d; border-bottom: 1px solid #238636; border-radius: 6px 6px 0 0; display: flex; align-items: center; gap: 8px;">' +
-				'<span style="color: #3fb950; font-size: 16px;">✓</span>' +
-				'<span style="color: #3fb950; font-weight: 600; font-size: 13px;">Build succeeded</span>' +
-				'<span style="color: #8b949e; font-size: 12px; margin-left: auto;">' +
-				(frm.doc.lab || "") +
-				"</span>" +
-				"</div>";
+			status_bar = make_status_bar(
+				"var(--bg-green)",
+				"var(--green-600)",
+				'<span style="color: var(--green-500); font-size: 16px;">✓</span>',
+				"Build succeeded",
+				"var(--green-500)"
+			);
 		} else if (frm.doc.log_type === "error") {
-			status_bar =
-				'<div style="padding: 10px 16px; background: #2d0a0a; border-bottom: 1px solid #da3633; border-radius: 6px 6px 0 0; display: flex; align-items: center; gap: 8px;">' +
-				'<span style="color: #f85149; font-size: 16px;">✗</span>' +
-				'<span style="color: #f85149; font-weight: 600; font-size: 13px;">Build failed</span>' +
-				'<span style="color: #8b949e; font-size: 12px; margin-left: auto;">' +
-				(frm.doc.lab || "") +
-				"</span>" +
-				"</div>";
+			status_bar = make_status_bar(
+				"var(--bg-red)",
+				"var(--red-600)",
+				'<span style="color: var(--red-500); font-size: 16px;">✗</span>',
+				"Build failed",
+				"var(--red-500)"
+			);
 		}
 
 		let container =
 			"<style>@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }</style>" +
-			"<div style=\"background: #0d1117; border: 1px solid #30363d; border-radius: 6px; font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; margin-top: 8px;\">" +
+			"<div style=\"background: var(--bg-color); border: 1px solid var(--border-color); border-radius: 6px; font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; margin-top: 8px;\">" +
 			status_bar +
 			'<div id="build-log-output" style="padding: 12px 0; max-height: 600px; overflow-y: auto;">' +
 			html_lines +

--- a/benchpress/benchpress/doctype/database_server/database_server.py
+++ b/benchpress/benchpress/doctype/database_server/database_server.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 from benchpress.mariadb_manager import DEFAULT_MARIADB_CONFIG
@@ -47,7 +48,7 @@ class DatabaseServer(Document):
 			queue="long",
 			timeout=600,
 		)
-		frappe.msgprint("MariaDB setup started.")
+		frappe.msgprint(_("MariaDB setup started."))
 
 	@frappe.whitelist()
 	def stop_mariadb(self):

--- a/benchpress/benchpress/doctype/lab/lab.js
+++ b/benchpress/benchpress/doctype/lab/lab.js
@@ -17,14 +17,13 @@ frappe.ui.form.on("Lab", {
 							frappe.call({
 								method: "benchpress.api.build_lab_image",
 								args: { lab_name: frm.doc.name },
-								callback: function (r) {
+								callback: function () {
 									frappe.show_alert({
 										message: __(
 											"Image build started. Check Build Log in the sidebar."
 										),
 										indicator: "blue",
 									});
-									// Wait a moment for the Build Log to be created, then reload to show link
 									setTimeout(function () {
 										frm.reload_doc();
 									}, 2000);

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -34,14 +34,64 @@ def _remove_stale_container(bench) -> None:
 		try:
 			client.containers.get(bench.container_id).remove(force=True)
 		except Exception:
-			pass
+			pass  # best-effort
 		bench.container_id = None
 
 	try:
 		container = client.containers.get(bench.bench_name)
 		container.remove(force=True)
 	except Exception:
-		pass
+		pass  # best-effort
+
+
+def remove_bench_volume(bench_name: str) -> None:
+	"""Remove the bench data volume if it exists."""
+	from benchpress.docker_manager import get_client
+
+	try:
+		get_client().volumes.get(f"benchpress-{bench_name}-data").remove(force=True)
+	except Exception:
+		pass  # best-effort
+
+
+def _make_log_appender(doctype: str, log_name: str, event: str, context: dict):
+	def append_log(line: str, log_type: str = "info") -> None:
+		frappe.publish_realtime(
+			event=event,
+			message={**context, "log": line, "type": log_type},
+			after_commit=False,
+		)
+		current = frappe.db.get_value(doctype, log_name, "message") or ""
+		frappe.db.set_value(doctype, log_name, "message", current + line + "\n", update_modified=False)
+		frappe.db.commit()
+
+	return append_log
+
+
+def create_site_in_container(
+	container_id: str, db_server, lab, site_name: str, admin_password: str, apps_csv: str
+) -> tuple[int, str]:
+	"""Run setup-site.sh inside a bench container using a temporary MariaDB user."""
+	bench_dir = f"{lab.mount_target or '/home/frappe'}/frappe-bench"
+	db_name, temp_user, temp_password = create_mariadb_user(db_server.name, site_name)
+	try:
+		return exec_in_container(
+			container_id,
+			"bash /opt/benchpress/scripts/setup-site.sh",
+			user="frappe",
+			workdir=bench_dir,
+			environment={
+				"SITE_NAME": site_name,
+				"ADMIN_PASSWORD": admin_password,
+				"APPS": apps_csv,
+				"DB_HOST": db_server.container_name,
+				"DB_NAME": db_name,
+				"MARIADB_ROOT_USERNAME": temp_user,
+				"MARIADB_ROOT_PASSWORD": temp_password,
+			},
+		)
+	finally:
+		drop_mariadb_user(db_server.name, site_name, db_name)
 
 
 def deploy_bench(bench_name: str) -> None:
@@ -62,17 +112,9 @@ def deploy_bench(bench_name: str) -> None:
 	frappe.db.commit()
 	deploy_log_name = deploy_log.name
 
-	def append_log(line: str, log_type: str = "info") -> None:
-		frappe.publish_realtime(
-			event="bench_deploy_log",
-			message={"bench": bench_name, "log": line, "type": log_type, "deploy_log": deploy_log_name},
-			after_commit=False,
-		)
-		current = frappe.db.get_value("Deploy Log", deploy_log_name, "message") or ""
-		frappe.db.set_value(
-			"Deploy Log", deploy_log_name, "message", current + line + "\n", update_modified=False
-		)
-		frappe.db.commit()
+	append_log = _make_log_appender(
+		"Deploy Log", deploy_log_name, "bench_deploy_log", {"bench": bench_name, "deploy_log": deploy_log_name}
+	)
 
 	try:
 		bench.status = "Deploying"
@@ -136,7 +178,7 @@ def deploy_bench(bench_name: str) -> None:
 				try:
 					remove_peer_from_server(bench.wg_public_key)
 				except Exception:
-					pass
+					pass  # best-effort
 
 			container_wg_ip = bench.wg_ip if bench.wg_ip else allocate_ip()
 			container_keys = generate_keypair()
@@ -162,8 +204,7 @@ def deploy_bench(bench_name: str) -> None:
 		bench_dir = f"{lab.mount_target or '/home/frappe'}/frappe-bench"
 		site_name = bench.site_name
 		config = {
-			"db_host": db_server.container_name,
-			"db_port": db_server.port or 3306,
+			**db_server.get_connection_config(),
 			"redis_cache": "redis://benchpress-redis:6379/0",
 			"redis_queue": "redis://benchpress-redis:6379/1",
 			"redis_socketio": "redis://benchpress-redis:6379/2",
@@ -178,38 +219,21 @@ def deploy_bench(bench_name: str) -> None:
 
 		append_log(f"=== Creating site {site_name} ===")
 
-		db_name, temp_user, temp_password = create_mariadb_user(db_server_name, site_name)
-		try:
-			apps_csv = ",".join(a.app_name for a in lab.apps if a.app_name.lower() != "frappe")
-			exit_code, output = exec_in_container(
-				container_id,
-				"bash /opt/benchpress/scripts/setup-site.sh",
-				user="frappe",
-				workdir=bench_dir,
-				environment={
-					"SITE_NAME": site_name,
-					"ADMIN_PASSWORD": admin_password,
-					"APPS": apps_csv,
-					"DB_HOST": db_server.container_name,
-					"DB_NAME": db_name,
-					"MARIADB_ROOT_USERNAME": temp_user,
-					"MARIADB_ROOT_PASSWORD": temp_password,
-				},
-			)
-			if exit_code != 0:
-				raise Exception(f"bench new-site failed (exit {exit_code}): {output}")
-			append_log("Site created successfully")
-		finally:
-			drop_mariadb_user(db_server_name, site_name, db_name)
+		apps_csv = ",".join(a.app_name for a in lab.apps if a.app_name.lower() != "frappe")
+		exit_code, output = create_site_in_container(
+			container_id, db_server, lab, site_name, admin_password, apps_csv
+		)
+		if exit_code != 0:
+			raise Exception(f"bench new-site failed (exit {exit_code}): {output}")
+		append_log("Site created successfully")
 
 		append_log("Building assets...")
 		exec_in_container(container_id, "bench build", user="frappe", workdir=bench_dir)
 
 		if not bench.ssh_username:
-			bench.ssh_username = bench.owner.split("@")[0].lower()[:32] or "frappe"
+			bench.ssh_username = bench._derive_username(bench.owner)
 
 		ssh_password = secrets.token_urlsafe(12)
-		settings = frappe.get_cached_doc("BenchPress Settings")
 		linkuser_args = [
 			bench.ssh_username,
 			bench.owner,
@@ -248,11 +272,7 @@ def deploy_bench(bench_name: str) -> None:
 				f"chown -R {cs_user}:{cs_user} {cs_home}/.config && chmod 600 {cs_home}/.config/code-server/config.yaml",
 				user="root",
 			)
-			exec_in_container(
-				container_id,
-				f"sudo -u {cs_user} screen -d -m -S codeserver code-server {cs_home}/frappe-bench",
-				user="root",
-			)
+			exec_in_container(container_id, "bash /opt/benchpress/scripts/restart.sh", user="root")
 			bench.code_server_password = code_server_password
 			bench.code_server_url = f"http://{bench.wg_ip or bench.container_ip or '127.0.0.1'}:8080/"
 			append_log(f"code-server ready at {bench.code_server_url}")
@@ -286,20 +306,13 @@ def redeploy_bench(bench_name: str) -> None:
 		try:
 			stop_container(bench.container_id)
 		except Exception:
-			pass
+			pass  # best-effort
 		try:
 			remove_container(bench.container_id)
 		except Exception:
-			pass
+			pass  # best-effort
 
-	from benchpress.docker_manager import get_client
-
-	client = get_client()
-	try:
-		vol = client.volumes.get(f"benchpress-{bench_name}-data")
-		vol.remove(force=True)
-	except Exception:
-		pass
+	remove_bench_volume(bench_name)
 
 	if bench.database_server and bench.site_name:
 		from benchpress.mariadb_manager import drop_site_database
@@ -307,7 +320,7 @@ def redeploy_bench(bench_name: str) -> None:
 		try:
 			drop_site_database(bench.database_server, bench.site_name)
 		except Exception:
-			pass
+			pass  # best-effort
 
 	bench.container_id = None
 	bench.container_image = None
@@ -353,17 +366,9 @@ def build_lab(lab_name: str) -> None:
 	frappe.db.commit()
 	build_log_name = build_log.name
 
-	def append_log(line: str, log_type: str = "info") -> None:
-		frappe.publish_realtime(
-			event="lab_build_log",
-			message={"lab": lab_name, "log": line, "type": log_type, "build_log": build_log_name},
-			after_commit=False,
-		)
-		current = frappe.db.get_value("Build Log", build_log_name, "message") or ""
-		frappe.db.set_value(
-			"Build Log", build_log_name, "message", current + line + "\n", update_modified=False
-		)
-		frappe.db.commit()
+	append_log = _make_log_appender(
+		"Build Log", build_log_name, "lab_build_log", {"lab": lab_name, "build_log": build_log_name}
+	)
 
 	try:
 		_build_lab_with_logs(lab, append_log)

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -113,7 +113,10 @@ def deploy_bench(bench_name: str) -> None:
 	deploy_log_name = deploy_log.name
 
 	append_log = _make_log_appender(
-		"Deploy Log", deploy_log_name, "bench_deploy_log", {"bench": bench_name, "deploy_log": deploy_log_name}
+		"Deploy Log",
+		deploy_log_name,
+		"bench_deploy_log",
+		{"bench": bench_name, "deploy_log": deploy_log_name},
 	)
 
 	try:

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -56,7 +56,7 @@ def remove_bench_volume(bench_name: str) -> None:
 
 def _make_log_appender(doctype: str, log_name: str, event: str, context: dict):
 	def append_log(line: str, log_type: str = "info") -> None:
-		frappe.publish_realtime(
+		frappe.publish_realtime(  # nosemgrep -- the SPA listens via raw socket.io without doc-room subscription; room-scoping would drop its events
 			event=event,
 			message={**context, "log": line, "type": log_type},
 			after_commit=False,

--- a/benchpress/device_manager.py
+++ b/benchpress/device_manager.py
@@ -70,18 +70,6 @@ def unregister_device(device_name: str) -> bool:
 	if doc.owner != frappe.session.user and not is_admin():
 		frappe.throw(_("You do not have permission to remove this device."), frappe.PermissionError)
 
-	if doc.wg_public_key:
-		from benchpress.wg_manager import remove_peer_from_server, sync_wg_config
-
-		try:
-			remove_peer_from_server(doc.wg_public_key)
-			sync_wg_config()
-		except Exception:
-			frappe.log_error(
-				title=f"Device WG peer removal failed: {device_name}",
-				message=frappe.get_traceback(),
-			)
-
 	frappe.delete_doc("Bench Device", device_name, ignore_permissions=True, force=True)
 	frappe.db.commit()
 	return True

--- a/benchpress/docker_manager.py
+++ b/benchpress/docker_manager.py
@@ -45,6 +45,19 @@ def get_lab_template_dir() -> str:
 	return os.path.join(app_path, "lab-templates")
 
 
+def ensure_network(client: docker.DockerClient | None = None) -> None:
+	"""Create the benchpress Docker network if it does not exist."""
+	client = client or get_client()
+	try:
+		client.networks.get("benchpress")
+	except docker.errors.NotFound:
+		client.networks.create(
+			"benchpress",
+			driver="bridge",
+			ipam=docker.types.IPAMConfig(pool_configs=[docker.types.IPAMPool(subnet="172.30.0.0/24")]),
+		)
+
+
 def build_lab_image(lab_doc, log_fn=None, no_cache: bool = False) -> str:
 	"""Build Docker image with bench + apps (site created at runtime against shared MariaDB)."""
 	template_dir = get_lab_template_dir()
@@ -95,16 +108,7 @@ def create_bench_container(bench_doc, lab_doc) -> str:
 	Does NOT start the container. Returns the container ID.
 	"""
 	client = get_client()
-
-	# Ensure benchpress network exists
-	try:
-		client.networks.get("benchpress")
-	except docker.errors.NotFound:
-		client.networks.create(
-			"benchpress",
-			driver="bridge",
-			ipam=docker.types.IPAMConfig(pool_configs=[docker.types.IPAMPool(subnet="172.30.0.0/24")]),
-		)
+	ensure_network(client)
 
 	name = bench_doc.bench_name
 
@@ -188,8 +192,6 @@ def exec_in_container(
 
 def write_file_to_container(container_id: str, content: str, path: str) -> None:
 	"""Write a file into a running container using docker exec."""
-	import shlex
-
 	client = get_client()
 	container = client.containers.get(container_id)
 	escaped = content.replace("'", "'\\''")

--- a/benchpress/hooks.py
+++ b/benchpress/hooks.py
@@ -19,7 +19,7 @@ add_to_apps_screen = [
 		"logo": "/assets/benchpress/images/logo/logo.png",
 		"title": "BenchPress",
 		"route": "/frontend",
-		"has_permission": "benchpress.api.has_app_permission",
+		"has_permission": "benchpress.permissions.has_app_permission",
 	}
 ]
 

--- a/benchpress/install.py
+++ b/benchpress/install.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
 import os
 import subprocess
 

--- a/benchpress/lab-templates/scripts/linkuser.sh
+++ b/benchpress/lab-templates/scripts/linkuser.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # linkuser.sh — User provisioning for BenchPress containers
 # Renames the 'frappe' user to the dynamic username instead of creating a new one.
-# Args: USERNAME EMAIL LAB_NAME WG_IP SSH_PASSWORD BENCH_NAME BASE_DOMAIN MOUNT_TARGET ADMIN_PASSWORD
+# Args: USERNAME EMAIL LAB_NAME WG_IP SSH_PASSWORD BENCH_NAME BASE_DOMAIN MOUNT_TARGET
 
 set -e
 
@@ -13,7 +13,6 @@ SSH_PASSWORD="$5"
 BENCH_NAME="$6"
 BASE_DOMAIN="$7"
 MOUNT_TARGET="${8:-/home/frappe}"
-ADMIN_PASSWORD="$9"
 
 if [ -z "$USERNAME" ] || [ -z "$SSH_PASSWORD" ]; then
     echo "[error] USERNAME and SSH_PASSWORD are required"
@@ -61,8 +60,6 @@ BASHEOF
 fi
 
 chown -R "$USERNAME:$USERNAME" /home/frappe
-
-BENCH_DIR="/home/$USERNAME/frappe-bench"
 
 cat > "/.benchpress_config" << CFGEOF
 {

--- a/benchpress/lab-templates/scripts/setup-site.sh
+++ b/benchpress/lab-templates/scripts/setup-site.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
+set -e
 
-cd /home/frappe/frappe-bench
+# May fail under a custom mount_target, where the caller already sets workdir to the bench dir
+cd /home/frappe/frappe-bench || true
 
 echo "[*] Creating site ${SITE_NAME}..."
 

--- a/benchpress/mariadb_manager.py
+++ b/benchpress/mariadb_manager.py
@@ -10,8 +10,9 @@ import time
 import uuid
 
 import frappe
+from frappe import _
 
-from benchpress.docker_manager import get_client
+from benchpress.docker_manager import ensure_network, get_client
 
 DEFAULT_MARIADB_CONFIG = """[mysqld]
 character-set-server=utf8mb4
@@ -28,21 +29,6 @@ def _get_config_dir() -> str:
 
 def _get_compose_path() -> str:
 	return os.path.join(_get_config_dir(), "docker-compose.yml")
-
-
-def _ensure_network() -> None:
-	"""Create the benchpress Docker network if it does not exist."""
-	client = get_client()
-	try:
-		client.networks.get("benchpress")
-	except Exception:
-		import docker
-
-		client.networks.create(
-			"benchpress",
-			driver="bridge",
-			ipam=docker.types.IPAMConfig(pool_configs=[docker.types.IPAMPool(subnet="172.30.0.0/24")]),
-		)
 
 
 def _compose_cmd(*args: str) -> tuple[int, str]:
@@ -113,10 +99,10 @@ def setup_database_server(db_server_name: str) -> None:
 
 		_write_mariadb_config(db_server.custom_config)
 		_write_env_file(root_password, version, mem_limit)
-		_ensure_network()
+		client = get_client()
+		ensure_network(client)
 
 		# Ensure named volume exists (marked external in compose)
-		client = get_client()
 		try:
 			client.volumes.get(db_server.volume_name or "benchpress-mariadb-data")
 		except Exception:
@@ -124,17 +110,15 @@ def setup_database_server(db_server_name: str) -> None:
 
 		# Remove existing container if any (clean slate for compose)
 		try:
-			client = get_client()
 			old = client.containers.get(db_server.container_name)
 			old.remove(force=True)
 		except Exception:
-			pass
+			pass  # best-effort
 
 		exit_code, output = _compose_cmd("up", "-d", "mariadb")
 		if exit_code != 0:
 			raise Exception(f"docker compose up failed: {output}")
 
-		client = get_client()
 		container = client.containers.get(db_server.container_name)
 		wait_for_mariadb(db_server_name, container=container, root_pw=root_password, timeout=60)
 
@@ -243,7 +227,7 @@ def create_mariadb_user(
 	for query in queries:
 		exit_code, output = execute_sql(db_server_name, query)
 		if exit_code != 0:
-			frappe.throw(f"Failed to create temp user: {output}")
+			frappe.throw(_("Failed to create temp user: {0}").format(output))
 	return database, user, password
 
 
@@ -277,10 +261,10 @@ def drop_site_database(db_server_name: str, site_name: str) -> None:
 def check_mariadb_health(db_server_name: str) -> bool:
 	"""Check if MariaDB is responding."""
 	try:
-		exit_code, _ = execute_sql(db_server_name, "SELECT 1")
+		exit_code, _output = execute_sql(db_server_name, "SELECT 1")
 		return exit_code == 0
 	except Exception:
-		return False
+		return False  # best-effort
 
 
 PASSWORD_MISMATCH_MSG = (
@@ -296,7 +280,7 @@ def _detect_password_mismatch(container) -> bool:
 		logs = container.logs(tail=50).decode("utf-8", errors="replace")
 		return logs.count("Access denied for user 'root'") >= 3
 	except Exception:
-		return False
+		return False  # best-effort
 
 
 def _resolve_poll_container(db_server_name: str):
@@ -304,7 +288,7 @@ def _resolve_poll_container(db_server_name: str):
 		db_server = frappe.get_doc("Database Server", db_server_name)
 		return get_client().containers.get(db_server.container_name)
 	except Exception:
-		return None
+		return None  # best-effort
 
 
 def wait_for_mariadb(
@@ -313,21 +297,17 @@ def wait_for_mariadb(
 	container=None,
 	root_pw: str = "",
 ) -> None:
-	if container and root_pw:
-		for _ in range(timeout // 2):
-			exit_code, _ = container.exec_run(
+	direct = bool(container and root_pw)
+	poll_container = container if direct else None
+	for _attempt in range(timeout // 2):
+		if direct:
+			exit_code, _output = container.exec_run(
 				cmd=["mariadb", "-u", "root", f"-p{root_pw}", "-e", "SELECT 1"],
 			)
-			if exit_code == 0:
-				return
-			if _detect_password_mismatch(container):
-				raise Exception(PASSWORD_MISMATCH_MSG)
-			time.sleep(2)
-		raise Exception(f"MariaDB not ready after {timeout}s")
-
-	poll_container = None
-	for _ in range(timeout // 2):
-		if check_mariadb_health(db_server_name):
+			healthy = exit_code == 0
+		else:
+			healthy = check_mariadb_health(db_server_name)
+		if healthy:
 			return
 		if poll_container is None and db_server_name:
 			poll_container = _resolve_poll_container(db_server_name)
@@ -386,7 +366,7 @@ def backup_database_server(db_server_name: str, output_path: str = "/var/lib/mys
 		],
 	)
 	if exit_code != 0:
-		frappe.throw(f"Backup failed: {output.decode()}")
+		frappe.throw(_("Backup failed: {0}").format(output.decode()))
 	return backup_file
 
 
@@ -422,7 +402,7 @@ def scheduled_backup():
 
 def setup_redis() -> None:
 	"""Bring up shared Redis container via docker compose."""
-	_ensure_network()
+	ensure_network()
 	exit_code, output = _compose_cmd("up", "-d", "redis")
 	if exit_code != 0:
 		raise Exception(f"docker compose up redis failed: {output}")

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -137,10 +137,17 @@ class TestDeployManager(IntegrationTestCase):
 
 		mock_client.return_value.volumes.get.return_value = MagicMock()
 
+		status_at_deploy = {}
+
+		def capture_status(bench_name):
+			status_at_deploy["status"] = frappe.db.get_value("Bench Instance", bench_name, "status")
+
+		mock_deploy.side_effect = capture_status
+
 		redeploy_bench(bench.name)
 
-		# deploy_bench is called, which sets status back — but before that it was "Draft"
 		mock_deploy.assert_called_once_with(bench.name)
+		self.assertEqual(status_at_deploy["status"], "Draft")
 
 	@patch("benchpress.deploy_manager.deploy_bench")
 	@patch("benchpress.deploy_manager.remove_container")

--- a/benchpress/tests/test_mariadb_manager.py
+++ b/benchpress/tests/test_mariadb_manager.py
@@ -1,9 +1,8 @@
 # Copyright (c) 2026, Venkatesh and Contributors
 # See license.txt
 
-import base64
 import hashlib
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import frappe
 from frappe.tests import IntegrationTestCase
@@ -123,7 +122,7 @@ class TestMariadbManager(IntegrationTestCase):
 
 	@patch("benchpress.mariadb_manager.execute_sql")
 	def test_drop_mariadb_user_runs_drop_queries(self, mock_exec):
-		from benchpress.mariadb_manager import drop_mariadb_user, get_database_name
+		from benchpress.mariadb_manager import drop_mariadb_user
 
 		mock_exec.return_value = (0, "")
 		drop_mariadb_user("db-server", "site.localhost")

--- a/benchpress/wg_manager.py
+++ b/benchpress/wg_manager.py
@@ -35,21 +35,13 @@ def get_peer_transfer_stats() -> dict:
 
 
 def generate_keypair() -> dict:
-	if _wg_available():
-		private = subprocess.run(["wg", "genkey"], capture_output=True, text=True, check=True).stdout.strip()
-		public = subprocess.run(
-			["wg", "pubkey"], input=private, capture_output=True, text=True, check=True
-		).stdout.strip()
-		return {"private_key": private, "public_key": public}
-
-	import base64
-	import secrets
-
-	private_bytes = secrets.token_bytes(32)
-	return {
-		"private_key": base64.b64encode(private_bytes).decode(),
-		"public_key": base64.b64encode(private_bytes).decode(),  # placeholder — wg not available
-	}
+	if not _wg_available():
+		frappe.throw(_("WireGuard tools are not installed on this server (wg command not found)."))
+	private = subprocess.run(["wg", "genkey"], capture_output=True, text=True, check=True).stdout.strip()
+	public = subprocess.run(
+		["wg", "pubkey"], input=private, capture_output=True, text=True, check=True
+	).stdout.strip()
+	return {"private_key": private, "public_key": public}
 
 
 def allocate_ip() -> str:
@@ -70,6 +62,7 @@ def generate_peer_config(
 	server_public_key: str,
 	server_endpoint: str,
 	server_port: int,
+	keepalive: int = 30,
 ) -> str:
 	return f"""[Interface]
 PrivateKey = {private_key}
@@ -79,7 +72,7 @@ Address = {peer_ip}/32
 PublicKey = {server_public_key}
 AllowedIPs = 10.10.0.0/24
 Endpoint = {server_endpoint}:{server_port}
-PersistentKeepalive = 30
+PersistentKeepalive = {keepalive}
 """
 
 
@@ -101,9 +94,6 @@ def remove_peer_from_server(public_key: str) -> None:
 		check=True,
 		capture_output=True,
 	)
-
-
-# --- Host WireGuard Server Management ---
 
 
 @frappe.whitelist()
@@ -169,9 +159,6 @@ def sync_wg_config() -> None:
 	subprocess.run(["sudo", "bash", "-c", f"wg-quick save {WG_INTERFACE}"], capture_output=True)
 
 
-# --- Inside-Container VPN Setup ---
-
-
 def _get_container_ip(container_id: str) -> str:
 	from benchpress.docker_manager import get_client
 
@@ -195,7 +182,7 @@ def _get_docker_gateway() -> str:
 		if configs and "Gateway" in configs[0]:
 			return configs[0]["Gateway"]
 	except Exception:
-		pass
+		pass  # best-effort
 	return "172.30.0.1"
 
 
@@ -211,16 +198,13 @@ def setup_container_vpn(
 
 	gateway = _get_docker_gateway()
 
-	config = (
-		f"[Interface]\n"
-		f"PrivateKey = {private_key}\n"
-		f"Address = {peer_ip}/32\n"
-		f"\n"
-		f"[Peer]\n"
-		f"PublicKey = {server_public_key}\n"
-		f"Endpoint = {gateway}:{server_port}\n"
-		f"AllowedIPs = 10.10.0.0/24\n"
-		f"PersistentKeepalive = 25\n"
+	config = generate_peer_config(
+		private_key=private_key,
+		peer_ip=peer_ip,
+		server_public_key=server_public_key,
+		server_endpoint=gateway,
+		server_port=server_port,
+		keepalive=25,
 	)
 
 	exec_in_container(container_id, "mkdir -p /etc/wireguard", user="root")

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "feather-icons": "^4.29.2",
-    "frappe-ui": "^0.1.192",
+    "frappe-ui": "^0.1.270",
     "qrcode": "^1.5.4",
     "socket.io-client": "^4.7.2",
     "vue": "^3.5.13",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,14 +1,16 @@
 <template>
-	<div class="flex h-screen">
-		<Sidebar :header="headerConfig" :sections="sections" />
-		<div class="flex-1 overflow-auto bg-surface-white">
-			<router-view />
+	<FrappeUIProvider>
+		<div class="flex h-screen">
+			<Sidebar :header="headerConfig" :sections="sections" />
+			<div class="flex-1 overflow-auto bg-surface-white">
+				<router-view />
+			</div>
 		</div>
-	</div>
+	</FrappeUIProvider>
 </template>
 
 <script setup>
-import { Sidebar } from "frappe-ui";
+import { FrappeUIProvider, Sidebar } from "frappe-ui";
 import { computed } from "vue";
 import { session } from "@/data/session";
 import { userContext } from "@/data/userContext";

--- a/frontend/src/data/session.js
+++ b/frontend/src/data/session.js
@@ -34,7 +34,7 @@ export const session = reactive({
 		onSuccess() {
 			userResource.reset();
 			session.user = sessionUser();
-			router.replace({ name: "Login" });
+			window.location.href = "/login";
 		},
 	}),
 	user: sessionUser(),

--- a/frontend/src/pages/Devices.vue
+++ b/frontend/src/pages/Devices.vue
@@ -178,7 +178,7 @@
 </template>
 
 <script setup>
-import { ref, watch, nextTick } from "vue";
+import { ref, nextTick } from "vue";
 import {
 	createResource,
 	Badge,
@@ -205,8 +205,6 @@ function formatBytes(bytes) {
 const showAddDialog = ref(false);
 const showRemoveDialog = ref(false);
 const deviceToRemove = ref(null);
-const downloadingConfig = ref(null);
-const removingDevice = ref(null);
 const autoGenKey = ref(true);
 
 const newDevice = ref({ name: "", type: "Laptop", publicKey: "" });
@@ -257,24 +255,26 @@ const configText = ref("");
 const configDeviceName = ref("");
 const qrCanvas = ref(null);
 
-const showConfigAction = createResource({
+const wgConfigAction = createResource({
 	url: "benchpress.api.get_device_wg_config",
-	onSuccess(data) {
-		configText.value = data;
-		showConfigDialog.value = true;
-		nextTick(() => {
-			nextTick(() => {
-				if (qrCanvas.value && configText.value) {
-					QRCode.toCanvas(qrCanvas.value, configText.value, { width: 200, margin: 2 });
-				}
-			});
-		});
-	},
 });
 
 function showConfig(device) {
 	configDeviceName.value = device.device_name;
-	showConfigAction.submit({ device_name: device.name });
+	wgConfigAction.submit(
+		{ device_name: device.name },
+		{
+			onSuccess(data) {
+				configText.value = data;
+				showConfigDialog.value = true;
+				nextTick(() => {
+					if (qrCanvas.value && configText.value) {
+						QRCode.toCanvas(qrCanvas.value, configText.value, { width: 200, margin: 2 });
+					}
+				});
+			},
+		}
+	);
 }
 
 const devices = createResource({
@@ -317,28 +317,14 @@ function confirmRemove(device) {
 
 function removeDevice() {
 	if (!deviceToRemove.value) return;
-	removingDevice.value = deviceToRemove.value.name;
-	removeAction.submit(
-		{ device_name: deviceToRemove.value.name },
-		{
-			onSuccess() {
-				removingDevice.value = null;
-			},
-		}
-	);
+	removeAction.submit({ device_name: deviceToRemove.value.name });
 }
 
-const configAction = createResource({
-	url: "benchpress.api.get_device_wg_config",
-});
-
-async function downloadConfig(device) {
-	downloadingConfig.value = device.name;
-	configAction.submit(
+function downloadConfig(device) {
+	wgConfigAction.submit(
 		{ device_name: device.name },
 		{
 			onSuccess(data) {
-				downloadingConfig.value = null;
 				const blob = new Blob([data], { type: "text/plain" });
 				const url = URL.createObjectURL(blob);
 				const a = document.createElement("a");
@@ -346,9 +332,6 @@ async function downloadConfig(device) {
 				a.download = `${device.device_name}.conf`;
 				a.click();
 				URL.revokeObjectURL(url);
-			},
-			onError() {
-				downloadingConfig.value = null;
 			},
 		}
 	);

--- a/frontend/src/pages/Devices.vue
+++ b/frontend/src/pages/Devices.vue
@@ -269,7 +269,10 @@ function showConfig(device) {
 				showConfigDialog.value = true;
 				nextTick(() => {
 					if (qrCanvas.value && configText.value) {
-						QRCode.toCanvas(qrCanvas.value, configText.value, { width: 200, margin: 2 });
+						QRCode.toCanvas(qrCanvas.value, configText.value, {
+							width: 200,
+							margin: 2,
+						});
 					}
 				});
 			},

--- a/frontend/src/pages/Labs.vue
+++ b/frontend/src/pages/Labs.vue
@@ -114,17 +114,14 @@ const filteredRows = computed(() => {
 
 	let rows = labs.data;
 
-	// Status filter
 	if (statusFilter.value !== "All") {
 		rows = rows.filter((r) => r.status === statusFilter.value);
 	}
 
-	// Version filter
 	if (versionFilter.value !== "All") {
 		rows = rows.filter((r) => r.frappe_version === versionFilter.value);
 	}
 
-	// Search filter (lab_id, title, or app names via app_count context)
 	if (searchQuery.value) {
 		const q = searchQuery.value.toLowerCase();
 		rows = rows.filter(

--- a/frontend/src/pages/NewLab.vue
+++ b/frontend/src/pages/NewLab.vue
@@ -120,7 +120,7 @@
 <script setup>
 import { reactive } from "vue";
 import { useRouter } from "vue-router";
-import { createListResource, Button, FormControl, ErrorMessage } from "frappe-ui";
+import { createListResource, toast, Button, FormControl, ErrorMessage } from "frappe-ui";
 
 const router = useRouter();
 
@@ -159,7 +159,7 @@ const lab = createListResource({
 
 async function createLab() {
 	if (!form.lab_id || !form.title || !form.frappe_version) {
-		frappe.toast({ message: "Please fill all required fields", indicator: "red" });
+		toast.error("Please fill all required fields");
 		return;
 	}
 
@@ -176,7 +176,7 @@ async function createLab() {
 		});
 		router.push("/labs");
 	} catch (err) {
-		// error is handled by frappe-ui resource
+		// lab.insert.error is rendered by the ErrorMessage above
 	}
 }
 </script>

--- a/setup.sh
+++ b/setup.sh
@@ -188,7 +188,7 @@ else
 fi
 
 # Quick sanity check
-if sudo -n wg show &>/dev/null 2>&1 || sudo -n wg show 2>&1 | grep -qv "password"; then
+if sudo -n wg show &>/dev/null || sudo -n wg show 2>&1 | grep -qv "password"; then
     success "Passwordless sudo for wg is working"
 else
     warn "Could not verify passwordless sudo — check $SUDOERS_FILE manually"
@@ -215,7 +215,7 @@ echo ""
 
 info "Step 6/6: WireGuard server initialization"
 
-if sudo wg show wg0 &>/dev/null 2>&1; then
+if sudo wg show wg0 &>/dev/null; then
     success "wg0 interface is already running"
     WG_PUBKEY=$(sudo wg show wg0 public-key 2>/dev/null || echo "")
 else
@@ -224,7 +224,7 @@ else
     bench --site "$SITE_NAME" execute benchpress.wg_manager.setup_wg_server
     success "WireGuard server initialized"
 
-    if sudo wg show wg0 &>/dev/null 2>&1; then
+    if sudo wg show wg0 &>/dev/null; then
         WG_PUBKEY=$(sudo wg show wg0 public-key 2>/dev/null || echo "")
         success "wg0 is up"
     else
@@ -253,7 +253,6 @@ echo ""
 echo "  2. Open BenchPress Settings DocType in Frappe Desk:"
 echo ""
 echo "  3. Fill in:"
-echo "     - WG Server Public Key  : (shown above)"
 echo "     - WG Server Endpoint    : <your server's public IP>"
 echo "     - WG Server Port        : 51820"
 echo ""


### PR DESCRIPTION
## What this PR does

Full-codebase cleanup pass driven by a multi-agent review (AI-slop/comment audit, duplicate detection, Frappe-convention check against frappe core and the first-party frappe-ui apps CRM/Gameplan/Insights).

### Consolidations — one canonical implementation each

| Was duplicated (and had diverged) | Now |
|---|---|
| Site creation in `deploy_bench` + `api._create_site_on_bench` | `deploy_manager.create_site_in_container()` — **fixes hardcoded `"admin"` password and ignored `lab.mount_target` in the api copy** |
| Docker network creation in `docker_manager` + `mariadb_manager` | `docker_manager.ensure_network()` |
| WG peer config template (keepalive had diverged 30 vs 25) | `generate_peer_config(keepalive=...)`, both paths byte-equivalent |
| ssh username fallback (unsanitized `split("@")`) | canonical `BenchInstance._derive_username` (regex-sanitized) |
| Two identical `append_log` closures | `_make_log_appender()` factory |
| WG peer cleanup pre-delete **and** in `on_trash` (ran twice) | `on_trash` only |
| Bench volume removal ×2 | `remove_bench_volume()` |
| Inline db config rebuild | `DatabaseServer.get_connection_config()` (first call site) |

Deliberately **not** merged: the three bench-teardown paths (api delete / redeploy / stale-container) genuinely differ in error propagation and scope — forcing one helper would change behavior or create a flag-soup.

### Behavior fixes
- `generate_keypair` now raises a translated error when `wg` is unavailable instead of returning the **private key as a fake public key**
- SPA logout → full-page `/login` redirect (route `"Login"` never existed; matches CRM/Gameplan)
- NewLab validation toast: `frappe.toast` is a desk-only global → `toast.error` from frappe-ui, with `FrappeUIProvider` mounted in App.vue (exact CRM pattern); frappe-ui pin bumped to `^0.1.270` to match the APIs used
- `setup-site.sh` runs under `set -e` so a failed `bench new-site` propagates to the deploy exit-code check
- `bench_instance.js` realtime listener no longer stacks a new handler on every form refresh
- `build_log.js` switched from a hardcoded GitHub-dark palette to frappe CSS variables — **the build log viewer now follows the active desk theme** (visible change, intended)

### Cleanups
Dead VPN-config buttons gated on a field that doesn't exist, dead `bench.save()` before `delete_doc`, unused imports/vars/script args, untranslated `frappe.throw/msgprint` wrapped in `_()`, `# best-effort` markers on intentional exception swallows, duplicate enqueue/get_client/settings fetches, merged `wait_for_mariadb` poll loops, stale setup.sh epilogue step (the WG public key is auto-saved by `setup_wg_server`), `hooks.py` references `benchpress.permissions.has_app_permission` directly instead of via an api.py re-export.

## Verification
- `ruff check` clean; `py_compile` clean on all changed files
- **54/54 app tests pass** in the backend container (incl. a previously assertion-less test that now actually asserts the Draft reset)
- `vite build` succeeds in-container; `bash -n` clean on all shell scripts
- Frontend fixes verified against CRM/Gameplan/Insights reference implementations

## Notes for reviewers
- `Devices.vue`: the double `nextTick` before the QR render was collapsed to one (matches how the reka-ui dialog mounts). Worth a 30-second smoke test of "Show Configuration" — failure mode would be an empty dialog, not an error.
- ssh-username fallback edge cases change for invalid owners (e.g. `1234@x.com` → `user1234` instead of `1234`): the old values were invalid/collision-prone Linux usernames that would have broken `linkuser.sh` anyway.