### PR TITLE
ci: add frontend build check + CI badges (P0-10, #43)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,3 +104,35 @@ jobs:
           bench --site test_site run-tests --app benchpress
         env:
           TYPE: server
+
+  frontend:
+    runs-on: ubuntu-latest
+    name: Frontend
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          check-latest: true
+          cache: yarn
+          cache-dependency-path: frontend/yarn.lock
+
+      # socket.js resolves sites/common_site_config.json from the bench root
+      # (two directories above the app) at build time, so the build only works
+      # in a bench-shaped tree. Stub it here; remove this step once #28 lands.
+      - name: Stub bench site config
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/../../sites"
+          echo '{"socketio_port": 9000}' > "${GITHUB_WORKSPACE}/../../sites/common_site_config.json"
+
+      - name: Install
+        working-directory: frontend
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        working-directory: frontend
+        run: yarn build

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 **Press a button. Get a Frappe bench. Self-hosted, Docker-powered, VPN-secured.**
 
+[![CI](https://github.com/Venkateshvenki404224/benchpress/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/Venkateshvenki404224/benchpress/actions/workflows/ci.yml)
+[![Linters](https://github.com/Venkateshvenki404224/benchpress/actions/workflows/linter.yml/badge.svg)](https://github.com/Venkateshvenki404224/benchpress/actions/workflows/linter.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Frappe Framework](https://img.shields.io/badge/Built%20on-Frappe%20v16-blue)](https://frappeframework.com)
 [![FOSS Hack 2026](https://img.shields.io/badge/FOSS%20Hack-2026-orange)](https://fossunited.org)

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1783,10 +1783,10 @@ fraction.js@^5.3.4:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-5.3.4.tgz#8c0fcc6a9908262df4ed197427bdeef563e0699a"
   integrity sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==
 
-frappe-ui@^0.1.192:
-  version "0.1.270"
-  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-0.1.270.tgz#048dcfa944841eecbeaa060a64d3a58337616a70"
-  integrity sha512-zsLCq4BDnWWtqzTwcEUodfAFrjUkfhKZeKEPmzk/pSbd7tqg34gtT0s6gGnmHNUMd14KnM9DnME9D7+MsHzuUw==
+frappe-ui@^0.1.270:
+  version "0.1.278"
+  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-0.1.278.tgz#108f14bb550e1065a04a37f099bbc2c4626e98f6"
+  integrity sha512-KbHBtFc4UxMdS4hIG5qZcQcd5mBPrGfKNV22TRygUm/Cd2bXVLPoighuB6Q3CLCvZn3Rq9s7hxsSm85Op7Ql+w==
   dependencies:
     "@floating-ui/dom" "^1.7.4"
     "@floating-ui/vue" "^1.1.6"


### PR DESCRIPTION
Part of #43.

The repo already runs ruff lint (via pre-commit in the **Linters** workflow) and the backend test suite (**CI / Server** job, bench + MariaDB + Redis) on every PR — both green. This PR wires in the remaining pieces of P0-10:

## Changes

- **New `Frontend` job in `ci.yml`** — `yarn install --frozen-lockfile` + `yarn build` on every PR/push to `develop`, with yarn caching.
  - `frontend/src/socket.js` on `develop` still imports `sites/common_site_config.json` from the bench root (#28), so the job stubs that file two directories above the workspace, exactly where a real bench would have it. Verified locally: build fails without the stub, passes with it. Once #28 lands (the fix is already on `feat/boot-info-adoption`), the stub step can be removed.
- **README badges** for the CI and Linters workflows.

## Not included

- Nightly Playwright E2E job (listed as optional in #43) — needs a running site in CI; better done after #28/#44-style site bootstrap is stable.
- Branch protection (required checks) is a repo setting, being applied separately via API.

## Verification

- `yaml.safe_load` passes on the edited workflow.
- Frontend build reproduced locally against this branch's tree in a bench-shaped layout with the stub: `BUILD_OK`.