### PR TITLE
feat(security): reduce lab container privilege — drop privileged, use NET_ADMIN + /dev/net/tun (#34)

### DIFF
--- a/benchpress/docker_manager.py
+++ b/benchpress/docker_manager.py
@@ -144,14 +144,22 @@ def create_bench_container(bench_doc, lab_doc) -> str:
 	device_read_bps = [{"Path": dev, "Rate": bps} for dev in devices]
 	device_write_bps = [{"Path": dev, "Rate": bps} for dev in devices]
 
+	# Security: lab containers must NOT be privileged. The student has in-container
+	# root (sudo for bench/dev work), so privileged=True is a host-escape primitive:
+	# in-container root + privileged -> Docker host root -> `docker exec
+	# benchpress-mariadb mariadb -u root` reads EVERY tenant's database, defeating
+	# the per-site DB isolation (Press-style scoped grants in mariadb_manager).
+	# WireGuard (entry.sh `wg-quick up wg0`) needs only NET_ADMIN + /dev/net/tun,
+	# NOT full privilege. For defense-in-depth (container-root != host-root), enable
+	# Docker daemon userns-remap on the host (see docs/wireguard-setup.md).
 	container = client.containers.create(
 		image=lab_doc.image_tag,
 		name=name,
 		labels=labels,
 		detach=True,
 		hostname=name,
-		privileged=True,
 		cap_add=["NET_ADMIN"],
+		devices=["/dev/net/tun:/dev/net/tun:rwm"],
 		volumes={
 			f"benchpress-{name}-data": {"bind": "/home/frappe", "mode": "rw"},
 		},


### PR DESCRIPTION
Tracer-bullet start for **#34 [P0-07] Reduce container privilege and document threat model**.

### This slice
- Drops `privileged=True` from lab-container creation in `docker_manager.py`.
- Replaces it with the minimum capability set WireGuard actually needs: `cap_add=["NET_ADMIN"]` + `devices=["/dev/net/tun:/dev/net/tun:rwm"]`.
- Inline rationale: in-container root + `privileged` is a host-escape primitive that defeats per-site DB isolation.

### Still to do under #34
- Document the threat model + host-side `userns-remap` defense-in-depth guidance.
- Verify WireGuard (`wg-quick up wg0`) still comes up with only NET_ADMIN.
- Tests around the container create kwargs (no `privileged`, correct caps/devices).

Base: `version-16` (integration branch). Draft until the above lands.

Refs #34