### PR TITLE
feat(db): finish Database Server MariaDB config — confirm custom_config, drop dead max_connections (#49)

### DIFF
--- a/benchpress/benchpress/doctype/database_server/database_server.json
+++ b/benchpress/benchpress/doctype/database_server/database_server.json
@@ -22,7 +22,6 @@
   "volume_name",
   "created_at",
   "configuration_section",
-  "max_connections",
   "custom_config",
   "error_section",
   "error_message"
@@ -130,12 +129,7 @@
    "label": "MariaDB Configuration"
   },
   {
-   "default": "500",
-   "fieldname": "max_connections",
-   "fieldtype": "Int",
-   "label": "Max Connections"
-  },
-  {
+   "description": "Full MariaDB server config (INI). Seeded with sensible defaults on creation; edit to tune the server (e.g. max_connections, buffer pool). Re-run setup to apply.",
    "fieldname": "custom_config",
    "fieldtype": "Code",
    "label": "Custom Config",

--- a/benchpress/tests/test_mariadb_manager.py
+++ b/benchpress/tests/test_mariadb_manager.py
@@ -2,6 +2,8 @@
 # See license.txt
 
 import hashlib
+import os
+import tempfile
 from unittest.mock import MagicMock, patch
 
 import frappe
@@ -146,3 +148,28 @@ class TestMariadbManager(IntegrationTestCase):
 		self.assertIn(db_name, combined)
 		self.assertIn("DROP DATABASE", combined)
 		self.assertIn("DROP USER", combined)
+
+	@patch("benchpress.mariadb_manager._get_config_dir")
+	def test_write_mariadb_config_writes_custom_config_verbatim(self, mock_config_dir):
+		"""Database Server.custom_config flows verbatim into the mounted mariadb.cnf."""
+		from benchpress.mariadb_manager import _write_mariadb_config
+
+		with tempfile.TemporaryDirectory() as tmp:
+			mock_config_dir.return_value = tmp
+			custom = "[mysqld]\nmax_connections=1234\ninnodb_buffer_pool_size=1073741824\n"
+			_write_mariadb_config(custom)
+			with open(os.path.join(tmp, "mariadb.cnf")) as f:
+				written = f.read()
+		self.assertEqual(written, custom)
+
+	@patch("benchpress.mariadb_manager._get_config_dir")
+	def test_write_mariadb_config_falls_back_to_default(self, mock_config_dir):
+		"""An empty custom_config falls back to DEFAULT_MARIADB_CONFIG."""
+		from benchpress.mariadb_manager import DEFAULT_MARIADB_CONFIG, _write_mariadb_config
+
+		with tempfile.TemporaryDirectory() as tmp:
+			mock_config_dir.return_value = tmp
+			_write_mariadb_config(None)
+			with open(os.path.join(tmp, "mariadb.cnf")) as f:
+				written = f.read()
+		self.assertEqual(written, DEFAULT_MARIADB_CONFIG)


### PR DESCRIPTION
## What & why

Final RALPH slice for **#49 [P2-02] Finish or remove half-wired Lab/Settings fields** — the last open inventory item: the **Database Server "MariaDB Configuration"** section (tracked as `Database Server.custom_config`).

### Finding: `custom_config` is already wired
`custom_config` flows **end-to-end** today:

`field` → `before_insert` default → `setup_database_server` → `_write_mariadb_config` → `config/mariadb.cnf` → mounted `:ro` into the MariaDB container at `/etc/mysql/conf.d/benchpress.cnf`.

It's also editable in the **Desk form** (regular DocType), so the inventory's *"no UI to edit it"* was inaccurate. What it lacked was the **test** leg of *"field → deploy behavior → test."*

### The real dead weight: `max_connections`
The sibling `max_connections` field (default `500`, shown in Desk) is **never read by any code** — `custom_config`'s `[mysqld]` block already carries `max_connections=500`. Setting it did nothing: classic half-wired dead weight.

## Changes
- **`custom_config` = wired (confirmed).** Added 2 unit tests for `_write_mariadb_config` (custom value written **verbatim** to `mariadb.cnf`; empty/`None` → `DEFAULT_MARIADB_CONFIG` fallback). Added a field `description` so the Desk editor self-documents it as the single MariaDB tuning knob.
- **`max_connections` = removed** (the `Lab.mount_target` precedent, PR #73). It's redundant with the already-wired free-form `custom_config`, so *remove* is cleaner than wiring a second source of truth for the same setting.
- **No change to `mariadb_manager.py`** — the wiring was already correct.

## Decision: wire vs. remove
Per the issue's "wire **or** remove" mandate:
- `custom_config` → **keep + prove** (it's the working, general escape hatch).
- `max_connections` → **remove** (dead + redundant). Honoring both would create two sources of truth for the same `[mysqld]` setting.

## Verification (live bench, host `apps/` bind-mounted)
- `bench migrate` clean.
- **13/13** `test_mariadb_manager` pass (2 new).
- Live throwaway doc: `custom_config` persists verbatim; `max_connections` gone from meta (`get_field` → `None`); empty `custom_config` seeds `DEFAULT_MARIADB_CONFIG`. Throwaway docs deleted; live default Database Server untouched.
- `pre-commit run` clean (ruff + ruff-format + json/ast checks).
- Note: Frappe leaves the orphan `max_connections` DB column on field removal (by design) — harmless, nothing reads it.

## Issue #49 inventory — now complete
- [x] `Lab.shell` — wired (PR #72)
- [x] `Lab.mount_target` — removed (PR #73)
- [x] IOPS/BPS block-I/O limits — wired (PR #74)
- [x] `Lab.pids_limit` — wired (PR #81)
- [x] **`Database Server.custom_config` — wired (confirmed + tested); dead `max_connections` removed — this PR**

Every flagged field is now wired or removed.

Closes #49

> Independent of the #49 Lab stack (touches `database_server.json` + `test_mariadb_manager.py` only), so this targets `develop` directly.