### PR TITLE
test(wg_manager): cover wg-unavailable path in generate_keypair (#41)

### DIFF
--- a/benchpress/tests/test_wg_manager.py
+++ b/benchpress/tests/test_wg_manager.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+
+def _completed(stdout):
+	"""Stand in for a subprocess.CompletedProcess with the given stdout."""
+	result = MagicMock()
+	result.stdout = stdout
+	return result
+
+
+class TestWgManager(IntegrationTestCase):
+	@patch("benchpress.wg_manager.subprocess.run")
+	@patch("benchpress.wg_manager._wg_available", return_value=False)
+	def test_generate_keypair_throws_when_wg_unavailable(self, _mock_available, mock_run):
+		from benchpress.wg_manager import generate_keypair
+
+		with self.assertRaises(frappe.ValidationError):
+			generate_keypair()
+
+		# No keypair may be derived (and therefore stored) without the wg binary.
+		mock_run.assert_not_called()
+
+	@patch("benchpress.wg_manager._wg_available", return_value=True)
+	@patch("benchpress.wg_manager.subprocess.run")
+	def test_generate_keypair_returns_distinct_keys_from_wg(self, mock_run, _mock_available):
+		from benchpress.wg_manager import generate_keypair
+
+		mock_run.side_effect = [_completed("PRIVATEKEY123\n"), _completed("PUBLICKEY456\n")]
+
+		keys = generate_keypair()
+
+		self.assertEqual(keys["private_key"], "PRIVATEKEY123")
+		self.assertEqual(keys["public_key"], "PUBLICKEY456")
+		# Guards the original bug where the public key was the private key blob.
+		self.assertNotEqual(keys["private_key"], keys["public_key"])
+
+	@patch("benchpress.wg_manager._wg_available", return_value=True)
+	@patch("benchpress.wg_manager.subprocess.run")
+	def test_generate_keypair_derives_public_from_private(self, mock_run, _mock_available):
+		from benchpress.wg_manager import generate_keypair
+
+		mock_run.side_effect = [_completed("PRIV==\n"), _completed("PUB==\n")]
+
+		generate_keypair()
+
+		# pubkey must be derived from the freshly generated private key on stdin.
+		pubkey_call = mock_run.call_args_list[1]
+		self.assertEqual(pubkey_call.args[0], ["wg", "pubkey"])
+		self.assertEqual(pubkey_call.kwargs["input"], "PRIV==")


### PR DESCRIPTION
## Summary

Adds the missing test coverage that was the last open acceptance criterion on #41.

The silent placeholder-key bug itself is **already fixed in code**: `wg_manager.generate_keypair()` now `frappe.throw()`s when the `wg` binary is missing and derives the public key from a real `wg genkey` (commits `e02edcc`, `176dd36`, `1d89342`). What was missing was a test guarding the regression.

## What this adds

`benchpress/tests/test_wg_manager.py` with 3 tests:

- **`test_generate_keypair_throws_when_wg_unavailable`** — patches `_wg_available` → `False`, asserts `frappe.ValidationError` is raised and that `subprocess.run` is *never reached*, proving no code path can derive/store an invalid keypair when wg is absent.
- **`test_generate_keypair_returns_distinct_keys_from_wg`** — asserts `private_key != public_key` (the exact symptom of the original bug, where the public key was the private-key blob).
- **`test_generate_keypair_derives_public_from_private`** — asserts `wg pubkey` receives the freshly generated private key on stdin.

## Acceptance criteria (#41)

- [x] Deploy/device creation fails with an actionable error when `wg` is unavailable — *already in code*
- [x] No code path can store an invalid keypair — *already in code*
- [x] **Test covers the wg-unavailable path** — *this PR*

## Testing

```
$ bench --site frontend run-tests --module benchpress.tests.test_wg_manager
Ran 3 tests in 0.089s
OK
```

`pre-commit run --files benchpress/tests/test_wg_manager.py` passes (ruff, ruff-format, ast, whitespace).

## Notes for next iteration

The proposed-fix item *"surface the missing-wg condition in the preflight/doctor check (#30)"* is **not** addressed here — `doctor.py` still has no WireGuard check. Good follow-up task.

Closes #41