### PR TITLE
docs(upgrade): versioned CHANGELOG for multi-release upgrades (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to BenchPress are recorded here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+> **Why this file exists.** When you upgrade an install across more than one
+> release, read every entry between your current version and the target version
+> before running the upgrade — some changes need manual steps. The
+> [upgrade runbook](docs/upgrading.md) points here for exactly that reason.
+>
+> This changelog was introduced partway through development, so it does not
+> restate the project's full early history — for changes before the first entry
+> below, see the git log and GitHub release notes.
+
+**Maintaining this changelog**
+
+- Add a bullet under `## [Unreleased]` in the same change that ships the work,
+  grouped under one of: **Added**, **Changed**, **Deprecated**, **Removed**,
+  **Fixed**, **Security**. Lead with what an operator would notice, and link the
+  issue or PR.
+- Flag anything that needs a manual step during upgrade (a schema change, a
+  config or setting rename, a removed field) so multi-release upgrades stay safe.
+- On a release, rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD`, tag the
+  commit `vX.Y.Z`, and open a fresh empty `## [Unreleased]` above it. Bump the
+  version per Semantic Versioning: MAJOR for breaking changes, MINOR for
+  backwards-compatible features, PATCH for fixes.
+
+## [Unreleased]
+
+### Added
+
+- Documented, backup-gated upgrade path for installed instances: a manual
+  runbook ([`docs/upgrading.md`](docs/upgrading.md)) and a scripted
+  [`upgrade.sh`](upgrade.sh) that chains backup → app update → `bench migrate` →
+  asset rebuild → restart → health verify. The pre-upgrade backup is a hard
+  gate — the upgrade aborts if it fails, so there is always something to roll
+  back to. ([#47](https://github.com/Venkateshvenki404224/benchpress/issues/47))
+- This changelog, so installs can be upgraded safely across multiple releases.
+  ([#47](https://github.com/Venkateshvenki404224/benchpress/issues/47))
+
+[Unreleased]: https://github.com/Venkateshvenki404224/benchpress/commits/develop

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
 - [Logs & Monitoring](docs/logs-and-monitoring.md) -- Build logs, deploy logs, and stats
 - [VPN Device Management](docs/device-management.md) -- Register devices for WireGuard access
 - [WireGuard Setup](docs/wireguard-setup.md) -- Detailed WireGuard configuration
+- [Upgrading a BenchPress Install](docs/upgrading.md) -- Backup-gated upgrade and rollback runbook
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 - [VPN Device Management](docs/device-management.md) -- Register devices for WireGuard access
 - [WireGuard Setup](docs/wireguard-setup.md) -- Detailed WireGuard configuration
 - [Upgrading a BenchPress Install](docs/upgrading.md) -- Backup-gated upgrade and rollback runbook
+- [Changelog](CHANGELOG.md) -- Notable changes per release; read before a multi-release upgrade
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -99,3 +99,4 @@ Once BenchPress is running, follow the [Creating Labs](creating-labs.md) guide t
 | [Logs and Monitoring](logs-and-monitoring.md) | Build logs, deploy logs, and container stats |
 | [VPN Device Management](device-management.md) | Register devices for persistent WireGuard access |
 | [WireGuard Setup](wireguard-setup.md) | Detailed WireGuard configuration and troubleshooting |
+| [Upgrading a BenchPress Install](upgrading.md) | Backup-gated upgrade and rollback runbook |

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -9,9 +9,10 @@ release to a newer one.
 > Frappe app and its site). Rebuilding the **lab images** your benches run on is
 > a separate, opt-in step covered in [Lab image policy](#lab-image-policy-after-an-upgrade).
 >
-> This is the documented runbook. A scripted `benchpress upgrade` command that
-> automates these steps (with the same backup gate and rollback) is the next
-> slice — see [What's not automated yet](#whats-not-automated-yet).
+> Prefer one command? `apps/benchpress/upgrade.sh` runs Steps 0–5 below with the
+> same backup gate and abort-on-failure behaviour — see
+> [Scripted upgrade](#scripted-upgrade). The manual steps remain the reference
+> for what each step does and for [rollback](#rollback).
 
 ---
 
@@ -27,6 +28,33 @@ release to a newer one.
 Throughout this guide, replace `<your-site>` with your real site name and run
 commands from the bench root (the directory that contains `apps/`, `sites/`,
 and `env/`).
+
+---
+
+## Scripted upgrade
+
+To run the whole flow as one command, use the bundled script. It performs
+Steps 0–5 below, enforces the **Step 0 backup gate** (it aborts if the backup
+fails), and stops on the first error so a failed upgrade never silently
+continues:
+
+```bash
+# from the bench root
+bash apps/benchpress/upgrade.sh <your-site>
+```
+
+Upgrade to a specific branch or tag, or preview every step without changing
+anything:
+
+```bash
+bash apps/benchpress/upgrade.sh <your-site> version-16   # checkout a target ref
+bash apps/benchpress/upgrade.sh <your-site> --dry-run    # print steps only
+```
+
+The script does **not** roll back automatically (that is a later slice). On
+failure it prints the recorded pre-upgrade revision and points you at the
+[Rollback](#rollback) section. The manual steps below document exactly what each
+step runs — read them before relying on the script in production.
 
 ---
 
@@ -193,11 +221,11 @@ Treat lab rebuilds as an opt-in follow-up, not part of the control-plane upgrade
 
 ## What's not automated yet
 
-This runbook is the manual, supported path today. Still to come:
+The [upgrade script](#scripted-upgrade) now chains Steps 0–5 with the backup
+gate and abort-on-failure. Still to come:
 
-- A scripted `benchpress upgrade` command that chains Steps 0–5 with the same
-  backup gate and abort-on-failure behaviour.
-- Automatic rollback when a step fails mid-upgrade.
+- Automatic rollback when a step fails mid-upgrade (the script aborts and points
+  you at the recorded revision + backup, but does not restore them for you).
 - A versioned `CHANGELOG` so installs can be upgraded across several releases
   safely.
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,205 @@
+# Upgrading a BenchPress Install
+
+This runbook upgrades an existing BenchPress install end-to-end — app code,
+database schema, and frontend assets — with a pre-upgrade backup gate and a
+tested rollback path. Follow it whenever you move an install from one BenchPress
+release to a newer one.
+
+> **Scope.** This guide covers upgrading the **BenchPress control plane** (the
+> Frappe app and its site). Rebuilding the **lab images** your benches run on is
+> a separate, opt-in step covered in [Lab image policy](#lab-image-policy-after-an-upgrade).
+>
+> This is the documented runbook. A scripted `benchpress upgrade` command that
+> automates these steps (with the same backup gate and rollback) is the next
+> slice — see [What's not automated yet](#whats-not-automated-yet).
+
+---
+
+## Before you start
+
+| Check | Why |
+|-------|-----|
+| You know your site name (e.g. `your-site.localhost`) | Every command is scoped to one site |
+| You can reach the host bench shell | Upgrades run as bench commands, not in the dashboard |
+| No build or deploy job is in flight | Migrating mid-deploy can leave benches in a bad state |
+| You have read the release notes for the target version | Schema or config changes may need manual steps |
+
+Throughout this guide, replace `<your-site>` with your real site name and run
+commands from the bench root (the directory that contains `apps/`, `sites/`,
+and `env/`).
+
+---
+
+## Step 0 — Take a backup (the gate)
+
+**The upgrade must not proceed unless this step succeeds.** A failed backup
+means there is nothing to roll back to, so stop and fix the backup before
+touching app code.
+
+```bash
+bench --site <your-site> backup --with-files
+```
+
+A successful run prints the paths of the database dump and the public/private
+file archives, written under:
+
+```
+sites/<your-site>/private/backups/
+```
+
+Record the timestamp of this backup — you will need it if you roll back. Also
+record the exact app revision you are upgrading **from**, so you can return to
+it:
+
+```bash
+git -C apps/benchpress rev-parse HEAD > /tmp/benchpress-rollback-sha
+git -C apps/benchpress describe --tags --always
+```
+
+> If `bench backup` fails (disk full, MariaDB unreachable, permissions), **do
+> not continue.** Resolve the failure and re-run Step 0 from the top.
+
+---
+
+## Step 1 — Update the app code
+
+Pull the target BenchPress revision into the bind-mounted app directory:
+
+```bash
+git -C apps/benchpress fetch origin
+git -C apps/benchpress checkout <target-branch-or-tag>
+git -C apps/benchpress pull
+```
+
+Re-install Python dependencies in case the new release added any:
+
+```bash
+bench pip install -e apps/benchpress
+```
+
+---
+
+## Step 2 — Run database migrations
+
+Apply schema and fixture changes for the new release:
+
+```bash
+bench --site <your-site> migrate
+```
+
+If `migrate` fails, **stop here and roll back** (see
+[Rollback](#rollback)). A partially-migrated site should not be put back into
+service.
+
+---
+
+## Step 3 — Rebuild frontend assets
+
+The BenchPress dashboard is a Vue SPA and must be rebuilt after an upgrade:
+
+```bash
+cd apps/benchpress/frontend
+yarn install
+yarn build
+cd -
+```
+
+Then refresh Frappe's asset bundles:
+
+```bash
+bench build --app benchpress
+bench --site <your-site> clear-cache
+```
+
+---
+
+## Step 4 — Restart services
+
+```bash
+bench restart
+```
+
+On a development bench, stop `bench start` and start it again instead.
+
+---
+
+## Step 5 — Verify health
+
+Confirm the upgrade landed cleanly before declaring it done:
+
+1. **Dashboard loads** — open `http://<your-site>:8000/frontend` and sign in.
+2. **Migrations are clean** — `bench --site <your-site> migrate` a second time is
+   a no-op (no pending patches).
+3. **Benches are still healthy** — open the Bench Instances list; existing
+   benches should still report a healthy container status.
+4. **Run the doctor** (if available) — `bench --site <your-site> execute
+   benchpress.doctor.run` reports host and dependency readiness.
+
+If any check fails and cannot be fixed forward quickly, roll back.
+
+---
+
+## Rollback
+
+Rolling back has two parts: restore the **code** to the revision you recorded in
+Step 0, then restore the **data** from the Step 0 backup.
+
+1. Return the app to the previous revision:
+
+   ```bash
+   git -C apps/benchpress checkout "$(cat /tmp/benchpress-rollback-sha)"
+   bench pip install -e apps/benchpress
+   ```
+
+2. Restore the pre-upgrade backup (use the database dump and file archives
+   printed in Step 0):
+
+   ```bash
+   bench --site <your-site> restore \
+     sites/<your-site>/private/backups/<timestamp>-database.sql.gz \
+     --with-public-files  sites/<your-site>/private/backups/<timestamp>-files.tar \
+     --with-private-files sites/<your-site>/private/backups/<timestamp>-private-files.tar
+   ```
+
+3. Rebuild assets and restart:
+
+   ```bash
+   bench build --app benchpress
+   bench --site <your-site> clear-cache
+   bench restart
+   ```
+
+4. Re-run [Step 5](#step-5--verify-health) against the restored install.
+
+> Restore overwrites the current database. Only restore onto the same site you
+> backed up, and only after confirming the upgrade cannot be fixed forward.
+
+---
+
+## Lab image policy after an upgrade
+
+Upgrading the control plane does **not** rebuild the Docker images your benches
+run on. When a new release changes a Lab's recommended Frappe version (or you
+bump it yourself):
+
+- **Existing benches keep their current image** until you explicitly redeploy
+  them — upgrades are non-disruptive to running benches by default.
+- To adopt the new version, open the Lab, run **Build Image**, then redeploy the
+  affected benches. See [Creating Labs](creating-labs.md).
+
+Treat lab rebuilds as an opt-in follow-up, not part of the control-plane upgrade.
+
+---
+
+## What's not automated yet
+
+This runbook is the manual, supported path today. Still to come:
+
+- A scripted `benchpress upgrade` command that chains Steps 0–5 with the same
+  backup gate and abort-on-failure behaviour.
+- Automatic rollback when a step fails mid-upgrade.
+- A versioned `CHANGELOG` so installs can be upgraded across several releases
+  safely.
+
+Until those ship, follow the steps above in order and do not skip the Step 0
+backup gate.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -23,7 +23,7 @@ release to a newer one.
 | You know your site name (e.g. `your-site.localhost`) | Every command is scoped to one site |
 | You can reach the host bench shell | Upgrades run as bench commands, not in the dashboard |
 | No build or deploy job is in flight | Migrating mid-deploy can leave benches in a bad state |
-| You have read the release notes for the target version | Schema or config changes may need manual steps |
+| You have read the [CHANGELOG](../CHANGELOG.md) for the target version | Schema or config changes may need manual steps |
 
 Throughout this guide, replace `<your-site>` with your real site name and run
 commands from the bench root (the directory that contains `apps/`, `sites/`,
@@ -222,12 +222,12 @@ Treat lab rebuilds as an opt-in follow-up, not part of the control-plane upgrade
 ## What's not automated yet
 
 The [upgrade script](#scripted-upgrade) now chains Steps 0–5 with the backup
-gate and abort-on-failure. Still to come:
+gate and abort-on-failure, and the [CHANGELOG](../CHANGELOG.md) records what
+changed between releases so you know which manual steps a multi-release upgrade
+needs. Still to come:
 
 - Automatic rollback when a step fails mid-upgrade (the script aborts and points
   you at the recorded revision + backup, but does not restore them for you).
-- A versioned `CHANGELOG` so installs can be upgraded across several releases
-  safely.
 
-Until those ship, follow the steps above in order and do not skip the Step 0
+Until that ships, follow the steps above in order and do not skip the Step 0
 backup gate.

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+# BenchPress upgrade script
+# Upgrades an existing BenchPress install end-to-end with a pre-upgrade backup
+# gate and abort-on-failure, following docs/upgrading.md.
+#
+# Usage:
+#   cd /path/to/frappe-bench
+#   bash apps/benchpress/upgrade.sh <site-name> [target-ref] [--dry-run]
+#
+# Examples:
+#   bash apps/benchpress/upgrade.sh sponge.localhost
+#   bash apps/benchpress/upgrade.sh sponge.localhost version-16
+#   bash apps/benchpress/upgrade.sh sponge.localhost --dry-run
+#
+# This is the scripted counterpart to the manual runbook in docs/upgrading.md.
+# It does NOT roll back automatically (that is a later slice) — on failure it
+# points you at the recorded revision and your backup so you can follow the
+# runbook's Rollback section.
+
+set -e
+
+BENCH_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+APP_DIR="$BENCH_DIR/apps/benchpress"
+ROLLBACK_FILE="/tmp/benchpress-rollback-sha"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info()    { echo -e "${BLUE}[*]${NC} $1"; }
+success() { echo -e "${GREEN}[✓]${NC} $1"; }
+warn()    { echo -e "${YELLOW}[!]${NC} $1"; }
+error()   { echo -e "${RED}[✗]${NC} $1"; exit 1; }
+
+usage() {
+    echo "Usage: bash apps/benchpress/upgrade.sh <site-name> [target-ref] [--dry-run]"
+    echo ""
+    echo "  <site-name>   Site to upgrade (required), e.g. sponge.localhost"
+    echo "  [target-ref]  Git branch or tag to upgrade to (optional; defaults to"
+    echo "                fast-forwarding the current branch)"
+    echo "  --dry-run     Print every step without changing anything"
+}
+
+# --- Parse arguments ---
+
+DRY_RUN=0
+SITE_NAME=""
+TARGET_REF=""
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=1 ;;
+        -h|--help) usage; exit 0 ;;
+        -*) usage; error "Unknown option: $arg" ;;
+        *)
+            if [ -z "$SITE_NAME" ]; then
+                SITE_NAME="$arg"
+            elif [ -z "$TARGET_REF" ]; then
+                TARGET_REF="$arg"
+            else
+                error "Unexpected argument: $arg"
+            fi
+            ;;
+    esac
+done
+
+# run COMMAND... — execute it, or just print it in dry-run mode.
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo -e "${YELLOW}[dry-run]${NC} $*"
+    else
+        "$@"
+    fi
+}
+
+echo ""
+echo "=============================="
+echo "  BenchPress Upgrade"
+echo "=============================="
+echo ""
+
+if [ -z "$SITE_NAME" ]; then
+    usage
+    error "Site name required."
+fi
+
+# Upgrades touch the host bench (git, yarn, bench restart) — none of it belongs
+# inside a container.
+if [ -f "/.dockerenv" ]; then
+    warn "Running inside a Docker container — run the upgrade on the host bench."
+    warn "  bash apps/benchpress/upgrade.sh $SITE_NAME"
+    exit 0
+fi
+
+# apps/frappe exists in every valid bench; this confirms we are at the bench root.
+if [ ! -d "$BENCH_DIR/apps/frappe" ]; then
+    error "Run this script from your frappe-bench (bash apps/benchpress/upgrade.sh). Found: $BENCH_DIR"
+fi
+
+if [ ! -d "$APP_DIR" ]; then
+    error "BenchPress app not found at $APP_DIR"
+fi
+
+info "Bench directory : $BENCH_DIR"
+info "Site            : $SITE_NAME"
+if [ -n "$TARGET_REF" ]; then
+    info "Target revision : $TARGET_REF"
+else
+    info "Target revision : (fast-forward current branch)"
+fi
+[ "$DRY_RUN" -eq 1 ] && warn "DRY RUN — no changes will be made"
+echo ""
+
+# --- Step 0: Pre-upgrade backup (the gate) ---
+
+info "Step 0/5: Pre-upgrade backup (the gate)"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo -e "${YELLOW}[dry-run]${NC} bench --site $SITE_NAME backup --with-files"
+    echo -e "${YELLOW}[dry-run]${NC} record current revision to $ROLLBACK_FILE"
+else
+    # The gate: if there is no backup, there is nothing to roll back to.
+    if ! bench --site "$SITE_NAME" backup --with-files; then
+        error "Backup failed — aborting. Nothing has changed and there is nothing to roll back to. Fix the backup (disk space, MariaDB, permissions) and re-run."
+    fi
+    success "Backup complete"
+
+    ROLLBACK_SHA="$(git -C "$APP_DIR" rev-parse HEAD)"
+    echo "$ROLLBACK_SHA" > "$ROLLBACK_FILE"
+    success "Recorded rollback revision $ROLLBACK_SHA -> $ROLLBACK_FILE"
+fi
+
+echo ""
+
+# From here on a failure leaves a partially-upgraded install, so guide the
+# operator to the recorded revision and backup instead of failing silently.
+on_failure() {
+    echo ""
+    echo -e "${RED}[✗] Upgrade failed after the backup.${NC}"
+    echo "    Your install may be partially upgraded. To roll back:"
+    echo "      1. Restore code: git -C apps/benchpress checkout \$(cat $ROLLBACK_FILE)"
+    echo "      2. Restore data: bench --site $SITE_NAME restore <Step 0 backup>"
+    echo "    See the Rollback section of docs/upgrading.md for the full procedure."
+}
+trap on_failure ERR
+
+# --- Step 1: Update the app code ---
+
+info "Step 1/5: Update app code"
+run git -C "$APP_DIR" fetch origin --tags
+if [ -n "$TARGET_REF" ]; then
+    run git -C "$APP_DIR" checkout "$TARGET_REF"
+else
+    run git -C "$APP_DIR" pull --ff-only
+fi
+run bench pip install -e "$APP_DIR"
+success "App code updated"
+echo ""
+
+# --- Step 2: Run database migrations ---
+
+info "Step 2/5: Run database migrations"
+run bench --site "$SITE_NAME" migrate
+success "Migrations applied"
+echo ""
+
+# --- Step 3: Rebuild frontend assets ---
+
+info "Step 3/5: Rebuild frontend assets"
+run yarn --cwd "$APP_DIR/frontend" install
+run yarn --cwd "$APP_DIR/frontend" build
+run bench build --app benchpress
+run bench --site "$SITE_NAME" clear-cache
+success "Assets rebuilt"
+echo ""
+
+# --- Step 4: Restart services ---
+
+info "Step 4/5: Restart services"
+run bench restart
+success "Services restarted (on a dev bench, restart 'bench start' yourself)"
+echo ""
+
+# --- Step 5: Verify health ---
+
+info "Step 5/5: Verify health"
+# A clean second migrate is a no-op — it confirms there are no pending patches.
+run bench --site "$SITE_NAME" migrate
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo -e "${YELLOW}[dry-run]${NC} bench --site $SITE_NAME execute benchpress.doctor.run"
+else
+    bench --site "$SITE_NAME" execute benchpress.doctor.run \
+        || warn "doctor check unavailable or reported issues — review the output above"
+fi
+success "Verification complete"
+echo ""
+
+trap - ERR
+
+echo "=============================="
+echo "  Upgrade Complete"
+echo "=============================="
+echo ""
+success "BenchPress is upgraded. Open the dashboard and confirm it loads:"
+echo "    http://$SITE_NAME/frontend"
+echo ""
+echo "If anything looks wrong, roll back using the recorded revision and your"
+echo "Step 0 backup — see docs/upgrading.md (Rollback)."
+echo ""


### PR DESCRIPTION
## What & why

RALPH slice for **#47 [P1-07] — Documented and scripted upgrade path**.

Prior slices shipped the manual runbook (#76) and the scripted `upgrade.sh` (#77). Both flagged a **versioned CHANGELOG** as the next TODO, and the runbook's "Before you start" table tells operators to *"read the release notes for the target version"* — with nowhere to read them. This PR fills that gap.

It's the smallest, lowest-risk remaining unit for #47: the only other open item (automatic mid-upgrade rollback) is larger and needs a live install to exercise.

## Changes

- **`CHANGELOG.md`** (new, app root) — [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) + [SemVer](https://semver.org/), the conventional format GitHub surfaces automatically. Seeded with a single `[Unreleased]` section capturing the upgrade-path work it ships alongside, plus a compact **"Maintaining this changelog"** contract in the preamble (append under Unreleased, flag manual upgrade steps, cut/tag on release).
- **`docs/upgrading.md`** — the prereq table now links the CHANGELOG; *"What's not automated yet"* drops the now-shipped CHANGELOG bullet, leaving only automatic rollback.
- **`README.md`** — adds Changelog to the Detailed Guides list.

## Key decisions

- **Tracer bullet = establish the mechanism**, not backfill all history. The `[Unreleased]` seed is accurate and self-consistent (nothing is tagged yet, so everything is genuinely unreleased); a preamble note points to git/GitHub for earlier history, avoiding any mislabeling of merge state.
- Maintenance guidance lives in the **preamble**, not a trailing section, so future version entries append cleanly under `[Unreleased]` without a heading collision.

## Verification

- All relative links resolve (`../CHANGELOG.md`, `docs/upgrading.md`, `upgrade.sh`).
- `pre-commit` clean — markdown is outside every hook's scope (prettier handles only js/vue/scss; trailing-whitespace excludes `.md`), so a no-op as expected.
- Docs-only change — no code/DocType/frontend touched, so no browser/test feedback loop applies.

## Acceptance criteria (#47)

- [x] One documented command/runbook upgrades an install end-to-end (#76, #77)
- [x] Upgrade aborts safely if the pre-upgrade backup fails (#77 Step 0 gate)
- [x] **Versioned release notes / CHANGELOG for multi-release upgrades — this PR**
- [ ] Automatic rollback on mid-upgrade failure *(next slice; needs a live install to test)*

> Stacked on `feat/p1-47-upgrade-script` (#77); auto-retargets to `develop` once the #47 stack merges.

Relates to #47.