### PR TITLE
feat(cli): `bench benchpress quickstart` walking-skeleton command (#26)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ everything-claude-code/
 # Frontend build output
 benchpress/public/frontend/
 benchpress/www/frontend.html
+
+# Local planning docs (not committed)
+plans/

--- a/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
+++ b/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
@@ -25,7 +25,11 @@
   "column_break_resource",
   "container_cpu_quota",
   "wg_server_private_key",
-  "code_server_version"
+  "code_server_version",
+  "quickstart_section",
+  "default_lab",
+  "column_break_quickstart",
+  "default_admin_password"
  ],
  "fields": [
   {
@@ -138,6 +142,29 @@
    "fieldname": "code_server_version",
    "fieldtype": "Data",
    "label": "Code Server Version"
+  },
+  {
+   "fieldname": "quickstart_section",
+   "fieldtype": "Section Break",
+   "label": "Quickstart Defaults"
+  },
+  {
+   "description": "Lab the `bench benchpress quickstart` command deploys by default. Seeded on first run if left blank.",
+   "fieldname": "default_lab",
+   "fieldtype": "Link",
+   "label": "Default Lab",
+   "options": "Lab"
+  },
+  {
+   "fieldname": "column_break_quickstart",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "admin",
+   "description": "Administrator password set on the quickstart bench's site.",
+   "fieldname": "default_admin_password",
+   "fieldtype": "Data",
+   "label": "Default Admin Password"
   }
  ],
  "grid_page_length": 50,

--- a/benchpress/commands.py
+++ b/benchpress/commands.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+import click
+
+
+@click.group("benchpress")
+def benchpress():
+	"""BenchPress CLI commands."""
+
+
+@benchpress.command("quickstart")
+@click.option("--site", required=True, help="Site to provision the bench against.")
+def quickstart(site: str):
+	"""Deploy a ready-to-use ERPNext bench in one command (TB1 walking skeleton)."""
+	import frappe
+
+	from benchpress.quickstart import run_quickstart
+
+	frappe.init(site=site)
+	frappe.connect()
+	try:
+		run_quickstart()
+	finally:
+		frappe.destroy()
+
+
+commands = [benchpress]

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -124,8 +124,12 @@ def deploy_bench(bench_name: str) -> None:
 		bench.save(ignore_permissions=True)
 		frappe.db.commit()
 
-		admin_password = secrets.token_urlsafe(10)
-		bench.admin_password = admin_password
+		# Honor a pre-set admin password (e.g. set by the quickstart CLI); only
+		# generate a random one when none was provided.
+		admin_password = bench.get_password("admin_password", raise_exception=False)
+		if not admin_password:
+			admin_password = secrets.token_urlsafe(10)
+			bench.admin_password = admin_password
 
 		append_log("=== Checking shared infrastructure (MariaDB + Redis) ===")
 		db_server_name = ensure_infrastructure()

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -22,6 +22,7 @@ from benchpress.mariadb_manager import (
 	ensure_infrastructure,
 	wait_for_mariadb,
 )
+from benchpress.platform import resolve_access_url
 
 
 def _remove_stale_container(bench) -> None:
@@ -281,7 +282,7 @@ def deploy_bench(bench_name: str) -> None:
 			)
 			exec_in_container(container_id, "bash /opt/benchpress/scripts/restart.sh", user="root")
 			bench.code_server_password = code_server_password
-			bench.code_server_url = f"http://{bench.wg_ip or bench.container_ip or '127.0.0.1'}:8080/"
+			bench.code_server_url = f"http://{resolve_access_url(bench)}:8080/"
 			append_log(f"code-server ready at {bench.code_server_url}")
 
 		bench.status = "Running"

--- a/benchpress/platform.py
+++ b/benchpress/platform.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""Platform-level helpers for resolving how a user reaches a deployed bench.
+
+Centralizing the host-resolution rule here means later tracer bullets (TB3 adds a
+WSL2 localhost-forwarding branch) change one function instead of every call site.
+"""
+
+
+def resolve_access_url(bench) -> str:
+	"""Return the host a user reaches ``bench`` at.
+
+	Prefers the WireGuard peer IP, falls back to the container's bridge IP, then to
+	loopback. Callers format their own scheme/port around this (``http://<host>:8000/``,
+	``ssh user@<host>``, ...). This is intentionally just the host today; TB3 will add
+	the WSL2 branch that returns a localhost-forwarded address.
+	"""
+	return bench.wg_ip or bench.container_ip or "127.0.0.1"

--- a/benchpress/quickstart.py
+++ b/benchpress/quickstart.py
@@ -1,32 +1,39 @@
 # Copyright (c) 2026, Venkatesh and contributors
 # For license information, please see license.txt
 
-"""TB1 walking-skeleton ``quickstart`` orchestration.
+"""TB2 ``quickstart`` orchestration — config-driven and idempotent.
 
-One command, end to end: ensure a hardcoded ERPNext Lab exists, build its image,
-deploy a Bench Instance with predictable ``Administrator / admin`` credentials, and
-block until the site is up. Everything that is not load-bearing for the wiring is
-deliberately hardcoded here and paid back in later tracer bullets (TB2+).
+One command, end to end: ensure the default ERPNext Lab exists, build its image,
+deploy a Bench Instance with the preset ``Administrator / <default_admin_password>``
+credentials, and block until the site is up. The presets (which Lab, which admin
+password) live in **BenchPress Settings** so they are editable from Desk; the
+hardcoded Lab below is only the create-if-missing seed for a fresh install.
+
+Re-running is idempotent: an already-Running default bench reprints its access
+banner instead of redeploying.
 """
 
 import time
 
 import click
 import frappe
+from frappe import _
 
 from benchpress.benchpress.doctype.bench_instance import get_instance_id
 from benchpress.deploy_manager import build_lab, deploy_bench
+from benchpress.platform import resolve_access_url
 
-# --- Deliberately hardcoded in TB1 (paid back in TB2 via a Settings preset) ---
+# Seed for the default Lab, created on first run when Settings.default_lab is unset.
+# The *live* preset is BenchPress Settings.default_lab — this dict only bootstraps a
+# fresh install so there is something to point that field at.
 QUICKSTART_LAB_ID = "erpnext-quickstart"
 QUICKSTART_FRAPPE_VERSION = "version-15"
-QUICKSTART_ADMIN_PASSWORD = "admin"
 QUICKSTART_LAB = {
 	"doctype": "Lab",
 	"lab_id": QUICKSTART_LAB_ID,
 	"title": "ERPNext Quickstart",
 	"frappe_version": QUICKSTART_FRAPPE_VERSION,
-	"description": "Zero-config ERPNext bench (TB1 walking skeleton).",
+	"description": "Zero-config ERPNext bench (BenchPress quickstart default).",
 	"memory_limit": "4g",
 	"cpu_cores": 2,
 	"apps": [
@@ -45,29 +52,57 @@ QUICKSTART_LAB = {
 	],
 }
 
+DEFAULT_ADMIN_PASSWORD = "admin"
+
 
 def _echo(message: str, fg: str | None = None) -> None:
 	click.echo(click.style(message, fg=fg) if fg else message)
 
 
 def run_quickstart() -> None:
-	"""Drive the full Lab -> image -> bench -> banner slice, blocking throughout."""
-	lab = _ensure_lab()
+	"""Drive the full Lab -> image -> bench -> banner slice, blocking throughout.
+
+	Idempotent: if the default bench is already Running, reprint its banner and stop.
+	"""
+	settings = frappe.get_cached_doc("BenchPress Settings")
+	lab = _ensure_lab(settings)
+
+	bench_name = get_instance_id(frappe.session.user, lab.name)
+	if frappe.db.exists("Bench Instance", bench_name):
+		bench = frappe.get_doc("Bench Instance", bench_name)
+		if bench.status == "Running":
+			_echo(f"==> Default bench '{bench_name}' is already running; reprinting access details.")
+			_print_banner(bench)
+			return
+
 	_ensure_image(lab)
-	bench = _deploy(lab)
+	bench = _deploy(lab, settings)
 	_start_web_server(bench)
 	_print_banner(bench)
 
 
-def _ensure_lab():
-	"""Create the hardcoded ERPNext Lab if it does not already exist."""
+def _ensure_lab(settings):
+	"""Resolve the default Lab from Settings, seeding it on a fresh install.
+
+	Uses ``BenchPress Settings.default_lab`` when set; otherwise creates the hardcoded
+	ERPNext seed Lab and records it back into Settings so subsequent runs (and Desk)
+	share the same source of truth.
+	"""
+	if settings.default_lab and frappe.db.exists("Lab", settings.default_lab):
+		_echo(f"==> Using default Lab '{settings.default_lab}' from BenchPress Settings.")
+		return frappe.get_doc("Lab", settings.default_lab)
+
 	if frappe.db.exists("Lab", QUICKSTART_LAB_ID):
 		_echo(f"==> Lab '{QUICKSTART_LAB_ID}' already exists.")
+		lab = frappe.get_doc("Lab", QUICKSTART_LAB_ID)
 	else:
-		_echo(f"==> Creating Lab '{QUICKSTART_LAB_ID}'...")
-		frappe.get_doc(QUICKSTART_LAB).insert(ignore_permissions=True)
-		frappe.db.commit()
-	return frappe.get_doc("Lab", QUICKSTART_LAB_ID)
+		_echo(f"==> Creating default Lab '{QUICKSTART_LAB_ID}'...")
+		lab = frappe.get_doc(QUICKSTART_LAB).insert(ignore_permissions=True)
+
+	frappe.db.set_single_value("BenchPress Settings", "default_lab", lab.name)
+	# CLI one-shot: nothing else commits before frappe.destroy(), so persist the seed here.
+	frappe.db.commit()  # nosemgrep
+	return lab
 
 
 def _ensure_image(lab) -> None:
@@ -84,7 +119,7 @@ def _ensure_image(lab) -> None:
 	_echo(f"==> Image ready: {lab.image_tag}")
 
 
-def _deploy(lab):
+def _deploy(lab, settings):
 	"""Create (or reuse) the Bench Instance with preset creds and deploy inline."""
 	bench_name = get_instance_id(frappe.session.user, lab.name)
 
@@ -113,11 +148,12 @@ def _deploy(lab):
 			)
 		bench.insert(ignore_permissions=True)
 
-	# Override the random password deploy_bench would otherwise generate, so
-	# beginners get predictable Administrator / admin credentials.
-	bench.admin_password = QUICKSTART_ADMIN_PASSWORD
+	# Override the random password deploy_bench would otherwise generate, so beginners
+	# get predictable Administrator credentials sourced from Settings.
+	bench.admin_password = settings.default_admin_password or DEFAULT_ADMIN_PASSWORD
 	bench.save(ignore_permissions=True)
-	frappe.db.commit()
+	# Persist the bench before the inline deploy_bench; the CLI commits nothing else.
+	frappe.db.commit()  # nosemgrep
 
 	# Run the deploy INLINE (the API enqueues to the "long" queue; a CLI must
 	# block until the site is actually up).
@@ -152,7 +188,7 @@ def _start_web_server(bench) -> None:
 	)
 
 	# Block until the port actually accepts connections, so the printed URL works.
-	for _ in range(15):
+	for _attempt in range(15):
 		exit_code, _output = exec_in_container(
 			bench.container_id,
 			"ss -ltn 2>/dev/null | grep -q ':8000 '",
@@ -162,13 +198,14 @@ def _start_web_server(bench) -> None:
 		if exit_code == 0:
 			return
 		time.sleep(2)
-	frappe.throw("Web server did not start listening on :8000; inspect the container.")
+	frappe.throw(_("Web server did not start listening on :8000; inspect the container."))
 
 
 def _print_banner(bench) -> None:
 	"""Print the success banner: web URL, credentials, SSH details, bench name."""
-	host = bench.wg_ip or bench.container_ip or "127.0.0.1"
+	host = resolve_access_url(bench)
 	web_url = f"http://{host}:8000/"
+	admin_password = bench.get_password("admin_password", raise_exception=False) or DEFAULT_ADMIN_PASSWORD
 	ssh_password = bench.get_password("ssh_password", raise_exception=False) or "(see Bench Instance)"
 
 	line = "=" * 64
@@ -178,7 +215,7 @@ def _print_banner(bench) -> None:
 	_echo(line, fg="green")
 	_echo(f"  Web URL   : {web_url}")
 	_echo("  Login     : Administrator")
-	_echo(f"  Password  : {QUICKSTART_ADMIN_PASSWORD}")
+	_echo(f"  Password  : {admin_password}")
 	_echo("")
 	_echo(f"  SSH       : ssh {bench.ssh_username}@{host}")
 	_echo(f"  SSH pass  : {ssh_password}")

--- a/benchpress/quickstart.py
+++ b/benchpress/quickstart.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""TB1 walking-skeleton ``quickstart`` orchestration.
+
+One command, end to end: ensure a hardcoded ERPNext Lab exists, build its image,
+deploy a Bench Instance with predictable ``Administrator / admin`` credentials, and
+block until the site is up. Everything that is not load-bearing for the wiring is
+deliberately hardcoded here and paid back in later tracer bullets (TB2+).
+"""
+
+import time
+
+import click
+import frappe
+
+from benchpress.benchpress.doctype.bench_instance import get_instance_id
+from benchpress.deploy_manager import build_lab, deploy_bench
+
+# --- Deliberately hardcoded in TB1 (paid back in TB2 via a Settings preset) ---
+QUICKSTART_LAB_ID = "erpnext-quickstart"
+QUICKSTART_FRAPPE_VERSION = "version-15"
+QUICKSTART_ADMIN_PASSWORD = "admin"
+QUICKSTART_LAB = {
+	"doctype": "Lab",
+	"lab_id": QUICKSTART_LAB_ID,
+	"title": "ERPNext Quickstart",
+	"frappe_version": QUICKSTART_FRAPPE_VERSION,
+	"description": "Zero-config ERPNext bench (TB1 walking skeleton).",
+	"memory_limit": "4g",
+	"cpu_cores": 2,
+	"apps": [
+		{
+			"app_name": "frappe",
+			"app_label": "Frappe",
+			"git_url": "https://github.com/frappe/frappe",
+			"branch": QUICKSTART_FRAPPE_VERSION,
+		},
+		{
+			"app_name": "erpnext",
+			"app_label": "ERPNext",
+			"git_url": "https://github.com/frappe/erpnext",
+			"branch": QUICKSTART_FRAPPE_VERSION,
+		},
+	],
+}
+
+
+def _echo(message: str, fg: str | None = None) -> None:
+	click.echo(click.style(message, fg=fg) if fg else message)
+
+
+def run_quickstart() -> None:
+	"""Drive the full Lab -> image -> bench -> banner slice, blocking throughout."""
+	lab = _ensure_lab()
+	_ensure_image(lab)
+	bench = _deploy(lab)
+	_start_web_server(bench)
+	_print_banner(bench)
+
+
+def _ensure_lab():
+	"""Create the hardcoded ERPNext Lab if it does not already exist."""
+	if frappe.db.exists("Lab", QUICKSTART_LAB_ID):
+		_echo(f"==> Lab '{QUICKSTART_LAB_ID}' already exists.")
+	else:
+		_echo(f"==> Creating Lab '{QUICKSTART_LAB_ID}'...")
+		frappe.get_doc(QUICKSTART_LAB).insert(ignore_permissions=True)
+		frappe.db.commit()
+	return frappe.get_doc("Lab", QUICKSTART_LAB_ID)
+
+
+def _ensure_image(lab) -> None:
+	"""Build the lab image (blocking) unless a cached one is already Ready."""
+	if lab.status == "Ready" and lab.image_tag:
+		_echo(f"==> Using cached image: {lab.image_tag}")
+		return
+
+	_echo("==> Building ERPNext image (this can take several minutes)...")
+	build_lab(lab.name)
+	lab.reload()
+	if lab.status != "Ready" or not lab.image_tag:
+		frappe.throw(f"Image build failed; inspect the Build Log for lab '{lab.name}'.")
+	_echo(f"==> Image ready: {lab.image_tag}")
+
+
+def _deploy(lab):
+	"""Create (or reuse) the Bench Instance with preset creds and deploy inline."""
+	bench_name = get_instance_id(frappe.session.user, lab.name)
+
+	if frappe.db.exists("Bench Instance", bench_name):
+		_echo(f"==> Reusing existing Bench Instance '{bench_name}'.")
+		bench = frappe.get_doc("Bench Instance", bench_name)
+	else:
+		_echo("==> Creating Bench Instance...")
+		bench = frappe.get_doc(
+			{
+				"doctype": "Bench Instance",
+				"lab": lab.name,
+				"frappe_version": lab.frappe_version,
+				"status": "Draft",
+			}
+		)
+		for app in lab.apps:
+			bench.append(
+				"apps",
+				{
+					"app_name": app.app_name,
+					"app_label": app.app_label,
+					"git_url": app.git_url,
+					"branch": app.branch,
+				},
+			)
+		bench.insert(ignore_permissions=True)
+
+	# Override the random password deploy_bench would otherwise generate, so
+	# beginners get predictable Administrator / admin credentials.
+	bench.admin_password = QUICKSTART_ADMIN_PASSWORD
+	bench.save(ignore_permissions=True)
+	frappe.db.commit()
+
+	# Run the deploy INLINE (the API enqueues to the "long" queue; a CLI must
+	# block until the site is actually up).
+	_echo("==> Deploying bench (blocks until the site is up)...")
+	deploy_bench(bench.name)
+
+	bench.reload()
+	if bench.status != "Running":
+		frappe.throw(f"Deploy did not reach Running (status={bench.status}); inspect the Deploy Log.")
+	return bench
+
+
+def _start_web_server(bench) -> None:
+	"""Start the Frappe dev web server inside the container so the banner URL is live.
+
+	``entry.sh`` starts Redis/SSH/code-server but not the web server, so nothing
+	listens on :8000 after a deploy. TB1 starts it here (reusing ``exec_in_container``)
+	rather than touching the Docker template; a later tracer bullet should move this
+	into the container entrypoint so it survives restarts.
+	"""
+	from benchpress.docker_manager import exec_in_container
+
+	user = bench.ssh_username or "frappe"
+	bench_dir = f"/home/{user}/frappe-bench"
+
+	_echo("==> Starting web server on :8000...")
+	exec_in_container(
+		bench.container_id,
+		"screen -d -m -S web bench serve --port 8000",
+		user=user,
+		workdir=bench_dir,
+	)
+
+	# Block until the port actually accepts connections, so the printed URL works.
+	for _ in range(15):
+		exit_code, _output = exec_in_container(
+			bench.container_id,
+			"ss -ltn 2>/dev/null | grep -q ':8000 '",
+			user="root",
+			workdir="/",
+		)
+		if exit_code == 0:
+			return
+		time.sleep(2)
+	frappe.throw("Web server did not start listening on :8000; inspect the container.")
+
+
+def _print_banner(bench) -> None:
+	"""Print the success banner: web URL, credentials, SSH details, bench name."""
+	host = bench.wg_ip or bench.container_ip or "127.0.0.1"
+	web_url = f"http://{host}:8000/"
+	ssh_password = bench.get_password("ssh_password", raise_exception=False) or "(see Bench Instance)"
+
+	line = "=" * 64
+	_echo("")
+	_echo(line, fg="green")
+	_echo("  BenchPress quickstart complete - your ERPNext site is up!", fg="green")
+	_echo(line, fg="green")
+	_echo(f"  Web URL   : {web_url}")
+	_echo("  Login     : Administrator")
+	_echo(f"  Password  : {QUICKSTART_ADMIN_PASSWORD}")
+	_echo("")
+	_echo(f"  SSH       : ssh {bench.ssh_username}@{host}")
+	_echo(f"  SSH pass  : {ssh_password}")
+	_echo(f"  Bench     : {bench.name}")
+	_echo(line, fg="green")
+	_echo("")

--- a/benchpress/tests/test_quickstart.py
+++ b/benchpress/tests/test_quickstart.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from benchpress.benchpress.doctype.bench_instance import get_instance_id
+
+TEST_LAB_ID = "test-lab-quickstart"
+TEST_ADMIN_PASSWORD = "quickstart-secret-123"
+
+
+def _running_deploy(bench_name):
+	"""Stand-in for deploy_bench: mark the bench Running without touching Docker."""
+	bench = frappe.get_doc("Bench Instance", bench_name)
+	bench.status = "Running"
+	bench.container_id = "fake-container"
+	bench.container_ip = "172.18.0.9"
+	bench.save(ignore_permissions=True)
+	frappe.db.commit()
+
+
+class TestQuickstart(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+
+		# A pre-built Lab so _ensure_image short-circuits (no real image build).
+		if not frappe.db.exists("Lab", TEST_LAB_ID):
+			frappe.get_doc(
+				{
+					"doctype": "Lab",
+					"lab_id": TEST_LAB_ID,
+					"title": "Test Lab (Quickstart)",
+					"frappe_version": "version-15",
+				}
+			).insert(ignore_permissions=True)
+		frappe.db.set_value("Lab", TEST_LAB_ID, "status", "Ready")
+		frappe.db.set_value("Lab", TEST_LAB_ID, "image_tag", "benchpress/test-lab-quickstart:latest")
+		frappe.db.commit()
+
+		# Stash the live Settings presets so we can restore them after the run.
+		# set_single_value bypasses the singleton's mandatory base_domain, which is
+		# unset in a fresh test DB.
+		cls._orig_default_lab = frappe.db.get_single_value("BenchPress Settings", "default_lab")
+		cls._orig_admin_password = frappe.db.get_single_value("BenchPress Settings", "default_admin_password")
+		frappe.db.set_single_value("BenchPress Settings", "default_lab", TEST_LAB_ID)
+		frappe.db.set_single_value("BenchPress Settings", "default_admin_password", TEST_ADMIN_PASSWORD)
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+
+		frappe.db.set_single_value("BenchPress Settings", "default_lab", cls._orig_default_lab)
+		frappe.db.set_single_value("BenchPress Settings", "default_admin_password", cls._orig_admin_password)
+
+		bench_name = get_instance_id("Administrator", TEST_LAB_ID)
+		if frappe.db.exists("Bench Instance", bench_name):
+			frappe.delete_doc("Bench Instance", bench_name, force=True, ignore_permissions=True)
+		if frappe.db.exists("Lab", TEST_LAB_ID):
+			frappe.delete_doc("Lab", TEST_LAB_ID, force=True, ignore_permissions=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def _clear_bench(self):
+		bench_name = get_instance_id("Administrator", TEST_LAB_ID)
+		if frappe.db.exists("Bench Instance", bench_name):
+			frappe.delete_doc("Bench Instance", bench_name, force=True, ignore_permissions=True)
+			frappe.db.commit()
+		return bench_name
+
+	@patch("benchpress.docker_manager.exec_in_container", return_value=(0, ""))
+	@patch("benchpress.quickstart.build_lab")
+	@patch("benchpress.quickstart.deploy_bench", side_effect=_running_deploy)
+	def test_reads_presets_from_settings(self, mock_deploy, mock_build, mock_exec):
+		from benchpress.quickstart import run_quickstart
+
+		bench_name = self._clear_bench()
+		run_quickstart()
+
+		# The bench was created against the Settings-configured default Lab.
+		self.assertTrue(frappe.db.exists("Bench Instance", bench_name))
+		bench = frappe.get_doc("Bench Instance", bench_name)
+		self.assertEqual(bench.lab, TEST_LAB_ID)
+		# A cached Ready image means no build was triggered.
+		mock_build.assert_not_called()
+		mock_deploy.assert_called_once_with(bench_name)
+
+	@patch("benchpress.docker_manager.exec_in_container", return_value=(0, ""))
+	@patch("benchpress.quickstart.build_lab")
+	@patch("benchpress.quickstart.deploy_bench", side_effect=_running_deploy)
+	def test_admin_password_is_preset_not_random(self, mock_deploy, mock_build, mock_exec):
+		from benchpress.quickstart import run_quickstart
+
+		bench_name = self._clear_bench()
+		run_quickstart()
+
+		bench = frappe.get_doc("Bench Instance", bench_name)
+		self.assertEqual(bench.get_password("admin_password"), TEST_ADMIN_PASSWORD)
+
+	@patch("benchpress.docker_manager.exec_in_container", return_value=(0, ""))
+	@patch("benchpress.quickstart.build_lab")
+	@patch("benchpress.quickstart.deploy_bench", side_effect=_running_deploy)
+	def test_second_run_is_idempotent_reprint(self, mock_deploy, mock_build, mock_exec):
+		from benchpress.quickstart import run_quickstart
+
+		self._clear_bench()
+		run_quickstart()  # first run deploys
+		run_quickstart()  # second run should reprint the banner, not redeploy
+
+		# deploy_bench ran exactly once across both invocations.
+		mock_deploy.assert_called_once()


### PR DESCRIPTION
## TB1 — Walking-skeleton `quickstart` command

Tracer bullet #1 of the **Zero-Config One-Command Installer** (#26).

One non-interactive command takes a bench that already has BenchPress installed from nothing to a running, log-in-able ERPNext site — no manual Frappe config:

```bash
bench benchpress quickstart --site <site>
```

It **blocks** until the site is up, then prints a banner with the web URL and `Administrator / admin`.

### Tracer bullets (issue #26)
- [x] TB1 — walking-skeleton `quickstart` command
- [x] TB2 — presets, idempotency, `resolve_access_url`
- [ ] TB3 — WSL2 platform detection / `localhost`-forwarded URL
- [ ] TB4 — `install.sh` bare-metal bootstrap
- [ ] TB5 — WSL2 bootstrap branches + docs

### What's here
- **`benchpress/commands.py`** *(new)* — thin Click entry point (`benchpress quickstart --site`). Registered via the module-level `commands` list that Frappe's `bench_helper` imports; no logic in the CLI layer.
- **`benchpress/quickstart.py`** *(new)* — orchestration, reusing existing managers: ensure the hardcoded ERPNext Lab → `build_lab` → create a Bench Instance with `admin_password="admin"` → run `deploy_bench` **inline (blocking)** → start the web server → print the success banner.
- **`benchpress/deploy_manager.py`** — guard the admin-password line so a pre-set password survives instead of always being overwritten by `secrets.token_urlsafe(10)`.
- **`.gitignore`** — ignore local `plans/` planning docs.

### Deliberately hardcoded in TB1 (paid back in TB2+)
Pinned ERPNext lab definition, `admin` password, native-Ubuntu access URL, no idempotency. See the plan for the full deferral list.

### Known follow-up (out of scope here)
`entry.sh` starts Redis/SSH/code-server but **not** the Frappe web server, so TB1 starts `bench serve` from the quickstart command. This does not survive a container restart — a later tracer bullet should move web-server startup into the container entrypoint/supervisor. Noted in a code comment.

### Verification
- `bench benchpress quickstart --site benchpress.localhost` blocked through image build + deploy; Bench Instance reached **Running**; banner printed a reachable URL + `Administrator / admin`.
- **Login confirmed** via the Frappe login API **and** a real headless-Chromium (Playwright) session — filled `Administrator / admin`, landed on the ERPNext setup wizard.
- `ruff check` / `ruff format` clean.
