### PR TITLE
chore: ruff-format cleanup for version-16 base

### DIFF
--- a/benchpress/tests/test_device_wrappers.py
+++ b/benchpress/tests/test_device_wrappers.py
@@ -14,9 +14,7 @@ from benchpress.vpn_adapter import (
 	unregister_device,
 )
 
-RECONCILE_HOOK = (
-	"vpn_management.vpn_management.doctype.vpn_peer.vpn_peer.VPNPeer._enqueue_reconcile"
-)
+RECONCILE_HOOK = "vpn_management.vpn_management.doctype.vpn_peer.vpn_peer.VPNPeer._enqueue_reconcile"
 
 
 def _fake_server():
@@ -182,6 +180,4 @@ class TestDeviceRoundTrip(IntegrationTestCase):
 		unregister_device(result["name"])
 
 		self.assertFalse(frappe.db.exists("VPN Peer", result["name"]))
-		self.assertEqual(
-			frappe.db.count("IP Allocation", {"ip_address": result["wg_ip"], "allocated": 1}), 0
-		)
+		self.assertEqual(frappe.db.count("IP Allocation", {"ip_address": result["wg_ip"], "allocated": 1}), 0)

--- a/benchpress/vpn_adapter.py
+++ b/benchpress/vpn_adapter.py
@@ -157,9 +157,7 @@ def get_device_config(device_docname: str) -> str:
 def _device_peer_filters() -> dict:
 	"""Everything the user owns except the peers that belong to bench containers."""
 	filters = {"owner_user": frappe.session.user}
-	bench_peers = frappe.get_all(
-		"Bench Instance", filters={"vpn_peer": ("is", "set")}, pluck="vpn_peer"
-	)
+	bench_peers = frappe.get_all("Bench Instance", filters={"vpn_peer": ("is", "set")}, pluck="vpn_peer")
 	if bench_peers:
 		filters["name"] = ("not in", bench_peers)
 	return filters


### PR DESCRIPTION
The #85 squash merge landed these two files format-dirty; push CI never runs on version-16 so the Frappe Linter only trips on the next PR. Formatting only — no logic change (vpn_adapter.py is guardrailed, so this ships as a reviewed PR rather than a direct push).

## Summary

<!-- What does this PR do and why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional change)
- [ ] Documentation update
- [ ] Performance improvement

## Test Plan

<!-- How did you verify this works? -->

- [ ] Tested locally with `bench start`
- [ ] Frontend builds without errors (`yarn build`)
- [ ] Linters pass (`ruff check`, `prettier`)

## Checklist

- [ ] Commit messages follow conventional commits format
- [ ] No `frappe.db.sql` in new code (use `frappe.qb`)
- [ ] No `console.log` left in JS
- [ ] Permission checks on new whitelisted endpoints
- [ ] No hardcoded credentials or API keys
