### PR TITLE
fix(api): create_site_in_container arity mismatch — add-site flow (#87)

### DIFF
--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -330,7 +330,6 @@ def _create_site_on_bench(site_doc_name: str) -> None:
 	site = frappe.get_doc("Bench Site", site_doc_name)
 	bench = frappe.get_doc("Bench Instance", site.bench)
 	db_server = frappe.get_doc("Database Server", bench.database_server)
-	lab = frappe.get_cached_doc("Lab", bench.lab)
 
 	try:
 		admin_password = bench.get_password("admin_password")
@@ -339,7 +338,7 @@ def _create_site_on_bench(site_doc_name: str) -> None:
 		apps_csv = ",".join(a.app_name for a in site.apps_installed if a.app_name.lower() != "frappe")
 
 		exit_code, output = create_site_in_container(
-			bench.container_id, db_server, lab, site_name, admin_password, apps_csv
+			bench.container_id, db_server, site_name, admin_password, apps_csv
 		)
 
 		if exit_code != 0:

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -190,6 +190,52 @@ class TestDeployManager(IntegrationTestCase):
 		redeploy_bench(bench.name)
 		mock_drop_db.assert_called_once_with(self.db_server_name, bench.site_name)
 
+	# --- _create_site_on_bench (add-site path) ---
+
+	def _make_bench_site(self, bench):
+		site = frappe.get_doc(
+			{
+				"doctype": "Bench Site",
+				"site_name": "arity-test-site",
+				"bench": bench.name,
+				"status": "Creating",
+				"apps_installed": [{"app_name": "benchpress", "app_label": "BenchPress"}],
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+		self.addCleanup(
+			lambda n=site.name: frappe.delete_doc("Bench Site", n, force=True, ignore_permissions=True)
+			if frappe.db.exists("Bench Site", n)
+			else None
+		)
+		return site
+
+	@patch("benchpress.deploy_manager.create_site_in_container", autospec=True)
+	def test_create_site_on_bench_matches_signature_and_activates_site(self, mock_create):
+		from benchpress.api import _create_site_on_bench
+
+		bench = self._fresh_bench()
+		bench.database_server = self.db_server_name
+		bench.container_id = "container-arity-test"
+		bench.admin_password = "test-admin-pw"
+		bench.save(ignore_permissions=True)
+		frappe.db.commit()
+
+		site = self._make_bench_site(bench)
+		# autospec enforces the real 5-arg signature: a stale 6-arg call raises
+		# TypeError inside the except block, which would leave status = Error.
+		mock_create.return_value = (0, "site created")
+
+		_create_site_on_bench(site.name)
+
+		site.reload()
+		self.assertEqual(site.status, "Active")
+		mock_create.assert_called_once()
+		args = mock_create.call_args.args
+		self.assertEqual(args[0], "container-arity-test")
+		self.assertEqual(args[2], "arity-test-site")
+		self.assertEqual(args[4], "benchpress")
+
 	# --- build_linkuser_args (Lab.shell wiring) ---
 
 	def test_build_linkuser_args_includes_lab_shell(self):


### PR DESCRIPTION
Closes #87

## What
`_create_site_on_bench` called `create_site_in_container` with 6 args (`container_id, db_server, lab, site_name, admin_password, apps_csv`) but the function takes 5 and never used `lab`. Every add-site enqueue raised `TypeError`, was swallowed by the except block, and left the Bench Site stuck in **Error** — the add-site flow was dead.

## Changes
- `benchpress/api.py`: drop `lab` from the call (and the now-unused `frappe.get_cached_doc("Lab", ...)` fetch). No change to `create_site_in_container` internals.
- `benchpress/tests/test_deploy_manager.py`: new test `test_create_site_on_bench_matches_signature_and_activates_site` — patches `create_site_in_container` with **autospec=True** so the real 5-arg signature is enforced, and asserts the Bench Site transitions Creating → Active.

## Verification
- `bench --site frontend run-tests --app benchpress --module benchpress.tests.test_deploy_manager` → 9/9 pass.
- Regression check: temporarily reintroducing the 6-arg call makes the new test fail with `AssertionError: 'Error' != 'Active'` (TypeError from autospec drives the except path), confirming the test guards the contract.
- `pre-commit run` on changed files: all hooks pass.

## Scope guardrails (per issue #87)
- Both call sites now match the 5-arg signature (`deploy_manager.py` L205 was already correct; grepped all callers).
- `setup-site.sh`, MariaDB user creation, and deploy pipeline order untouched.