### PR TITLE
feat(labs): wire Lab.pids_limit end-to-end (#49)

### DIFF
--- a/benchpress/benchpress/doctype/lab/lab.json
+++ b/benchpress/benchpress/doctype/lab/lab.json
@@ -20,6 +20,7 @@
   "cpu_cores",
   "iops_limit",
   "bps_limit",
+  "pids_limit",
   "column_break_resources",
   "enable_ssh",
   "enable_code_server",
@@ -109,6 +110,13 @@
    "fieldname": "bps_limit",
    "fieldtype": "Int",
    "label": "Max Bytes/sec (Block I/O)",
+   "non_negative": 1
+  },
+  {
+   "description": "Max number of processes (PIDs) the container may spawn. Leave 0 for the default (500).",
+   "fieldname": "pids_limit",
+   "fieldtype": "Int",
+   "label": "Max Processes (PID limit)",
    "non_negative": 1
   },
   {

--- a/benchpress/benchpress/doctype/lab/lab.json
+++ b/benchpress/benchpress/doctype/lab/lab.json
@@ -18,6 +18,8 @@
   "resources_section",
   "memory_limit",
   "cpu_cores",
+  "iops_limit",
+  "bps_limit",
   "column_break_resources",
   "enable_ssh",
   "enable_code_server",
@@ -94,6 +96,20 @@
    "fieldname": "cpu_cores",
    "fieldtype": "Int",
    "label": "CPU Cores"
+  },
+  {
+   "description": "Read/write IOPS cap per host block device. Leave 0 for the default (1000).",
+   "fieldname": "iops_limit",
+   "fieldtype": "Int",
+   "label": "Max IOPS (Block I/O)",
+   "non_negative": 1
+  },
+  {
+   "description": "Read/write throughput cap in bytes/sec per host block device. Leave 0 for the default (40 MiB/s).",
+   "fieldname": "bps_limit",
+   "fieldtype": "Int",
+   "label": "Max Bytes/sec (Block I/O)",
+   "non_negative": 1
   },
   {
    "fieldname": "column_break_resources",

--- a/benchpress/tests/test_docker_manager.py
+++ b/benchpress/tests/test_docker_manager.py
@@ -1,12 +1,16 @@
 # Copyright (c) 2026, Venkatesh and Contributors
 # See license.txt
 
+import types
 import unittest
 from unittest.mock import MagicMock, patch
 
 import docker
+import frappe
+from frappe.tests import IntegrationTestCase
 
-from benchpress.docker_manager import get_container_health
+import benchpress.docker_manager as docker_manager
+from benchpress.docker_manager import DEFAULT_BPS, DEFAULT_IOPS, get_container_health
 
 
 def _client_returning(status):
@@ -32,3 +36,61 @@ class TestContainerHealth(unittest.TestCase):
 		client.containers.get.side_effect = docker.errors.NotFound("no such container")
 		get_client.return_value = client
 		self.assertEqual(get_container_health("gone"), "Unknown")
+
+
+def _make_lab(lab_id, **extra):
+	if frappe.db.exists("Lab", lab_id):
+		frappe.delete_doc("Lab", lab_id, force=True, ignore_permissions=True)
+	doc = frappe.get_doc(
+		{
+			"doctype": "Lab",
+			"lab_id": lab_id,
+			"title": f"Test Lab {lab_id}",
+			"frappe_version": "version-15",
+			"image_tag": "benchpress/test:latest",
+			**extra,
+		}
+	).insert(ignore_permissions=True)
+	frappe.db.commit()
+	return doc
+
+
+class TestDockerManagerBlockIO(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+
+	def _container_create_kwargs(self, lab):
+		"""Run create_bench_container with Docker mocked and return the
+		kwargs passed to client.containers.create."""
+		bench = types.SimpleNamespace(bench_name="blockio-test-bench")
+		with (
+			patch("benchpress.docker_manager.get_client") as mock_client,
+			patch("benchpress.docker_manager.ensure_network"),
+			patch("benchpress.docker_manager._get_host_block_devices", return_value=["/dev/sda"]),
+		):
+			mock_client.return_value.containers.create.return_value = MagicMock(id="cid")
+			docker_manager.create_bench_container(bench, lab)
+			return mock_client.return_value.containers.create.call_args.kwargs
+
+	def test_lab_block_io_limits_passed_to_container(self):
+		lab = _make_lab("blockio-custom", iops_limit=500, bps_limit=2 * 1024 * 1024)
+		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
+
+		kwargs = self._container_create_kwargs(lab)
+
+		self.assertEqual(kwargs["device_read_iops"], [{"Path": "/dev/sda", "Rate": 500}])
+		self.assertEqual(kwargs["device_write_iops"], [{"Path": "/dev/sda", "Rate": 500}])
+		self.assertEqual(kwargs["device_read_bps"], [{"Path": "/dev/sda", "Rate": 2 * 1024 * 1024}])
+		self.assertEqual(kwargs["device_write_bps"], [{"Path": "/dev/sda", "Rate": 2 * 1024 * 1024}])
+
+	def test_unset_block_io_limits_fall_back_to_defaults(self):
+		# iops_limit / bps_limit default to 0, which means "use the default".
+		lab = _make_lab("blockio-default")
+		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
+
+		kwargs = self._container_create_kwargs(lab)
+
+		self.assertEqual(kwargs["device_read_iops"], [{"Path": "/dev/sda", "Rate": DEFAULT_IOPS}])
+		self.assertEqual(kwargs["device_write_bps"], [{"Path": "/dev/sda", "Rate": DEFAULT_BPS}])

--- a/benchpress/tests/test_docker_manager.py
+++ b/benchpress/tests/test_docker_manager.py
@@ -10,7 +10,12 @@ import frappe
 from frappe.tests import IntegrationTestCase
 
 import benchpress.docker_manager as docker_manager
-from benchpress.docker_manager import DEFAULT_BPS, DEFAULT_IOPS, get_container_health
+from benchpress.docker_manager import (
+	DEFAULT_BPS,
+	DEFAULT_IOPS,
+	DEFAULT_PIDS_LIMIT,
+	get_container_health,
+)
 
 
 def _client_returning(status):
@@ -94,3 +99,20 @@ class TestDockerManagerBlockIO(IntegrationTestCase):
 
 		self.assertEqual(kwargs["device_read_iops"], [{"Path": "/dev/sda", "Rate": DEFAULT_IOPS}])
 		self.assertEqual(kwargs["device_write_bps"], [{"Path": "/dev/sda", "Rate": DEFAULT_BPS}])
+
+	def test_lab_pids_limit_passed_to_container(self):
+		lab = _make_lab("pids-custom", pids_limit=250)
+		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
+
+		kwargs = self._container_create_kwargs(lab)
+
+		self.assertEqual(kwargs["pids_limit"], 250)
+
+	def test_unset_pids_limit_falls_back_to_default(self):
+		# pids_limit defaults to 0, which means "use the default".
+		lab = _make_lab("pids-default")
+		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
+
+		kwargs = self._container_create_kwargs(lab)
+
+		self.assertEqual(kwargs["pids_limit"], DEFAULT_PIDS_LIMIT)

--- a/frontend/src/pages/NewLab.vue
+++ b/frontend/src/pages/NewLab.vue
@@ -79,6 +79,12 @@
 					type="number"
 					description="Per host block device. 0 = default (40 MiB/s)."
 				/>
+				<FormControl
+					label="Max Processes (PID limit)"
+					v-model="form.pids_limit"
+					type="number"
+					description="0 = default (500)."
+				/>
 			</div>
 		</div>
 
@@ -156,6 +162,7 @@ const form = reactive({
 	cpu_cores: 1,
 	iops_limit: 0,
 	bps_limit: 0,
+	pids_limit: 0,
 	apps: [],
 });
 
@@ -189,6 +196,7 @@ async function createLab() {
 			cpu_cores: form.cpu_cores,
 			iops_limit: form.iops_limit,
 			bps_limit: form.bps_limit,
+			pids_limit: form.pids_limit,
 			apps: form.apps.filter((a) => a.app_name && a.git_url && a.branch),
 		});
 		router.push("/labs");

--- a/frontend/src/pages/NewLab.vue
+++ b/frontend/src/pages/NewLab.vue
@@ -67,6 +67,18 @@
 					placeholder="e.g. 512m"
 				/>
 				<FormControl label="CPU Cores" v-model="form.cpu_cores" type="number" />
+				<FormControl
+					label="Max IOPS (Block I/O)"
+					v-model="form.iops_limit"
+					type="number"
+					description="Per host block device. 0 = default (1000)."
+				/>
+				<FormControl
+					label="Max Bytes/sec (Block I/O)"
+					v-model="form.bps_limit"
+					type="number"
+					description="Per host block device. 0 = default (40 MiB/s)."
+				/>
 			</div>
 		</div>
 
@@ -142,6 +154,8 @@ const form = reactive({
 	description: "",
 	memory_limit: "512m",
 	cpu_cores: 1,
+	iops_limit: 0,
+	bps_limit: 0,
 	apps: [],
 });
 
@@ -173,6 +187,8 @@ async function createLab() {
 			description: form.description,
 			memory_limit: form.memory_limit,
 			cpu_cores: form.cpu_cores,
+			iops_limit: form.iops_limit,
+			bps_limit: form.bps_limit,
 			apps: form.apps.filter((a) => a.app_name && a.git_url && a.branch),
 		});
 		router.push("/labs");


### PR DESCRIPTION
## Summary

Wires the half-wired **`Lab.pids_limit`** field end-to-end — the follow-up flagged while shipping the IOPS/BPS limits in #74. Part of #49 [P2-02] "finish or remove half-wired Lab/Settings fields".

`docker_manager.create_bench_container` already read `getattr(lab_doc, "pids_limit", None) or DEFAULT_PIDS_LIMIT` and passed it as the container `pids_limit` kwarg — but the Lab DocType had **no such field**, so `getattr` always returned `None` and every container silently used the hardcoded `DEFAULT_PIDS_LIMIT` (500). The read side was wired; nothing could set it.

## Key decisions

- **Wire, not remove.** A per-lab PID cap is a real fork-bomb / runaway-process guard, and the deploy path was already plumbed for it — the same call the IOPS/BPS slice (#74) made for the identical pattern.
- **Raw `Int`, `0 = use default`**, matching `docker_manager`'s existing `int(... or DEFAULT)` contract, so **no change to `docker_manager.py`**.
- **Stacked on #74** (`feat/p2-49-wire-block-io-limits`): both touch `lab.json`'s `resources_section` + `NewLab.vue`, so `pids_limit` slots beside IOPS/BPS with no conflict. Auto-retargets to `develop` once #74 merges.

## Files changed

- `benchpress/benchpress/doctype/lab/lab.json` — add `pids_limit` `Int` field (`non_negative`, beside IOPS/BPS in *Resources & Access*).
- `frontend/src/pages/NewLab.vue` — `FormControl` + form default + insert payload.
- `benchpress/tests/test_docker_manager.py` — 2 tests (custom value → kwarg; `0` → `DEFAULT_PIDS_LIMIT` fallback).

## Verification (live bench, host `apps/` bind-mounted)

- `bench migrate` adds the column (`frappe.db.has_column` → `true`).
- **4/4** `test_docker_manager` tests pass (2 new).
- Doc insert with `pids_limit=321` persists and reads back `321`.
- `yarn build` clean; `pids_limit` present in the `NewLab` bundle; `/frontend` serves `200`.
- `pre-commit run --all-files` clean.

## Field inventory progress (#49)

- [x] `Lab.shell` — wired (#72)
- [x] `Lab.mount_target` — removed (#73)
- [x] IOPS/BPS block-I/O limits — wired (#74)
- [x] **`Lab.pids_limit` — wired (this PR)**
- [ ] `Database Server.custom_config` — last documented inventory item

Relates to #49.