### PR TITLE
feat(labs): wire Lab block-I/O (IOPS/BPS) limits end-to-end (#49)

### DIFF
--- a/benchpress/benchpress/doctype/lab/lab.json
+++ b/benchpress/benchpress/doctype/lab/lab.json
@@ -18,6 +18,8 @@
   "resources_section",
   "memory_limit",
   "cpu_cores",
+  "iops_limit",
+  "bps_limit",
   "column_break_resources",
   "enable_ssh",
   "enable_code_server",
@@ -96,6 +98,20 @@
    "fieldname": "cpu_cores",
    "fieldtype": "Int",
    "label": "CPU Cores"
+  },
+  {
+   "description": "Read/write IOPS cap per host block device. Leave 0 for the default (1000).",
+   "fieldname": "iops_limit",
+   "fieldtype": "Int",
+   "label": "Max IOPS (Block I/O)",
+   "non_negative": 1
+  },
+  {
+   "description": "Read/write throughput cap in bytes/sec per host block device. Leave 0 for the default (40 MiB/s).",
+   "fieldname": "bps_limit",
+   "fieldtype": "Int",
+   "label": "Max Bytes/sec (Block I/O)",
+   "non_negative": 1
   },
   {
    "fieldname": "column_break_resources",

--- a/benchpress/tests/test_docker_manager.py
+++ b/benchpress/tests/test_docker_manager.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+import types
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+import benchpress.docker_manager as docker_manager
+from benchpress.docker_manager import DEFAULT_BPS, DEFAULT_IOPS
+
+
+def _make_lab(lab_id, **extra):
+	if frappe.db.exists("Lab", lab_id):
+		frappe.delete_doc("Lab", lab_id, force=True, ignore_permissions=True)
+	doc = frappe.get_doc(
+		{
+			"doctype": "Lab",
+			"lab_id": lab_id,
+			"title": f"Test Lab {lab_id}",
+			"frappe_version": "version-15",
+			"image_tag": "benchpress/test:latest",
+			**extra,
+		}
+	).insert(ignore_permissions=True)
+	frappe.db.commit()
+	return doc
+
+
+class TestDockerManagerBlockIO(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+
+	def _container_create_kwargs(self, lab):
+		"""Run create_bench_container with Docker mocked and return the
+		kwargs passed to client.containers.create."""
+		bench = types.SimpleNamespace(bench_name="blockio-test-bench")
+		with (
+			patch("benchpress.docker_manager.get_client") as mock_client,
+			patch("benchpress.docker_manager.ensure_network"),
+			patch("benchpress.docker_manager._get_host_block_devices", return_value=["/dev/sda"]),
+		):
+			mock_client.return_value.containers.create.return_value = MagicMock(id="cid")
+			docker_manager.create_bench_container(bench, lab)
+			return mock_client.return_value.containers.create.call_args.kwargs
+
+	def test_lab_block_io_limits_passed_to_container(self):
+		lab = _make_lab("blockio-custom", iops_limit=500, bps_limit=2 * 1024 * 1024)
+		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
+
+		kwargs = self._container_create_kwargs(lab)
+
+		self.assertEqual(kwargs["device_read_iops"], [{"Path": "/dev/sda", "Rate": 500}])
+		self.assertEqual(kwargs["device_write_iops"], [{"Path": "/dev/sda", "Rate": 500}])
+		self.assertEqual(kwargs["device_read_bps"], [{"Path": "/dev/sda", "Rate": 2 * 1024 * 1024}])
+		self.assertEqual(kwargs["device_write_bps"], [{"Path": "/dev/sda", "Rate": 2 * 1024 * 1024}])
+
+	def test_unset_block_io_limits_fall_back_to_defaults(self):
+		# iops_limit / bps_limit default to 0, which means "use the default".
+		lab = _make_lab("blockio-default")
+		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
+
+		kwargs = self._container_create_kwargs(lab)
+
+		self.assertEqual(kwargs["device_read_iops"], [{"Path": "/dev/sda", "Rate": DEFAULT_IOPS}])
+		self.assertEqual(kwargs["device_write_bps"], [{"Path": "/dev/sda", "Rate": DEFAULT_BPS}])

--- a/frontend/src/pages/NewLab.vue
+++ b/frontend/src/pages/NewLab.vue
@@ -67,6 +67,18 @@
 					placeholder="e.g. 512m"
 				/>
 				<FormControl label="CPU Cores" v-model="form.cpu_cores" type="number" />
+				<FormControl
+					label="Max IOPS (Block I/O)"
+					v-model="form.iops_limit"
+					type="number"
+					description="Per host block device. 0 = default (1000)."
+				/>
+				<FormControl
+					label="Max Bytes/sec (Block I/O)"
+					v-model="form.bps_limit"
+					type="number"
+					description="Per host block device. 0 = default (40 MiB/s)."
+				/>
 			</div>
 		</div>
 
@@ -142,6 +154,8 @@ const form = reactive({
 	description: "",
 	memory_limit: "512m",
 	cpu_cores: 1,
+	iops_limit: 0,
+	bps_limit: 0,
 	apps: [],
 });
 
@@ -173,6 +187,8 @@ async function createLab() {
 			description: form.description,
 			memory_limit: form.memory_limit,
 			cpu_cores: form.cpu_cores,
+			iops_limit: form.iops_limit,
+			bps_limit: form.bps_limit,
 			apps: form.apps.filter((a) => a.app_name && a.git_url && a.branch),
 		});
 		router.push("/labs");


### PR DESCRIPTION
## What & why

Third slice of #49 (**[P2-02] Finish or remove half-wired Lab/Settings fields**) — the "wire **or** remove" mandate, this time for the **IOPS/BPS block-I/O limits**.

`docker_manager.create_bench_container` *already* read the limits:

```python
iops = int(getattr(lab_doc, "iops_limit", None) or DEFAULT_IOPS)   # 1000
bps  = int(getattr(lab_doc, "bps_limit", None) or DEFAULT_BPS)     # 40 MiB/s
```

…but the **Lab DocType had no such fields**, so `getattr` always returned `None` and every container fell back to the hardcoded defaults. The read side was wired; nothing could set it. This makes the field settable end-to-end: **field → deploy behavior → test**.

## Changes

- **`lab.json`** — added `iops_limit` / `bps_limit` `Int` fields in *Resources & Access*, beside Memory/CPU (`non_negative`, descriptions stating `0 = default`).
- **`NewLab.vue`** — surfaced both as number inputs in the SPA *New Lab* form (the primary Lab-creation path) and added them to the create payload.
- **`test_docker_manager.py`** — 2 new tests.

## Key decision

Kept the fields as raw `Int` (IOPS count / bytes-per-sec) to match `docker_manager`'s existing `int(... or DEFAULT)` contract — **no code change to `docker_manager.py`**. The `or DEFAULT` fallback already makes an unset `0` mean "use default", so the wiring goes live purely from adding the fields.

## Verification

- ✅ `test_docker_manager` — 2/2 pass (custom values flow into Docker `device_*_iops/bps` kwargs; unset `0` → `DEFAULT_IOPS`/`DEFAULT_BPS`).
- ✅ `test_deploy_manager` — 6/6 pass (no regression).
- ✅ `bench migrate` applies the columns (confirmed present in live Lab meta).
- ✅ `bench build` succeeds; `/frontend/labs/new` serves **200** and the built `NewLab` bundle contains the new fields.
- ✅ `pre-commit` clean (ruff / ruff-format / prettier / json / whitespace).
- ⚠️ Interactive browser test skipped — the agent-browser container (`172.30.0.168:9229`) the chrome-devtools MCP targets isn't running in this env; verified via HTTP 200 + served-bundle grep instead.

## Field inventory progress (#49)

- [x] `Lab.shell` — wired (#72)
- [x] `Lab.mount_target` — removed (#73)
- [x] **IOPS/BPS block-I/O limits — wired (this PR)**
- [ ] `Database Server.custom_config` — field exists, no UI to edit

> Note: `Lab.pids_limit` is half-wired the same way (read in `docker_manager`, no field) — a candidate to fold into a follow-up.

Closes part of #49.