### PR TITLE
feat: Phase 3 — bench health, routing master switch & install hardening

### DIFF
--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -88,6 +88,7 @@ def get_benches() -> list[dict]:
 			"public_url",
 			"is_public",
 			"public_username",
+			"health_status",
 			"status",
 			"container_id",
 			"container_ip",

--- a/benchpress/benchpress/doctype/bench_instance/bench_instance.json
+++ b/benchpress/benchpress/doctype/bench_instance/bench_instance.json
@@ -25,6 +25,7 @@
   "is_public",
   "public_username",
   "public_password",
+  "health_status",
   "container_section",
   "container_id",
   "container_image",
@@ -145,6 +146,13 @@
    "fieldname": "public_password",
    "fieldtype": "Password",
    "label": "Public Password",
+   "read_only": 1
+  },
+  {
+   "fieldname": "health_status",
+   "fieldtype": "Select",
+   "label": "Public Health",
+   "options": "\nHealthy\nUnhealthy\nUnknown",
    "read_only": 1
   },
   {

--- a/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
+++ b/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
@@ -10,6 +10,7 @@
   "docker_socket",
   "default_image",
   "column_break_docker",
+  "enable_public_routing",
   "base_domain",
   "traefik_network",
   "acme_email",
@@ -52,6 +53,13 @@
    "fieldtype": "Column Break"
   },
   {
+   "default": "0",
+   "description": "Master switch. When off, deployed benches are not routed through Traefik and get no public URL.",
+   "fieldname": "enable_public_routing",
+   "fieldtype": "Check",
+   "label": "Enable Public Routing"
+  },
+  {
    "fieldname": "base_domain",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -59,7 +67,7 @@
    "reqd": 1
   },
   {
-   "default": "traefik-public",
+   "default": "benchpress",
    "fieldname": "traefik_network",
    "fieldtype": "Data",
    "label": "Traefik Network"

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -22,7 +22,7 @@ from benchpress.mariadb_manager import (
 	ensure_infrastructure,
 	wait_for_mariadb,
 )
-from benchpress.traefik_manager import ensure_traefik
+from benchpress.traefik_manager import ensure_traefik, routing_enabled
 
 
 def _remove_stale_container(bench) -> None:
@@ -189,7 +189,7 @@ def _provision_running_container(bench, lab, settings, container_id, db_server, 
 			raise Exception(f"bench new-site failed (exit {exit_code}): {output}")
 		append_log("Site created successfully")
 
-	if settings.base_domain:
+	if routing_enabled(settings):
 		public_host = f"https://{bench.bench_name}.{settings.base_domain}"
 		exec_in_container(
 			container_id,
@@ -291,7 +291,7 @@ def deploy_bench(bench_name: str) -> None:
 		wait_for_mariadb(db_server_name, timeout=60)
 		append_log(f"MariaDB reachable at {db_server.container_name}:{db_server.port or 3306}")
 
-		if settings.base_domain:
+		if routing_enabled(settings):
 			append_log("=== Ensuring Traefik reverse proxy ===")
 			ensure_traefik()
 
@@ -323,7 +323,7 @@ def deploy_bench(bench_name: str) -> None:
 
 		_provision_running_container(bench, lab, settings, container_id, db_server, append_log)
 
-		if settings.base_domain:
+		if routing_enabled(settings):
 			bench.public_url = f"https://{bench.bench_name}.{settings.base_domain}"
 
 		bench.status = "Running"

--- a/benchpress/hooks.py
+++ b/benchpress/hooks.py
@@ -175,6 +175,7 @@ scheduler_events = {
 		],
 		"*/5 * * * *": [
 			"benchpress.mariadb_manager.scheduled_health_check",
+			"benchpress.traefik_manager.scheduled_bench_health_check",
 		],
 		"0 2 * * *": [
 			"benchpress.mariadb_manager.scheduled_backup",

--- a/benchpress/tests/test_traefik_manager.py
+++ b/benchpress/tests/test_traefik_manager.py
@@ -9,6 +9,7 @@ from benchpress.traefik_manager import (
 	_render_traefik_config,
 	compute_bench_labels,
 	make_basicauth_users,
+	routing_enabled,
 )
 
 BENCH = frappe._dict(bench_name="abc123", is_public=1)
@@ -29,8 +30,16 @@ class TestComputeBenchLabels(IntegrationTestCase):
 		labels = compute_bench_labels(BENCH, LAB, frappe._dict(base_domain=""))
 		self.assertFalse(any(k.startswith("traefik.") for k in labels))
 
+	def test_no_traefik_labels_when_master_switch_off(self):
+		labels = compute_bench_labels(
+			BENCH, LAB, frappe._dict(base_domain="lab.test", enable_public_routing=0)
+		)
+		self.assertFalse(any(k.startswith("traefik.") for k in labels))
+
 	def test_traefik_labels_with_base_domain(self):
-		labels = compute_bench_labels(BENCH, LAB, frappe._dict(base_domain="lab.test"))
+		labels = compute_bench_labels(
+			BENCH, LAB, frappe._dict(base_domain="lab.test", enable_public_routing=1)
+		)
 		self.assertEqual(labels["traefik.enable"], "true")
 		self.assertEqual(labels["traefik.docker.network"], "benchpress")
 		self.assertEqual(labels["traefik.http.routers.abc123.rule"], "Host(`abc123.lab.test`)")
@@ -41,12 +50,16 @@ class TestComputeBenchLabels(IntegrationTestCase):
 		self.assertEqual(labels["traefik.http.services.abc123-svc.loadbalancer.server.port"], "8000")
 
 	def test_public_bench_has_no_basicauth_middleware(self):
-		labels = compute_bench_labels(BENCH, LAB, frappe._dict(base_domain="lab.test"))
+		labels = compute_bench_labels(
+			BENCH, LAB, frappe._dict(base_domain="lab.test", enable_public_routing=1)
+		)
 		self.assertNotIn("traefik.http.routers.abc123.middlewares", labels)
 		self.assertFalse(any(".basicauth." in k for k in labels))
 
 	def test_private_bench_adds_basicauth_middleware(self):
-		labels = compute_bench_labels(PRIVATE_BENCH, LAB, frappe._dict(base_domain="lab.test"))
+		labels = compute_bench_labels(
+			PRIVATE_BENCH, LAB, frappe._dict(base_domain="lab.test", enable_public_routing=1)
+		)
 		self.assertEqual(labels["traefik.http.routers.abc123.middlewares"], "abc123-auth")
 		users = labels["traefik.http.middlewares.abc123-auth.basicauth.users"]
 		self.assertTrue(users.startswith("lab:$apr1$"))
@@ -83,3 +96,11 @@ class TestRenderTraefikConfig(IntegrationTestCase):
 	def test_blank_email_when_unset(self):
 		config = _render_traefik_config(frappe._dict(le_use_staging=1, acme_email=None))
 		self.assertIn('email: ""', config)
+
+
+class TestRoutingEnabled(IntegrationTestCase):
+	def test_requires_switch_and_domain(self):
+		self.assertTrue(routing_enabled(frappe._dict(enable_public_routing=1, base_domain="lab.test")))
+		self.assertFalse(routing_enabled(frappe._dict(enable_public_routing=0, base_domain="lab.test")))
+		self.assertFalse(routing_enabled(frappe._dict(enable_public_routing=1, base_domain="")))
+		self.assertFalse(routing_enabled(frappe._dict(enable_public_routing=0, base_domain="")))

--- a/benchpress/traefik_manager.py
+++ b/benchpress/traefik_manager.py
@@ -160,10 +160,15 @@ def _decrypt_public_password(bench) -> str:
 	return bench.get("public_password") or ""
 
 
+def routing_enabled(settings) -> bool:
+	"""Public routing is active only when the master switch and a base domain are both set."""
+	return bool(settings.enable_public_routing and settings.base_domain)
+
+
 def compute_bench_labels(bench, lab, settings) -> dict[str, str]:
 	"""Single source of truth for a bench container's Docker labels.
 
-	Traefik routing labels are added only when a base_domain is configured.
+	Traefik routing labels are added only when public routing is enabled.
 	"""
 	labels = {
 		"benchpress.managed": "true",
@@ -171,7 +176,7 @@ def compute_bench_labels(bench, lab, settings) -> dict[str, str]:
 		"benchpress.lab": lab.lab_id,
 	}
 
-	if settings.base_domain:
+	if routing_enabled(settings):
 		name = bench.bench_name
 		host = f"{name}.{settings.base_domain}"
 		labels.update(
@@ -194,3 +199,42 @@ def compute_bench_labels(bench, lab, settings) -> dict[str, str]:
 			labels[f"traefik.http.routers.{name}.middlewares"] = f"{name}-auth"
 
 	return labels
+
+
+def scheduled_bench_health_check():
+	"""Cron — probe each routed running bench's web process and store its Public Health."""
+	import frappe
+	import requests
+
+	settings = frappe.get_cached_doc("BenchPress Settings")
+	if not routing_enabled(settings):
+		return
+
+	from benchpress.wg_manager import _get_container_ip
+
+	benches = frappe.get_all(
+		"Bench Instance",
+		filters={"status": "Running"},
+		fields=["name", "bench_name", "container_id"],
+	)
+	for bench in benches:
+		if not bench.container_id:
+			continue
+		try:
+			ip = _get_container_ip(bench.container_id)
+			host = f"{bench.bench_name}.{settings.base_domain}"
+			try:
+				resp = requests.get(
+					f"http://{ip}:8000/api/method/ping",
+					headers={"Host": host},
+					timeout=3,
+				)
+				status = "Healthy" if resp.status_code == 200 else "Unhealthy"
+			except requests.RequestException:
+				status = "Unhealthy"
+			frappe.db.set_value("Bench Instance", bench.name, "health_status", status, update_modified=False)
+		except Exception:
+			frappe.log_error(
+				title=f"Bench health check failed: {bench.name}",
+				message=frappe.get_traceback(),
+			)

--- a/frontend/src/pages/BenchInstances.vue
+++ b/frontend/src/pages/BenchInstances.vue
@@ -48,6 +48,48 @@ const columns = [
 		},
 	},
 	{
+		label: "Public",
+		key: "is_public",
+		width: "140px",
+		getLabel: ({ row }) => (row.is_public ? "Public" : "Private"),
+		prefix: ({ row }) => {
+			const badge = h(Badge, {
+				label: row.is_public ? "Public" : "Private",
+				theme: row.is_public ? "green" : "gray",
+				size: "sm",
+			});
+			return row.public_url
+				? h(
+						"a",
+						{
+							href: row.public_url,
+							target: "_blank",
+							rel: "noopener",
+							onClick: (e) => e.stopPropagation(),
+						},
+						[badge]
+				  )
+				: badge;
+		},
+	},
+	{
+		label: "Health",
+		key: "health_status",
+		width: "120px",
+		getLabel: ({ row }) => row.health_status || "—",
+		prefix: ({ row }) =>
+			row.health_status
+				? h(Badge, {
+						label: row.health_status,
+						theme:
+							{ Healthy: "green", Unhealthy: "red", Unknown: "gray" }[
+								row.health_status
+							] || "gray",
+						size: "sm",
+				  })
+				: null,
+	},
+	{
 		label: "IP Address",
 		key: "wg_ip",
 		width: "140px",
@@ -66,6 +108,9 @@ let benches = createListResource({
 		"frappe_version",
 		"domain",
 		"status",
+		"is_public",
+		"public_url",
+		"health_status",
 		"container_id",
 		"container_ip",
 		"wg_ip",

--- a/frontend/src/pages/LabDetail.vue
+++ b/frontend/src/pages/LabDetail.vue
@@ -406,10 +406,17 @@
 									<h2 class="text-base font-semibold text-ink-gray-9">
 										Container Status
 									</h2>
-									<Badge
-										:label="activeBench.status"
-										:theme="statusColor(activeBench.status)"
-									/>
+									<div class="flex items-center gap-2">
+										<Badge
+											v-if="activeBench.health_status"
+											:label="activeBench.health_status"
+											:theme="healthColor(activeBench.health_status)"
+										/>
+										<Badge
+											:label="activeBench.status"
+											:theme="statusColor(activeBench.status)"
+										/>
+									</div>
 								</div>
 								<div class="grid grid-cols-2 gap-4">
 									<div class="rounded-lg border border-outline-gray-1 p-4">
@@ -1057,6 +1064,11 @@ function statusColor(status) {
 		Inactive: "gray",
 	};
 	return map[status] || "gray";
+}
+
+function healthColor(health) {
+	const map = { Healthy: "green", Unhealthy: "red", Unknown: "gray" };
+	return map[health] || "gray";
 }
 </script>
 

--- a/setup.sh
+++ b/setup.sh
@@ -57,7 +57,7 @@ echo ""
 
 # --- Step 1: Docker group ---
 
-info "Step 1/6: Docker group"
+info "Step 1/7: Docker group"
 
 if groups "$BENCH_USER" | grep -q '\bdocker\b'; then
     success "User '$BENCH_USER' is already in the docker group"
@@ -80,7 +80,7 @@ echo ""
 
 # --- Step 2: Shared infrastructure (MariaDB + Redis) ---
 
-info "Step 2/6: Shared infrastructure (MariaDB + Redis)"
+info "Step 2/7: Shared infrastructure (MariaDB + Redis)"
 
 COMPOSE_DIR="$BENCH_DIR/apps/benchpress/benchpress/config"
 COMPOSE_FILE="$COMPOSE_DIR/docker-compose.yml"
@@ -150,9 +150,57 @@ fi
 
 echo ""
 
-# --- Step 3: IP forwarding ---
+# --- Step 3: Traefik reverse proxy ---
 
-info "Step 3/6: IP forwarding"
+info "Step 3/7: Traefik reverse proxy"
+
+# traefik.yml is rendered from BenchPress Settings at first deploy; these .env
+# defaults document the ACME intent and pin the Let's Encrypt staging CA so
+# host setup never burns the production rate limit.
+if ! grep -q '^ACME_EMAIL=' "$ENV_FILE" 2>/dev/null; then
+    echo "ACME_EMAIL=" >> "$ENV_FILE"
+    warn "Added empty ACME_EMAIL to $ENV_FILE — set a real address before issuing production certs"
+fi
+if ! grep -q '^ACME_CA_SERVER=' "$ENV_FILE" 2>/dev/null; then
+    echo "ACME_CA_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory" >> "$ENV_FILE"
+    success "Defaulted ACME_CA_SERVER to the Let's Encrypt staging endpoint"
+fi
+
+# Warn (do not fail) if something else already owns the HTTP/HTTPS ports.
+if command -v ss &>/dev/null; then
+    for port in 80 443; do
+        if ss -ltn 2>/dev/null | grep -qE "[:.]$port[[:space:]]"; then
+            warn "Host port :$port is already in use — Traefik may fail to bind it"
+        fi
+    done
+fi
+
+info "Starting Traefik reverse proxy..."
+docker compose -f "$COMPOSE_FILE" up -d traefik
+success "Traefik container is up"
+
+if docker exec benchpress-traefik traefik version &>/dev/null; then
+    success "Traefik responding ($(docker exec benchpress-traefik traefik version 2>/dev/null | head -1))"
+else
+    warn "Could not run 'traefik version' — check 'docker logs benchpress-traefik'"
+fi
+
+if curl -fsS http://127.0.0.1:8090/api/overview &>/dev/null; then
+    success "Traefik dashboard reachable at http://127.0.0.1:8090/"
+else
+    warn "Traefik dashboard not reachable on 127.0.0.1:8090 yet — give it a few seconds"
+fi
+
+warn "DNS: point a WILDCARD record  *.<base_domain>  →  this host's public IP"
+warn "     (set <base_domain> in BenchPress Settings, e.g. *.labs.example.com)"
+info "TLS: Traefik uses the Let's Encrypt STAGING CA by default (untrusted certs, high limits)."
+info "     Turn off 'Use Let's Encrypt Staging' in BenchPress Settings for production certs."
+
+echo ""
+
+# --- Step 4: IP forwarding ---
+
+info "Step 4/7: IP forwarding"
 
 SYSCTL_CONF="/etc/sysctl.d/99-benchpress.conf"
 
@@ -175,9 +223,9 @@ fi
 
 echo ""
 
-# --- Step 4: Sudoers for WireGuard ---
+# --- Step 5: Sudoers for WireGuard ---
 
-info "Step 4/6: Sudoers (WireGuard + Docker socket)"
+info "Step 5/7: Sudoers (WireGuard + Docker socket)"
 
 SUDOERS_FILE="/etc/sudoers.d/benchpress"
 
@@ -204,9 +252,9 @@ fi
 
 echo ""
 
-# --- Step 5: WireGuard install check ---
+# --- Step 6: WireGuard install check ---
 
-info "Step 5/6: WireGuard tools"
+info "Step 6/7: WireGuard tools"
 
 if command -v wg &>/dev/null && command -v wg-quick &>/dev/null; then
     success "WireGuard tools already installed ($(wg --version 2>/dev/null || echo 'wg found'))"
@@ -219,9 +267,9 @@ fi
 
 echo ""
 
-# --- Step 6: WireGuard server init ---
+# --- Step 7: WireGuard server init ---
 
-info "Step 6/6: WireGuard server initialization"
+info "Step 7/7: WireGuard server initialization"
 
 if sudo wg show wg0 &>/dev/null; then
     success "wg0 interface is already running"


### PR DESCRIPTION
## Phase 3 — Health status, master switch, install flow & hardening

Builds on **Phase 2** (PR #62, this branch's base) to make public routing **operable** and **safe-by-default**. Implements `specs/phase-3-health-and-polish.md`.

### Changes
- **Health** — `bench_instance.health_status` ("Public Health") read-only Select; `traefik_manager.scheduled_bench_health_check()` probes `http://<container-ip>:8000/api/method/ping` with the public `Host` header per running routed bench and stores `Healthy`/`Unhealthy` (mirrors `mariadb_manager.scheduled_health_check`); registered in the existing `*/5 * * * *` cron.
- **Master switch & guards** — `benchpress_settings.enable_public_routing` (Check, default **off**); `traefik_network` default → `benchpress`. New `routing_enabled(settings)` helper gates **all** Traefik logic — label emission, `ensure_traefik`, `public_url`, and canonical `host_name` — on `enable_public_routing AND base_domain`. When off, deploy emits only the original `benchpress.*` labels and never calls Traefik (no crash).
- **API** — `get_benches` now returns `health_status`.
- **Frontend** — health `Badge` next to Container Status in `LabDetail.vue`; `Public` (badge + link when `public_url`) and `Health` columns in `BenchInstances.vue`.
- **Install** — `setup.sh` gains a "Traefik reverse proxy" step after shared-infra: ACME env defaults (staging CA), `:80`/`:443` port-in-use warnings, `up -d traefik`, `traefik version` + dashboard checks, wildcard-DNS + staging/prod reminders. Steps renumbered 1/7..7/7.
- **Tests** — existing label tests updated for the new gate; added master-switch-off and `routing_enabled` coverage.

### Verification
- `pre-commit run` (ruff, ruff-format, prettier, whitespace/json/ast) — clean.
- Core gating exercised against the real `traefik_manager`: master-switch-off ⇒ only `benchpress.*` labels; on ⇒ full Traefik (+ basicauth for private). `routing_enabled` truth table verified.
- `bash -n setup.sh` clean; DocType JSON validated.
- Adversarial multi-agent review of the diff (spec/python/frontend/shell) — 0 confirmed findings.

### Notes
- Stacked on PR #62 — base is `feature/phase-0-traefik-http-routing` so the diff is Phase 3 only.
- Out of scope (tracked elsewhere): doctor/preflight (#30), full prod/troubleshooting docs (#36), socketio over public URL (stays VPN-only), friendlier subdomain slugs.