### PR TITLE
docs: production-safety & compatibility guide (#36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 ### Detailed Guides
 
 - [Getting Started](docs/getting-started.md) -- Installation and first setup
+- [Production Safety & Compatibility](docs/production-safety.md) -- Readiness caveats, supported platforms, and version matrix
 - [Creating Labs & Deploying](docs/creating-labs.md) -- Labs, builds, and deployments
 - [Connecting to Benches](docs/connecting-to-benches.md) -- SSH, VPN, and connection info
 - [Logs & Monitoring](docs/logs-and-monitoring.md) -- Build logs, deploy logs, and stats

--- a/docs/production-safety.md
+++ b/docs/production-safety.md
@@ -1,0 +1,90 @@
+# Production Safety & Compatibility
+
+This page tells you, before you install, **whether BenchPress is safe to run on your
+host** and **which platform and tool versions are supported**. Read it first if you
+are evaluating BenchPress for anything beyond a throwaway machine.
+
+> This is the first slice of the production-readiness docs (see issue
+> [#36](https://github.com/Venkateshvenki404224/benchpress/issues/36)). A full
+> troubleshooting guide (symptom → cause → fix) and an uninstall/rollback runbook
+> are tracked there and will follow.
+
+---
+
+## Production readiness
+
+**BenchPress is alpha software. Do not run it on a host you cannot afford to lose.**
+
+It is built for developers and small teams spinning up disposable Frappe/ERPNext
+environments — not yet for production hosting of customer data. Concretely:
+
+- **Host-level privilege.** `setup.sh` adds your user to the `docker` group, edits
+  `/etc/sudoers.d`, enables IP forwarding via `/etc/sysctl.d`, and brings up a
+  WireGuard interface. These are real, persistent changes to the host.
+- **Privileged containers.** Bench containers currently run with elevated Docker
+  privileges to support in-container networking. Treat every bench as having host
+  reach until that is hardened.
+- **No backup/restore guarantees yet.** Bench data lives in Docker volumes. Take
+  your own backups; there is no built-in restore path you should rely on.
+- **Single-tenant assumption.** Quotas, rate limits, and audit trails are still in
+  progress. Run BenchPress for people you trust, on a host dedicated to it.
+
+Use it on a dedicated dev box, a VM, or a cloud instance you can rebuild — not on
+your daily-driver workstation or a shared production server.
+
+---
+
+## Supported host platforms
+
+BenchPress installs onto an existing Frappe Bench and drives the host's Docker and
+WireGuard. The setup script is Linux-only (it uses `apt`, `systemd`/`sysctl`,
+`/etc/sudoers.d`, and the WireGuard kernel module).
+
+| Platform | Status | Notes |
+|----------|--------|-------|
+| Ubuntu 22.04 / 24.04 | Supported | Primary target; CI and development happen here. |
+| Debian 12+ | Supported | Same `apt` + systemd toolchain as Ubuntu. |
+| Windows 11 via WSL2 (Ubuntu) | Experimental | App and Docker work; WireGuard/kernel-module steps depend on your WSL kernel. See issue [#26](https://github.com/Venkateshvenki404224/benchpress/issues/26). |
+| Other Linux (Fedora, Arch, …) | Untested | Likely workable, but `setup.sh` assumes `apt`; adapt package install steps manually. |
+| macOS / native Windows | Not supported as a host | No `apt`/systemd/WireGuard kernel module. On Windows, use WSL2. |
+
+> A browser on **any** OS can reach a deployed bench over VPN or (later) a public
+> URL — the platform table above is only about the **host that runs BenchPress**.
+
+---
+
+## Compatibility matrix
+
+These are the versions BenchPress is built and tested against. Pinned values come
+from the project's CI and packaging config.
+
+| Component | Required / Tested | Where it's enforced |
+|-----------|-------------------|---------------------|
+| Frappe Framework (host bench) | v16 | `bench get-app` target; README badge |
+| Python | 3.14+ | `pyproject.toml` (`requires-python`), CI |
+| Node.js | 24 | CI (`ci.yml`) — for the frontend build |
+| Docker Engine | 20+ | Container management |
+| Docker Compose | v2+ | Shared MariaDB + Redis infrastructure |
+| WireGuard | Any recent | Optional; required only for VPN access |
+| Vue (frontend) | 3.5+ | `frontend/package.json` |
+| frappe-ui | 0.1.270+ | `frontend/package.json` |
+
+### Frappe versions available to deployed benches
+
+A bench you deploy can target a different Frappe version than the host. Lab
+definitions accept:
+
+| Frappe version | Lab support |
+|----------------|-------------|
+| version-16 | Available |
+| version-15 | Available (default for starter templates) |
+| version-14 | Available |
+| develop | Available (unstable; tracks Frappe nightly) |
+
+---
+
+## See also
+
+- [Getting Started](getting-started.md) — install and deploy your first bench
+- [WireGuard Setup](wireguard-setup.md) — VPN configuration and troubleshooting
+- [Connecting to Benches](connecting-to-benches.md) — SSH and connection info


### PR DESCRIPTION
## What

First tracer-bullet slice of the production-readiness docs requested in #36 (P0-09).

Adds **`docs/production-safety.md`** covering:

- **Production-readiness caveat** — BenchPress is alpha; host-level privilege, privileged containers, no backup/restore guarantees, single-tenant assumption. "Run it on a host you can rebuild."
- **Supported host platforms** — Ubuntu/Debian supported, WSL2 experimental, macOS/native Windows unsupported as a host (setup.sh is Linux-only: apt/sysctl/sudoers/WireGuard kernel module).
- **Compatibility matrix** — explicit, sourced from repo facts:
  - Python 3.14+ (`pyproject.toml`, CI), Node 24 (`ci.yml`)
  - Frappe host v16; bench Frappe versions 14/15/16/develop (`lab.json`)
  - Docker 20+ / Compose v2+, Vue 3.5+ / frappe-ui 0.1.270 (`frontend/package.json`)

Links it from the README under **Detailed Guides** so it is discoverable.

## Why this scope

#36 lists 7 doc topics. Per the RALPH "smallest unit of work" rule, this PR ships the most self-contained, fact-verifiable slice that satisfies two acceptance criteria today:

- [x] Docs are linked from README
- [x] Compatibility matrix is explicit

## Still open in #36 (next iterations)

- [ ] Troubleshooting guide (symptom → cause → fix), ideally driven by the `doctor` command output once that work merges
- [ ] Network/firewall guide
- [ ] Uninstall/rollback guide
- [ ] New user can install + deploy first bench using docs only (end-to-end pass)

## Testing

Docs-only change — no frontend/code behavior changes, so the agent-browser feedback loop is not applicable. Markdown is not covered by any pre-commit hook; relative links verified to resolve within `docs/`.

Closes part of #36.