### PR TITLE
feat(labs): wire Lab.shell to container provisioning (#49)

### DIFF
--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -54,6 +54,25 @@ def remove_bench_volume(bench_name: str) -> None:
 		pass  # best-effort
 
 
+def build_linkuser_args(bench, lab, settings, ssh_password: str) -> list[str]:
+	"""Positional arguments for linkuser.sh, in the order the script reads them.
+
+	Order must match scripts/linkuser.sh:
+	USERNAME EMAIL LAB_NAME WG_IP SSH_PASSWORD BENCH_NAME BASE_DOMAIN MOUNT_TARGET LOGIN_SHELL
+	"""
+	return [
+		bench.ssh_username,
+		bench.owner,
+		lab.title,
+		bench.wg_ip or "0.0.0.0",
+		ssh_password,
+		bench.bench_name,
+		settings.base_domain or "localhost",
+		lab.mount_target or "/home/frappe",
+		lab.shell or "/bin/bash",
+	]
+
+
 def _make_log_appender(doctype: str, log_name: str, event: str, context: dict):
 	def append_log(line: str, log_type: str = "info") -> None:
 		frappe.publish_realtime(  # nosemgrep -- the SPA listens via raw socket.io without doc-room subscription; room-scoping would drop its events
@@ -237,16 +256,7 @@ def deploy_bench(bench_name: str) -> None:
 			bench.ssh_username = bench._derive_username(bench.owner)
 
 		ssh_password = secrets.token_urlsafe(12)
-		linkuser_args = [
-			bench.ssh_username,
-			bench.owner,
-			lab.title,
-			bench.wg_ip or "0.0.0.0",
-			ssh_password,
-			bench.bench_name,
-			settings.base_domain or "localhost",
-			lab.mount_target or "/home/frappe",
-		]
+		linkuser_args = build_linkuser_args(bench, lab, settings, ssh_password)
 		append_log(f"=== Provisioning SSH user '{bench.ssh_username}' ===")
 		linkuser_cmd = "bash /opt/benchpress/scripts/linkuser.sh " + " ".join(f"'{a}'" for a in linkuser_args)
 		exit_code, output = exec_in_container(container_id, linkuser_cmd, user="root")

--- a/benchpress/lab-templates/scripts/linkuser.sh
+++ b/benchpress/lab-templates/scripts/linkuser.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # linkuser.sh — User provisioning for BenchPress containers
 # Renames the 'frappe' user to the dynamic username instead of creating a new one.
-# Args: USERNAME EMAIL LAB_NAME WG_IP SSH_PASSWORD BENCH_NAME BASE_DOMAIN MOUNT_TARGET
+# Args: USERNAME EMAIL LAB_NAME WG_IP SSH_PASSWORD BENCH_NAME BASE_DOMAIN MOUNT_TARGET LOGIN_SHELL
 
 set -e
 
@@ -13,6 +13,7 @@ SSH_PASSWORD="$5"
 BENCH_NAME="$6"
 BASE_DOMAIN="$7"
 MOUNT_TARGET="${8:-/home/frappe}"
+LOGIN_SHELL="${9:-/bin/bash}"
 
 if [ -z "$USERNAME" ] || [ -z "$SSH_PASSWORD" ]; then
     echo "[error] USERNAME and SSH_PASSWORD are required"
@@ -27,7 +28,13 @@ groupmod -n "$USERNAME" frappe
 usermod --login "$USERNAME" --home "/home/$USERNAME" frappe
 ln -sfn /home/frappe "/home/$USERNAME"
 
-usermod --shell /bin/bash "$USERNAME"
+# Honor the lab's configured login shell; fall back to bash if it is missing
+# or not executable in this image (also guards against a malformed value).
+if [ ! -x "$LOGIN_SHELL" ]; then
+    echo "[warn] login shell '$LOGIN_SHELL' not found or not executable; falling back to /bin/bash"
+    LOGIN_SHELL="/bin/bash"
+fi
+usermod --shell "$LOGIN_SHELL" "$USERNAME"
 usermod -aG sudo "$USERNAME"
 
 echo "[*] Setting SSH password..."

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -189,3 +189,31 @@ class TestDeployManager(IntegrationTestCase):
 
 		redeploy_bench(bench.name)
 		mock_drop_db.assert_called_once_with(self.db_server_name, bench.site_name)
+
+	# --- build_linkuser_args (Lab.shell wiring) ---
+
+	def test_build_linkuser_args_includes_lab_shell(self):
+		from benchpress.deploy_manager import build_linkuser_args
+
+		bench = self._fresh_bench()
+		bench.ssh_username = "tester"
+		self.lab.shell = "/bin/zsh"
+		settings = frappe.get_single("BenchPress Settings")
+
+		args = build_linkuser_args(bench, self.lab, settings, "secret-pw")
+
+		self.assertEqual(len(args), 9)
+		self.assertEqual(args[4], "secret-pw")  # SSH_PASSWORD position
+		self.assertEqual(args[-1], "/bin/zsh")  # LOGIN_SHELL position
+
+	def test_build_linkuser_args_defaults_shell_to_bash(self):
+		from benchpress.deploy_manager import build_linkuser_args
+
+		bench = self._fresh_bench()
+		bench.ssh_username = "tester"
+		self.lab.shell = None
+		settings = frappe.get_single("BenchPress Settings")
+
+		args = build_linkuser_args(bench, self.lab, settings, "pw")
+
+		self.assertEqual(args[-1], "/bin/bash")


### PR DESCRIPTION
## What

First tracer-bullet slice of **#49 [P2-02] Finish or remove half-wired Lab/Settings fields**: wires the `Lab.shell` field end-to-end (field → deploy behavior → test).

`Lab.shell` had a default of `/bin/bash` but was never honored — `linkuser.sh` hardcoded `usermod --shell /bin/bash`. Now the lab's configured login shell flows through to the provisioned container user.

## Changes

- **`deploy_manager.py`** — extracted `build_linkuser_args(bench, lab, settings, ssh_password)` so the positional arg list (now including `LOGIN_SHELL`) is unit-testable without spinning up a container. `deploy_bench` calls the helper instead of building the list inline.
- **`lab-templates/scripts/linkuser.sh`** — accepts a 9th positional arg `LOGIN_SHELL` (default `/bin/bash`), validates it with `[ -x ]` and falls back to `/bin/bash` if it is missing / not executable in the image. The guard also neutralizes a malformed value before it reaches `usermod`.
- **`tests/test_deploy_manager.py`** — 2 unit tests: custom shell is passed through, and `None`/empty defaults to `/bin/bash`.

## Verification

- `bench run-tests --module benchpress.tests.test_deploy_manager` → **8/8 pass** (incl. 2 new).
- `bash -n linkuser.sh` clean; `pre-commit` clean (ruff lint/format/imports, whitespace, AST).
- Browser test N/A — `shell` is a Desk-side Lab config gated on `enable_ssh` with no SPA surface (confirmed no `shell` refs in `frontend/src`).

## Scope note

This slice wires **one** field. The remaining half-wired fields in #49 (`Lab.mount_target`, IOPS/BPS block-I/O limits, `Database Server.custom_config`) are intentionally left for follow-up RALPH iterations to keep the change small and reviewable.

Closes part of #49.