### PR TITLE
fix(frontend): resolve socketio_port at runtime, not build-time (#28)

### DIFF
--- a/frontend/src/socket.js
+++ b/frontend/src/socket.js
@@ -1,11 +1,20 @@
 import { io } from "socket.io-client";
-import { socketio_port } from "../../../../sites/common_site_config.json";
+
+// Resolve the socket.io port at runtime. Frappe exposes `window.socketio_port`
+// in the boot data block on desk/website pages (frappe core's website.js reads
+// the same global); when it is absent we fall back to Frappe's default port.
+// This replaces a build-time `import` of sites/common_site_config.json, which
+// only exists inside a running bench and broke `yarn build` in CI/contributor
+// checkouts.
+function getSocketioPort() {
+	return window.socketio_port || 9000;
+}
 
 let socket = null;
 export function initSocket() {
 	const host = window.location.hostname;
 	const siteName = window.site_name;
-	const port = window.location.port ? `:${socketio_port}` : "";
+	const port = window.location.port ? `:${getSocketioPort()}` : "";
 	const protocol = port ? "http" : "https";
 	const url = `${protocol}://${host}${port}/${siteName}`;
 


### PR DESCRIPTION
## What

Fixes the P0 frontend production-build blocker from #28.

`frontend/src/socket.js` imported `socketio_port` directly from
`../../../../sites/common_site_config.json`. That file only exists inside a
running bench, so `yarn build` failed in CI and contributor checkouts:

```
Could not resolve "../../../../sites/common_site_config.json" from "src/socket.js"
```

## How

Resolve the port at runtime instead of build-time, mirroring **frappe-ui's own
`initSocket`** and frappe core's `website.js` (both read `window.socketio_port`):

```js
function getSocketioPort() {
  return window.socketio_port || 9000;
}
```

- No build-time dependency on `sites/common_site_config.json`.
- Safe fallback to Frappe's default port `9000` (what BenchPress deploys use).
- Public `initSocket()` / `useSocket()` API unchanged.

## Acceptance criteria (#28)

- [x] `cd frontend && yarn build` succeeds with no `sites/` file present.
- [x] Socket port resolved via runtime-injected config / safe fallback, not a brittle relative import.
- [x] CI frontend install+build check — already added in #43.
- [x] Config-loading behaviour documented in an inline comment in `socket.js`.

## Verification

- `yarn build` → `✓ built` with no `sites/common_site_config.json` on disk.
- Served `/frontend` returns HTTP 200 and the SPA mounts.

## Notes / follow-ups

- The CI stub step that writes `sites/common_site_config.json` (`ci.yml`) is now
  dead and can be dropped in a later workflow-scoped change.
- Optional: add `socketio_port` to the www-page boot dict so non-default ports
  are honoured; the `9000` fallback covers current deployments.
- agent-browser interactive test skipped — Chrome devtools endpoint was not
  reachable in this environment; verified via build + curl.

Closes #28