### PR TITLE
feat(labs): add ERPNext + India Compliance lab template (#37)

### DIFF
--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe import _
 
+from benchpress import lab_templates
 from benchpress.permissions import (
 	get_bench_owner_filter,
 	is_admin,
@@ -60,6 +61,18 @@ def get_lab(name: str) -> dict:
 			for a in lab.apps
 		],
 	}
+
+
+@frappe.whitelist()
+def get_lab_templates() -> list[dict]:
+	return lab_templates.get_templates()
+
+
+@frappe.whitelist()
+def create_lab_from_template(template: str, lab_id: str, title: str | None = None) -> dict:
+	require_admin()
+	name = lab_templates.create_lab_from_template(template, lab_id, title)
+	return {"name": name, "status": "Draft"}
 
 
 @frappe.whitelist()

--- a/benchpress/lab_templates.py
+++ b/benchpress/lab_templates.py
@@ -14,7 +14,7 @@ from frappe import _
 
 # Bumped whenever the template set or its fields change so an install can tell
 # which catalog a lab was created against.
-CATALOG_VERSION = 1
+CATALOG_VERSION = 2
 
 LAB_TEMPLATES = [
 	{
@@ -54,6 +54,54 @@ LAB_TEMPLATES = [
 				"app_name": "crm",
 				"app_label": "Frappe CRM",
 				"git_url": "https://github.com/frappe/crm",
+				"branch": "main",
+			}
+		],
+	},
+	{
+		"key": "hrms",
+		"title": "Frappe HR",
+		"description": "HR & payroll suite — employees, leaves, attendance and payroll.",
+		"frappe_version": "version-15",
+		"memory_limit": "2g",
+		"cpu_cores": 2,
+		"apps": [
+			{
+				"app_name": "hrms",
+				"app_label": "Frappe HR",
+				"git_url": "https://github.com/frappe/hrms",
+				"branch": "version-15",
+			}
+		],
+	},
+	{
+		"key": "lms",
+		"title": "Frappe Learning",
+		"description": "Learning management system — courses, quizzes and batches.",
+		"frappe_version": "version-15",
+		"memory_limit": "1g",
+		"cpu_cores": 1,
+		"apps": [
+			{
+				"app_name": "lms",
+				"app_label": "Frappe Learning",
+				"git_url": "https://github.com/frappe/lms",
+				"branch": "main",
+			}
+		],
+	},
+	{
+		"key": "helpdesk",
+		"title": "Frappe Helpdesk",
+		"description": "Customer support desk — tickets, SLAs and a knowledge base.",
+		"frappe_version": "version-15",
+		"memory_limit": "1g",
+		"cpu_cores": 1,
+		"apps": [
+			{
+				"app_name": "helpdesk",
+				"app_label": "Frappe Helpdesk",
+				"git_url": "https://github.com/frappe/helpdesk",
 				"branch": "main",
 			}
 		],

--- a/benchpress/lab_templates.py
+++ b/benchpress/lab_templates.py
@@ -14,7 +14,7 @@ from frappe import _
 
 # Bumped whenever the template set or its fields change so an install can tell
 # which catalog a lab was created against.
-CATALOG_VERSION = 2
+CATALOG_VERSION = 3
 
 LAB_TEMPLATES = [
 	{
@@ -104,6 +104,30 @@ LAB_TEMPLATES = [
 				"git_url": "https://github.com/frappe/helpdesk",
 				"branch": "main",
 			}
+		],
+	},
+	{
+		"key": "india-compliance",
+		"title": "ERPNext + India Compliance",
+		"description": "ERPNext with GST, e-invoicing and TDS for Indian businesses.",
+		"frappe_version": "version-15",
+		"memory_limit": "2g",
+		"cpu_cores": 2,
+		# india_compliance extends ERPNext, so ERPNext must install first. The
+		# build/deploy pipeline installs apps in this listed order.
+		"apps": [
+			{
+				"app_name": "erpnext",
+				"app_label": "ERPNext",
+				"git_url": "https://github.com/frappe/erpnext",
+				"branch": "version-15",
+			},
+			{
+				"app_name": "india_compliance",
+				"app_label": "India Compliance",
+				"git_url": "https://github.com/resilient-tech/india-compliance",
+				"branch": "version-15",
+			},
 		],
 	},
 ]

--- a/benchpress/lab_templates.py
+++ b/benchpress/lab_templates.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""Catalog of ready-made lab templates.
+
+Templates are versioned in code so an admin can spin up a common stack
+(Frappe, ERPNext, CRM) without typing every app's git URL and resources by
+hand. ``create_lab_from_template`` materialises a template into an ordinary,
+editable Lab document, after which the normal build/deploy flow takes over.
+"""
+
+import frappe
+from frappe import _
+
+# Bumped whenever the template set or its fields change so an install can tell
+# which catalog a lab was created against.
+CATALOG_VERSION = 1
+
+LAB_TEMPLATES = [
+	{
+		"key": "frappe",
+		"title": "Frappe Framework",
+		"description": "Bare Frappe bench with no extra apps — the lightest starting point.",
+		"frappe_version": "version-15",
+		"memory_limit": "512m",
+		"cpu_cores": 1,
+		"apps": [],
+	},
+	{
+		"key": "erpnext",
+		"title": "ERPNext",
+		"description": "Full ERP suite: accounting, inventory, manufacturing and more.",
+		"frappe_version": "version-15",
+		"memory_limit": "2g",
+		"cpu_cores": 2,
+		"apps": [
+			{
+				"app_name": "erpnext",
+				"app_label": "ERPNext",
+				"git_url": "https://github.com/frappe/erpnext",
+				"branch": "version-15",
+			}
+		],
+	},
+	{
+		"key": "crm",
+		"title": "Frappe CRM",
+		"description": "Lightweight sales CRM on Frappe — leads, deals and contacts.",
+		"frappe_version": "version-15",
+		"memory_limit": "1g",
+		"cpu_cores": 1,
+		"apps": [
+			{
+				"app_name": "crm",
+				"app_label": "Frappe CRM",
+				"git_url": "https://github.com/frappe/crm",
+				"branch": "main",
+			}
+		],
+	},
+]
+
+
+def get_templates() -> list[dict]:
+	"""Return the full catalog of lab templates."""
+	return LAB_TEMPLATES
+
+
+def get_template(key: str) -> dict:
+	"""Return a single template by key, or throw if it is unknown."""
+	for template in LAB_TEMPLATES:
+		if template["key"] == key:
+			return template
+	frappe.throw(_("Unknown lab template '{0}'.").format(key or ""))
+
+
+def create_lab_from_template(template_key: str, lab_id: str, title: str | None = None) -> str:
+	"""Build a Lab document from a template and return its name."""
+	template = get_template(template_key)
+	lab = frappe.get_doc(
+		{
+			"doctype": "Lab",
+			"lab_id": lab_id,
+			"title": title or template["title"],
+			"description": template["description"],
+			"frappe_version": template["frappe_version"],
+			"memory_limit": template["memory_limit"],
+			"cpu_cores": template["cpu_cores"],
+			"apps": [dict(app) for app in template["apps"]],
+		}
+	)
+	lab.insert()
+	return lab.name

--- a/benchpress/tests/test_lab_templates.py
+++ b/benchpress/tests/test_lab_templates.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from benchpress import lab_templates
+
+REQUIRED_FIELDS = {
+	"key",
+	"title",
+	"description",
+	"frappe_version",
+	"memory_limit",
+	"cpu_cores",
+	"apps",
+}
+
+
+class TestLabTemplates(IntegrationTestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def _make_lab(self, template_key, lab_id, title=None):
+		if frappe.db.exists("Lab", lab_id):
+			frappe.delete_doc("Lab", lab_id, force=True, ignore_permissions=True)
+		name = lab_templates.create_lab_from_template(template_key, lab_id, title)
+		self.addCleanup(
+			lambda n=name: frappe.delete_doc("Lab", n, force=True, ignore_permissions=True)
+			if frappe.db.exists("Lab", n)
+			else None
+		)
+		return frappe.get_doc("Lab", name)
+
+	def test_catalog_is_non_empty_and_well_formed(self):
+		templates = lab_templates.get_templates()
+		self.assertTrue(templates)
+		for template in templates:
+			self.assertTrue(REQUIRED_FIELDS.issubset(template))
+			self.assertIsInstance(template["apps"], list)
+
+	def test_template_keys_are_unique(self):
+		keys = [template["key"] for template in lab_templates.get_templates()]
+		self.assertEqual(len(keys), len(set(keys)))
+
+	def test_get_template_returns_match(self):
+		self.assertEqual(lab_templates.get_template("erpnext")["key"], "erpnext")
+
+	def test_get_template_unknown_throws(self):
+		with self.assertRaises(frappe.ValidationError):
+			lab_templates.get_template("does-not-exist")
+
+	def test_create_lab_from_template_populates_apps_and_resources(self):
+		lab = self._make_lab("erpnext", "tmpl-erpnext-test")
+		self.assertEqual(lab.frappe_version, "version-15")
+		self.assertEqual(lab.memory_limit, "2g")
+		self.assertEqual(lab.cpu_cores, 2)
+		self.assertEqual(len(lab.apps), 1)
+		self.assertEqual(lab.apps[0].app_name, "erpnext")
+
+	def test_create_lab_from_template_with_no_apps(self):
+		lab = self._make_lab("frappe", "tmpl-frappe-test", title="My Frappe Lab")
+		self.assertEqual(lab.title, "My Frappe Lab")
+		self.assertEqual(len(lab.apps), 0)
+
+	def test_create_lab_from_template_unknown_throws(self):
+		with self.assertRaises(frappe.ValidationError):
+			lab_templates.create_lab_from_template("nope", "tmpl-nope-test")

--- a/benchpress/tests/test_lab_templates.py
+++ b/benchpress/tests/test_lab_templates.py
@@ -52,6 +52,12 @@ class TestLabTemplates(IntegrationTestCase):
 			self.assertEqual(len(template["apps"]), 1)
 			self.assertEqual(template["apps"][0]["app_name"], key)
 
+	def test_india_compliance_template_installs_erpnext_first(self):
+		template = lab_templates.get_template("india-compliance")
+		app_names = [app["app_name"] for app in template["apps"]]
+		# india_compliance extends ERPNext; order matters at install time.
+		self.assertEqual(app_names, ["erpnext", "india_compliance"])
+
 	def test_get_template_unknown_throws(self):
 		with self.assertRaises(frappe.ValidationError):
 			lab_templates.get_template("does-not-exist")

--- a/benchpress/tests/test_lab_templates.py
+++ b/benchpress/tests/test_lab_templates.py
@@ -46,6 +46,12 @@ class TestLabTemplates(IntegrationTestCase):
 	def test_get_template_returns_match(self):
 		self.assertEqual(lab_templates.get_template("erpnext")["key"], "erpnext")
 
+	def test_first_party_app_templates_present(self):
+		for key in ("hrms", "lms", "helpdesk"):
+			template = lab_templates.get_template(key)
+			self.assertEqual(len(template["apps"]), 1)
+			self.assertEqual(template["apps"][0]["app_name"], key)
+
 	def test_get_template_unknown_throws(self):
 		with self.assertRaises(frappe.ValidationError):
 			lab_templates.get_template("does-not-exist")

--- a/docs/creating-labs.md
+++ b/docs/creating-labs.md
@@ -30,6 +30,9 @@ install.
 | **Frappe Framework** (`frappe`) | none (bare bench) | 512m / 1 core |
 | **ERPNext** (`erpnext`) | `erpnext` | 2g / 2 cores |
 | **Frappe CRM** (`crm`) | `crm` | 1g / 1 core |
+| **Frappe HR** (`hrms`) | `hrms` | 2g / 2 cores |
+| **Frappe Learning** (`lms`) | `lms` | 1g / 1 core |
+| **Frappe Helpdesk** (`helpdesk`) | `helpdesk` | 1g / 1 core |
 
 Creating a lab from a template produces an ordinary, fully editable Lab — you
 can tweak the apps, version, or limits afterwards just like a hand-built one.

--- a/docs/creating-labs.md
+++ b/docs/creating-labs.md
@@ -18,6 +18,34 @@ Create Lab  -->  Build Image  -->  Deploy Bench  -->  Connect & Develop
 
 ---
 
+## Starting from a Template
+
+BenchPress ships a small, versioned catalog of ready-made lab templates so you
+don't have to type every app's Git URL and resource limit by hand. Each
+template pre-fills the Frappe version, recommended memory/CPU, and the apps to
+install.
+
+| Template | Apps | Recommended resources |
+|----------|------|------------------------|
+| **Frappe Framework** (`frappe`) | none (bare bench) | 512m / 1 core |
+| **ERPNext** (`erpnext`) | `erpnext` | 2g / 2 cores |
+| **Frappe CRM** (`crm`) | `crm` | 1g / 1 core |
+
+Creating a lab from a template produces an ordinary, fully editable Lab — you
+can tweak the apps, version, or limits afterwards just like a hand-built one.
+
+The catalog and the create action are exposed as whitelisted APIs:
+
+```
+benchpress.api.get_lab_templates()
+benchpress.api.create_lab_from_template(template="erpnext", lab_id="erp-demo", title="ERP Demo")
+```
+
+> Adding to the catalog: templates live in `benchpress/lab_templates.py` and are
+> versioned with `CATALOG_VERSION`. Append an entry and bump the version.
+
+---
+
 ## Creating a New Lab
 
 ### Navigate to the Labs page

--- a/docs/creating-labs.md
+++ b/docs/creating-labs.md
@@ -33,6 +33,7 @@ install.
 | **Frappe HR** (`hrms`) | `hrms` | 2g / 2 cores |
 | **Frappe Learning** (`lms`) | `lms` | 1g / 1 core |
 | **Frappe Helpdesk** (`helpdesk`) | `helpdesk` | 1g / 1 core |
+| **ERPNext + India Compliance** (`india-compliance`) | `erpnext` + `india_compliance` | 2g / 2 cores |
 
 Creating a lab from a template produces an ordinary, fully editable Lab — you
 can tweak the apps, version, or limits afterwards just like a hand-built one.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -17,6 +17,7 @@ import { userContext } from "@/data/userContext";
 
 import ServerIcon from "~icons/lucide/server";
 import FlaskConicalIcon from "~icons/lucide/flask-conical";
+import LayoutTemplateIcon from "~icons/lucide/layout-template";
 import ScrollTextIcon from "~icons/lucide/scroll-text";
 import HammerIcon from "~icons/lucide/hammer";
 import ShieldIcon from "~icons/lucide/shield";
@@ -59,16 +60,16 @@ const headerConfig = computed(() => {
 });
 
 const sections = computed(() => {
-	const items = [
-		{
-			label: "",
-			items: [
-				{ label: "Labs", icon: FlaskConicalIcon, to: "/labs" },
-				{ label: "Bench Instances", icon: ServerIcon, to: "/bench-instances" },
-				{ label: "VPN Devices", icon: ShieldIcon, to: "/devices" },
-			],
-		},
-	];
+	const labItems = [{ label: "Labs", icon: FlaskConicalIcon, to: "/labs" }];
+	if (userContext.isAdmin) {
+		labItems.push({ label: "Templates", icon: LayoutTemplateIcon, to: "/labs/templates" });
+	}
+	labItems.push(
+		{ label: "Bench Instances", icon: ServerIcon, to: "/bench-instances" },
+		{ label: "VPN Devices", icon: ShieldIcon, to: "/devices" }
+	);
+
+	const items = [{ label: "", items: labItems }];
 
 	const logItems = [{ label: "Deploy Logs", icon: ScrollTextIcon, to: "/deploy-logs" }];
 	if (userContext.isAdmin) {

--- a/frontend/src/pages/LabTemplates.vue
+++ b/frontend/src/pages/LabTemplates.vue
@@ -1,0 +1,152 @@
+<template>
+	<div class="p-4">
+		<div class="mb-4 flex items-center justify-between">
+			<div>
+				<h1 class="text-xl font-semibold text-ink-gray-9">Lab Templates</h1>
+				<p class="mt-1 text-sm text-ink-gray-5">
+					Spin up a ready-made stack in one click, then tweak it like any other lab.
+				</p>
+			</div>
+			<Button appearance="minimal" @click="$router.push('/labs')">Back to Labs</Button>
+		</div>
+
+		<div
+			v-if="templates.data && templates.data.length"
+			class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
+		>
+			<div
+				v-for="template in templates.data"
+				:key="template.key"
+				class="flex flex-col rounded-lg border border-outline-gray-1 bg-surface-white p-4"
+			>
+				<div class="mb-2 flex items-start justify-between gap-2">
+					<h2 class="text-base font-medium text-ink-gray-8">{{ template.title }}</h2>
+					<Badge theme="blue" variant="subtle" :label="template.frappe_version" />
+				</div>
+				<p class="mb-3 flex-1 text-sm text-ink-gray-5">{{ template.description }}</p>
+
+				<div class="mb-3 flex flex-wrap gap-1">
+					<Badge
+						v-for="app in template.apps"
+						:key="app.app_name"
+						theme="gray"
+						variant="subtle"
+						:label="app.app_label || app.app_name"
+					/>
+					<Badge
+						v-if="!template.apps.length"
+						theme="gray"
+						variant="subtle"
+						label="Bare bench"
+					/>
+				</div>
+
+				<div class="mb-4 flex items-center gap-4 text-xs text-ink-gray-5">
+					<span>{{ template.memory_limit }} RAM</span>
+					<span
+						>{{ template.cpu_cores }}
+						{{ template.cpu_cores === 1 ? "core" : "cores" }}</span
+					>
+				</div>
+
+				<Button class="w-full" appearance="primary" @click="openCreate(template)">
+					Use this template
+				</Button>
+			</div>
+		</div>
+		<div v-else-if="templates.loading" class="text-base text-ink-gray-5">Loading...</div>
+		<div v-else class="py-12 text-center text-base text-ink-gray-5">
+			No templates available.
+		</div>
+
+		<Dialog
+			:options="{ title: `New lab from ${selectedTemplate?.title || 'template'}` }"
+			v-model="showCreateDialog"
+		>
+			<template #body-content>
+				<div class="space-y-4">
+					<FormControl
+						label="Lab ID"
+						v-model="form.lab_id"
+						type="text"
+						placeholder="e.g. crm-lab"
+						description="Lowercase letters, numbers and single '.', '_' or '-' separators"
+						:required="true"
+					/>
+					<FormControl
+						label="Title"
+						v-model="form.title"
+						type="text"
+						:placeholder="selectedTemplate?.title"
+						description="Optional — defaults to the template name"
+					/>
+					<ErrorMessage :message="createAction.error" />
+				</div>
+			</template>
+			<template #actions>
+				<Button
+					appearance="primary"
+					class="w-full"
+					:loading="createAction.loading"
+					@click="createFromTemplate"
+				>
+					Create Lab
+				</Button>
+			</template>
+		</Dialog>
+	</div>
+</template>
+
+<script setup>
+import { reactive, ref } from "vue";
+import { useRouter } from "vue-router";
+import {
+	Badge,
+	Button,
+	Dialog,
+	ErrorMessage,
+	FormControl,
+	createResource,
+	toast,
+} from "frappe-ui";
+
+const router = useRouter();
+
+const showCreateDialog = ref(false);
+const selectedTemplate = ref(null);
+const form = reactive({ lab_id: "", title: "" });
+
+const templates = createResource({
+	url: "benchpress.api.get_lab_templates",
+	auto: true,
+});
+
+const createAction = createResource({
+	url: "benchpress.api.create_lab_from_template",
+	onSuccess(data) {
+		showCreateDialog.value = false;
+		toast.success("Lab created from template");
+		router.push({ name: "LabDetail", params: { labId: data.name } });
+	},
+});
+
+function openCreate(template) {
+	selectedTemplate.value = template;
+	form.lab_id = "";
+	form.title = "";
+	createAction.error = null;
+	showCreateDialog.value = true;
+}
+
+function createFromTemplate() {
+	if (!form.lab_id) {
+		toast.error("Lab ID is required");
+		return;
+	}
+	createAction.submit({
+		template: selectedTemplate.value.key,
+		lab_id: form.lab_id,
+		title: form.title || null,
+	});
+}
+</script>

--- a/frontend/src/pages/Labs.vue
+++ b/frontend/src/pages/Labs.vue
@@ -2,14 +2,18 @@
 	<div class="p-4">
 		<div class="mb-4 flex items-center justify-between">
 			<h1 class="text-xl font-semibold text-ink-gray-9">Labs</h1>
-			<Button
-				v-if="userContext.isAdmin"
-				appearance="primary"
-				icon-left="plus"
-				@click="$router.push('/labs/new')"
-			>
-				New Lab
-			</Button>
+			<div v-if="userContext.isAdmin" class="flex gap-2">
+				<Button
+					appearance="minimal"
+					icon-left="grid"
+					@click="$router.push('/labs/templates')"
+				>
+					From Template
+				</Button>
+				<Button appearance="primary" icon-left="plus" @click="$router.push('/labs/new')">
+					New Lab
+				</Button>
+			</div>
 		</div>
 
 		<!-- Search & Filters -->

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -3,7 +3,7 @@ import { createRouter, createWebHistory } from "vue-router";
 import { session } from "./data/session";
 import { userContext, waitForUserContext } from "./data/userContext";
 
-const ADMIN_ONLY_ROUTES = new Set(["NewLab", "Settings", "BuildLogs"]);
+const ADMIN_ONLY_ROUTES = new Set(["NewLab", "LabTemplates", "Settings", "BuildLogs"]);
 
 const routes = [
 	{
@@ -25,6 +25,11 @@ const routes = [
 		path: "/labs/new",
 		name: "NewLab",
 		component: () => import("@/pages/NewLab.vue"),
+	},
+	{
+		path: "/labs/templates",
+		name: "LabTemplates",
+		component: () => import("@/pages/LabTemplates.vue"),
 	},
 	{
 		path: "/labs/:labId",


### PR DESCRIPTION
## What

Adds the **ERPNext + India Compliance** starter template to the lab catalog — the last entry from #37's own starter-template list, completing the catalog.

Closes the catalog-expansion track of #37 [P1-01].

## Why

#37 lists India Compliance as a starter template. It was deferred in PR #78 because it is the first **multi-app** template and uses a **third-party** source with install-ordering concerns — so it warranted its own slice.

## Changes

- **`benchpress/lab_templates.py`** — new `india-compliance` template (`erpnext` + `india_compliance`); `CATALOG_VERSION` 2 → 3.
- **`benchpress/tests/test_lab_templates.py`** — locks the new key and asserts `erpnext` installs before `india_compliance`.
- **`docs/creating-labs.md`** — one new catalog row.

## Key decisions

- **Data-only.** The gallery (`LabTemplates.vue`) and `get_lab_templates` are fully data-driven, so this first multi-app template renders with **no frontend code change** — two app chips: *ERPNext* + *India Compliance*.
- **Install order matters.** `india_compliance` extends ERPNext, so ERPNext is listed first. Both the image build (`docker_manager`) and site install (`deploy_manager`) iterate apps in child-table order, which equals the listed order — verified live.
- **Third-party source** `resilient-tech/india-compliance`, pinned to `version-15` to match the ERPNext branch. Resources `2g`/`2` mirror the ERPNext baseline; all values remain editable recommendations on the created Lab.

## Verification

Run on the **live running bench** (host `apps/` is bind-mounted):

- `get_lab_templates` returns the 7th template with both apps.
- `create_lab_from_template("india-compliance", …)` produced a Lab at `version-15` / `2g` / `2` cores with apps `[erpnext, india_compliance]` **in order**, then cleaned up.
- AST catalog check (well-formed, unique keys) + `pre-commit` (ruff + ruff-format) clean.

> Browser click-through not run — chrome-devtools MCP can't reach Chrome in this env; the gallery is unchanged, data-driven code and the live API was verified directly.

## Stacking

Stacked on **#78** (`feat/p1-37-expand-template-catalog`). Auto-retargets to `develop` once the #69 → #75 → #78 stack merges.

The #37 starter-template list is now complete: `frappe`, `erpnext`, `crm`, `hrms`, `lms`, `helpdesk`, `india-compliance`.