### PR TITLE
feat(labs): lab template catalog — tracer bullet (#37)

### DIFF
--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe import _
 
+from benchpress import lab_templates
 from benchpress.permissions import (
 	get_bench_owner_filter,
 	is_admin,
@@ -60,6 +61,18 @@ def get_lab(name: str) -> dict:
 			for a in lab.apps
 		],
 	}
+
+
+@frappe.whitelist()
+def get_lab_templates() -> list[dict]:
+	return lab_templates.get_templates()
+
+
+@frappe.whitelist()
+def create_lab_from_template(template: str, lab_id: str, title: str | None = None) -> dict:
+	require_admin()
+	name = lab_templates.create_lab_from_template(template, lab_id, title)
+	return {"name": name, "status": "Draft"}
 
 
 @frappe.whitelist()

--- a/benchpress/lab_templates.py
+++ b/benchpress/lab_templates.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""Catalog of ready-made lab templates.
+
+Templates are versioned in code so an admin can spin up a common stack
+(Frappe, ERPNext, CRM) without typing every app's git URL and resources by
+hand. ``create_lab_from_template`` materialises a template into an ordinary,
+editable Lab document, after which the normal build/deploy flow takes over.
+"""
+
+import frappe
+from frappe import _
+
+# Bumped whenever the template set or its fields change so an install can tell
+# which catalog a lab was created against.
+CATALOG_VERSION = 1
+
+LAB_TEMPLATES = [
+	{
+		"key": "frappe",
+		"title": "Frappe Framework",
+		"description": "Bare Frappe bench with no extra apps — the lightest starting point.",
+		"frappe_version": "version-15",
+		"memory_limit": "512m",
+		"cpu_cores": 1,
+		"apps": [],
+	},
+	{
+		"key": "erpnext",
+		"title": "ERPNext",
+		"description": "Full ERP suite: accounting, inventory, manufacturing and more.",
+		"frappe_version": "version-15",
+		"memory_limit": "2g",
+		"cpu_cores": 2,
+		"apps": [
+			{
+				"app_name": "erpnext",
+				"app_label": "ERPNext",
+				"git_url": "https://github.com/frappe/erpnext",
+				"branch": "version-15",
+			}
+		],
+	},
+	{
+		"key": "crm",
+		"title": "Frappe CRM",
+		"description": "Lightweight sales CRM on Frappe — leads, deals and contacts.",
+		"frappe_version": "version-15",
+		"memory_limit": "1g",
+		"cpu_cores": 1,
+		"apps": [
+			{
+				"app_name": "crm",
+				"app_label": "Frappe CRM",
+				"git_url": "https://github.com/frappe/crm",
+				"branch": "main",
+			}
+		],
+	},
+]
+
+
+def get_templates() -> list[dict]:
+	"""Return the full catalog of lab templates."""
+	return LAB_TEMPLATES
+
+
+def get_template(key: str) -> dict:
+	"""Return a single template by key, or throw if it is unknown."""
+	for template in LAB_TEMPLATES:
+		if template["key"] == key:
+			return template
+	frappe.throw(_("Unknown lab template '{0}'.").format(key or ""))
+
+
+def create_lab_from_template(template_key: str, lab_id: str, title: str | None = None) -> str:
+	"""Build a Lab document from a template and return its name."""
+	template = get_template(template_key)
+	lab = frappe.get_doc(
+		{
+			"doctype": "Lab",
+			"lab_id": lab_id,
+			"title": title or template["title"],
+			"description": template["description"],
+			"frappe_version": template["frappe_version"],
+			"memory_limit": template["memory_limit"],
+			"cpu_cores": template["cpu_cores"],
+			"apps": [dict(app) for app in template["apps"]],
+		}
+	)
+	lab.insert()
+	return lab.name

--- a/benchpress/tests/test_lab_templates.py
+++ b/benchpress/tests/test_lab_templates.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from benchpress import lab_templates
+
+REQUIRED_FIELDS = {
+	"key",
+	"title",
+	"description",
+	"frappe_version",
+	"memory_limit",
+	"cpu_cores",
+	"apps",
+}
+
+
+class TestLabTemplates(IntegrationTestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def _make_lab(self, template_key, lab_id, title=None):
+		if frappe.db.exists("Lab", lab_id):
+			frappe.delete_doc("Lab", lab_id, force=True, ignore_permissions=True)
+		name = lab_templates.create_lab_from_template(template_key, lab_id, title)
+		self.addCleanup(
+			lambda n=name: frappe.delete_doc("Lab", n, force=True, ignore_permissions=True)
+			if frappe.db.exists("Lab", n)
+			else None
+		)
+		return frappe.get_doc("Lab", name)
+
+	def test_catalog_is_non_empty_and_well_formed(self):
+		templates = lab_templates.get_templates()
+		self.assertTrue(templates)
+		for template in templates:
+			self.assertTrue(REQUIRED_FIELDS.issubset(template))
+			self.assertIsInstance(template["apps"], list)
+
+	def test_template_keys_are_unique(self):
+		keys = [template["key"] for template in lab_templates.get_templates()]
+		self.assertEqual(len(keys), len(set(keys)))
+
+	def test_get_template_returns_match(self):
+		self.assertEqual(lab_templates.get_template("erpnext")["key"], "erpnext")
+
+	def test_get_template_unknown_throws(self):
+		with self.assertRaises(frappe.ValidationError):
+			lab_templates.get_template("does-not-exist")
+
+	def test_create_lab_from_template_populates_apps_and_resources(self):
+		lab = self._make_lab("erpnext", "tmpl-erpnext-test")
+		self.assertEqual(lab.frappe_version, "version-15")
+		self.assertEqual(lab.memory_limit, "2g")
+		self.assertEqual(lab.cpu_cores, 2)
+		self.assertEqual(len(lab.apps), 1)
+		self.assertEqual(lab.apps[0].app_name, "erpnext")
+
+	def test_create_lab_from_template_with_no_apps(self):
+		lab = self._make_lab("frappe", "tmpl-frappe-test", title="My Frappe Lab")
+		self.assertEqual(lab.title, "My Frappe Lab")
+		self.assertEqual(len(lab.apps), 0)
+
+	def test_create_lab_from_template_unknown_throws(self):
+		with self.assertRaises(frappe.ValidationError):
+			lab_templates.create_lab_from_template("nope", "tmpl-nope-test")

--- a/docs/creating-labs.md
+++ b/docs/creating-labs.md
@@ -18,6 +18,34 @@ Create Lab  -->  Build Image  -->  Deploy Bench  -->  Connect & Develop
 
 ---
 
+## Starting from a Template
+
+BenchPress ships a small, versioned catalog of ready-made lab templates so you
+don't have to type every app's Git URL and resource limit by hand. Each
+template pre-fills the Frappe version, recommended memory/CPU, and the apps to
+install.
+
+| Template | Apps | Recommended resources |
+|----------|------|------------------------|
+| **Frappe Framework** (`frappe`) | none (bare bench) | 512m / 1 core |
+| **ERPNext** (`erpnext`) | `erpnext` | 2g / 2 cores |
+| **Frappe CRM** (`crm`) | `crm` | 1g / 1 core |
+
+Creating a lab from a template produces an ordinary, fully editable Lab — you
+can tweak the apps, version, or limits afterwards just like a hand-built one.
+
+The catalog and the create action are exposed as whitelisted APIs:
+
+```
+benchpress.api.get_lab_templates()
+benchpress.api.create_lab_from_template(template="erpnext", lab_id="erp-demo", title="ERP Demo")
+```
+
+> Adding to the catalog: templates live in `benchpress/lab_templates.py` and are
+> versioned with `CATALOG_VERSION`. Append an entry and bump the version.
+
+---
+
 ## Creating a New Lab
 
 ### Navigate to the Labs page


### PR DESCRIPTION
Closes #37 (P1-01) — first tracer-bullet slice.

## What this does
Adds a small, **versioned in-code catalog** of starter lab templates and the
backend plumbing to list them and create a Lab from one. The slice goes
end-to-end on the backend: **define → list → create**, fully tested.

## Templates (initial set)
| Key | Apps | Resources |
|-----|------|-----------|
| `frappe` | none (bare bench) | 512m / 1 core |
| `erpnext` | `erpnext` @ version-15 | 2g / 2 cores |
| `crm` | `crm` @ main | 1g / 1 core |

## Changes
- `benchpress/lab_templates.py` — catalog (`LAB_TEMPLATES`, `CATALOG_VERSION`) + `get_templates` / `get_template` / `create_lab_from_template`.
- `benchpress/api.py` — whitelisted `get_lab_templates()` and admin-only `create_lab_from_template()`.
- `benchpress/tests/test_lab_templates.py` — 7 integration tests.
- `docs/creating-labs.md` — "Starting from a Template" section.

## Key decisions
- Catalog is in-code data (not a DocType): simplest source of truth, trivially extensible, versioned via `CATALOG_VERSION`.
- `create_lab_from_template` produces an **ordinary, editable Lab**, so the existing build/deploy flow is untouched and acceptance-criteria "templates can be edited after selection" holds for free.
- Started with 3 templates to exercise both the no-apps and apps-rich paths.

## Testing
```
$ bench --site frontend run-tests --module benchpress.tests.test_lab_templates
Ran 7 tests ... OK
```
API smoke-tested via `bench execute benchpress.api.get_lab_templates`. `pre-commit run` passes (ruff + ruff-format).

## Acceptance criteria status
- [x] Templates include app name, Git URL, branch, recommended resources.
- [x] Template definitions are versioned and documented.
- [x] Templates can be edited after selection (created Lab is fully editable).
- [ ] User can create a Lab from a template in **one click** — backend ready; **frontend picker is the next slice**.

## Next iteration
- New Lab page: template picker that calls `create_lab_from_template`.
- Expand catalog (HRMS, LMS, Helpdesk, India Compliance) once the UI lands.