### PR TITLE
feat: add BenchPress doctor preflight command (#30)

### DIFF
--- a/benchpress/commands.py
+++ b/benchpress/commands.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+import click
+import frappe
+from frappe.commands import pass_context
+from frappe.exceptions import SiteNotSpecifiedError
+from frappe.utils.bench_helper import CliCtxObj
+
+
+@click.group("benchpress")
+def benchpress():
+	"""BenchPress operational commands."""
+
+
+@benchpress.command("doctor")
+@click.option("--site", help="Site to run the doctor against.")
+@click.option(
+	"--json", "as_json", is_flag=True, default=False, help="Emit machine-readable JSON instead of the report."
+)
+@click.option("--strict", is_flag=True, default=False, help="Exit non-zero when any check fails (CI gate).")
+@pass_context
+def doctor(context: CliCtxObj, site: str | None = None, as_json: bool = False, strict: bool = False):
+	"""Check host readiness for BenchPress and print a pass/warn/fail report."""
+	from benchpress.doctor import run
+
+	sites = [site] if site else context.sites
+	if not sites:
+		raise SiteNotSpecifiedError
+
+	for site_name in sites:
+		frappe.init(site_name)
+		frappe.connect()
+		try:
+			run(as_json=as_json, strict=strict)
+		finally:
+			frappe.destroy()
+
+
+commands = [benchpress]

--- a/benchpress/doctor.py
+++ b/benchpress/doctor.py
@@ -118,7 +118,7 @@ def _summary(results: list[dict]) -> dict:
 
 def _read_text(path: str) -> str:
 	try:
-		with open(path) as f:
+		with open(path) as f:  # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal  # fmt: skip
 			return f.read()
 	except OSError:
 		return ""

--- a/benchpress/doctor.py
+++ b/benchpress/doctor.py
@@ -3,12 +3,14 @@
 
 import os
 import shutil
+import subprocess
 import sys
 
 import docker
 import frappe
 
-from benchpress import docker_manager
+from benchpress import docker_manager, traefik_manager, wg_manager
+from benchpress.wg_manager import WG_INTERFACE
 
 PASS = "pass"
 WARN = "warn"
@@ -148,8 +150,81 @@ def _bench_dir() -> str:
 	return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 
 
+def _in_docker() -> bool:
+	return os.path.exists("/.dockerenv")
+
+
+def _skipped(name: str) -> dict:
+	return _result(WARN, name, "skipped (run on the host)")
+
+
+def _run(cmd: list[str]):
+	try:
+		return subprocess.run(cmd, capture_output=True, text=True, timeout=5, check=False)
+	except (subprocess.SubprocessError, OSError) as e:
+		frappe.log_error(title=f"doctor subprocess failed: {cmd[0]}", message=str(e))
+		return None
+
+
+def _settings():
+	try:
+		return frappe.get_cached_doc("BenchPress Settings")
+	except frappe.DoesNotExistError:
+		return None
+
+
+def _compose_path() -> str:
+	return os.path.join(frappe.get_app_path("benchpress"), "config", "docker-compose.yml")
+
+
+def _network_subnet(attrs: dict) -> str:
+	for cfg in (attrs.get("IPAM") or {}).get("Config") or []:
+		if cfg.get("Subnet"):
+			return cfg["Subnet"]
+	return ""
+
+
+def _port_from_addr(addr: str) -> int | None:
+	port = addr.rpartition(":")[2]
+	try:
+		return int(port)
+	except ValueError:
+		return None
+
+
+def _parse_listening_ports(ss_output: str) -> dict:
+	tcp, udp = set(), set()
+	for line in ss_output.splitlines():
+		parts = line.split()
+		if len(parts) < 5:
+			continue
+		port = _port_from_addr(parts[4])
+		if port is None:
+			continue
+		proto = parts[0].lower()
+		if proto.startswith("tcp"):
+			tcp.add(port)
+		elif proto.startswith("udp"):
+			udp.add(port)
+	return {"tcp": tcp, "udp": udp}
+
+
+def _container_is_running(name: str) -> bool:
+	try:
+		return (docker_manager.get_client().containers.get(name).status or "").lower() == "running"
+	except (docker.errors.DockerException, OSError):  # best-effort
+		return False
+
+
+def _wireguard_kernel_available() -> bool:
+	if os.path.exists("/sys/module/wireguard"):
+		return True
+	proc = _run(["modprobe", "-n", "wireguard"])
+	return proc is not None and proc.returncode == 0
+
+
 def _check_os() -> list[dict]:
-	return [_evaluate_os(_read_os_release(), _read_text("/proc/version"), os.path.exists("/.dockerenv"))]
+	return [_evaluate_os(_read_os_release(), _read_text("/proc/version"), _in_docker())]
 
 
 def _check_resources() -> list[dict]:
@@ -210,7 +285,224 @@ def _check_frappe() -> list[dict]:
 	return results
 
 
-CHECKS = [_check_os, _check_resources, _check_docker, _check_frappe]
+def _evaluate_compose(ok: bool, version: str) -> dict:
+	if ok:
+		return _result(PASS, "Docker Compose", version or "v2 available")
+	return _result(
+		FAIL,
+		"Docker Compose",
+		"docker compose v2 not available",
+		"sudo apt-get install docker-compose-plugin",
+	)
+
+
+def _evaluate_docker_network(found: bool, subnet: str) -> dict:
+	fix = "bash apps/benchpress/setup.sh <site>  (step 2 creates the benchpress network)"
+	if not found:
+		return _result(FAIL, "Docker network", "'benchpress' network not found", fix)
+	if subnet == "172.30.0.0/24":
+		return _result(PASS, "Docker network", f"'benchpress' present ({subnet})")
+	return _result(
+		WARN,
+		"Docker network",
+		f"'benchpress' present but subnet is {subnet or 'unknown'} (expected 172.30.0.0/24)",
+		fix,
+	)
+
+
+def _evaluate_container(name: str, status: str | None, down_severity: str, fix: str) -> dict:
+	label = f"Container {name}"
+	if (status or "").lower() == "running":
+		return _result(PASS, label, "running")
+	return _result(down_severity, label, f"status: {status or 'not found'}", fix)
+
+
+def _evaluate_ip_forward(value: str) -> dict:
+	if value.strip() == "1":
+		return _result(PASS, "IP forwarding", "net.ipv4.ip_forward = 1")
+	return _result(
+		FAIL,
+		"IP forwarding",
+		f"net.ipv4.ip_forward = {value.strip() or 'unknown'}",
+		"sudo sysctl -w net.ipv4.ip_forward=1",
+	)
+
+
+def _evaluate_sudoers(file_exists: bool, sudo_ok: bool) -> dict:
+	fix = "bash apps/benchpress/setup.sh <site>  (step 5)"
+	if not file_exists:
+		return _result(FAIL, "Sudoers", "/etc/sudoers.d/benchpress missing", fix)
+	if not sudo_ok:
+		return _result(FAIL, "Sudoers", "sudoers present but 'sudo -n wg show' failed", fix)
+	return _result(PASS, "Sudoers", "passwordless sudo for wg works")
+
+
+def _evaluate_wireguard_tools(have_wg: bool, have_wg_quick: bool, kernel: bool) -> dict:
+	fix = "bash apps/benchpress/setup.sh <site>  (step 6)"
+	missing = [t for t, ok in (("wg", have_wg), ("wg-quick", have_wg_quick)) if not ok]
+	if missing:
+		return _result(WARN, "WireGuard tools", f"missing: {', '.join(missing)} (VPN features disabled)", fix)
+	if not kernel:
+		return _result(WARN, "WireGuard tools", "wg + wg-quick installed but kernel module not loadable", fix)
+	return _result(PASS, "WireGuard tools", "wg + wg-quick installed, kernel module available")
+
+
+def _evaluate_wg_interface(up: bool, listen_port: str, expected: str) -> dict:
+	if not up:
+		return _result(
+			WARN, "WireGuard interface", f"{WG_INTERFACE} is not up", f"sudo wg-quick up {WG_INTERFACE}"
+		)
+	if listen_port and listen_port != expected:
+		return _result(
+			WARN,
+			"WireGuard interface",
+			f"{WG_INTERFACE} up but listening on {listen_port} (settings expect {expected})",
+			"align wg_server_port in BenchPress Settings, then restart the interface",
+		)
+	return _result(PASS, "WireGuard interface", f"{WG_INTERFACE} up, listening on {listen_port or expected}")
+
+
+def _evaluate_http_port(port: int, in_use: bool, traefik_up: bool) -> dict:
+	name = f"Port {port}/tcp"
+	if not in_use:
+		return _result(PASS, name, "free")
+	if traefik_up:
+		return _result(PASS, name, "in use by Traefik")
+	return _result(
+		WARN,
+		name,
+		"in use by another process",
+		f"free port {port} or stop the conflicting service before enabling public routing",
+	)
+
+
+def _evaluate_wg_port(port: int, bound: bool) -> dict:
+	name = f"Port {port}/udp (WireGuard)"
+	if bound:
+		return _result(PASS, name, "bound")
+	return _result(WARN, name, "not bound (WireGuard VPN unreachable)", f"sudo ufw allow {port}/udp")
+
+
+def _check_compose() -> list[dict]:
+	proc = _run(["docker", "compose", "version"])
+	ok = proc is not None and proc.returncode == 0
+	version = proc.stdout.strip().splitlines()[0] if ok and proc.stdout.strip() else ""
+	return [_evaluate_compose(ok, version)]
+
+
+def _check_docker_network() -> list[dict]:
+	try:
+		net = docker_manager.get_client().networks.get("benchpress")
+	except docker.errors.NotFound:
+		return [_evaluate_docker_network(False, "")]
+	except (docker.errors.DockerException, OSError) as e:
+		return [
+			_result(
+				FAIL,
+				"Docker network",
+				f"could not query Docker networks: {e}",
+				"ensure the Docker daemon is reachable, then re-run",
+			)
+		]
+	return [_evaluate_docker_network(True, _network_subnet(net.attrs))]
+
+
+def _check_infra_containers() -> list[dict]:
+	settings = _settings()
+	fix = f"docker compose -f {_compose_path()} up -d"
+	required = [("benchpress-mariadb", FAIL), ("benchpress-redis", FAIL)]
+	if settings is not None and traefik_manager.routing_enabled(settings):
+		required.append(("benchpress-traefik", WARN))
+
+	try:
+		client = docker_manager.get_client()
+	except (docker.errors.DockerException, OSError) as e:
+		return [_result(sev, f"Container {name}", f"Docker unreachable: {e}", fix) for name, sev in required]
+
+	results = []
+	for name, sev in required:
+		try:
+			status = client.containers.get(name).status
+		except docker.errors.NotFound:
+			status = None
+		except (docker.errors.DockerException, OSError) as e:
+			results.append(_result(sev, f"Container {name}", f"could not query: {e}", fix))
+			continue
+		results.append(_evaluate_container(name, status, sev, fix))
+	return results
+
+
+def _check_ip_forward() -> list[dict]:
+	if _in_docker():
+		return [_skipped("IP forwarding")]
+	return [_evaluate_ip_forward(_read_text("/proc/sys/net/ipv4/ip_forward"))]
+
+
+def _check_sudoers() -> list[dict]:
+	if _in_docker():
+		return [_skipped("Sudoers")]
+	file_exists = os.path.exists("/etc/sudoers.d/benchpress")
+	sudo_ok = False
+	if file_exists:
+		proc = _run(["sudo", "-n", "wg", "show"])
+		sudo_ok = proc is not None and proc.returncode == 0
+	return [_evaluate_sudoers(file_exists, sudo_ok)]
+
+
+def _check_wireguard_tools() -> list[dict]:
+	have_wg = wg_manager._wg_available()
+	have_wg_quick = shutil.which("wg-quick") is not None
+	kernel = have_wg and have_wg_quick and _wireguard_kernel_available()
+	return [_evaluate_wireguard_tools(have_wg, have_wg_quick, kernel)]
+
+
+def _check_wg_interface() -> list[dict]:
+	if _in_docker():
+		return [_skipped("WireGuard interface")]
+	proc = _run(["sudo", "-n", "wg", "show", WG_INTERFACE, "listen-port"])
+	up = proc is not None and proc.returncode == 0
+	listen_port = proc.stdout.strip() if up else ""
+	settings = _settings()
+	expected = str(settings.wg_server_port or 51820) if settings is not None else "51820"
+	return [_evaluate_wg_interface(up, listen_port, expected)]
+
+
+def _check_ports() -> list[dict]:
+	if _in_docker():
+		return [_skipped("Ports / firewall")]
+	proc = _run(["ss", "-ltnu"])
+	if proc is None or proc.returncode != 0:
+		return [
+			_result(
+				WARN,
+				"Ports / firewall",
+				"could not enumerate listening sockets",
+				"install iproute2 so 'ss' is available, then re-run",
+			)
+		]
+	listening = _parse_listening_ports(proc.stdout)
+	traefik_up = _container_is_running("benchpress-traefik")
+	results = [_evaluate_http_port(p, p in listening["tcp"], traefik_up) for p in (80, 443)]
+	settings = _settings()
+	wg_port = int(settings.wg_server_port or 51820) if settings is not None else 51820
+	results.append(_evaluate_wg_port(wg_port, wg_port in listening["udp"]))
+	return results
+
+
+CHECKS = [
+	_check_os,
+	_check_resources,
+	_check_docker,
+	_check_frappe,
+	_check_compose,
+	_check_docker_network,
+	_check_infra_containers,
+	_check_ip_forward,
+	_check_sudoers,
+	_check_wireguard_tools,
+	_check_wg_interface,
+	_check_ports,
+]
 
 
 def run(as_json: bool = False, strict: bool = False):
@@ -226,7 +518,7 @@ def run(as_json: bool = False, strict: bool = False):
 	env = {
 		"site": getattr(frappe.local, "site", None),
 		"bench": _bench_dir(),
-		"in_container": os.path.exists("/.dockerenv"),
+		"in_container": _in_docker(),
 	}
 	print(_format_report(results, env, tty=sys.stdout.isatty()))
 	return None

--- a/benchpress/doctor.py
+++ b/benchpress/doctor.py
@@ -1,0 +1,232 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+import os
+import shutil
+import sys
+
+import docker
+import frappe
+
+from benchpress import docker_manager
+
+PASS = "pass"
+WARN = "warn"
+FAIL = "fail"
+
+MIN_CPU_CORES = 2
+MIN_RAM_GB = 4
+MIN_FREE_DISK_GB = 20
+
+_TAG = {PASS: "[PASS]", WARN: "[WARN]", FAIL: "[FAIL]"}
+_ANSI = {PASS: "\033[32m", WARN: "\033[33m", FAIL: "\033[31m"}
+_ANSI_RESET = "\033[0m"
+
+
+def _result(status: str, name: str, detail: str, fix: str | None = None) -> dict:
+	return {"status": status, "name": name, "detail": detail, "fix": fix}
+
+
+def _threshold_status(value: float, minimum: float) -> str:
+	if value < minimum:
+		return FAIL
+	if value == minimum:
+		return WARN
+	return PASS
+
+
+def _evaluate_resources(cpu_count: int, ram_gb: float, free_gb: float) -> list[dict]:
+	cpu_status = _threshold_status(cpu_count, MIN_CPU_CORES)
+	ram_status = _threshold_status(ram_gb, MIN_RAM_GB)
+	disk_status = _threshold_status(free_gb, MIN_FREE_DISK_GB)
+	return [
+		_result(
+			cpu_status,
+			"CPU cores",
+			f"{cpu_count} detected (minimum {MIN_CPU_CORES})",
+			None if cpu_status == PASS else f"provision a host with at least {MIN_CPU_CORES} CPU cores",
+		),
+		_result(
+			ram_status,
+			"Memory",
+			f"{ram_gb:.1f} GB total (minimum {MIN_RAM_GB} GB)",
+			None if ram_status == PASS else f"provision a host with at least {MIN_RAM_GB} GB RAM",
+		),
+		_result(
+			disk_status,
+			"Free disk",
+			f"{free_gb:.1f} GB free at bench (minimum {MIN_FREE_DISK_GB} GB)",
+			None if disk_status == PASS else f"free up disk so at least {MIN_FREE_DISK_GB} GB is available",
+		),
+	]
+
+
+def _evaluate_os(os_release: dict, proc_version: str, in_docker: bool) -> dict:
+	name = os_release.get("PRETTY_NAME") or os_release.get("NAME") or "unknown OS"
+	detail = f"{name} (running inside container)" if in_docker else name
+
+	if "microsoft" in proc_version.lower():
+		return _result(
+			WARN,
+			"Operating system",
+			f"{detail} on WSL2",
+			"run the BenchPress host setup from a native Linux host; WSL2 networking and WireGuard are unreliable",
+		)
+
+	distro_id = (os_release.get("ID") or "").lower()
+	id_like = (os_release.get("ID_LIKE") or "").lower()
+	supported = ("ubuntu", "debian")
+	if distro_id in supported or any(s in id_like for s in supported):
+		return _result(PASS, "Operating system", detail)
+	return _result(
+		WARN,
+		"Operating system",
+		detail,
+		"BenchPress is verified on Ubuntu/Debian; other distros may work but are untested",
+	)
+
+
+def _format_report(results: list[dict], env: dict, tty: bool = False) -> str:
+	lines = ["BenchPress readiness check"]
+	site = env.get("site") or "?"
+	bench = env.get("bench") or "?"
+	location = "container" if env.get("in_container") else "host"
+	lines.append(f"site: {site}  bench: {bench}  running on: {location}")
+	lines.append("")
+
+	for r in results:
+		tag = _TAG.get(r["status"], "[????]")
+		if tty:
+			tag = f"{_ANSI.get(r['status'], '')}{tag}{_ANSI_RESET}"
+		lines.append(f"{tag} {r['name']}: {r['detail']}")
+		if r.get("fix"):
+			lines.append(f"        fix: {r['fix']}")
+
+	counts = _summary(results)
+	lines.append("")
+	lines.append(f"Summary: {counts['pass']} pass, {counts['warn']} warn, {counts['fail']} fail")
+	return "\n".join(lines)
+
+
+def _summary(results: list[dict]) -> dict:
+	return {
+		"pass": sum(1 for r in results if r["status"] == PASS),
+		"warn": sum(1 for r in results if r["status"] == WARN),
+		"fail": sum(1 for r in results if r["status"] == FAIL),
+	}
+
+
+def _read_text(path: str) -> str:
+	try:
+		with open(path) as f:
+			return f.read()
+	except OSError:
+		return ""
+
+
+def _read_os_release() -> dict:
+	data = {}
+	for line in _read_text("/etc/os-release").splitlines():
+		line = line.strip()
+		if not line or line.startswith("#") or "=" not in line:
+			continue
+		key, value = line.split("=", 1)
+		data[key.strip()] = value.strip().strip('"')
+	return data
+
+
+def _read_mem_total_gb() -> float:
+	for line in _read_text("/proc/meminfo").splitlines():
+		if line.startswith("MemTotal:"):
+			parts = line.split()
+			if len(parts) >= 2:
+				return int(parts[1]) / (1024**2)
+	return 0.0
+
+
+def _bench_dir() -> str:
+	return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+
+def _check_os() -> list[dict]:
+	return [_evaluate_os(_read_os_release(), _read_text("/proc/version"), os.path.exists("/.dockerenv"))]
+
+
+def _check_resources() -> list[dict]:
+	cpu_count = os.cpu_count() or 0
+	ram_gb = _read_mem_total_gb()
+	try:
+		free_gb = shutil.disk_usage(_bench_dir()).free / (1024**3)
+	except OSError:
+		free_gb = 0.0
+	return _evaluate_resources(cpu_count, ram_gb, free_gb)
+
+
+def _check_docker() -> list[dict]:
+	try:
+		client = docker_manager.get_client()
+		client.ping()
+		server_version = client.version().get("Version", "unknown")
+		return [_result(PASS, "Docker daemon", f"reachable, server version {server_version}")]
+	except (docker.errors.DockerException, OSError) as e:
+		return [
+			_result(
+				FAIL,
+				"Docker daemon",
+				f"unreachable: {e}",
+				"sudo systemctl start docker — if permission denied: sudo usermod -aG docker $USER, then log out and back in",
+			)
+		]
+
+
+def _check_frappe() -> list[dict]:
+	installed = "benchpress" in frappe.get_installed_apps()
+	results = [
+		_result(
+			PASS if installed else FAIL,
+			"BenchPress app",
+			"installed on site" if installed else "not installed on this site",
+			None if installed else "bench --site <site> install-app benchpress",
+		)
+	]
+
+	try:
+		frappe.get_cached_doc("BenchPress Settings")
+		results.append(_result(PASS, "BenchPress Settings", "singleton loads"))
+	except frappe.DoesNotExistError as e:
+		results.append(
+			_result(FAIL, "BenchPress Settings", f"could not load: {e}", "bench --site <site> migrate")
+		)
+
+	site = getattr(frappe.local, "site", None)
+	results.append(
+		_result(
+			PASS if site else FAIL,
+			"Site context",
+			f"bound to '{site}'" if site else "no site bound",
+			None if site else "invoke within a site: bench --site <site> execute benchpress.doctor.run",
+		)
+	)
+	return results
+
+
+CHECKS = [_check_os, _check_resources, _check_docker, _check_frappe]
+
+
+def run(as_json: bool = False, strict: bool = False):
+	"""Print a host-readiness report (pass/warn/fail) for BenchPress."""
+	results = []
+	for check in CHECKS:
+		try:
+			results.extend(check())
+		except Exception as e:
+			frappe.log_error(title=f"doctor check failed: {check.__name__}", message=frappe.get_traceback())
+			results.append(_result(FAIL, check.__name__, f"check raised an unexpected error: {e}"))
+
+	env = {
+		"site": getattr(frappe.local, "site", None),
+		"bench": _bench_dir(),
+		"in_container": os.path.exists("/.dockerenv"),
+	}
+	print(_format_report(results, env, tty=sys.stdout.isatty()))
+	return None

--- a/benchpress/doctor.py
+++ b/benchpress/doctor.py
@@ -520,5 +520,12 @@ def run(as_json: bool = False, strict: bool = False):
 		"bench": _bench_dir(),
 		"in_container": _in_docker(),
 	}
-	print(_format_report(results, env, tty=sys.stdout.isatty()))
+
+	if as_json:
+		print(frappe.as_json(results))
+	else:
+		print(_format_report(results, env, tty=sys.stdout.isatty()))
+
+	if strict and _summary(results)["fail"]:
+		raise SystemExit(1)
 	return None

--- a/benchpress/install.py
+++ b/benchpress/install.py
@@ -93,3 +93,6 @@ def _print_manual_instructions(site: str) -> None:
 	print("\nRun the setup script manually to configure Docker, WireGuard, and permissions:")
 	print(f"\n  bash apps/benchpress/setup.sh {site}\n")
 	print("Or follow the manual steps in: apps/benchpress/docs/wireguard-setup.md\n")
+	print("Then check host readiness with the doctor:")
+	print(f"\n  bench --site {site} execute benchpress.doctor.run")
+	print("  bench benchpress doctor\n")

--- a/benchpress/tests/test_doctor.py
+++ b/benchpress/tests/test_doctor.py
@@ -10,10 +10,22 @@ from benchpress.doctor import (
 	MIN_RAM_GB,
 	PASS,
 	WARN,
+	_evaluate_compose,
+	_evaluate_container,
+	_evaluate_docker_network,
+	_evaluate_http_port,
+	_evaluate_ip_forward,
 	_evaluate_os,
 	_evaluate_resources,
+	_evaluate_sudoers,
+	_evaluate_wg_interface,
+	_evaluate_wg_port,
+	_evaluate_wireguard_tools,
 	_format_report,
+	_network_subnet,
+	_parse_listening_ports,
 	_result,
+	_skipped,
 	_summary,
 )
 
@@ -100,3 +112,136 @@ class TestSummary(IntegrationTestCase):
 			_result(FAIL, "f", ""),
 		]
 		self.assertEqual(_summary(results), {"pass": 2, "warn": 1, "fail": 3})
+
+
+class TestSkipped(IntegrationTestCase):
+	def test_skipped_is_warn_on_the_host(self):
+		result = _skipped("IP forwarding")
+		self.assertEqual(result["status"], WARN)
+		self.assertIn("run on the host", result["detail"])
+
+
+class TestEvaluateCompose(IntegrationTestCase):
+	def test_available_passes(self):
+		self.assertEqual(_evaluate_compose(True, "Docker Compose version v2.27.0")["status"], PASS)
+
+	def test_missing_fails_with_install_fix(self):
+		result = _evaluate_compose(False, "")
+		self.assertEqual(result["status"], FAIL)
+		self.assertIn("docker-compose-plugin", result["fix"])
+
+
+class TestEvaluateDockerNetwork(IntegrationTestCase):
+	def test_missing_fails(self):
+		self.assertEqual(_evaluate_docker_network(False, "")["status"], FAIL)
+
+	def test_expected_subnet_passes(self):
+		self.assertEqual(_evaluate_docker_network(True, "172.30.0.0/24")["status"], PASS)
+
+	def test_wrong_subnet_warns(self):
+		self.assertEqual(_evaluate_docker_network(True, "10.0.0.0/24")["status"], WARN)
+
+
+class TestNetworkSubnet(IntegrationTestCase):
+	def test_extracts_subnet(self):
+		attrs = {"IPAM": {"Config": [{"Subnet": "172.30.0.0/24"}]}}
+		self.assertEqual(_network_subnet(attrs), "172.30.0.0/24")
+
+	def test_missing_config_returns_empty(self):
+		self.assertEqual(_network_subnet({}), "")
+
+
+class TestEvaluateContainer(IntegrationTestCase):
+	def test_running_passes(self):
+		self.assertEqual(_evaluate_container("benchpress-redis", "running", FAIL, "fix")["status"], PASS)
+
+	def test_stopped_uses_severity(self):
+		self.assertEqual(_evaluate_container("benchpress-traefik", "exited", WARN, "fix")["status"], WARN)
+
+	def test_not_found_carries_fix(self):
+		result = _evaluate_container("benchpress-mariadb", None, FAIL, "do x")
+		self.assertEqual(result["status"], FAIL)
+		self.assertEqual(result["fix"], "do x")
+
+
+class TestEvaluateIpForward(IntegrationTestCase):
+	def test_enabled_passes(self):
+		self.assertEqual(_evaluate_ip_forward("1\n")["status"], PASS)
+
+	def test_disabled_fails_with_sysctl_fix(self):
+		result = _evaluate_ip_forward("0\n")
+		self.assertEqual(result["status"], FAIL)
+		self.assertIn("ip_forward=1", result["fix"])
+
+
+class TestEvaluateSudoers(IntegrationTestCase):
+	def test_missing_file_fails(self):
+		self.assertEqual(_evaluate_sudoers(False, False)["status"], FAIL)
+
+	def test_sudo_check_failing_fails(self):
+		self.assertEqual(_evaluate_sudoers(True, False)["status"], FAIL)
+
+	def test_configured_passes(self):
+		self.assertEqual(_evaluate_sudoers(True, True)["status"], PASS)
+
+
+class TestEvaluateWireguardTools(IntegrationTestCase):
+	def test_missing_tool_warns(self):
+		result = _evaluate_wireguard_tools(False, True, False)
+		self.assertEqual(result["status"], WARN)
+		self.assertIn("wg", result["detail"])
+
+	def test_no_kernel_module_warns(self):
+		self.assertEqual(_evaluate_wireguard_tools(True, True, False)["status"], WARN)
+
+	def test_all_present_passes(self):
+		self.assertEqual(_evaluate_wireguard_tools(True, True, True)["status"], PASS)
+
+
+class TestEvaluateWgInterface(IntegrationTestCase):
+	def test_down_warns_with_bring_up_fix(self):
+		result = _evaluate_wg_interface(False, "", "51820")
+		self.assertEqual(result["status"], WARN)
+		self.assertIn("wg-quick up", result["fix"])
+
+	def test_port_mismatch_warns(self):
+		self.assertEqual(_evaluate_wg_interface(True, "51821", "51820")["status"], WARN)
+
+	def test_matching_port_passes(self):
+		self.assertEqual(_evaluate_wg_interface(True, "51820", "51820")["status"], PASS)
+
+
+class TestEvaluatePorts(IntegrationTestCase):
+	def test_free_http_port_passes(self):
+		self.assertEqual(_evaluate_http_port(80, False, False)["status"], PASS)
+
+	def test_http_port_owned_by_traefik_passes(self):
+		self.assertEqual(_evaluate_http_port(443, True, True)["status"], PASS)
+
+	def test_http_port_taken_by_other_warns(self):
+		self.assertEqual(_evaluate_http_port(80, True, False)["status"], WARN)
+
+	def test_wg_port_bound_passes(self):
+		self.assertEqual(_evaluate_wg_port(51820, True)["status"], PASS)
+
+	def test_wg_port_unbound_warns_with_port_in_fix(self):
+		result = _evaluate_wg_port(51820, False)
+		self.assertEqual(result["status"], WARN)
+		self.assertIn("51820", result["fix"])
+
+
+class TestParseListeningPorts(IntegrationTestCase):
+	def test_parses_tcp_and_udp(self):
+		out = (
+			"Netid State  Recv-Q Send-Q Local Address:Port Peer Address:Port\n"
+			"tcp   LISTEN 0      128    0.0.0.0:80         0.0.0.0:*\n"
+			"tcp   LISTEN 0      128    [::]:443           [::]:*\n"
+			"udp   UNCONN 0      0      0.0.0.0:51820      0.0.0.0:*\n"
+		)
+		parsed = _parse_listening_ports(out)
+		self.assertEqual(parsed["tcp"], {80, 443})
+		self.assertEqual(parsed["udp"], {51820})
+
+	def test_ignores_header_only(self):
+		header = "Netid State Recv-Q Send-Q Local Address:Port Peer Address:Port\n"
+		self.assertEqual(_parse_listening_ports(header), {"tcp": set(), "udp": set()})

--- a/benchpress/tests/test_doctor.py
+++ b/benchpress/tests/test_doctor.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+from frappe.tests import IntegrationTestCase
+
+from benchpress.doctor import (
+	FAIL,
+	MIN_CPU_CORES,
+	MIN_FREE_DISK_GB,
+	MIN_RAM_GB,
+	PASS,
+	WARN,
+	_evaluate_os,
+	_evaluate_resources,
+	_format_report,
+	_result,
+	_summary,
+)
+
+UBUNTU = {"ID": "ubuntu", "ID_LIKE": "debian", "PRETTY_NAME": "Ubuntu 22.04.4 LTS"}
+GENERIC_PROC = "Linux version 6.8.0-124-generic (buildd@lcy02) gcc"
+WSL_PROC = "Linux version 5.15.133.1-microsoft-standard-WSL2 (oe-user@oe-host)"
+
+
+def _status_for(results, name):
+	return next(r["status"] for r in results if r["name"] == name)
+
+
+class TestEvaluateResources(IntegrationTestCase):
+	def test_below_threshold_fails(self):
+		results = _evaluate_resources(MIN_CPU_CORES - 1, MIN_RAM_GB - 1, MIN_FREE_DISK_GB - 1)
+		self.assertEqual(_status_for(results, "CPU cores"), FAIL)
+		self.assertEqual(_status_for(results, "Memory"), FAIL)
+		self.assertEqual(_status_for(results, "Free disk"), FAIL)
+
+	def test_at_threshold_warns(self):
+		results = _evaluate_resources(MIN_CPU_CORES, MIN_RAM_GB, MIN_FREE_DISK_GB)
+		for name in ("CPU cores", "Memory", "Free disk"):
+			self.assertEqual(_status_for(results, name), WARN)
+
+	def test_above_threshold_passes(self):
+		results = _evaluate_resources(MIN_CPU_CORES + 2, MIN_RAM_GB + 4, MIN_FREE_DISK_GB + 50)
+		for name in ("CPU cores", "Memory", "Free disk"):
+			self.assertEqual(_status_for(results, name), PASS)
+
+
+class TestEvaluateOs(IntegrationTestCase):
+	def test_ubuntu_passes(self):
+		self.assertEqual(_evaluate_os(UBUNTU, GENERIC_PROC, False)["status"], PASS)
+
+	def test_wsl2_warns(self):
+		result = _evaluate_os(UBUNTU, WSL_PROC, False)
+		self.assertEqual(result["status"], WARN)
+		self.assertIn("WSL2", result["detail"])
+
+	def test_unknown_distro_warns(self):
+		unknown = {"ID": "arch", "PRETTY_NAME": "Arch Linux"}
+		self.assertEqual(_evaluate_os(unknown, GENERIC_PROC, False)["status"], WARN)
+
+
+class TestFormatReport(IntegrationTestCase):
+	def test_tags_and_summary_present(self):
+		report = _format_report(
+			[_result(PASS, "A", "ok"), _result(FAIL, "B", "bad", "do x")], {"site": "frontend"}
+		)
+		self.assertIn("[PASS]", report)
+		self.assertIn("[FAIL]", report)
+		self.assertIn("Summary:", report)
+
+	def test_no_ansi_when_not_tty(self):
+		report = _format_report([_result(PASS, "A", "ok")], {"site": "frontend"}, tty=False)
+		self.assertNotIn("\x1b", report)
+
+	def test_ansi_when_tty(self):
+		report = _format_report([_result(PASS, "A", "ok")], {"site": "frontend"}, tty=True)
+		self.assertIn("\x1b", report)
+
+
+class TestSecretSafety(IntegrationTestCase):
+	def test_report_never_leaks_secret_shapes(self):
+		results = [
+			_result(PASS, "A", "ok"),
+			_result(WARN, "B", "borderline", "fix it"),
+			_result(FAIL, "C", "bad", "do x"),
+		]
+		env = {"site": "frontend", "bench": "/home/frappe/frappe-bench", "in_container": True}
+		report = _format_report(results, env, tty=False)
+		for needle in ("$apr1$", "PrivateKey", "-----BEGIN", "@"):
+			self.assertNotIn(needle, report)
+
+
+class TestSummary(IntegrationTestCase):
+	def test_counts_by_status(self):
+		results = [
+			_result(PASS, "a", ""),
+			_result(PASS, "b", ""),
+			_result(WARN, "c", ""),
+			_result(FAIL, "d", ""),
+			_result(FAIL, "e", ""),
+			_result(FAIL, "f", ""),
+		]
+		self.assertEqual(_summary(results), {"pass": 2, "warn": 1, "fail": 3})

--- a/benchpress/tests/test_doctor.py
+++ b/benchpress/tests/test_doctor.py
@@ -1,8 +1,14 @@
 # Copyright (c) 2026, Venkatesh and Contributors
 # See license.txt
 
+import contextlib
+import io
+import json
+from unittest.mock import patch
+
 from frappe.tests import IntegrationTestCase
 
+from benchpress import doctor
 from benchpress.doctor import (
 	FAIL,
 	MIN_CPU_CORES,
@@ -27,6 +33,7 @@ from benchpress.doctor import (
 	_result,
 	_skipped,
 	_summary,
+	run,
 )
 
 UBUNTU = {"ID": "ubuntu", "ID_LIKE": "debian", "PRETTY_NAME": "Ubuntu 22.04.4 LTS"}
@@ -228,6 +235,30 @@ class TestEvaluatePorts(IntegrationTestCase):
 		result = _evaluate_wg_port(51820, False)
 		self.assertEqual(result["status"], WARN)
 		self.assertIn("51820", result["fix"])
+
+
+class TestRun(IntegrationTestCase):
+	def _run_capturing(self, checks, **kwargs):
+		buf = io.StringIO()
+		with patch.object(doctor, "CHECKS", checks), contextlib.redirect_stdout(buf):
+			run(**kwargs)
+		return buf.getvalue()
+
+	def test_json_output_is_valid_results_array(self):
+		checks = [lambda: [_result(PASS, "A", "ok"), _result(WARN, "B", "borderline", "fix it")]]
+		parsed = json.loads(self._run_capturing(checks, as_json=True))
+		self.assertEqual([r["name"] for r in parsed], ["A", "B"])
+		self.assertEqual(parsed[1]["fix"], "fix it")
+
+	def test_strict_exits_nonzero_on_fail(self):
+		checks = [lambda: [_result(FAIL, "A", "bad", "do x")]]
+		with self.assertRaises(SystemExit) as ctx:
+			self._run_capturing(checks, strict=True)
+		self.assertEqual(ctx.exception.code, 1)
+
+	def test_strict_exits_zero_without_fail(self):
+		checks = [lambda: [_result(PASS, "A", "ok"), _result(WARN, "B", "meh")]]
+		self._run_capturing(checks, strict=True)
 
 
 class TestParseListeningPorts(IntegrationTestCase):

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,6 +84,46 @@ http://your-site.localhost:8000/frontend
 
 ---
 
+## Troubleshooting
+
+If any step above failed — or a deploy errors out with a cryptic message — **run the doctor first**. It inspects the same host surface `setup.sh` configures (Docker, WireGuard, IP forwarding, sudoers, ports, shared infrastructure) and prints a `pass / warn / fail` report with the exact command to fix each problem. Its output is redaction-safe, so you can paste it straight into a GitHub issue.
+
+Two equivalent ways to run it:
+
+```bash
+bench --site your-site.localhost execute benchpress.doctor.run
+bench benchpress doctor --site your-site.localhost
+```
+
+> `bench benchpress doctor` is registered at app load; if bench does not recognise it yet, run `bench restart` once.
+
+Flags (on either path):
+
+| Flag | Effect |
+|------|--------|
+| `--json` | Emit the results as machine-readable JSON instead of the text report. With `execute`: `--kwargs "{'as_json': 1}"`. |
+| `--strict` | Exit non-zero when any check is `FAIL` — use it as a CI / pre-deploy gate. With `execute`: `--kwargs "{'strict': 1}"`. |
+
+Sample report:
+
+```
+BenchPress readiness check
+site: frontend  bench: /home/frappe/frappe-bench  running on: host
+
+[PASS] Operating system: Ubuntu 22.04.4 LTS
+[PASS] Docker daemon: reachable, server version 24.0.7
+[WARN] WireGuard interface: wg0 is not up
+        fix: sudo wg-quick up wg0
+[FAIL] IP forwarding: net.ipv4.ip_forward = 0
+        fix: sudo sysctl -w net.ipv4.ip_forward=1
+
+Summary: 9 pass, 1 warn, 1 fail
+```
+
+Host-only checks (IP forwarding, sudoers, the `wg0` interface, listening ports) need direct host access. Run the doctor **on the host bench**, not inside a container — in a container those rows degrade to `[WARN] skipped (run on the host)` rather than failing.
+
+---
+
 ## Your First Lab and Bench
 
 Once BenchPress is running, follow the [Creating Labs](creating-labs.md) guide to create your first lab template and deploy a bench instance.


### PR DESCRIPTION
Phase one of the BenchPress doctor/preflight work for issue #30. This PR establishes the doctor framework, safe report formatting, initial checks, tests, CLI registration, and getting-started docs.

Closes #30

## Summary
- Add `benchpress/doctor.py` with result model, check runner, report formatter, and initial checks.
- Add doctor command wiring in `benchpress/commands.py`.
- Add install/docs entry points so doctor becomes the first troubleshooting step.
- Add tests for resource thresholds, OS detection, report formatting, and paste-safety.

## Product value
- Gives admins a safe preflight report before deploying BenchPress.
- Starts the foundation for host readiness checks needed by Phase 1 public browser access.
- Keeps output paste-safe for GitHub/support debugging.

## Verification
- GitHub checks are running/passing except Server is still in progress at time of PR metadata update.
- Files changed: `benchpress/commands.py`, `benchpress/doctor.py`, `benchpress/install.py`, `benchpress/tests/test_doctor.py`, `docs/getting-started.md`.

## Follow-up scope
If needed after review, split remaining deeper host matrix items into follow-up issues:
- Docker Compose v2 / Traefik network / ports 80-443
- WireGuard/Headscale readiness
- sudoers/sysctl/firewall checks
- JSON/strict mode refinements
