### PR TITLE
feat(labs): lab template picker UI — one-click create (#37)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -17,6 +17,7 @@ import { userContext } from "@/data/userContext";
 
 import ServerIcon from "~icons/lucide/server";
 import FlaskConicalIcon from "~icons/lucide/flask-conical";
+import LayoutTemplateIcon from "~icons/lucide/layout-template";
 import ScrollTextIcon from "~icons/lucide/scroll-text";
 import HammerIcon from "~icons/lucide/hammer";
 import ShieldIcon from "~icons/lucide/shield";
@@ -59,16 +60,16 @@ const headerConfig = computed(() => {
 });
 
 const sections = computed(() => {
-	const items = [
-		{
-			label: "",
-			items: [
-				{ label: "Labs", icon: FlaskConicalIcon, to: "/labs" },
-				{ label: "Bench Instances", icon: ServerIcon, to: "/bench-instances" },
-				{ label: "VPN Devices", icon: ShieldIcon, to: "/devices" },
-			],
-		},
-	];
+	const labItems = [{ label: "Labs", icon: FlaskConicalIcon, to: "/labs" }];
+	if (userContext.isAdmin) {
+		labItems.push({ label: "Templates", icon: LayoutTemplateIcon, to: "/labs/templates" });
+	}
+	labItems.push(
+		{ label: "Bench Instances", icon: ServerIcon, to: "/bench-instances" },
+		{ label: "VPN Devices", icon: ShieldIcon, to: "/devices" }
+	);
+
+	const items = [{ label: "", items: labItems }];
 
 	const logItems = [{ label: "Deploy Logs", icon: ScrollTextIcon, to: "/deploy-logs" }];
 	if (userContext.isAdmin) {

--- a/frontend/src/pages/LabTemplates.vue
+++ b/frontend/src/pages/LabTemplates.vue
@@ -1,0 +1,152 @@
+<template>
+	<div class="p-4">
+		<div class="mb-4 flex items-center justify-between">
+			<div>
+				<h1 class="text-xl font-semibold text-ink-gray-9">Lab Templates</h1>
+				<p class="mt-1 text-sm text-ink-gray-5">
+					Spin up a ready-made stack in one click, then tweak it like any other lab.
+				</p>
+			</div>
+			<Button appearance="minimal" @click="$router.push('/labs')">Back to Labs</Button>
+		</div>
+
+		<div
+			v-if="templates.data && templates.data.length"
+			class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
+		>
+			<div
+				v-for="template in templates.data"
+				:key="template.key"
+				class="flex flex-col rounded-lg border border-outline-gray-1 bg-surface-white p-4"
+			>
+				<div class="mb-2 flex items-start justify-between gap-2">
+					<h2 class="text-base font-medium text-ink-gray-8">{{ template.title }}</h2>
+					<Badge theme="blue" variant="subtle" :label="template.frappe_version" />
+				</div>
+				<p class="mb-3 flex-1 text-sm text-ink-gray-5">{{ template.description }}</p>
+
+				<div class="mb-3 flex flex-wrap gap-1">
+					<Badge
+						v-for="app in template.apps"
+						:key="app.app_name"
+						theme="gray"
+						variant="subtle"
+						:label="app.app_label || app.app_name"
+					/>
+					<Badge
+						v-if="!template.apps.length"
+						theme="gray"
+						variant="subtle"
+						label="Bare bench"
+					/>
+				</div>
+
+				<div class="mb-4 flex items-center gap-4 text-xs text-ink-gray-5">
+					<span>{{ template.memory_limit }} RAM</span>
+					<span
+						>{{ template.cpu_cores }}
+						{{ template.cpu_cores === 1 ? "core" : "cores" }}</span
+					>
+				</div>
+
+				<Button class="w-full" appearance="primary" @click="openCreate(template)">
+					Use this template
+				</Button>
+			</div>
+		</div>
+		<div v-else-if="templates.loading" class="text-base text-ink-gray-5">Loading...</div>
+		<div v-else class="py-12 text-center text-base text-ink-gray-5">
+			No templates available.
+		</div>
+
+		<Dialog
+			:options="{ title: `New lab from ${selectedTemplate?.title || 'template'}` }"
+			v-model="showCreateDialog"
+		>
+			<template #body-content>
+				<div class="space-y-4">
+					<FormControl
+						label="Lab ID"
+						v-model="form.lab_id"
+						type="text"
+						placeholder="e.g. crm-lab"
+						description="Lowercase letters, numbers and single '.', '_' or '-' separators"
+						:required="true"
+					/>
+					<FormControl
+						label="Title"
+						v-model="form.title"
+						type="text"
+						:placeholder="selectedTemplate?.title"
+						description="Optional — defaults to the template name"
+					/>
+					<ErrorMessage :message="createAction.error" />
+				</div>
+			</template>
+			<template #actions>
+				<Button
+					appearance="primary"
+					class="w-full"
+					:loading="createAction.loading"
+					@click="createFromTemplate"
+				>
+					Create Lab
+				</Button>
+			</template>
+		</Dialog>
+	</div>
+</template>
+
+<script setup>
+import { reactive, ref } from "vue";
+import { useRouter } from "vue-router";
+import {
+	Badge,
+	Button,
+	Dialog,
+	ErrorMessage,
+	FormControl,
+	createResource,
+	toast,
+} from "frappe-ui";
+
+const router = useRouter();
+
+const showCreateDialog = ref(false);
+const selectedTemplate = ref(null);
+const form = reactive({ lab_id: "", title: "" });
+
+const templates = createResource({
+	url: "benchpress.api.get_lab_templates",
+	auto: true,
+});
+
+const createAction = createResource({
+	url: "benchpress.api.create_lab_from_template",
+	onSuccess(data) {
+		showCreateDialog.value = false;
+		toast.success("Lab created from template");
+		router.push({ name: "LabDetail", params: { labId: data.name } });
+	},
+});
+
+function openCreate(template) {
+	selectedTemplate.value = template;
+	form.lab_id = "";
+	form.title = "";
+	createAction.error = null;
+	showCreateDialog.value = true;
+}
+
+function createFromTemplate() {
+	if (!form.lab_id) {
+		toast.error("Lab ID is required");
+		return;
+	}
+	createAction.submit({
+		template: selectedTemplate.value.key,
+		lab_id: form.lab_id,
+		title: form.title || null,
+	});
+}
+</script>

--- a/frontend/src/pages/Labs.vue
+++ b/frontend/src/pages/Labs.vue
@@ -2,14 +2,18 @@
 	<div class="p-4">
 		<div class="mb-4 flex items-center justify-between">
 			<h1 class="text-xl font-semibold text-ink-gray-9">Labs</h1>
-			<Button
-				v-if="userContext.isAdmin"
-				appearance="primary"
-				icon-left="plus"
-				@click="$router.push('/labs/new')"
-			>
-				New Lab
-			</Button>
+			<div v-if="userContext.isAdmin" class="flex gap-2">
+				<Button
+					appearance="minimal"
+					icon-left="grid"
+					@click="$router.push('/labs/templates')"
+				>
+					From Template
+				</Button>
+				<Button appearance="primary" icon-left="plus" @click="$router.push('/labs/new')">
+					New Lab
+				</Button>
+			</div>
 		</div>
 
 		<!-- Search & Filters -->

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -3,7 +3,7 @@ import { createRouter, createWebHistory } from "vue-router";
 import { session } from "./data/session";
 import { userContext, waitForUserContext } from "./data/userContext";
 
-const ADMIN_ONLY_ROUTES = new Set(["NewLab", "Settings", "BuildLogs"]);
+const ADMIN_ONLY_ROUTES = new Set(["NewLab", "LabTemplates", "Settings", "BuildLogs"]);
 
 const routes = [
 	{
@@ -25,6 +25,11 @@ const routes = [
 		path: "/labs/new",
 		name: "NewLab",
 		component: () => import("@/pages/NewLab.vue"),
+	},
+	{
+		path: "/labs/templates",
+		name: "LabTemplates",
+		component: () => import("@/pages/LabTemplates.vue"),
 	},
 	{
 		path: "/labs/:labId",


### PR DESCRIPTION
Tracer-bullet **slice 2** for #37 (P1-01). The backend catalog + create API landed in PR #69; this PR wires the **frontend** so the path is end-to-end one-click.

> Stacked on #69 (`feat/p1-37-lab-template-catalog`). Targets that branch and auto-retargets to `develop` once #69 merges.

## What this does
A dedicated **Lab Templates gallery** at `/labs/templates`:
- Card per template (title, frappe-version badge, description, app chips / "Bare bench", RAM + cores).
- **"Use this template"** → small dialog asks for a Lab ID (+ optional title) → calls `create_lab_from_template` → routes to the new Lab detail. One click to an editable Lab.

## Entry points
- New **admin-only** "Templates" item in the sidebar (under Labs).
- "From Template" button on the Labs page header.

## Key decisions
- **Separate gallery page, not embedded in NewLab.vue** — directly satisfies the "create a Lab in one click" criterion and avoids colliding with the resource-field work other branches are doing in `NewLab.vue`.
- Reused the existing `createResource` idiom and frappe-ui `Badge`/`Dialog`/`FormControl` to match `Devices.vue` / `Labs.vue`.
- **Admin-only** end-to-end: route added to `ADMIN_ONLY_ROUTES`, nav item gated on `userContext.isAdmin` — mirrors the admin-only `create_lab_from_template` API.

## Files
- `frontend/src/pages/LabTemplates.vue` (new) — gallery + create dialog
- `frontend/src/router.js` — `/labs/templates` route (before `/labs/:labId`)
- `frontend/src/App.vue` — admin-only "Templates" sidebar item
- `frontend/src/pages/Labs.vue` — "From Template" header button

## Acceptance criteria (#37)
- [x] **User can create a Lab from a template in one click** — gallery + dialog (was the open item from PR #69)
- [x] Templates can be edited after selection (created Lab is an ordinary Draft Lab)
- [x] Templates include app name, Git URL, branch, recommended resources *(PR #69)*
- [x] Template definitions are versioned and documented *(PR #69)*

## Testing
- `bench build --app benchpress` (vite) builds clean; `LabTemplates-*.js` bundle serves **HTTP 200**.
- Live `benchpress.api.get_lab_templates` returns the catalog (page data source).
- Smoke: `create_lab_from_template(template=crm, lab_id=…)` created a correct Lab (1g / 1 core / version-15 / Draft / custom title), then cleaned up.
- `pre-commit run` (prettier + eslint) passes on changed files.

## Notes for next iteration
- Interactive browser click-through **not** run: the chrome-devtools MCP could not reach Chrome in this env (no browser container; `172.30.0.168:9229` unreachable). Verified via build + live API instead.
- Next slice: expand the catalog (HRMS, LMS, Helpdesk, India Compliance) now that the picker exists.

Refs #37