### PR TITLE
feat(health): per-bench container health tracer bullet (#39)

### DIFF
--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -91,6 +91,8 @@ def get_benches() -> list[dict]:
 			"wg_ip",
 			"cpu_usage",
 			"memory_usage",
+			"container_health",
+			"last_health_check",
 			"started_at",
 			"ssh_username",
 			"code_server_url",

--- a/benchpress/benchpress/doctype/bench_instance/bench_instance.json
+++ b/benchpress/benchpress/doctype/bench_instance/bench_instance.json
@@ -31,6 +31,8 @@
   "cpu_usage",
   "column_break_stats",
   "memory_usage",
+  "container_health",
+  "last_health_check",
   "wireguard_section",
   "wg_ip",
   "wg_public_key",
@@ -172,6 +174,19 @@
    "fieldname": "memory_usage",
    "fieldtype": "Float",
    "label": "Memory Usage (%)",
+   "read_only": 1
+  },
+  {
+   "fieldname": "container_health",
+   "fieldtype": "Select",
+   "label": "Container Health",
+   "options": "\nHealthy\nUnhealthy\nUnknown",
+   "read_only": 1
+  },
+  {
+   "fieldname": "last_health_check",
+   "fieldtype": "Datetime",
+   "label": "Last Health Check",
    "read_only": 1
   },
   {

--- a/benchpress/docker_manager.py
+++ b/benchpress/docker_manager.py
@@ -217,6 +217,28 @@ def write_file_to_container(container_id: str, content: str, path: str) -> None:
 	)
 
 
+def get_container_health(container_id: str) -> str:
+	"""Return a coarse health label for a bench container.
+
+	A "running" container is Healthy; any other known Docker state (exited,
+	paused, dead, restarting) is Unhealthy; a missing container or inspect
+	failure is Unknown. This deliberately mirrors the actual container state so
+	a bench whose DB status drifts from reality is flagged.
+	"""
+	client = get_client()
+	try:
+		container = client.containers.get(container_id)
+		return "Healthy" if container.status == "running" else "Unhealthy"
+	except docker.errors.NotFound:
+		return "Unknown"
+	except Exception:
+		frappe.log_error(
+			title=f"Failed to get health for container {container_id}",
+			message=frappe.get_traceback(),
+		)
+		return "Unknown"
+
+
 def get_container_stats(container_id: str) -> dict:
 	"""Returns dict with cpu_percent, memory_percent, and memory_usage_mb."""
 	client = get_client()

--- a/benchpress/stats_collector.py
+++ b/benchpress/stats_collector.py
@@ -2,8 +2,9 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe.utils import now_datetime
 
-from benchpress.docker_manager import get_container_stats
+from benchpress.docker_manager import get_container_health, get_container_stats
 
 
 def collect_all_stats() -> None:
@@ -38,7 +39,22 @@ def _collect_bench_stats() -> None:
 				message=frappe.get_traceback(),
 			)
 
+		_update_bench_health(bench)
+
 	frappe.db.commit()
+
+
+def _update_bench_health(bench: dict) -> None:
+	"""Record the container health and check timestamp for a single bench."""
+	frappe.db.set_value(
+		"Bench Instance",
+		bench["name"],
+		{
+			"container_health": get_container_health(bench["container_id"]),
+			"last_health_check": now_datetime(),
+		},
+		update_modified=False,
+	)
 
 
 def _collect_device_stats() -> None:

--- a/benchpress/tests/test_docker_manager.py
+++ b/benchpress/tests/test_docker_manager.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import docker
+
+from benchpress.docker_manager import get_container_health
+
+
+def _client_returning(status):
+	client = MagicMock()
+	client.containers.get.return_value.status = status
+	return client
+
+
+class TestContainerHealth(unittest.TestCase):
+	@patch("benchpress.docker_manager.get_client")
+	def test_running_container_is_healthy(self, get_client):
+		get_client.return_value = _client_returning("running")
+		self.assertEqual(get_container_health("abc123"), "Healthy")
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_exited_container_is_unhealthy(self, get_client):
+		get_client.return_value = _client_returning("exited")
+		self.assertEqual(get_container_health("abc123"), "Unhealthy")
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_missing_container_is_unknown(self, get_client):
+		client = MagicMock()
+		client.containers.get.side_effect = docker.errors.NotFound("no such container")
+		get_client.return_value = client
+		self.assertEqual(get_container_health("gone"), "Unknown")

--- a/frontend/src/pages/BenchInstances.vue
+++ b/frontend/src/pages/BenchInstances.vue
@@ -55,7 +55,34 @@ const columns = [
 	},
 	{ label: "CPU %", key: "cpu_usage", width: "80px" },
 	{ label: "Memory %", key: "memory_usage", width: "100px" },
+	{
+		label: "Health",
+		key: "container_health",
+		width: "110px",
+		getLabel: ({ row }) => row.container_health || "—",
+		prefix: ({ row }) => {
+			if (!row.container_health) return null;
+			const color =
+				{
+					Healthy: "green",
+					Unhealthy: "red",
+					Unknown: "gray",
+				}[row.container_health] || "gray";
+			return h(Badge, { label: row.container_health, theme: color, size: "sm" });
+		},
+	},
+	{
+		label: "Last Check",
+		key: "last_health_check",
+		width: "150px",
+		getLabel: ({ row }) => formatCheckTime(row.last_health_check),
+	},
 ];
+
+function formatCheckTime(value) {
+	if (!value) return "—";
+	return value.slice(0, 16).replace("T", " ");
+}
 
 let benches = createListResource({
 	doctype: "Bench Instance",
@@ -71,6 +98,8 @@ let benches = createListResource({
 		"wg_ip",
 		"cpu_usage",
 		"memory_usage",
+		"container_health",
+		"last_health_check",
 		"started_at",
 	],
 	orderBy: "creation desc",


### PR DESCRIPTION
## Summary

First **tracer-bullet** slice of **#39 [P1-03] Add health checks, alerts, and richer observability**: a thin end-to-end vertical that surfaces whether each running bench's Docker container is actually alive.

This goes through every layer — Docker inspect → scheduler → DocType field → API → frontend — so the architecture is validated before the broader observability work is built out.

## What's included

- **`docker_manager.get_container_health()`** — maps the live Docker container state to a coarse label:
  - `running` → **Healthy**
  - `exited` / `paused` / `dead` / `restarting` → **Unhealthy**
  - missing container or inspect failure → **Unknown**
  - This deliberately mirrors *actual* container state, so a bench whose DB `status` has drifted from reality gets flagged.
- **`stats_collector._update_bench_health()`** — records `container_health` + `last_health_check` inside the **existing per-minute stats cron loop**, so there's **no new scheduler and no extra overhead** (addresses "Scheduler updates health without excessive overhead").
- **Bench Instance** DocType: new read-only fields `container_health` (Select) and `last_health_check` (Datetime), placed in the Resource Usage section. Named distinctly from the phase-3 `health_status` ("Public Health") to avoid a field collision.
- **`api.get_benches()`** returns the two fields.
- **`BenchInstances.vue`**: a **Health** badge column (green/red/gray) + a **Last Check** column — mirrors the existing Status-badge pattern.

## Acceptance criteria (this slice)

- [x] Bench detail/list shows **health status** and **last check time**.
- [x] Scheduler updates health **without** extra overhead (piggybacks existing cron).
- [ ] _Follow-up:_ admin "failing benches at a glance" summary.
- [ ] _Follow-up:_ failed deploy/build actionable error summary.

## Verification

- `bench run-tests --module benchpress.tests.test_docker_manager` → **3/3 pass** (Healthy / Unhealthy / Unknown mappings).
- `bench migrate` adds both columns to `tabBench Instance`.
- `get_benches()` returns `container_health: "Healthy"` + `last_health_check` for a live record.
- `bench build` rebuilds the SPA; the `BenchInstances` chunk contains the new columns; page + asset both serve HTTP 200.
- `pre-commit run` (ruff, ruff-format, prettier, whitespace) → all pass.

## Notes for next iterations

This tracer covers **container liveness only**. Remaining #39 scope to fan out next: Frappe-web / Redis / MariaDB connectivity checks, last deploy/build duration + failure reason, CPU/RAM/disk threshold warnings, and an admin dashboard summary of failing benches.

Browser pixel-render was not verified (no Chrome available in this environment); validated instead via HTTP 200 + a grep that the compiled bundle ships the new columns.

Closes #39 only partially — keeping the issue open for the follow-up slices above.

Refs #39