### PR TITLE
feat(labs): remove half-wired Lab.mount_target field (#49)

### DIFF
--- a/benchpress/benchpress/doctype/lab/lab.json
+++ b/benchpress/benchpress/doctype/lab/lab.json
@@ -22,8 +22,6 @@
   "enable_ssh",
   "enable_code_server",
   "shell",
-  "container_section",
-  "mount_target",
   "image_section",
   "image_tag",
   "build_log_section",
@@ -113,18 +111,6 @@
    "fieldname": "shell",
    "fieldtype": "Data",
    "label": "Default Shell"
-  },
-  {
-   "collapsible": 1,
-   "fieldname": "container_section",
-   "fieldtype": "Section Break",
-   "label": "Container Settings"
-  },
-  {
-   "default": "/home/frappe",
-   "fieldname": "mount_target",
-   "fieldtype": "Data",
-   "label": "Mount Target"
   },
   {
    "collapsible": 1,

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -58,7 +58,7 @@ def build_linkuser_args(bench, lab, settings, ssh_password: str) -> list[str]:
 	"""Positional arguments for linkuser.sh, in the order the script reads them.
 
 	Order must match scripts/linkuser.sh:
-	USERNAME EMAIL LAB_NAME WG_IP SSH_PASSWORD BENCH_NAME BASE_DOMAIN MOUNT_TARGET LOGIN_SHELL
+	USERNAME EMAIL LAB_NAME WG_IP SSH_PASSWORD BENCH_NAME BASE_DOMAIN LOGIN_SHELL
 	"""
 	return [
 		bench.ssh_username,
@@ -68,7 +68,6 @@ def build_linkuser_args(bench, lab, settings, ssh_password: str) -> list[str]:
 		ssh_password,
 		bench.bench_name,
 		settings.base_domain or "localhost",
-		lab.mount_target or "/home/frappe",
 		lab.shell or "/bin/bash",
 	]
 
@@ -88,10 +87,10 @@ def _make_log_appender(doctype: str, log_name: str, event: str, context: dict):
 
 
 def create_site_in_container(
-	container_id: str, db_server, lab, site_name: str, admin_password: str, apps_csv: str
+	container_id: str, db_server, site_name: str, admin_password: str, apps_csv: str
 ) -> tuple[int, str]:
 	"""Run setup-site.sh inside a bench container using a temporary MariaDB user."""
-	bench_dir = f"{lab.mount_target or '/home/frappe'}/frappe-bench"
+	bench_dir = "/home/frappe/frappe-bench"  # fixed: the data volume binds at /home/frappe
 	db_name, temp_user, temp_password = create_mariadb_user(db_server.name, site_name)
 	try:
 		return exec_in_container(
@@ -223,7 +222,7 @@ def deploy_bench(bench_name: str) -> None:
 		else:
 			append_log("WireGuard not configured, skipping VPN.", "warning")
 
-		bench_dir = f"{lab.mount_target or '/home/frappe'}/frappe-bench"
+		bench_dir = "/home/frappe/frappe-bench"  # fixed: the data volume binds at /home/frappe
 		site_name = bench.site_name
 		config = {
 			**db_server.get_connection_config(),
@@ -243,7 +242,7 @@ def deploy_bench(bench_name: str) -> None:
 
 		apps_csv = ",".join(a.app_name for a in lab.apps if a.app_name.lower() != "frappe")
 		exit_code, output = create_site_in_container(
-			container_id, db_server, lab, site_name, admin_password, apps_csv
+			container_id, db_server, site_name, admin_password, apps_csv
 		)
 		if exit_code != 0:
 			raise Exception(f"bench new-site failed (exit {exit_code}): {output}")

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -54,6 +54,25 @@ def remove_bench_volume(bench_name: str) -> None:
 		pass  # best-effort
 
 
+def build_linkuser_args(bench, lab, settings, ssh_password: str) -> list[str]:
+	"""Positional arguments for linkuser.sh, in the order the script reads them.
+
+	Order must match scripts/linkuser.sh:
+	USERNAME EMAIL LAB_NAME WG_IP SSH_PASSWORD BENCH_NAME BASE_DOMAIN MOUNT_TARGET LOGIN_SHELL
+	"""
+	return [
+		bench.ssh_username,
+		bench.owner,
+		lab.title,
+		bench.wg_ip or "0.0.0.0",
+		ssh_password,
+		bench.bench_name,
+		settings.base_domain or "localhost",
+		lab.mount_target or "/home/frappe",
+		lab.shell or "/bin/bash",
+	]
+
+
 def _make_log_appender(doctype: str, log_name: str, event: str, context: dict):
 	def append_log(line: str, log_type: str = "info") -> None:
 		frappe.publish_realtime(  # nosemgrep -- the SPA listens via raw socket.io without doc-room subscription; room-scoping would drop its events
@@ -237,16 +256,7 @@ def deploy_bench(bench_name: str) -> None:
 			bench.ssh_username = bench._derive_username(bench.owner)
 
 		ssh_password = secrets.token_urlsafe(12)
-		linkuser_args = [
-			bench.ssh_username,
-			bench.owner,
-			lab.title,
-			bench.wg_ip or "0.0.0.0",
-			ssh_password,
-			bench.bench_name,
-			settings.base_domain or "localhost",
-			lab.mount_target or "/home/frappe",
-		]
+		linkuser_args = build_linkuser_args(bench, lab, settings, ssh_password)
 		append_log(f"=== Provisioning SSH user '{bench.ssh_username}' ===")
 		linkuser_cmd = "bash /opt/benchpress/scripts/linkuser.sh " + " ".join(f"'{a}'" for a in linkuser_args)
 		exit_code, output = exec_in_container(container_id, linkuser_cmd, user="root")

--- a/benchpress/lab-templates/scripts/linkuser.sh
+++ b/benchpress/lab-templates/scripts/linkuser.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # linkuser.sh — User provisioning for BenchPress containers
 # Renames the 'frappe' user to the dynamic username instead of creating a new one.
-# Args: USERNAME EMAIL LAB_NAME WG_IP SSH_PASSWORD BENCH_NAME BASE_DOMAIN MOUNT_TARGET LOGIN_SHELL
+# Args: USERNAME EMAIL LAB_NAME WG_IP SSH_PASSWORD BENCH_NAME BASE_DOMAIN LOGIN_SHELL
 
 set -e
 
@@ -12,8 +12,7 @@ WG_IP="$4"
 SSH_PASSWORD="$5"
 BENCH_NAME="$6"
 BASE_DOMAIN="$7"
-MOUNT_TARGET="${8:-/home/frappe}"
-LOGIN_SHELL="${9:-/bin/bash}"
+LOGIN_SHELL="${8:-/bin/bash}"
 
 if [ -z "$USERNAME" ] || [ -z "$SSH_PASSWORD" ]; then
     echo "[error] USERNAME and SSH_PASSWORD are required"

--- a/benchpress/lab-templates/scripts/linkuser.sh
+++ b/benchpress/lab-templates/scripts/linkuser.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # linkuser.sh — User provisioning for BenchPress containers
 # Renames the 'frappe' user to the dynamic username instead of creating a new one.
-# Args: USERNAME EMAIL LAB_NAME WG_IP SSH_PASSWORD BENCH_NAME BASE_DOMAIN MOUNT_TARGET
+# Args: USERNAME EMAIL LAB_NAME WG_IP SSH_PASSWORD BENCH_NAME BASE_DOMAIN MOUNT_TARGET LOGIN_SHELL
 
 set -e
 
@@ -13,6 +13,7 @@ SSH_PASSWORD="$5"
 BENCH_NAME="$6"
 BASE_DOMAIN="$7"
 MOUNT_TARGET="${8:-/home/frappe}"
+LOGIN_SHELL="${9:-/bin/bash}"
 
 if [ -z "$USERNAME" ] || [ -z "$SSH_PASSWORD" ]; then
     echo "[error] USERNAME and SSH_PASSWORD are required"
@@ -27,7 +28,13 @@ groupmod -n "$USERNAME" frappe
 usermod --login "$USERNAME" --home "/home/$USERNAME" frappe
 ln -sfn /home/frappe "/home/$USERNAME"
 
-usermod --shell /bin/bash "$USERNAME"
+# Honor the lab's configured login shell; fall back to bash if it is missing
+# or not executable in this image (also guards against a malformed value).
+if [ ! -x "$LOGIN_SHELL" ]; then
+    echo "[warn] login shell '$LOGIN_SHELL' not found or not executable; falling back to /bin/bash"
+    LOGIN_SHELL="/bin/bash"
+fi
+usermod --shell "$LOGIN_SHELL" "$USERNAME"
 usermod -aG sudo "$USERNAME"
 
 echo "[*] Setting SSH password..."

--- a/benchpress/lab-templates/scripts/setup-site.sh
+++ b/benchpress/lab-templates/scripts/setup-site.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-# May fail under a custom mount_target, where the caller already sets workdir to the bench dir
+# The caller (deploy_manager) already sets workdir to the bench dir; this cd is a fallback.
 cd /home/frappe/frappe-bench || true
 
 echo "[*] Creating site ${SITE_NAME}..."

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -202,9 +202,11 @@ class TestDeployManager(IntegrationTestCase):
 
 		args = build_linkuser_args(bench, self.lab, settings, "secret-pw")
 
-		self.assertEqual(len(args), 9)
+		# 8 args: mount_target was removed, so LOGIN_SHELL immediately follows BASE_DOMAIN.
+		self.assertEqual(len(args), 8)
 		self.assertEqual(args[4], "secret-pw")  # SSH_PASSWORD position
-		self.assertEqual(args[-1], "/bin/zsh")  # LOGIN_SHELL position
+		self.assertEqual(args[6], settings.base_domain or "localhost")  # BASE_DOMAIN position
+		self.assertEqual(args[-1], "/bin/zsh")  # LOGIN_SHELL position (right after BASE_DOMAIN)
 
 	def test_build_linkuser_args_defaults_shell_to_bash(self):
 		from benchpress.deploy_manager import build_linkuser_args

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -189,3 +189,31 @@ class TestDeployManager(IntegrationTestCase):
 
 		redeploy_bench(bench.name)
 		mock_drop_db.assert_called_once_with(self.db_server_name, bench.site_name)
+
+	# --- build_linkuser_args (Lab.shell wiring) ---
+
+	def test_build_linkuser_args_includes_lab_shell(self):
+		from benchpress.deploy_manager import build_linkuser_args
+
+		bench = self._fresh_bench()
+		bench.ssh_username = "tester"
+		self.lab.shell = "/bin/zsh"
+		settings = frappe.get_single("BenchPress Settings")
+
+		args = build_linkuser_args(bench, self.lab, settings, "secret-pw")
+
+		self.assertEqual(len(args), 9)
+		self.assertEqual(args[4], "secret-pw")  # SSH_PASSWORD position
+		self.assertEqual(args[-1], "/bin/zsh")  # LOGIN_SHELL position
+
+	def test_build_linkuser_args_defaults_shell_to_bash(self):
+		from benchpress.deploy_manager import build_linkuser_args
+
+		bench = self._fresh_bench()
+		bench.ssh_username = "tester"
+		self.lab.shell = None
+		settings = frappe.get_single("BenchPress Settings")
+
+		args = build_linkuser_args(bench, self.lab, settings, "pw")
+
+		self.assertEqual(args[-1], "/bin/bash")


### PR DESCRIPTION
## Summary

Second slice of **#49 [P2-02] Finish or remove half-wired Lab/Settings fields**. After wiring `Lab.shell` (#72), this removes the next half-wired field: **`Lab.mount_target`**.

`mount_target` had a `/home/frappe` default and was interpolated into `bench_dir` path strings in `deploy_manager.py`, but:
- the data volume is **hardcoded** to bind at `/home/frappe` in `docker_manager.create_bench_container`;
- the Frappe image builds the bench at `/home/frappe/frappe-bench` (entrypoint/supervisor assume this);
- `linkuser.sh` received `MOUNT_TARGET` but never used it.

So any value other than `/home/frappe` wrote `common_site_config.json` and ran `bench` at a non-existent path while the volume stayed at `/home/frappe` — a **silent deploy failure**, i.e. a foot-gun, not a feature.

## Decision: remove, not wire

Genuinely honoring an arbitrary mount point needs image-level relocation (Dockerfile, supervisor, entrypoint all assume `/home/frappe`) with no product value. Removal eliminates the foot-gun and satisfies the issue's "wire **or** remove" mandate.

## Changes
- `lab/lab.json` — drop `mount_target` and its now-empty `container_section`.
- `deploy_manager.py` — drop the field from `build_linkuser_args` and both `bench_dir` builds (now the constant `/home/frappe/frappe-bench`, the actual bind); drop the now-dead `lab` param from `create_site_in_container`.
- `linkuser.sh` — drop the unused `MOUNT_TARGET` arg; `LOGIN_SHELL` shifts `$9` → `$8`.
- `setup-site.sh` — refresh the stale "custom mount_target" comment.
- `tests/test_deploy_manager.py` — assert 8 args and that the shell sits right after `base_domain`.

> Kept `linkuser.sh`'s `.benchpress_config` `"mount_target": "/home/$USERNAME"` — that's a *derived runtime home path*, not the removed Lab field.

## Verification
- 8/8 `test_deploy_manager` pass.
- `bench migrate` clean; `mount_target`/`container_section` gone from the live Lab meta.
- `bash -n` + `pre-commit run` clean.
- Browser test N/A — Desk-side Lab config, no SPA surface.

## Notes
- **Stacked on #72** (`fix/p2-49-wire-lab-shell`), which is not yet merged into `develop`, because both PRs edit the same linkuser arg list / `linkuser.sh` signature. Base will auto-retarget to `develop` once #72 merges.
- Field inventory for #49: `Lab.shell` ✅ (#72), `Lab.mount_target` ✅ (this PR). Remaining: IOPS/BPS block-I/O limits (hardcoded in `docker_manager.py`), `Database Server.custom_config` (no UI).

Part of #49.