### PR TITLE
Implemented phase three

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,18 @@ jobs:
         env:
           TYPE: server
 
+      - name: Page load
+        working-directory: /home/runner/frappe-bench
+        run: |
+          bench --site test_site serve --port 8000 > /tmp/bench-serve.log 2>&1 &
+          for _ in $(seq 1 30); do
+            curl -fsS -o /dev/null http://127.0.0.1:8000/api/method/ping && break
+            sleep 2
+          done
+          body=$(curl -fsS -H 'Host: test_site' http://127.0.0.1:8000/frontend) || { cat /tmp/bench-serve.log; exit 1; }
+          echo "$body" | grep -q 'id="app"'
+          echo "$body" | grep -q '<title>Benchpress'
+
   frontend:
     runs-on: ubuntu-latest
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,10 +122,28 @@ jobs:
           pip install frappe-bench
           bench init --skip-redis-config-generation --skip-assets --python "$(which python)" ~/frappe-bench
 
+      # benchpress declares required_apps = ["vpn_management"] (a private repo),
+      # so install-app benchpress only resolves if the app is already on the bench.
+      - name: Setup vpn_management deploy key
+        env:
+          DEPLOY_KEY: ${{ secrets.VPN_MANAGEMENT_DEPLOY_KEY }}
+        run: |
+          if [ -z "$DEPLOY_KEY" ]; then
+            echo "::error::Secret VPN_MANAGEMENT_DEPLOY_KEY is not set. Add a read-only deploy key on Venkateshvenki404224/vpn_management and store its private half in this secret."
+            exit 1
+          fi
+          eval "$(ssh-agent -s)"
+          echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> "$GITHUB_ENV"
+          echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> "$GITHUB_ENV"
+          ssh-add - <<< "$DEPLOY_KEY"
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
       - name: Install
         working-directory: /home/runner/frappe-bench
         run: |
           bench get-app https://github.com/NagariaHussain/doppio
+          bench get-app --branch version-16 git@github.com:Venkateshvenki404224/vpn_management.git
           bench get-app benchpress $GITHUB_WORKSPACE
           bench setup requirements --dev
           bench new-site --db-root-password root --admin-password admin test_site

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -2,15 +2,38 @@
 # See license.txt
 
 import time
+from unittest.mock import patch
 
 import frappe
 from frappe.tests import IntegrationTestCase
 
 from benchpress import api
+from benchpress.benchpress.doctype.bench_instance import get_instance_id
 
+# Generous ceilings (ms) meant to catch N+1 / accidental-blocking regressions,
+# not micro-benchmarks. Every endpoint below runs with its side effects mocked.
 BUDGETS_MS = {
 	"get_labs": 500,
+	"get_lab": 300,
+	"get_lab_templates": 200,
 	"get_user_context": 250,
+	"get_benches": 600,
+	"list_devices": 500,
+	"create_lab_from_template": 300,
+	"build_lab_image": 300,
+	"create_bench": 1500,
+	"create_site": 1500,
+	"bench_action": 800,
+	"get_deploy_logs": 400,
+	"add_device": 400,
+	"remove_device": 400,
+	"get_device_wg_config": 400,
+	"get_code_server_credentials": 400,
+	"restart_code_server": 500,
+	"enqueue_deploy": 400,
+	"enqueue_redeploy": 400,
+	"enqueue_stop": 500,
+	"enqueue_start": 500,
 }
 
 
@@ -21,10 +44,84 @@ def _timed(function):
 	return result, elapsed_ms
 
 
+def _lab_app():
+	return {
+		"app_name": "frappe",
+		"app_label": "Frappe",
+		"git_url": "https://github.com/frappe/frappe",
+		"branch": "version-15",
+	}
+
+
+def _ensure_lab(lab_id, **extra):
+	if frappe.db.exists("Lab", lab_id):
+		frappe.delete_doc("Lab", lab_id, force=True, ignore_permissions=True)
+	return frappe.get_doc(
+		{
+			"doctype": "Lab",
+			"lab_id": lab_id,
+			"title": f"API Timing {lab_id}",
+			"frappe_version": "version-15",
+			"image_tag": "benchpress/test:latest",
+			**extra,
+		}
+	).insert(ignore_permissions=True)
+
+
+def _ensure_bench(lab, **extra):
+	name = get_instance_id("Administrator", lab.name)
+	if frappe.db.exists("Bench Instance", name):
+		frappe.delete_doc("Bench Instance", name, force=True, ignore_permissions=True)
+	return frappe.get_doc(
+		{
+			"doctype": "Bench Instance",
+			"lab": lab.name,
+			"frappe_version": lab.frappe_version,
+			**extra,
+		}
+	).insert(ignore_permissions=True)
+
+
 class TestApi(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.lab = _ensure_lab("api-timing-lab", apps=[_lab_app()])
+		cls.bench = _ensure_bench(
+			cls.lab,
+			status="Running",
+			container_id="ci-container",
+			code_server_url="http://localhost:8443",
+			code_server_password="cs-secret",
+		)
+		cls.action_lab = _ensure_lab("api-timing-action-lab")
+		cls.action_bench = _ensure_bench(cls.action_lab, status="Stopped", container_id="ci-action")
+		cls.create_lab = _ensure_lab("api-timing-create-lab", apps=[_lab_app()])
+		cls.deploy_log = frappe.get_doc(
+			{
+				"doctype": "Deploy Log",
+				"bench": cls.bench.name,
+				"log_type": "info",
+				"message": "fixture log line",
+				"timestamp": frappe.utils.now_datetime(),
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		frappe.delete_doc("Deploy Log", cls.deploy_log.name, force=True, ignore_permissions=True)
+		for lab in (cls.lab, cls.action_lab, cls.create_lab):
+			bench_name = get_instance_id("Administrator", lab.name)
+			if frappe.db.exists("Bench Instance", bench_name):
+				frappe.delete_doc("Bench Instance", bench_name, force=True, ignore_permissions=True)
+			frappe.delete_doc("Lab", lab.name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def setUp(self):
 		frappe.set_user("Administrator")
 
 	def assert_within_budget(self, endpoint, elapsed_ms):
@@ -33,6 +130,8 @@ class TestApi(IntegrationTestCase):
 			BUDGETS_MS[endpoint],
 			f"{endpoint} took {elapsed_ms:.0f}ms, budget is {BUDGETS_MS[endpoint]}ms",
 		)
+
+	# --- Read / contract endpoints (no mocks needed) -------------------------
 
 	def test_get_labs_shape_and_timing(self):
 		labs, elapsed_ms = _timed(api.get_labs)
@@ -43,8 +142,164 @@ class TestApi(IntegrationTestCase):
 			self.assertIn("bench_count", lab)
 		self.assert_within_budget("get_labs", elapsed_ms)
 
+	def test_get_lab_shape_and_timing(self):
+		lab, elapsed_ms = _timed(lambda: api.get_lab(self.lab.name))
+		self.assertEqual(lab["name"], self.lab.name)
+		self.assertIsInstance(lab["apps"], list)
+		self.assert_within_budget("get_lab", elapsed_ms)
+
+	def test_get_lab_templates_shape_and_timing(self):
+		templates, elapsed_ms = _timed(api.get_lab_templates)
+		self.assertIsInstance(templates, list)
+		for template in templates:
+			self.assertIn("key", template)
+			self.assertIn("title", template)
+		self.assert_within_budget("get_lab_templates", elapsed_ms)
+
 	def test_get_user_context_shape_and_timing(self):
 		context, elapsed_ms = _timed(api.get_user_context)
 		for key in ("is_admin", "user", "roles"):
 			self.assertIn(key, context)
 		self.assert_within_budget("get_user_context", elapsed_ms)
+
+	def test_get_benches_shape_and_timing(self):
+		benches, elapsed_ms = _timed(api.get_benches)
+		self.assertIsInstance(benches, list)
+		for bench in benches:
+			for key in ("app_count", "site_count", "ssh_password", "admin_password", "code_server_password"):
+				self.assertIn(key, bench)
+		self.assert_within_budget("get_benches", elapsed_ms)
+
+	def test_list_devices_shape_and_timing(self):
+		devices, elapsed_ms = _timed(api.list_devices)
+		self.assertIsInstance(devices, list)
+		self.assert_within_budget("list_devices", elapsed_ms)
+
+	def test_get_deploy_logs_shape_and_timing(self):
+		logs, elapsed_ms = _timed(lambda: api.get_deploy_logs(self.bench.name))
+		self.assertIsInstance(logs, list)
+		self.assertGreaterEqual(len(logs), 1)
+		for key in ("name", "message", "log_type", "timestamp"):
+			self.assertIn(key, logs[0])
+		self.assert_within_budget("get_deploy_logs", elapsed_ms)
+
+	def test_get_code_server_credentials_shape_and_timing(self):
+		creds, elapsed_ms = _timed(lambda: api.get_code_server_credentials(self.bench.name))
+		self.assertEqual(creds["url"], "http://localhost:8443")
+		self.assertEqual(creds["password"], "cs-secret")
+		self.assert_within_budget("get_code_server_credentials", elapsed_ms)
+
+	# --- Enqueue endpoints (patch frappe.enqueue, assert contract) -----------
+
+	def test_create_lab_from_template_contract_and_timing(self):
+		with patch("benchpress.lab_templates.create_lab_from_template", return_value="LAB-fixture") as create:
+			result, elapsed_ms = _timed(lambda: api.create_lab_from_template("frappe", "cli-1"))
+		create.assert_called_once()
+		self.assertEqual(result, {"name": "LAB-fixture", "status": "Draft"})
+		self.assert_within_budget("create_lab_from_template", elapsed_ms)
+
+	def test_build_lab_image_contract_and_timing(self):
+		with patch("frappe.enqueue") as enqueue:
+			result, elapsed_ms = _timed(lambda: api.build_lab_image(self.lab.name))
+		enqueue.assert_called_once()
+		self.assertEqual(result, {"name": self.lab.name, "status": "Building"})
+		self.assert_within_budget("build_lab_image", elapsed_ms)
+
+	def test_create_bench_contract_and_timing(self):
+		data = frappe.as_json({"lab": self.create_lab.name, "bench_name": "cli-bench"})
+		with patch("frappe.enqueue") as enqueue:
+			result, elapsed_ms = _timed(lambda: api.create_bench(data))
+		self.addCleanup(
+			frappe.delete_doc, "Bench Instance", result["name"], force=True, ignore_permissions=True
+		)
+		enqueue.assert_called_once()
+		self.assertEqual(result["status"], "Deploying")
+		self.assertTrue(frappe.db.exists("Bench Instance", result["name"]))
+		self.assert_within_budget("create_bench", elapsed_ms)
+
+	def test_create_site_contract_and_timing(self):
+		data = frappe.as_json({"bench": self.bench.name, "site_name": "cli-site", "apps": []})
+		with patch("frappe.enqueue") as enqueue:
+			result, elapsed_ms = _timed(lambda: api.create_site(data))
+		self.addCleanup(frappe.delete_doc, "Bench Site", result["name"], force=True, ignore_permissions=True)
+		enqueue.assert_called_once()
+		self.assertEqual(result["status"], "Creating")
+		self.assert_within_budget("create_site", elapsed_ms)
+
+	# --- Docker / manager side effects (patch module functions) --------------
+
+	def test_bench_action_start_stop_restart_and_timing(self):
+		with (
+			patch("benchpress.docker_manager.start_container"),
+			patch("benchpress.docker_manager.stop_container"),
+			patch("benchpress.docker_manager.restart_container"),
+			patch("benchpress.docker_manager.remove_container"),
+		):
+			for action, expected in (("start", "Running"), ("stop", "Stopped"), ("restart", "Running")):
+				result, elapsed_ms = _timed(lambda: api.bench_action(self.action_bench.name, action))
+				self.assertEqual(result["name"], self.action_bench.name)
+				self.assertEqual(result["status"], expected)
+				self.assert_within_budget("bench_action", elapsed_ms)
+
+	def test_restart_code_server_contract_and_timing(self):
+		with patch("benchpress.docker_manager.exec_in_container", return_value=(0, "ok")):
+			result, elapsed_ms = _timed(lambda: api.restart_code_server(self.bench.name))
+		self.assertEqual(result, {"ok": True})
+		self.assert_within_budget("restart_code_server", elapsed_ms)
+
+	# --- Device endpoints (patch benchpress.vpn_adapter.*) -------------------
+
+	def test_add_device_contract_and_timing(self):
+		fake = {"name": "dev-1", "wg_ip": "172.27.0.9", "wg_config": "[Interface]"}
+		with patch("benchpress.vpn_adapter.register_device", return_value=fake) as register:
+			result, elapsed_ms = _timed(lambda: api.add_device("Laptop", "Laptop"))
+		register.assert_called_once()
+		self.assertEqual(result, fake)
+		self.assert_within_budget("add_device", elapsed_ms)
+
+	def test_remove_device_contract_and_timing(self):
+		with patch("benchpress.vpn_adapter.unregister_device", return_value=True) as unregister:
+			result, elapsed_ms = _timed(lambda: api.remove_device("dev-1"))
+		unregister.assert_called_once()
+		self.assertEqual(result, {"status": "removed"})
+		self.assert_within_budget("remove_device", elapsed_ms)
+
+	def test_get_device_wg_config_contract_and_timing(self):
+		with patch("benchpress.vpn_adapter.get_device_config", return_value="[Interface]\n") as config:
+			result, elapsed_ms = _timed(lambda: api.get_device_wg_config("dev-1"))
+		config.assert_called_once()
+		self.assertIsInstance(result, str)
+		self.assert_within_budget("get_device_wg_config", elapsed_ms)
+
+	# --- Bench Instance controller methods -----------------------------------
+
+	def test_enqueue_deploy_calls_job_and_timing(self):
+		bench = frappe.get_doc("Bench Instance", self.bench.name)
+		with patch("frappe.enqueue") as enqueue:
+			_, elapsed_ms = _timed(bench.enqueue_deploy)
+		enqueue.assert_called_once()
+		self.assertEqual(enqueue.call_args.args[0], "benchpress.deploy_manager.deploy_bench")
+		self.assert_within_budget("enqueue_deploy", elapsed_ms)
+
+	def test_enqueue_redeploy_calls_job_and_timing(self):
+		bench = frappe.get_doc("Bench Instance", self.bench.name)
+		with patch("frappe.enqueue") as enqueue:
+			_, elapsed_ms = _timed(bench.enqueue_redeploy)
+		enqueue.assert_called_once()
+		self.assertEqual(enqueue.call_args.args[0], "benchpress.deploy_manager.redeploy_bench")
+		self.assert_within_budget("enqueue_redeploy", elapsed_ms)
+
+	def test_enqueue_stop_calls_stop_bench_and_timing(self):
+		bench = frappe.get_doc("Bench Instance", self.bench.name)
+		with patch("benchpress.deploy_manager.stop_bench") as stop_bench:
+			_, elapsed_ms = _timed(bench.enqueue_stop)
+		stop_bench.assert_called_once_with(bench.name)
+		self.assert_within_budget("enqueue_stop", elapsed_ms)
+
+	def test_enqueue_start_starts_container_and_timing(self):
+		bench = frappe.get_doc("Bench Instance", self.bench.name)
+		with patch("benchpress.docker_manager.start_container") as start_container:
+			_, elapsed_ms = _timed(bench.enqueue_start)
+		start_container.assert_called_once_with(bench.container_id)
+		self.assertEqual(bench.status, "Running")
+		self.assert_within_budget("enqueue_start", elapsed_ms)

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+import time
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from benchpress import api
+
+BUDGETS_MS = {
+	"get_labs": 500,
+	"get_user_context": 250,
+}
+
+
+def _timed(function):
+	start = time.perf_counter()
+	result = function()
+	elapsed_ms = (time.perf_counter() - start) * 1000
+	return result, elapsed_ms
+
+
+class TestApi(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+
+	def assert_within_budget(self, endpoint, elapsed_ms):
+		self.assertLess(
+			elapsed_ms,
+			BUDGETS_MS[endpoint],
+			f"{endpoint} took {elapsed_ms:.0f}ms, budget is {BUDGETS_MS[endpoint]}ms",
+		)
+
+	def test_get_labs_shape_and_timing(self):
+		labs, elapsed_ms = _timed(api.get_labs)
+		self.assertIsInstance(labs, list)
+		for lab in labs:
+			self.assertIn("app_names", lab)
+			self.assertIn("app_count", lab)
+			self.assertIn("bench_count", lab)
+		self.assert_within_budget("get_labs", elapsed_ms)
+
+	def test_get_user_context_shape_and_timing(self):
+		context, elapsed_ms = _timed(api.get_user_context)
+		for key in ("is_admin", "user", "roles"):
+			self.assertIn(key, context)
+		self.assert_within_budget("get_user_context", elapsed_ms)

--- a/benchpress/tests/test_api_authorization.py
+++ b/benchpress/tests/test_api_authorization.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+"""Authorization suite for the whitelisted API.
+
+Phase 2 asserted the happy path; this proves the negative paths: Guest,
+wrong-role, and cross-user callers are all rejected by the endpoint guards
+(`require_admin`, `require_bench_access`, and the owner-scoped bench filter).
+Each denial test has a positive control so a guard that vacuously throws for
+everyone — or silently returns an empty result — is caught as a failure.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from benchpress import api
+from benchpress.benchpress.doctype.bench_instance import get_instance_id
+
+
+def _ensure_user(email, first_name, role):
+	if not frappe.db.exists("User", email):
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": first_name,
+				"send_welcome_email": 0,
+				"roles": [{"role": role}],
+			}
+		).insert(ignore_permissions=True)
+	return email
+
+
+def _ensure_lab(lab_id):
+	if frappe.db.exists("Lab", lab_id):
+		frappe.delete_doc("Lab", lab_id, force=True, ignore_permissions=True)
+	return frappe.get_doc(
+		{
+			"doctype": "Lab",
+			"lab_id": lab_id,
+			"title": f"Authz {lab_id}",
+			"frappe_version": "version-15",
+			"image_tag": "benchpress/test:latest",
+		}
+	).insert(ignore_permissions=True)
+
+
+def _ensure_owned_bench(owner, lab):
+	"""Insert a Running bench whose owner is `owner` (owner comes from the session)."""
+	name = get_instance_id(owner, lab.name)
+	if frappe.db.exists("Bench Instance", name):
+		frappe.delete_doc("Bench Instance", name, force=True, ignore_permissions=True)
+	frappe.set_user(owner)
+	try:
+		return frappe.get_doc(
+			{
+				"doctype": "Bench Instance",
+				"lab": lab.name,
+				"frappe_version": lab.frappe_version,
+				"status": "Running",
+				"container_id": "authz-container",
+				"code_server_url": "http://localhost:8443",
+				"code_server_password": "cs-secret",
+			}
+		).insert(ignore_permissions=True)
+	finally:
+		frappe.set_user("Administrator")
+
+
+class TestApiAuthorization(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.user_a = _ensure_user("authz-user-a@example.com", "Authz UserA", "BenchPress User")
+		cls.user_b = _ensure_user("authz-user-b@example.com", "Authz UserB", "BenchPress User")
+		cls.admin_user = _ensure_user("authz-admin@example.com", "Authz Admin", "BenchPress Admin")
+		cls.lab = _ensure_lab("authz-lab")
+		cls.bench = _ensure_owned_bench(cls.user_a, cls.lab)
+		cls.deploy_log = frappe.get_doc(
+			{
+				"doctype": "Deploy Log",
+				"bench": cls.bench.name,
+				"log_type": "info",
+				"message": "authz fixture log line",
+				"timestamp": frappe.utils.now_datetime(),
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		frappe.delete_doc("Deploy Log", cls.deploy_log.name, force=True, ignore_permissions=True)
+		frappe.delete_doc("Bench Instance", cls.bench.name, force=True, ignore_permissions=True)
+		frappe.delete_doc("Lab", cls.lab.name, force=True, ignore_permissions=True)
+		for email in (cls.user_a, cls.user_b, cls.admin_user):
+			if frappe.db.exists("User", email):
+				frappe.delete_doc("User", email, force=True, ignore_permissions=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def assert_denied(self, action):
+		with self.assertRaises(frappe.PermissionError):
+			action()
+
+	# --- Guest / unauthenticated rejected ------------------------------------
+
+	def test_guest_denied_from_admin_only_endpoints(self):
+		frappe.set_user("Guest")
+		self.assert_denied(lambda: api.create_lab_from_template("frappe", "authz-guest"))
+		self.assert_denied(lambda: api.build_lab_image(self.lab.name))
+
+	def test_guest_denied_from_bench_scoped_endpoints(self):
+		frappe.set_user("Guest")
+		bench = self.bench.name
+		self.assert_denied(lambda: api.bench_action(bench, "start"))
+		self.assert_denied(lambda: api.get_deploy_logs(bench))
+		self.assert_denied(lambda: api.get_code_server_credentials(bench))
+		self.assert_denied(lambda: api.restart_code_server(bench))
+
+	# --- Wrong-role (BenchPress User) blocked from admin-only endpoints -------
+
+	def test_non_admin_denied_from_create_lab_from_template(self):
+		frappe.set_user(self.user_a)
+		self.assert_denied(lambda: api.create_lab_from_template("frappe", "authz-user"))
+
+	def test_non_admin_denied_from_build_lab_image(self):
+		frappe.set_user(self.user_a)
+		self.assert_denied(lambda: api.build_lab_image(self.lab.name))
+
+	def test_owner_denied_from_deleting_own_bench(self):
+		# user_a passes require_bench_access on its own bench, but delete is admin-only.
+		frappe.set_user(self.user_a)
+		self.assert_denied(lambda: api.bench_action(self.bench.name, "delete"))
+
+	# --- Cross-user isolation (user_b against user_a's bench) -----------------
+
+	def test_cross_user_denied_from_get_deploy_logs(self):
+		frappe.set_user(self.user_b)
+		self.assert_denied(lambda: api.get_deploy_logs(self.bench.name))
+
+	def test_cross_user_denied_from_bench_action(self):
+		frappe.set_user(self.user_b)
+		self.assert_denied(lambda: api.bench_action(self.bench.name, "start"))
+
+	def test_cross_user_denied_from_get_code_server_credentials(self):
+		frappe.set_user(self.user_b)
+		self.assert_denied(lambda: api.get_code_server_credentials(self.bench.name))
+
+	def test_cross_user_denied_from_restart_code_server(self):
+		frappe.set_user(self.user_b)
+		self.assert_denied(lambda: api.restart_code_server(self.bench.name))
+
+	def test_get_benches_hides_other_users_bench(self):
+		frappe.set_user(self.user_b)
+		names = [bench["name"] for bench in api.get_benches()]
+		self.assertNotIn(self.bench.name, names)
+
+	# --- Positive controls: the guards permit the legitimate caller ----------
+
+	def test_owner_reads_own_bench_credentials(self):
+		frappe.set_user(self.user_a)
+		creds = api.get_code_server_credentials(self.bench.name)
+		self.assertEqual(creds["password"], "cs-secret")
+
+	def test_owner_sees_own_bench_in_get_benches(self):
+		frappe.set_user(self.user_a)
+		names = [bench["name"] for bench in api.get_benches()]
+		self.assertIn(self.bench.name, names)
+
+	def test_admin_allowed_to_create_lab_from_template(self):
+		frappe.set_user(self.admin_user)
+		with patch("benchpress.lab_templates.create_lab_from_template", return_value="LAB-authz") as create:
+			result = api.create_lab_from_template("frappe", "authz-admin")
+		create.assert_called_once()
+		self.assertEqual(result, {"name": "LAB-authz", "status": "Draft"})

--- a/benchpress/tests/test_device_wrappers.py
+++ b/benchpress/tests/test_device_wrappers.py
@@ -162,6 +162,40 @@ class TestDeviceOwnership(IntegrationTestCase):
 class TestDeviceRoundTrip(IntegrationTestCase):
 	"""add → list → remove against real VPN Peer rows (reconcile enqueue stubbed out)."""
 
+	def setUp(self):
+		super().setUp()
+		self._ensure_endpoint_host_configured()
+		self._ensure_wg0_pool_materialized()
+
+	def _ensure_endpoint_host_configured(self):
+		"""Config rendering needs a public endpoint host — set on the local stack, empty in CI."""
+		if not frappe.db.get_single_value("VPN Settings", "vpn_endpoint_host"):
+			frappe.db.set_single_value("VPN Settings", "vpn_endpoint_host", "vpn.test.local")
+
+	def _ensure_wg0_pool_materialized(self):
+		"""A bare CI bench has the wg0 server but no pool; the local stack has both."""
+		if frappe.db.exists("IP Allocation", {"server": "wg0"}):
+			return
+		from vpn_management import allocation
+
+		pool = frappe.db.get_value("Network Pool", {"server": "wg0"}, "name")
+		if not pool:
+			with patch("frappe.enqueue"):
+				pool = (
+					frappe.get_doc(
+						{
+							"doctype": "Network Pool",
+							"pool_name": "pool-wg0",
+							"server": "wg0",
+							"cidr": "172.27.0.0/24",
+							"gateway_ip": "172.27.0.1",
+						}
+					)
+					.insert(ignore_permissions=True)
+					.name
+				)
+		allocation.materialize(pool)
+
 	@patch(RECONCILE_HOOK)
 	def test_add_list_remove_round_trip(self, _reconcile):
 		result = register_device("Contract Phone", "Mobile")

--- a/benchpress/tests/test_device_wrappers.py
+++ b/benchpress/tests/test_device_wrappers.py
@@ -14,9 +14,7 @@ from benchpress.vpn_adapter import (
 	unregister_device,
 )
 
-RECONCILE_HOOK = (
-	"vpn_management.vpn_management.doctype.vpn_peer.vpn_peer.VPNPeer._enqueue_reconcile"
-)
+RECONCILE_HOOK = "vpn_management.vpn_management.doctype.vpn_peer.vpn_peer.VPNPeer._enqueue_reconcile"
 
 
 def _fake_server():
@@ -182,6 +180,4 @@ class TestDeviceRoundTrip(IntegrationTestCase):
 		unregister_device(result["name"])
 
 		self.assertFalse(frappe.db.exists("VPN Peer", result["name"]))
-		self.assertEqual(
-			frappe.db.count("IP Allocation", {"ip_address": result["wg_ip"], "allocated": 1}), 0
-		)
+		self.assertEqual(frappe.db.count("IP Allocation", {"ip_address": result["wg_ip"], "allocated": 1}), 0)

--- a/benchpress/vpn_adapter.py
+++ b/benchpress/vpn_adapter.py
@@ -157,9 +157,7 @@ def get_device_config(device_docname: str) -> str:
 def _device_peer_filters() -> dict:
 	"""Everything the user owns except the peers that belong to bench containers."""
 	filters = {"owner_user": frappe.session.user}
-	bench_peers = frappe.get_all(
-		"Bench Instance", filters={"vpn_peer": ("is", "set")}, pluck="vpn_peer"
-	)
+	bench_peers = frappe.get_all("Bench Instance", filters={"vpn_peer": ("is", "set")}, pluck="vpn_peer")
 	if bench_peers:
 		filters["name"] = ("not in", bench_peers)
 	return filters

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -1,0 +1,73 @@
+# Production readiness checklist
+
+Release-readiness verdict for every whitelisted endpoint and the security-sensitive
+components behind them. Seeded from the phase-3 authorization suite
+(`benchpress/tests/test_api_authorization.py`), the phase-2 contract/timing suite
+(`benchpress/tests/test_api.py`), the branch security review
+(`specs/api-test-suite/security-review-phase-3.md`), and a sweep of
+`ignore_permissions=True` and secret-handling (`get_decrypted_password` /
+`get_password`) paths.
+
+Last reviewed: 2026-07-02.
+
+**Legend** — ✅ Ready · ⚠️ Ready with follow-up · ❌ Not ready for release.
+
+## Whitelisted API endpoints (`benchpress/api.py`)
+
+| Endpoint | Guard | Authz test | Verdict | Notes |
+|---|---|---|---|---|
+| `get_labs` | login only | timing/contract | ✅ | Shared admin-curated catalog; no per-user data. |
+| `get_lab` | login only | timing/contract | ✅ | Single catalog row; no tenant data. |
+| `get_lab_templates` | login only | timing/contract | ✅ | Static template list. |
+| `create_lab_from_template` | `require_admin` | Guest + non-admin denied; admin allowed | ✅ | Admin-only proven. |
+| `build_lab_image` | `require_admin` | Guest + non-admin denied | ✅ | Admin-only proven. |
+| `get_benches` | owner filter | hides other users' bench; owner sees own | ⚠️ | Returns decrypted ssh/admin/code-server passwords in the list payload — owner-scoped, but prefer fetching secrets on demand. |
+| `create_bench` | login; own deterministic `instance_id` | contract | ✅ | `get_instance_id(session.user, lab)` embeds the caller, so a user can only create/mutate their own bench. |
+| `bench_action` | `require_bench_access` + delete is admin-only | cross-user denied; owner-delete denied | ✅ | start/stop/restart owner-scoped; delete admin-gated, both proven. |
+| `get_deploy_logs` | `require_bench_access` | cross-user denied | ✅ | |
+| `add_device` | login; peer `owner_user = session.user` | device round-trip | ✅ | Creates only the caller's own peer. |
+| `remove_device` | `_owned_device_peer` (owner or admin) | device wrapper tests | ✅ | Ownership enforced before delete. |
+| `list_devices` | owner filter (`owner_user`), excludes bench peers | device round-trip | ✅ | |
+| `get_device_wg_config` | `_owned_device_peer` (owner or admin) | device wrapper tests | ⚠️ | Guard exists; add an explicit cross-user negative test in the API authz suite. |
+| `create_site` | `require_bench_access` **only when `bench` set** | contract | ⚠️ | Bench-less call skips the guard and creates an orphan Bench Site; make `bench` mandatory / guard the empty case. |
+| `get_user_context` | login (own session) | timing/contract | ✅ | Returns only the caller's own identity/roles. |
+| `get_code_server_credentials` | `require_bench_access` | cross-user denied; owner allowed | ✅ | Decrypted password returned only after ownership check. |
+| `restart_code_server` | `require_bench_access` | cross-user denied | ✅ | |
+
+## Whitelisted controller methods
+
+| Method | Guard | Test | Verdict | Notes |
+|---|---|---|---|---|
+| `Bench Instance.enqueue_deploy` | `run_doc_method` read perm (`if_owner`) | contract | ✅ | Framework enforces doc read perm on call. |
+| `Bench Instance.enqueue_redeploy` | `run_doc_method` read perm (`if_owner`) | contract | ✅ | |
+| `Bench Instance.enqueue_stop` | `run_doc_method` read perm (`if_owner`) | contract | ✅ | |
+| `Bench Instance.enqueue_start` | `run_doc_method` read perm (`if_owner`) | contract | ✅ | |
+| `Database Server.setup_mariadb` | `has_permission(read)`; DocType admin-only | none | ⚠️ | Admin-only in practice (non-admins have zero perms), but a state-changing op should check `write`, and it has no authz test. |
+| `Database Server.start_mariadb` | `has_permission(read)`; DocType admin-only | none | ⚠️ | As above. |
+| `Database Server.stop_mariadb` | `has_permission(read)`; DocType admin-only | none | ⚠️ | As above. |
+| `Database Server.retry_setup` | `has_permission(read)`; DocType admin-only | none | ⚠️ | As above. |
+| `Database Server.get_logs` | `has_permission(read)`; DocType admin-only | none | ✅ | Read op; read check is correct. Add a test. |
+
+## Cross-cutting components
+
+| Component | Evidence | Verdict | Notes |
+|---|---|---|---|
+| Permission model (`permissions.py` + Bench Instance `if_owner`) | authz suite green | ✅ | Guest / wrong-role / cross-user all rejected; `only_for` raises for non-Administrators. |
+| Secret handling (`get_decrypted_password`, `get_password`, `get_root_password`) | api.py, mariadb_manager.py | ✅ | Decryption only behind owner/admin guards; DB root password never logged (only in generated SQL run inside the container). |
+| `ignore_permissions=True` (39 uses) | background jobs + system-context writes | ✅ | Confined to enqueued/system flows; user-facing ownership is tracked via `owner` / `owner_user`, and device peer inserts are deliberate (users hold no VPN role). |
+| SQL construction (`mariadb_manager`) | review §candidates | ✅ | Identifiers SHA1-hashed, SQL base64-wrapped before shelling — not injectable. |
+| Container isolation (`docker_manager.create_bench_container`) | review §candidates | ❌ | Non-privileged (NET_ADMIN + /dev/net/tun only), **but** lab users get in-container root. Not release-ready unless the Docker host enables `userns-remap` (see [wireguard-setup.md](wireguard-setup.md)); without it, container-root ≠ host-root is not guaranteed. |
+
+## Not ready for release — action required
+
+- **❌ Container privilege boundary.** Ship only on a host with Docker `userns-remap`
+  enabled. Lab users have in-container root; userns-remap is what keeps that from
+  becoming host root. This is a deployment precondition, not an app default.
+- **⚠️ `create_site` bench-less path.** Make `bench` mandatory (or guard the empty case)
+  so the endpoint cannot create an orphan Bench Site that bypasses `require_bench_access`.
+- **⚠️ Database Server state-changing methods.** Switch `setup`/`start`/`stop`/`retry`
+  to a `write` permission check and add authorization tests.
+- **⚠️ `get_benches` secret exposure.** Move ssh/admin/code-server password retrieval
+  out of the bulk list payload to an on-demand, per-bench call.
+- **⚠️ `get_device_wg_config` test gap.** Add an explicit cross-user negative test to the
+  API authorization suite (the guard exists; the coverage does not).


### PR DESCRIPTION
## Phase 1 — tracer bullet: API test harness + CI page-load gate

First slice of the [api-test-suite spec](specs/api-test-suite/README.md): proves the whole pipeline (new test file → `run-tests` auto-discovery → CI Server job → page-load gate) before phase 2 writes coverage for all 17 endpoints.

### What it does

- **`benchpress/tests/test_api.py`** — the reusable harness later phases extend:
  - module-level `BUDGETS_MS = {"get_labs": 500, "get_user_context": 250}` timing budgets
  - `_timed()` helper (`time.perf_counter()`) + `assert_within_budget`
  - `test_get_labs_shape_and_timing` — list shape, per-row `app_names`/`app_count`/`bench_count`, timing
  - `test_get_user_context_shape_and_timing` — `is_admin`/`user`/`roles` keys, timing
- **`.github/workflows/ci.yml`** — new **Page load** step in the Server job (after Run Tests, reusing the built site + assets): serves `test_site` in the background, polls `/api/method/ping` until up, then asserts `curl /frontend` returns the SPA shell (`id="app"` **and** `<title>Benchpress`). CI now fails if `/frontend` stops serving the SPA.
- Drive-by: ruff-format line joins on two existing files (separate `style:` commit).

### How to verify

```bash
# tests (both green locally, 0.24s; auto-discovered in the full 89-test suite run)
docker compose exec backend bench --site frontend run-tests --app benchpress --module benchpress.tests.test_api

# local mirror of the CI gate (passes against the running stack on :8081)
curl -fsS -H 'Host: frontend' http://localhost:8081/frontend | grep -e 'id="app"' -e '<title>Benchpress'
```

Visual proof: logged into `http://localhost:8081/frontend` with agent-browser — SPA mounts and the Labs page renders.

No production behavior changes — scaffolding for phases 2–4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)