### PR TITLE
fix: validate lab_id against Docker tag grammar

### DIFF
--- a/benchpress/benchpress/doctype/lab/lab.json
+++ b/benchpress/benchpress/doctype/lab/lab.json
@@ -32,6 +32,7 @@
  ],
  "fields": [
   {
+   "description": "Lowercase letters, numbers and single '.', '_' or '-' separators, e.g. crm-lab",
    "fieldname": "lab_id",
    "fieldtype": "Data",
    "label": "Lab ID",

--- a/benchpress/benchpress/doctype/lab/lab.py
+++ b/benchpress/benchpress/doctype/lab/lab.py
@@ -4,6 +4,9 @@
 # import frappe
 from frappe.model.document import Document
 
+from benchpress.docker_manager import validate_lab_id
+
 
 class Lab(Document):
-	pass
+	def validate(self):
+		validate_lab_id(self.lab_id)

--- a/benchpress/benchpress/doctype/lab/test_lab.py
+++ b/benchpress/benchpress/doctype/lab/test_lab.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Venkatesh and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests import IntegrationTestCase
 
 # On IntegrationTestCase, the doctype test records and all
@@ -11,10 +11,33 @@ EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
+def _new_lab(lab_id):
+	return frappe.get_doc(
+		{
+			"doctype": "Lab",
+			"lab_id": lab_id,
+			"title": "Test Lab",
+			"frappe_version": "version-15",
+		}
+	)
+
+
 class IntegrationTestLab(IntegrationTestCase):
 	"""
 	Integration tests for Lab.
 	Use this class for testing interactions between multiple components.
 	"""
 
-	pass
+	def test_valid_lab_id_inserts(self):
+		for lab_id in ("crm-lab", "dev-v15", "lab_2", "v16.0-beta"):
+			if frappe.db.exists("Lab", lab_id):
+				frappe.delete_doc("Lab", lab_id, force=True)
+			doc = _new_lab(lab_id)
+			doc.insert()
+			self.assertEqual(doc.name, lab_id)
+			doc.delete()
+
+	def test_invalid_lab_id_rejected(self):
+		for lab_id in ("TESTE V16", "DEV-v15", "with space", "-leading", "trailing-", "a..b", "", "x" * 65):
+			with self.assertRaises(frappe.ValidationError, msg=f"lab_id {lab_id!r} should be rejected"):
+				_new_lab(lab_id).insert()

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -381,9 +381,7 @@ def build_lab(lab_name: str) -> None:
 		frappe.db.commit()
 
 	except Exception as e:
-		lab.reload()
-		lab.status = "Error"
-		lab.save(ignore_permissions=True)
+		frappe.db.set_value("Lab", lab_name, "status", "Error")
 		frappe.db.commit()
 
 		append_log(f"=== Build failed: {e!s} ===", "error")

--- a/benchpress/docker_manager.py
+++ b/benchpress/docker_manager.py
@@ -3,14 +3,29 @@
 
 import json
 import os
+import re
 import subprocess
 
 import docker
 import frappe
+from frappe import _
 
 DEFAULT_PIDS_LIMIT = 500
 DEFAULT_IOPS = 1000
 DEFAULT_BPS = 40 * 1024 * 1024
+
+LAB_ID_MAX_LENGTH = 64
+LAB_ID_RE = re.compile(r"^[a-z0-9]+([._-][a-z0-9]+)*$")
+
+
+def validate_lab_id(lab_id: str) -> None:
+	"""Reject lab IDs that would produce an invalid Docker image tag."""
+	if not lab_id or not LAB_ID_RE.match(lab_id) or len(lab_id) > LAB_ID_MAX_LENGTH:
+		frappe.throw(
+			_(
+				"Lab ID '{0}' is not valid: use only lowercase letters, numbers and single '.', '_' or '-' separators (max {1} characters), e.g. 'crm-lab' or 'dev-v15'."
+			).format(lab_id or "", LAB_ID_MAX_LENGTH)
+		)
 
 
 def _get_host_block_devices() -> list[str]:
@@ -60,6 +75,7 @@ def ensure_network(client: docker.DockerClient | None = None) -> None:
 
 def build_lab_image(lab_doc, log_fn=None, no_cache: bool = False) -> str:
 	"""Build Docker image with bench + apps (site created at runtime against shared MariaDB)."""
+	validate_lab_id(lab_doc.lab_id)
 	template_dir = get_lab_template_dir()
 	image_tag = f"benchpress/{lab_doc.lab_id}:latest"
 	version_branch = lab_doc.frappe_version

--- a/frontend/src/pages/NewLab.vue
+++ b/frontend/src/pages/NewLab.vue
@@ -21,6 +21,7 @@
 					v-model="form.lab_id"
 					type="text"
 					placeholder="e.g. crm-lab"
+					description="Lowercase letters, numbers and single '.', '_' or '-' separators"
 					:required="true"
 				/>
 				<FormControl


### PR DESCRIPTION
Fixes #27

## Problem

`build_lab_image` tags images as `benchpress/{lab_id}:latest`, but `lab_id` is free text. An ID like `TESTE V16` (space + uppercase) produces an invalid Docker reference and the build fails with the cryptic `invalid tag 'benchpress/TESTE V16:latest': invalid reference format`.

## Fix

- **`docker_manager.validate_lab_id()`** — canonical validator: lowercase alphanumerics with single `.`/`_`/`-` separators, max 64 chars (a strict subset of Docker's repository-name grammar).
- **`Lab.validate`** calls it, so bad IDs are rejected at save time with an actionable message — in both the desk form and the SPA (`lab.insert.error` is already rendered by `ErrorMessage` in `NewLab.vue`).
- **`build_lab_image()`** calls it too, covering labs created before this fix: the build now fails fast with `=== Build failed: Lab ID 'TESTE V16' is not valid: ... ===` in the build log instead of the docker error.
- **`build_lab`'s error path** now uses `frappe.db.set_value` instead of `doc.save()` — previously a validation error raised during the `except` handler's save would escape, leaving the lab stuck in its prior status and the build log without the failure line.
- UX hints added to the `lab_id` field (desk description + SPA help text).

No rename patch for existing bad labs: instance IDs are `md5(email + lab_id)` and container labels carry the old ID, so auto-renaming is riskier than letting owners rename manually (the build-log message tells them what to fix).

## Testing

- 2 new integration tests (`test_lab.py`): valid IDs insert, invalid IDs (`TESTE V16`, `DEV-v15`, `-leading`, `a..b`, 65 chars, …) raise `ValidationError`. Full suite: 56/56 pass.
- Browser-verified with agent-browser against the running stack:
  - Desk form: saving `TESTE V16` shows the validation dialog with the descriptive message.
  - SPA New Lab: submitting `TESTE V16` renders the same message in the form's error alert; `teste-v16` creates the lab and lands on /labs.
  - Legacy path: a pre-existing `TESTE V16` lab (inserted with validation bypassed) now ends Build Image with status `Error` and the clear message in the Build Log, no unhandled exception.
- `pre-commit run --all-files` passes.

Note (out of scope, observed while testing): on develop the SPA's `www/frontend.html` template expects a `boot` dict (incl. `csrf_token`) but `www/frontend.py` does not exist, so all SPA POSTs currently fail with CSRF `Invalid Request` — the boot-info adoption PR addresses this; SPA verification here was done with a CSRF token injected into the page.