### PR TITLE
feat(labs): expand template catalog — Frappe HR, Learning, Helpdesk (#37)

### DIFF
--- a/benchpress/lab_templates.py
+++ b/benchpress/lab_templates.py
@@ -14,7 +14,7 @@ from frappe import _
 
 # Bumped whenever the template set or its fields change so an install can tell
 # which catalog a lab was created against.
-CATALOG_VERSION = 1
+CATALOG_VERSION = 2
 
 LAB_TEMPLATES = [
 	{
@@ -54,6 +54,54 @@ LAB_TEMPLATES = [
 				"app_name": "crm",
 				"app_label": "Frappe CRM",
 				"git_url": "https://github.com/frappe/crm",
+				"branch": "main",
+			}
+		],
+	},
+	{
+		"key": "hrms",
+		"title": "Frappe HR",
+		"description": "HR & payroll suite — employees, leaves, attendance and payroll.",
+		"frappe_version": "version-15",
+		"memory_limit": "2g",
+		"cpu_cores": 2,
+		"apps": [
+			{
+				"app_name": "hrms",
+				"app_label": "Frappe HR",
+				"git_url": "https://github.com/frappe/hrms",
+				"branch": "version-15",
+			}
+		],
+	},
+	{
+		"key": "lms",
+		"title": "Frappe Learning",
+		"description": "Learning management system — courses, quizzes and batches.",
+		"frappe_version": "version-15",
+		"memory_limit": "1g",
+		"cpu_cores": 1,
+		"apps": [
+			{
+				"app_name": "lms",
+				"app_label": "Frappe Learning",
+				"git_url": "https://github.com/frappe/lms",
+				"branch": "main",
+			}
+		],
+	},
+	{
+		"key": "helpdesk",
+		"title": "Frappe Helpdesk",
+		"description": "Customer support desk — tickets, SLAs and a knowledge base.",
+		"frappe_version": "version-15",
+		"memory_limit": "1g",
+		"cpu_cores": 1,
+		"apps": [
+			{
+				"app_name": "helpdesk",
+				"app_label": "Frappe Helpdesk",
+				"git_url": "https://github.com/frappe/helpdesk",
 				"branch": "main",
 			}
 		],

--- a/benchpress/tests/test_lab_templates.py
+++ b/benchpress/tests/test_lab_templates.py
@@ -46,6 +46,12 @@ class TestLabTemplates(IntegrationTestCase):
 	def test_get_template_returns_match(self):
 		self.assertEqual(lab_templates.get_template("erpnext")["key"], "erpnext")
 
+	def test_first_party_app_templates_present(self):
+		for key in ("hrms", "lms", "helpdesk"):
+			template = lab_templates.get_template(key)
+			self.assertEqual(len(template["apps"]), 1)
+			self.assertEqual(template["apps"][0]["app_name"], key)
+
 	def test_get_template_unknown_throws(self):
 		with self.assertRaises(frappe.ValidationError):
 			lab_templates.get_template("does-not-exist")

--- a/docs/creating-labs.md
+++ b/docs/creating-labs.md
@@ -30,6 +30,9 @@ install.
 | **Frappe Framework** (`frappe`) | none (bare bench) | 512m / 1 core |
 | **ERPNext** (`erpnext`) | `erpnext` | 2g / 2 cores |
 | **Frappe CRM** (`crm`) | `crm` | 1g / 1 core |
+| **Frappe HR** (`hrms`) | `hrms` | 2g / 2 cores |
+| **Frappe Learning** (`lms`) | `lms` | 1g / 1 core |
+| **Frappe Helpdesk** (`helpdesk`) | `helpdesk` | 1g / 1 core |
 
 Creating a lab from a template produces an ordinary, fully editable Lab — you
 can tweak the apps, version, or limits afterwards just like a hand-built one.


### PR DESCRIPTION
## What & why

Next RALPH slice for #37 **[P1-01] Add default Frappe/ERPNext lab template catalog** — the issue's explicitly-stated next step: *"expand the catalog (HRMS, LMS, Helpdesk, India Compliance) now that the picker exists."*

Adds the three **first-party Frappe** apps as one-click starter templates, building on the picker UI shipped in #75:

| Template | Apps | Branch | Recommended |
|----------|------|--------|-------------|
| **Frappe HR** (`hrms`) | `hrms` | `version-15` | 2g / 2 cores |
| **Frappe Learning** (`lms`) | `lms` | `main` | 1g / 1 core |
| **Frappe Helpdesk** (`helpdesk`) | `helpdesk` | `main` | 1g / 1 core |

## Key decisions

- **Data-only change.** The gallery (`LabTemplates.vue`) and `get_lab_templates` are fully data-driven — they iterate whatever the catalog returns — so the new templates surface in the UI with **no frontend code change**.
- **HRMS installs standalone** on a Frappe site (ERPNext optional), so its template lists `hrms` alone rather than `erpnext + hrms`.
- Bumped `CATALOG_VERSION` 1 → 2, per the documented *"append an entry and bump the version"* contract.
- Branches/resources are recommendations; the created Lab stays **fully editable**, matching the existing `erpnext`/`crm` entries.
- **Deferred India Compliance** — it's third-party (`resilient-tech`) and depends on ERPNext install ordering; that's a separate, larger slice (noted for the next iteration).

## Files changed

- `benchpress/lab_templates.py` — +3 templates, `CATALOG_VERSION` → 2.
- `benchpress/tests/test_lab_templates.py` — lock the 3 new keys + `app_name`.
- `docs/creating-labs.md` — 3 new rows in the catalog table.

## Verification

- Catalog structure validated via `ast` against the test's exact assertions (well-formed, unique keys, new keys present). ✅
- `pre-commit run` on changed files — clean (`ruff` + `ruff-format` pass; `prettier`/`eslint` skipped, no JS changed). ✅
- ⚠️ Could not run the frappe `IntegrationTestCase` or a browser click-through: no live benchpress bench in this env (running containers are a different project) and the chrome-devtools MCP can't reach Chrome here.

## Acceptance criteria progress (#37)

All four original criteria were already met by #69/#75; this PR enriches the catalog (better onboarding). Catalog now ships 6 starter templates.

> Stacked on #75 (`feat/p1-37-template-picker-ui`); auto-retargets to `develop` once #75 merges.

Relates to #37.