### PR TITLE
feat: ship user context via frappe boot info instead of an extra API round-trip

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -66,8 +66,6 @@ All endpoints use `@frappe.whitelist()`. Long-running ops are enqueued to the `"
 
 | Endpoint | Method | What It Does |
 |----------|--------|--------------|
-| `get_labs()` | GET | List all labs with app_count, bench_count |
-| `get_lab(name)` | GET | Single lab with apps list |
 | `build_lab_image(lab_name)` | POST | Enqueue background Docker image build |
 | `get_benches()` | GET | All benches with CPU/memory stats |
 | `create_bench(data)` | POST | Create bench from lab, enqueue deploy |

--- a/README.md
+++ b/README.md
@@ -312,8 +312,6 @@ All endpoints require authentication and use `@frappe.whitelist()`. Long-running
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `benchpress.api.get_labs` | GET | List all labs with app count and bench count |
-| `benchpress.api.get_lab` | GET | Get single lab with full apps list |
 | `benchpress.api.build_lab_image` | POST | Enqueue background Docker image build (queue: long, timeout: 3600s) |
 
 > **Note:** Lab creation uses `createListResource.insert` from `frappe-ui` directly (no custom API endpoint needed).

--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -4,62 +4,13 @@
 import frappe
 from frappe import _
 
+from benchpress.boot import get_bootinfo
 from benchpress.permissions import (
 	get_bench_owner_filter,
 	is_admin,
 	require_admin,
 	require_bench_access,
 )
-
-
-@frappe.whitelist()
-def get_labs() -> list[dict]:
-	labs = frappe.get_all(
-		"Lab",
-		fields=[
-			"name",
-			"lab_id",
-			"title",
-			"description",
-			"frappe_version",
-			"status",
-			"image_tag",
-			"memory_limit",
-			"cpu_cores",
-		],
-		order_by="creation desc",
-	)
-	for lab in labs:
-		apps = frappe.get_all(
-			"Lab App",
-			filters={"parent": lab["name"]},
-			fields=["app_name"],
-			limit_page_length=50,
-		)
-		lab["app_names"] = [a["app_name"] for a in apps]
-		lab["app_count"] = len(apps)
-		lab["bench_count"] = frappe.db.count("Bench Instance", {"lab": lab["name"]})
-	return labs
-
-
-@frappe.whitelist()
-def get_lab(name: str) -> dict:
-	lab = frappe.get_cached_doc("Lab", name)
-	return {
-		"name": lab.name,
-		"lab_id": lab.lab_id,
-		"title": lab.title,
-		"description": lab.description,
-		"frappe_version": lab.frappe_version,
-		"status": lab.status,
-		"image_tag": lab.image_tag,
-		"memory_limit": lab.memory_limit,
-		"cpu_cores": lab.cpu_cores,
-		"apps": [
-			{"app_name": a.app_name, "app_label": a.app_label, "git_url": a.git_url, "branch": a.branch}
-			for a in lab.apps
-		],
-	}
 
 
 @frappe.whitelist()
@@ -112,7 +63,7 @@ def get_benches() -> list[dict]:
 	return benches
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def create_bench(data: str) -> dict:
 	from benchpress.benchpress.doctype.bench_instance import get_instance_id
 
@@ -166,7 +117,7 @@ def create_bench(data: str) -> dict:
 	return {"name": doc.name, "status": "Deploying"}
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def bench_action(bench_name: str, action: str) -> dict:
 	from benchpress.docker_manager import (
 		remove_container,
@@ -218,13 +169,11 @@ def bench_action(bench_name: str, action: str) -> dict:
 		remove_bench_volume(bench.bench_name)
 
 		frappe.delete_doc("Bench Instance", bench_name, force=True)
-		frappe.db.commit()
 		return {"status": "deleted"}
 	else:
 		frappe.throw(_("Invalid action: {0}").format(action))
 
 	bench.save(ignore_permissions=True)
-	frappe.db.commit()
 	return {"name": bench.name, "status": bench.status}
 
 
@@ -269,7 +218,7 @@ def get_device_wg_config(device_name: str) -> str:
 	return get_device_config(device_name)
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def create_site(data: str) -> dict:
 	data = frappe.parse_json(data)
 
@@ -349,11 +298,7 @@ def _create_site_on_bench(site_doc_name: str) -> None:
 
 @frappe.whitelist()
 def get_user_context() -> dict:
-	return {
-		"is_admin": is_admin(),
-		"user": frappe.session.user,
-		"roles": frappe.get_roles(frappe.session.user),
-	}
+	return get_bootinfo()
 
 
 @frappe.whitelist()

--- a/benchpress/boot.py
+++ b/benchpress/boot.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+import frappe
+
+from benchpress.permissions import is_admin
+
+
+def get_bootinfo() -> dict:
+	return {
+		"is_admin": is_admin(),
+		"user": frappe.session.user,
+		"roles": frappe.get_roles(frappe.session.user),
+	}
+
+
+def extend_bootinfo(bootinfo):
+	bootinfo.benchpress = get_bootinfo()

--- a/benchpress/hooks.py
+++ b/benchpress/hooks.py
@@ -23,6 +23,8 @@ add_to_apps_screen = [
 	}
 ]
 
+extend_bootinfo = "benchpress.boot.extend_bootinfo"
+
 # Includes in <head>
 # ------------------
 
@@ -117,7 +119,6 @@ after_install = "benchpress.install.after_install"
 # Permissions evaluated in scripted ways
 
 permission_query_conditions = {
-	"Bench Instance": "benchpress.permissions.bench_instance_query_conditions",
 	"Deploy Log": "benchpress.permissions.deploy_log_query_conditions",
 }
 

--- a/benchpress/permissions.py
+++ b/benchpress/permissions.py
@@ -29,16 +29,6 @@ def get_bench_owner_filter() -> dict:
 	return {"owner": frappe.session.user}
 
 
-def bench_instance_query_conditions(user):
-	if not user:
-		user = frappe.session.user
-	if user == "Administrator":
-		return ""
-	if not set(frappe.get_roles(user)).isdisjoint(ADMIN_ROLES):
-		return ""
-	return f"`tabBench Instance`.owner = {frappe.db.escape(user)}"
-
-
 def deploy_log_query_conditions(user):
 	if not user:
 		user = frappe.session.user

--- a/benchpress/tests/test_permissions.py
+++ b/benchpress/tests/test_permissions.py
@@ -4,6 +4,33 @@
 import frappe
 from frappe.tests import IntegrationTestCase
 
+from benchpress.benchpress.doctype.bench_instance import get_instance_id
+
+
+def _make_lab(lab_id="test-lab-perms"):
+	if frappe.db.exists("Lab", lab_id):
+		return frappe.get_doc("Lab", lab_id)
+	return frappe.get_doc(
+		{
+			"doctype": "Lab",
+			"lab_id": lab_id,
+			"title": "Test Lab (Permissions)",
+			"frappe_version": "version-15",
+		}
+	).insert(ignore_permissions=True)
+
+
+def _make_bench(lab_name):
+	existing = get_instance_id(frappe.session.user, lab_name)
+	if frappe.db.exists("Bench Instance", existing):
+		return frappe.get_doc("Bench Instance", existing)
+	return frappe.get_doc(
+		{
+			"doctype": "Bench Instance",
+			"lab": lab_name,
+		}
+	).insert(ignore_permissions=True)
+
 
 class TestPermissions(IntegrationTestCase):
 	@classmethod
@@ -36,10 +63,19 @@ class TestPermissions(IntegrationTestCase):
 			).insert(ignore_permissions=True)
 		cls.regular_user = "perm-user@example.com"
 		cls.admin_user = "perm-admin@example.com"
+		cls.lab = _make_lab()
+		frappe.set_user(cls.regular_user)
+		cls.user_bench = _make_bench(cls.lab.name).name
+		frappe.set_user("Administrator")
+		cls.admin_bench = _make_bench(cls.lab.name).name
 
 	@classmethod
 	def tearDownClass(cls):
 		frappe.set_user("Administrator")
+		for name in [cls.user_bench, cls.admin_bench]:
+			if frappe.db.exists("Bench Instance", name):
+				frappe.delete_doc("Bench Instance", name, force=True, ignore_permissions=True)
+		cls.lab.delete(ignore_permissions=True)
 		for email in [cls.regular_user, cls.admin_user]:
 			if frappe.db.exists("User", email):
 				frappe.delete_doc("User", email, force=True, ignore_permissions=True)
@@ -103,24 +139,23 @@ class TestPermissions(IntegrationTestCase):
 		result = get_bench_owner_filter()
 		self.assertEqual(result, {"owner": self.regular_user})
 
-	def test_bench_instance_query_conditions_empty_for_administrator(self):
-		from benchpress.permissions import bench_instance_query_conditions
+	def test_bench_list_shows_only_own_benches_for_regular_user(self):
+		frappe.set_user(self.regular_user)
+		names = frappe.get_list("Bench Instance", pluck="name", limit_page_length=0)
+		self.assertIn(self.user_bench, names)
+		self.assertNotIn(self.admin_bench, names)
 
-		result = bench_instance_query_conditions("Administrator")
-		self.assertEqual(result, "")
+	def test_bench_list_shows_all_benches_for_benchpress_admin(self):
+		frappe.set_user(self.admin_user)
+		names = frappe.get_list("Bench Instance", pluck="name", limit_page_length=0)
+		self.assertIn(self.user_bench, names)
+		self.assertIn(self.admin_bench, names)
 
-	def test_bench_instance_query_conditions_empty_for_benchpress_admin(self):
-		from benchpress.permissions import bench_instance_query_conditions
-
-		result = bench_instance_query_conditions(self.admin_user)
-		self.assertEqual(result, "")
-
-	def test_bench_instance_query_conditions_has_owner_clause_for_user(self):
-		from benchpress.permissions import bench_instance_query_conditions
-
-		result = bench_instance_query_conditions(self.regular_user)
-		self.assertIn("owner", result)
-		self.assertIn("tabBench Instance", result)
+	def test_bench_list_shows_all_benches_for_administrator(self):
+		frappe.set_user("Administrator")
+		names = frappe.get_list("Bench Instance", pluck="name", limit_page_length=0)
+		self.assertIn(self.user_bench, names)
+		self.assertIn(self.admin_bench, names)
 
 	def test_deploy_log_query_conditions_empty_for_administrator(self):
 		from benchpress.permissions import deploy_log_query_conditions

--- a/benchpress/www/frontend.py
+++ b/benchpress/www/frontend.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+
+from benchpress.boot import get_bootinfo
+from benchpress.permissions import has_app_permission
+
+no_cache = 1
+
+
+def get_context():
+	if not has_app_permission():
+		frappe.throw(_("You do not have permission to access BenchPress"), frappe.PermissionError)
+
+	frappe.db.commit()  # nosemgrep -- GET-rendered pages are rolled back; persist the csrf_token generated above (matches CRM/Gameplan)
+	context = frappe._dict()
+	context.boot = get_boot()
+	return context
+
+
+def get_boot():
+	return frappe._dict(
+		{
+			"frappe_version": frappe.__version__,
+			"site_name": frappe.local.site,
+			"read_only_mode": frappe.flags.read_only,
+			"csrf_token": frappe.sessions.get_csrf_token(),
+			"socketio_port": frappe.conf.get("socketio_port"),
+			"benchpress": get_bootinfo(),
+		}
+	)

--- a/frontend/src/data/userContext.js
+++ b/frontend/src/data/userContext.js
@@ -5,28 +5,33 @@ export const userContext = reactive({
 	isAdmin: false,
 	user: "",
 	roles: [],
-	loading: true,
 	ready: false,
 });
 
-const userContextResource = createResource({
-	url: "/api/method/benchpress.api.get_user_context",
-	auto: true,
-	cache: "UserContext",
-	onSuccess(data) {
-		const ctx = data?.message ?? data;
-		userContext.isAdmin = ctx?.is_admin ?? false;
-		userContext.user = ctx?.user ?? "";
-		userContext.roles = ctx?.roles ?? [];
-		userContext.loading = false;
-		userContext.ready = true;
-	},
-	onError() {
-		userContext.loading = false;
-	},
-});
+function setUserContext(ctx) {
+	userContext.isAdmin = ctx?.is_admin ?? false;
+	userContext.user = ctx?.user ?? "";
+	userContext.roles = ctx?.roles ?? [];
+	userContext.ready = true;
+}
+
+let userContextResource = null;
+
+if (window.benchpress) {
+	setUserContext(window.benchpress);
+} else {
+	// boot data is only injected in production builds; fetch in vite dev mode
+	userContextResource = createResource({
+		url: "/api/method/benchpress.api.get_user_context",
+		auto: true,
+		cache: "UserContext",
+		onSuccess(data) {
+			setUserContext(data?.message ?? data);
+		},
+	});
+}
 
 export function waitForUserContext() {
 	if (userContext.ready) return Promise.resolve();
-	return userContextResource.promise;
+	return userContextResource ? userContextResource.promise : Promise.resolve();
 }

--- a/frontend/src/socket.js
+++ b/frontend/src/socket.js
@@ -1,10 +1,10 @@
 import { io } from "socket.io-client";
-import { socketio_port } from "../../../../sites/common_site_config.json";
 
 let socket = null;
 export function initSocket() {
+	const socketio_port = window.socketio_port || 9000;
 	const host = window.location.hostname;
-	const siteName = window.site_name;
+	const siteName = import.meta.env.DEV ? host : window.site_name;
 	const port = window.location.port ? `:${socketio_port}` : "";
 	const protocol = port ? "http" : "https";
 	const url = `${protocol}://${host}${port}/${siteName}`;


### PR DESCRIPTION
> **Stacked on #52** — merge #52 first, then retarget this PR to `develop` (GitHub does this automatically when the base branch merges).

## What this PR does

Finishes the boot-data design that was half-built: `frontend/vite.config.js` already had `jinjaBootData: true`, but nothing on the server populated it. This adds the missing half, copied from how **Frappe CRM / Gameplan / Insights** do it, and removes custom code the framework already covers.

### Boot info (new)
- **`benchpress/www/frontend.py`** — `get_context` gates on `has_app_permission` (Guest → login redirect) and renders `context.boot` into the served SPA page: `csrf_token`, `socketio_port`, `site_name`, `frappe_version`, `read_only_mode`, and `window.benchpress = {is_admin, user, roles}` (CRM/Gameplan `www/*.py` pattern)
- **`benchpress/boot.py`** — `get_bootinfo()` is the single canonical payload builder; the `extend_bootinfo` hook ships the same payload in desk boot; `api.get_user_context` now returns it too (kept as the vite dev-mode fallback)
- **`userContext.js`** reads `window.benchpress` synchronously in production — no more user-context API round-trip before the router can decide anything
- **`socket.js`** reads `window.socketio_port` / `window.site_name` (Insights pattern) instead of build-time importing `sites/common_site_config.json` — **`vite build` now works outside a bench checkout** (it previously failed on the host)

### Framework-redundancy cleanup
- Removed `bench_instance_query_conditions` hook + function: Bench Instance's `if_owner` DocPerm already makes frappe apply the owner constraint in list queries (`db_query.py` `requires_owner_constraint`); admins keep full visibility via their non-`if_owner` perm. `test_permissions.py` rewritten to assert the same guarantees through `frappe.get_list` — non-admin sees only own benches, admins see all
- Deleted dead `get_labs` / `get_lab` endpoints (zero callers — the SPA uses frappe-ui resources; README/ARCHITECTURE tables updated)
- Removed redundant `frappe.db.commit()` in `bench_action`; **kept** commit-before-enqueue calls deliberately — `enqueue_after_commit=False` means the queue-long container dequeues immediately and must see committed rows (verified against frappe source)
- `bench_action` / `create_bench` / `create_site` now declare `methods=["POST"]`, so the framework auto-commit contract this change relies on is enforced (frappe-ui's `frappeRequest` already POSTs); previously a plain GET could trigger irreversible docker side effects

## Verification
- `pre-commit run --all-files` clean (ruff, ruff-format, prettier); frappe semgrep rules: 0 blocking findings
- **54/54 backend tests pass** in the backend container
- `vite build` passes on host **and** in-container
- Runtime smoke test on the live bench: authenticated request to `/frontend` returns the page with `window["csrf_token"]`, `window["socketio_port"] = 9000`, `window["benchpress"] = {"is_admin": true, ...}` rendered; Guest is denied; the dev fallback endpoint returns the identical payload
- Boot contract traced through frappe source (`sessions.py` `extend_bootinfo`, website `template_page.py` `get_context`) and frappe-ui 0.1.270's `jinjaBootData` vite plugin

## Notes for reviewers
- The app payload is namespaced (`window.benchpress`) rather than flat like the reference apps, because one builder feeds both desk boot (`frappe.boot.benchpress`) and the SPA — avoids generic globals like `window.roles`
- After deploying this branch, restart the backend (`docker compose restart backend`) so gunicorn picks up the hooks/permissions changes
- Follow-up candidates (not in this PR): boot-supplied frappe version options for Labs/NewLab hardcoded lists; room-scoping the deploy/build log realtime broadcasts