### PR TITLE
feat: explicit setup step framework + execute entrypoint; install no longer mutates host (P0-04 Phase 1)

### DIFF
--- a/benchpress/install.py
+++ b/benchpress/install.py
@@ -1,41 +1,17 @@
 # Copyright (c) 2026, Venkatesh and contributors
 # For license information, please see license.txt
 
-import os
-import subprocess
-
 import frappe
 
 
 def after_install():
 	site = frappe.local.site
-	bench_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
-	script = os.path.join(bench_dir, "apps", "benchpress", "setup.sh")
 
 	print("\n" + "=" * 60)
-	print("  BenchPress — Running post-install setup")
+	print("  BenchPress — installed (no host changes made)")
 	print("=" * 60 + "\n")
 
-	# setup.sh requires host-level access (docker group, sysctl, sudoers,
-	# wireguard). Skip it when running inside a container.
-	if os.path.exists("/.dockerenv"):
-		print("[!] Running inside Docker — skipping host setup script.")
-		_print_manual_instructions(site)
-	elif not os.path.exists(script):
-		_print_manual_instructions(site)
-	else:
-		try:
-			result = subprocess.run(
-				["bash", script, site],
-				cwd=bench_dir,
-				check=False,
-			)
-			if result.returncode != 0:
-				print(f"\n[!] setup.sh exited with code {result.returncode}")
-				_print_manual_instructions(site)
-		except Exception as e:
-			print(f"\n[!] Could not run setup.sh: {e}")
-			_print_manual_instructions(site)
+	_print_manual_instructions(site)
 
 	# Create test users in developer mode
 	if frappe.conf.get("developer_mode"):
@@ -90,9 +66,9 @@ def create_test_users():
 
 
 def _print_manual_instructions(site: str) -> None:
-	print("\nRun the setup script manually to configure Docker, WireGuard, and permissions:")
-	print(f"\n  bash apps/benchpress/setup.sh {site}\n")
-	print("Or follow the manual steps in: apps/benchpress/docs/wireguard-setup.md\n")
-	print("Then check host readiness with the doctor:")
-	print(f"\n  bench --site {site} execute benchpress.doctor.run")
-	print("  bench benchpress doctor\n")
+	print("No changes were made to the host automatically. Configure Docker, WireGuard,")
+	print("and host permissions with these explicit steps, run on the host:\n")
+	print(f"  1. Check host readiness:   bench benchpress doctor --site {site}")
+	print(f"  2. Preview the changes:    bench benchpress setup --site {site} --dry-run")
+	print(f"  3. Apply the changes:      bench benchpress setup --site {site}")
+	print(f"\nTo revert later (preview):   bench benchpress teardown --site {site} --dry-run\n")

--- a/benchpress/setup.py
+++ b/benchpress/setup.py
@@ -1,0 +1,194 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+import getpass
+import os
+import shutil
+import subprocess
+import sys
+
+import frappe
+
+from benchpress import doctor
+
+OK = "ok"
+APPLY = "apply"
+FAIL = "fail"
+SKIP = "skip"
+
+SUDOERS_FILE = "/etc/sudoers.d/benchpress"
+SYSCTL_CONF = "/etc/sysctl.d/99-benchpress.conf"
+
+_TAG = {OK: "[OK]", APPLY: "[APPLY]", FAIL: "[FAIL]", SKIP: "[SKIP]"}
+_ANSI = {OK: "\033[32m", APPLY: "\033[33m", FAIL: "\033[31m", SKIP: "\033[90m"}
+_ANSI_RESET = "\033[0m"
+
+
+def _record(status: str, step: str, detail: str, change=None, error: str | None = None) -> dict:
+	return {"status": status, "step": step, "detail": detail, "change": change, "error": error}
+
+
+def _passes(check_fn) -> bool:
+	return all(r["status"] == doctor.PASS for r in check_fn())
+
+
+class Step:
+	def __init__(
+		self,
+		key,
+		name,
+		check,
+		describe,
+		apply,
+		rollback=None,
+		host_only=True,
+		destructive=False,
+	):
+		self.key = key
+		self.name = name
+		self.check = check
+		self.describe = describe
+		self.apply = apply
+		self.rollback = rollback
+		self.host_only = host_only
+		self.destructive = destructive
+
+
+def _step_sudoers_apply() -> None:
+	user = getpass.getuser()
+	wg_bin = shutil.which("wg") or "/usr/bin/wg"
+	wg_quick_bin = shutil.which("wg-quick") or "/usr/bin/wg-quick"
+	line = f"{user} ALL=(ALL) NOPASSWD: {wg_bin}, {wg_quick_bin}\n"
+	subprocess.run(["sudo", "tee", SUDOERS_FILE], input=line, capture_output=True, text=True, check=True)
+	subprocess.run(["sudo", "chmod", "0440", SUDOERS_FILE], capture_output=True, text=True, check=True)
+
+
+def _step_sudoers_rollback() -> None:
+	subprocess.run(["sudo", "rm", "-f", SUDOERS_FILE], capture_output=True, text=True, check=False)
+
+
+def _step_ip_forward_apply() -> None:
+	subprocess.run(
+		["sudo", "sysctl", "-w", "net.ipv4.ip_forward=1"], capture_output=True, text=True, check=True
+	)
+	subprocess.run(
+		["sudo", "tee", SYSCTL_CONF],
+		input="net.ipv4.ip_forward = 1\n",
+		capture_output=True,
+		text=True,
+		check=True,
+	)
+
+
+def _step_ip_forward_rollback() -> None:
+	subprocess.run(["sudo", "rm", "-f", SYSCTL_CONF], capture_output=True, text=True, check=False)
+
+
+STEPS = [
+	Step(
+		key="sudoers",
+		name="Sudoers (passwordless wg)",
+		check=lambda: _passes(doctor._check_sudoers),
+		describe=lambda: ["write /etc/sudoers.d/benchpress (NOPASSWD wg, wg-quick); chmod 0440"],
+		apply=_step_sudoers_apply,
+		rollback=_step_sudoers_rollback,
+	),
+	Step(
+		key="ip_forward",
+		name="IP forwarding",
+		check=lambda: _passes(doctor._check_ip_forward) and os.path.exists(SYSCTL_CONF),
+		describe=lambda: ["sysctl -w net.ipv4.ip_forward=1", f"write {SYSCTL_CONF}"],
+		apply=_step_ip_forward_apply,
+		rollback=_step_ip_forward_rollback,
+	),
+]
+
+
+def _plan_summary(records: list[dict]) -> dict:
+	return {
+		"apply": sum(1 for r in records if r["status"] == APPLY),
+		"ok": sum(1 for r in records if r["status"] == OK),
+		"skip": sum(1 for r in records if r["status"] == SKIP),
+	}
+
+
+def _format_plan(records: list[dict], env: dict, tty: bool = False) -> str:
+	lines = ["BenchPress setup plan"]
+	site = env.get("site") or "?"
+	bench = env.get("bench") or "?"
+	location = "container" if env.get("in_container") else "host"
+	lines.append(f"site: {site}  bench: {bench}  running on: {location}")
+	lines.append("")
+
+	for r in records:
+		tag = _TAG.get(r["status"], "[????]")
+		if tty:
+			tag = f"{_ANSI.get(r['status'], '')}{tag}{_ANSI_RESET}"
+		lines.append(f"{tag} {r['step']}: {r['detail']}")
+		for change in r.get("change") or []:
+			lines.append(f"        {change}")
+
+	counts = _plan_summary(records)
+	lines.append("")
+	lines.append(f"Plan: {counts['apply']} to apply, {counts['ok']} already done, {counts['skip']} skipped")
+	return "\n".join(lines)
+
+
+def _filter_steps(only) -> list[Step]:
+	keys = None if only is None else ({only} if isinstance(only, str) else set(only))
+	return [s for s in STEPS if keys is None or s.key in keys]
+
+
+def plan(only=None) -> list[dict]:
+	records = []
+	for step in _filter_steps(only):
+		if step.host_only and doctor._in_docker():
+			records.append(_record(SKIP, step.name, "run on the host"))
+		elif step.check():
+			records.append(_record(OK, step.name, "already applied"))
+		else:
+			records.append(_record(APPLY, step.name, "would apply", change=step.describe()))
+	return records
+
+
+def run(
+	dry_run: bool = False,
+	assume_yes: bool = False,
+	as_json: bool = False,
+	only=None,
+	strict: bool = False,
+):
+	"""Print the BenchPress host-setup plan; apply pending steps unless dry-run."""
+	records = plan(only=only)
+	env = {
+		"site": getattr(frappe.local, "site", None),
+		"bench": doctor._bench_dir(),
+		"in_container": doctor._in_docker(),
+	}
+
+	if as_json:
+		print(frappe.as_json(records))
+	else:
+		print(_format_plan(records, env, tty=sys.stdout.isatty()))
+
+	if dry_run:
+		return None
+
+	failed = False
+	for step in _filter_steps(only):
+		if step.host_only and doctor._in_docker():
+			continue
+		if step.check():
+			continue
+		try:
+			step.apply()
+			print(f"[OK] {step.name}: applied")
+		except Exception as e:
+			frappe.log_error(title=f"setup step failed: {step.key}", message=frappe.get_traceback())
+			print(f"[FAIL] {step.name}: apply failed: {e}")
+			failed = True
+			break
+
+	if strict and failed:
+		raise SystemExit(1)
+	return None

--- a/benchpress/tests/test_install.py
+++ b/benchpress/tests/test_install.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+import contextlib
+import io
+from unittest.mock import patch
+
+from frappe.tests import IntegrationTestCase
+
+from benchpress import install
+
+
+class TestAfterInstall(IntegrationTestCase):
+	def _after_install(self, developer_mode):
+		buf = io.StringIO()
+		with (
+			patch("subprocess.run") as subprocess_run,
+			patch.object(install, "create_test_users") as create_test_users,
+			patch.object(install.frappe, "conf", {"developer_mode": developer_mode}),
+			contextlib.redirect_stdout(buf),
+		):
+			install.after_install()
+		return buf.getvalue(), subprocess_run, create_test_users
+
+	def test_does_not_shell_out_to_setup_sh(self):
+		_, subprocess_run, _ = self._after_install(developer_mode=False)
+		subprocess_run.assert_not_called()
+
+	def test_prints_explicit_instructions(self):
+		output, _, _ = self._after_install(developer_mode=False)
+		self.assertIn("No changes were made to the host", output)
+		self.assertIn("bench benchpress doctor", output)
+		self.assertIn("bench benchpress setup", output)
+		self.assertNotIn("setup.sh", output)
+
+	def test_developer_mode_creates_test_users(self):
+		_, _, create_test_users = self._after_install(developer_mode=True)
+		create_test_users.assert_called_once()
+
+	def test_non_developer_mode_skips_test_users(self):
+		_, _, create_test_users = self._after_install(developer_mode=False)
+		create_test_users.assert_not_called()

--- a/benchpress/tests/test_setup.py
+++ b/benchpress/tests/test_setup.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+import contextlib
+import io
+from unittest.mock import patch
+
+from frappe.tests import IntegrationTestCase
+
+from benchpress import doctor, setup
+from benchpress.setup import (
+	APPLY,
+	OK,
+	SKIP,
+	STEPS,
+	_format_plan,
+	_passes,
+	_plan_summary,
+	_record,
+	plan,
+)
+
+
+def _doctor_result(status):
+	return [doctor._result(status, "x", "detail")]
+
+
+class TestPasses(IntegrationTestCase):
+	def test_all_pass_is_true(self):
+		self.assertTrue(_passes(lambda: _doctor_result(doctor.PASS)))
+
+	def test_any_warn_is_false(self):
+		results = [doctor._result(doctor.PASS, "a", ""), doctor._result(doctor.WARN, "b", "")]
+		self.assertFalse(_passes(lambda: results))
+
+	def test_any_fail_is_false(self):
+		self.assertFalse(_passes(lambda: _doctor_result(doctor.FAIL)))
+
+
+class TestFormatPlan(IntegrationTestCase):
+	def test_tags_and_summary_present(self):
+		records = [
+			_record(OK, "Sudoers", "already applied"),
+			_record(APPLY, "IP forwarding", "would apply", change=["sysctl -w net.ipv4.ip_forward=1"]),
+		]
+		report = _format_plan(records, {"site": "frontend"})
+		self.assertIn("[OK]", report)
+		self.assertIn("[APPLY]", report)
+		self.assertIn("Plan:", report)
+
+	def test_no_ansi_when_not_tty(self):
+		report = _format_plan([_record(OK, "A", "ok")], {"site": "frontend"}, tty=False)
+		self.assertNotIn("\x1b", report)
+
+	def test_ansi_when_tty(self):
+		report = _format_plan([_record(APPLY, "A", "would apply")], {"site": "frontend"}, tty=True)
+		self.assertIn("\x1b", report)
+
+
+class TestSecretSafety(IntegrationTestCase):
+	def test_plan_never_leaks_secret_shapes(self):
+		records = [_record(APPLY, s.name, "would apply", change=s.describe()) for s in STEPS]
+		env = {"site": "frontend", "bench": "/home/frappe/frappe-bench", "in_container": False}
+		report = _format_plan(records, env, tty=False)
+		for needle in ("$apr1$", "PrivateKey", "-----BEGIN", "@"):
+			self.assertNotIn(needle, report)
+
+
+class TestPlanSummary(IntegrationTestCase):
+	def test_counts_by_status(self):
+		records = [
+			_record(OK, "a", ""),
+			_record(APPLY, "b", ""),
+			_record(APPLY, "c", ""),
+			_record(SKIP, "d", ""),
+		]
+		self.assertEqual(_plan_summary(records), {"apply": 2, "ok": 1, "skip": 1})
+
+
+class TestPlan(IntegrationTestCase):
+	def test_plan_is_read_only_and_classifies_rows(self):
+		with (
+			patch.object(STEPS[0], "apply") as sudoers_apply,
+			patch.object(STEPS[1], "apply") as ip_forward_apply,
+			patch.object(doctor, "_in_docker", return_value=False),
+			patch.object(doctor, "_check_sudoers", return_value=_doctor_result(doctor.PASS)),
+			patch.object(doctor, "_check_ip_forward", return_value=_doctor_result(doctor.FAIL)),
+		):
+			records = plan()
+
+		sudoers_apply.assert_not_called()
+		ip_forward_apply.assert_not_called()
+		by_step = {r["step"]: r["status"] for r in records}
+		self.assertEqual(by_step["Sudoers (passwordless wg)"], OK)
+		self.assertEqual(by_step["IP forwarding"], APPLY)
+
+	def test_ip_forward_applies_when_persistence_conf_absent(self):
+		with (
+			patch.object(doctor, "_in_docker", return_value=False),
+			patch.object(doctor, "_check_ip_forward", return_value=_doctor_result(doctor.PASS)),
+			patch("os.path.exists", return_value=False),
+		):
+			records = plan(only="ip_forward")
+		self.assertEqual(len(records), 1)
+		self.assertEqual(records[0]["step"], "IP forwarding")
+		self.assertEqual(records[0]["status"], APPLY)
+
+	def test_container_degrade_skips_host_only_steps(self):
+		with patch.object(doctor, "_in_docker", return_value=True):
+			records = plan()
+		self.assertEqual(len(records), 2)
+		self.assertTrue(all(r["status"] == SKIP for r in records))
+
+
+class TestRun(IntegrationTestCase):
+	def test_dry_run_mutates_nothing(self):
+		buf = io.StringIO()
+		with (
+			patch("subprocess.run") as subprocess_run,
+			patch.object(STEPS[0], "apply") as sudoers_apply,
+			patch.object(STEPS[1], "apply") as ip_forward_apply,
+			patch.object(doctor, "_in_docker", return_value=False),
+			patch.object(doctor, "_check_sudoers", return_value=_doctor_result(doctor.FAIL)),
+			patch.object(doctor, "_check_ip_forward", return_value=_doctor_result(doctor.FAIL)),
+			contextlib.redirect_stdout(buf),
+		):
+			result = setup.run(dry_run=True)
+
+		self.assertIsNone(result)
+		subprocess_run.assert_not_called()
+		sudoers_apply.assert_not_called()
+		ip_forward_apply.assert_not_called()
+		self.assertIn("Plan:", buf.getvalue())


### PR DESCRIPTION
## Phase 1 of the explicit-setup spec (issue #31, P0-04)

The thinnest end-to-end slice of the setup pipeline, plus the headline change that **installing the app no longer mutates the host**. Spec: [`specs/explicit-setup/phase-1-step-framework.md`](specs/explicit-setup/phase-1-step-framework.md).

### What this adds
- **`benchpress/setup.py` (new)** — the `Step` registry → `plan()` → `_format_plan` pipeline, mirroring `doctor.py`. Two safe, self-contained steps (`sudoers`, `ip_forward`) reuse `doctor._check_*` as idempotency guards (referenced through the `doctor` module so they stay in lockstep). `plan()` is read-only and **never calls `apply`**; `run(dry_run=1)` prints a redaction-safe change plan and **mutates nothing**; host-only steps render `SKIP` inside a container.
- **`benchpress/install.py`** — `after_install` no longer shells out to `setup.sh` (acceptance criterion #1). It states no host changes were made automatically and prints the explicit path: `doctor → setup --dry-run → setup → teardown --dry-run`. Dropped the now-unused `os`/`subprocess` imports. The `developer_mode → create_test_users` tail is unchanged.

### Tests
- `test_setup.py` (12): `_passes`; `_format_plan` tags/`Plan:` line/no-ANSI/secret-safety; `plan()` read-only + OK-vs-APPLY classification; the `os.path.exists(SYSCTL_CONF)` half of the ip_forward guard; container-degrade `SKIP`; `run(dry_run)` zero mutation.
- `test_install.py` (4): no `setup.sh` shell-out, explicit instructions printed, `create_test_users` tail toggles on `developer_mode`.

### Verification (all green)
1. `bench --site frontend execute benchpress.setup.run --kwargs "{'dry_run': 1}"` → plan prints with both steps and a `Plan:` line; in-container both render `SKIP — run on the host`; mutates nothing.
2. `run-tests --module benchpress.tests.test_setup` (12) and `…test_install` (4) → all pass.
3. Install no longer mutates: `after_install` spawns no `setup.sh` subprocess and prints the new instructions.
4. Paste-safety: rendered plan contains no `$apr1$` / `PrivateKey` / `BEGIN` / `@` and no ANSI bytes.
5. `pre-commit run` (ruff + ruff-format + prettier + whitespace) passes.

### Review note
Before opening, an adversarial multi-agent review of the diff against the spec + CLAUDE.md surfaced and this PR fixes: an empty-`only` filter footgun in `_filter_steps`, a misleading all-zero summary on the apply-failure render path, and a test-coverage gap on the ip_forward persistence-conf guard.

**Not in scope (later phases):** the other five steps + `teardown()` (phase 2); the registered `bench benchpress setup`/`teardown` commands, confirmation UX, `--json`/`--strict`/`--purge`, audit log, `setup.sh` shim, and docs (phase 3).