### PR TITLE
ci: nightly run, path filters, server-job hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,43 @@ on:
     branches:
       - develop
   pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
 
 concurrency:
-  group: develop-benchpress-${{ github.event.number }}
+  group: develop-benchpress-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Job-level filtering instead of workflow-level paths-ignore: Server and
+  # Frontend are required checks on develop, and a workflow that never runs
+  # leaves them pending forever, while a skipped job counts as passing.
+  changes:
+    runs-on: ubuntu-latest
+    name: Detect Changes
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: dorny/paths-filter@v4
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            backend:
+              - '**'
+              - '!frontend/**'
+              - '!**/*.md'
+            frontend:
+              - '{frontend/**,.github/workflows/ci.yml}'
+
   tests:
     runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.backend == 'true'
+    timeout-minutes: 60
     strategy:
       fail-fast: false
     name: Server
@@ -47,6 +76,14 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.14'
+
+      - name: Check for valid Python & merge conflicts
+        run: |
+          python -m compileall -f "${GITHUB_WORKSPACE}"
+          if grep -lr --exclude-dir=node_modules "^<<<<<<< " "${GITHUB_WORKSPACE}"
+              then echo "Found merge conflicts"
+              exit 1
+          fi
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -107,6 +144,8 @@ jobs:
 
   frontend:
     runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.frontend == 'true'
     name: Frontend
 
     steps:


### PR DESCRIPTION
Stacked on #54 (retarget to `develop` after it merges). Adopts the CI patterns shared by frappe/crm, frappe/insights and frappe/gameplan, surveyed from their actual workflow files.

## Changes

- **Nightly cron + `workflow_dispatch`** on `ci.yml` — CRM and Insights both run their test suites on a daily schedule so `develop` rot is caught between PRs (and manual reruns become possible).
- **Path filters**: Server skips on frontend-only/docs-only PRs, Frontend skips on backend-only PRs (mirrors CRM's reciprocal `paths-ignore`). Implemented as a job-level `changes` job with `dorny/paths-filter@v4` instead of workflow-level `paths-ignore`, because `Server`/`Frontend` are required checks on `develop`: a workflow that never runs leaves required checks pending forever, while a skipped job counts as passing.
- **Server job hardening**: `timeout-minutes: 60` and the standard frappe sanity gate (`python -m compileall` + merge-conflict-marker grep) — all three reference apps have both.
- Concurrency group falls back to `github.ref` for non-PR events (CRM's pattern), so scheduled/push runs don't all share one empty-keyed group.

## Verification

- `yaml.safe_load` passes; `pre-commit run --all-files` all green.
- Filter semantics: `predicate-quantifier: 'every'` makes the negated backend patterns subtractive; the frontend filter uses brace expansion since `every` ANDs list entries.
- This PR touches only `.github/workflows/ci.yml`, which is included in the frontend filter — so both jobs should run here, which itself exercises the filter wiring.