### PR TITLE
Implemented phase three

### DIFF
--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -402,3 +402,11 @@ def restart_code_server(bench_name: str) -> dict:
 	if exit_code != 0:
 		frappe.throw(_("restart failed: {0}").format(output))
 	return {"ok": True}
+
+
+@frappe.whitelist()
+def run_diagnostics() -> list[dict]:
+	require_admin()
+	from benchpress.diagnostics import run_diagnostics as _run_diagnostics
+
+	return _run_diagnostics()

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -86,6 +86,34 @@ def _make_log_appender(doctype: str, log_name: str, event: str, context: dict):
 	return append_log
 
 
+def _notify_owner(user: str, subject: str, document_type: str, document_name: str) -> None:
+	"""Best-effort desk notification on a terminal deploy/build state.
+
+	type "Alert" both bypasses the for_user == from_user skip in
+	make_notification_logs (the job usually runs as the owner) and is exempt
+	from notification emails, so this stays desk-only. Never raises — a
+	notification failure must not disturb the deploy/build outcome.
+	"""
+	try:
+		from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification
+
+		email = frappe.db.get_value("User", user, "email") or user
+		enqueue_create_notification(
+			[email],
+			{
+				"type": "Alert",
+				"subject": subject,
+				"document_type": document_type,
+				"document_name": document_name,
+			},
+		)
+	except Exception:
+		frappe.log_error(
+			title=f"BenchPress notification failed: {document_name}",
+			message=frappe.get_traceback(),
+		)
+
+
 def create_site_in_container(
 	container_id: str, db_server, site_name: str, admin_password: str, apps_csv: str
 ) -> tuple[int, str]:
@@ -254,6 +282,12 @@ def deploy_bench(bench_name: str) -> None:
 		append_log("=== Deploy complete ===", "success")
 		frappe.db.set_value("Deploy Log", deploy_log_name, "log_type", "success")
 		frappe.db.commit()
+		_notify_owner(
+			bench.owner,
+			f"Bench deployed: {bench.bench_name} ({bench.site_name})",
+			"Bench Instance",
+			bench.name,
+		)
 
 	except Exception as e:
 		bench.reload()
@@ -267,6 +301,7 @@ def deploy_bench(bench_name: str) -> None:
 			title=f"BenchPress deploy failed: {bench_name}",
 			message=frappe.get_traceback(),
 		)
+		_notify_owner(bench.owner, f"Bench deploy failed: {bench.bench_name}", "Bench Instance", bench.name)
 
 
 def _setup_container_vpn(bench, container_id: str, append_log) -> None:
@@ -366,6 +401,7 @@ def build_lab(lab_name: str) -> None:
 		append_log(f"=== Build complete: {lab.image_tag} ===", "success")
 		frappe.db.set_value("Build Log", build_log_name, "log_type", "success")
 		frappe.db.commit()
+		_notify_owner(lab.owner, f"Lab build complete: {lab.title} ({lab.image_tag})", "Lab", lab_name)
 
 	except Exception as e:
 		frappe.db.set_value("Lab", lab_name, "status", "Error")
@@ -378,6 +414,7 @@ def build_lab(lab_name: str) -> None:
 			title=f"Lab image build failed: {lab_name}",
 			message=frappe.get_traceback(),
 		)
+		_notify_owner(lab.owner, f"Lab build failed: {lab.title}", "Lab", lab_name)
 
 
 def stop_bench(bench_name: str) -> None:

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -3,7 +3,6 @@
 
 import json
 import secrets
-import time
 
 import frappe
 
@@ -11,10 +10,10 @@ from benchpress.docker_manager import (
 	build_lab_image,
 	create_bench_container,
 	exec_in_container,
-	get_container_ip,
 	remove_container,
 	start_container,
 	stop_container,
+	wait_for_container_running,
 	write_file_to_container,
 )
 from benchpress.mariadb_manager import (
@@ -171,13 +170,11 @@ def deploy_bench(bench_name: str) -> None:
 		frappe.db.commit()
 
 		start_container(container_id)
-		time.sleep(5)
-
-		container_ip = get_container_ip(container_id)
-		if container_ip:
-			bench.container_ip = container_ip
-			bench.save(ignore_permissions=True)
-			frappe.db.commit()
+		append_log("Waiting for container to report running with an IP...")
+		container_ip = wait_for_container_running(container_id, timeout=60)
+		bench.container_ip = container_ip
+		bench.save(ignore_permissions=True)
+		frappe.db.commit()
 
 		settings = frappe.get_cached_doc("BenchPress Settings")
 

--- a/benchpress/diagnostics.py
+++ b/benchpress/diagnostics.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""Read-only environment diagnostics (issue #97).
+
+Every check wraps an existing primitive and only inspects — never creates,
+starts, or repairs anything. `run_diagnostics` structurally cannot throw:
+each check catches its own exceptions and reports them as a fail row.
+"""
+
+import docker
+import frappe
+
+from benchpress.docker_manager import get_client
+from benchpress.mariadb_manager import check_mariadb_health
+from benchpress.vpn_adapter import DEFAULT_INTERFACE
+
+REDIS_CONTAINER_NAME = "benchpress-redis"
+
+
+def _row(check: str, ok: bool, hint: str) -> dict:
+	return {"check": check, "status": "pass" if ok else "fail", "hint": hint}
+
+
+def run_diagnostics() -> list[dict]:
+	"""Read-only environment checks. Each row: {check, status: pass|fail, hint}.
+
+	Never raises and never mutates infrastructure.
+	"""
+	return [
+		_check_docker_socket(),
+		_check_docker_network(),
+		_check_mariadb(),
+		_check_redis(),
+		_check_vpn_server(),
+	]
+
+
+def _check_docker_socket() -> dict:
+	try:
+		get_client().ping()
+		return _row("docker_socket", True, "Docker daemon reachable")
+	except Exception as e:
+		return _row("docker_socket", False, f"Cannot reach Docker daemon: {e}")
+
+
+def _check_docker_network() -> dict:
+	try:
+		get_client().networks.get("benchpress")
+		return _row("docker_network", True, "benchpress network exists")
+	except docker.errors.NotFound:
+		return _row(
+			"docker_network",
+			False,
+			"benchpress network missing — it is created automatically on first deploy",
+		)
+	except Exception as e:
+		return _row("docker_network", False, f"Could not inspect networks: {e}")
+
+
+def _check_mariadb() -> dict:
+	try:
+		servers = frappe.get_all(
+			"Database Server",
+			fields=["name", "status", "container_name"],
+			order_by="creation asc",
+			limit=1,
+		)
+		if not servers:
+			return _row(
+				"mariadb",
+				False,
+				"No Database Server record — shared MariaDB is provisioned on first deploy",
+			)
+		server = servers[0]
+		if check_mariadb_health(server.name):
+			return _row("mariadb", True, f"MariaDB responding at {server.container_name}")
+		return _row(
+			"mariadb",
+			False,
+			f"MariaDB at {server.container_name} is not answering SELECT 1 (doc status: {server.status})",
+		)
+	except Exception as e:
+		return _row("mariadb", False, f"Could not check MariaDB: {e}")
+
+
+def _check_redis() -> dict:
+	try:
+		container = get_client().containers.get(REDIS_CONTAINER_NAME)
+		if container.status == "running":
+			return _row("redis", True, f"{REDIS_CONTAINER_NAME} is running")
+		return _row("redis", False, f"{REDIS_CONTAINER_NAME} status is {container.status}")
+	except docker.errors.NotFound:
+		return _row(
+			"redis",
+			False,
+			f"{REDIS_CONTAINER_NAME} container not found — shared Redis is provisioned on first deploy",
+		)
+	except Exception as e:
+		return _row("redis", False, f"Could not check Redis: {e}")
+
+
+def _check_vpn_server() -> dict:
+	try:
+		if "vpn_management" not in frappe.get_installed_apps():
+			return _row("vpn_server", False, "required app vpn_management is not installed")
+		if not frappe.db.exists("WireGuard Server", DEFAULT_INTERFACE):
+			return _row(
+				"vpn_server",
+				False,
+				f"WireGuard Server '{DEFAULT_INTERFACE}' is not configured",
+			)
+		public_key = frappe.db.get_value("WireGuard Server", DEFAULT_INTERFACE, "server_public_key")
+		if not public_key:
+			return _row(
+				"vpn_server",
+				False,
+				f"WireGuard Server '{DEFAULT_INTERFACE}' exists but has no server public key — "
+				"interface not initialized",
+			)
+		return _row("vpn_server", True, f"WireGuard server '{DEFAULT_INTERFACE}' configured")
+	except Exception as e:
+		return _row("vpn_server", False, f"Could not check VPN server: {e}")

--- a/benchpress/docker_manager.py
+++ b/benchpress/docker_manager.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import subprocess
+import time
 
 import docker
 import frappe
@@ -189,6 +190,25 @@ def get_container_ip(container_id: str) -> str:
 def start_container(container_id: str) -> None:
 	client = get_client()
 	client.containers.get(container_id).start()
+
+
+def wait_for_container_running(container_id: str, timeout: int = 60) -> str:
+	"""Poll until the container reports status "running" and has an IP on the
+	benchpress network. Returns the container IP. Mirrors wait_for_mariadb.
+	"""
+	client = get_client()
+	container = client.containers.get(container_id)
+	for _attempt in range(timeout // 2):
+		container.reload()
+		if container.status == "running":
+			networks = container.attrs.get("NetworkSettings", {}).get("Networks", {})
+			ip = networks.get("benchpress", {}).get("IPAddress", "") or container.attrs.get(
+				"NetworkSettings", {}
+			).get("IPAddress", "")
+			if ip:
+				return ip
+		time.sleep(2)
+	raise Exception(f"Container {container_id[:12]} not running with an IP after {timeout}s")
 
 
 def stop_container(container_id: str) -> None:

--- a/benchpress/tests/test_api_authorization.py
+++ b/benchpress/tests/test_api_authorization.py
@@ -118,6 +118,7 @@ class TestApiAuthorization(IntegrationTestCase):
 		frappe.set_user("Guest")
 		self.assert_denied(lambda: api.create_lab_from_template("frappe", "authz-guest"))
 		self.assert_denied(lambda: api.build_lab_image(self.lab.name))
+		self.assert_denied(lambda: api.run_diagnostics())
 
 	def test_guest_denied_from_bench_scoped_endpoints(self):
 		frappe.set_user("Guest")
@@ -136,6 +137,10 @@ class TestApiAuthorization(IntegrationTestCase):
 	def test_non_admin_denied_from_build_lab_image(self):
 		frappe.set_user(self.user_a)
 		self.assert_denied(lambda: api.build_lab_image(self.lab.name))
+
+	def test_non_admin_denied_from_run_diagnostics(self):
+		frappe.set_user(self.user_a)
+		self.assert_denied(lambda: api.run_diagnostics())
 
 	def test_owner_denied_from_deleting_own_bench(self):
 		# user_a passes require_bench_access on its own bench, but delete is admin-only.
@@ -183,3 +188,8 @@ class TestApiAuthorization(IntegrationTestCase):
 			result = api.create_lab_from_template("frappe", "authz-admin")
 		create.assert_called_once()
 		self.assertEqual(result, {"name": "LAB-authz", "status": "Draft"})
+
+	def test_admin_allowed_to_run_diagnostics(self):
+		frappe.set_user(self.admin_user)
+		with patch("benchpress.diagnostics.run_diagnostics", return_value=[]):
+			self.assertEqual(api.run_diagnostics(), [])

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -33,6 +33,35 @@ def _make_bench(lab_name):
 	return bench
 
 
+def _fresh_bench(case, lab_name):
+	frappe.set_user("Administrator")
+	existing = get_instance_id("Administrator", lab_name)
+	if frappe.db.exists("Bench Instance", existing):
+		frappe.delete_doc("Bench Instance", existing, force=True, ignore_permissions=True)
+		frappe.db.commit()
+	bench = _make_bench(lab_name)
+	case.addCleanup(
+		lambda n=bench.name: frappe.delete_doc("Bench Instance", n, force=True, ignore_permissions=True)
+		if frappe.db.exists("Bench Instance", n)
+		else None
+	)
+	case.addCleanup(frappe.db.commit)
+	return bench
+
+
+def _ensure_owner(email):
+	if not frappe.db.exists("User", email):
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": "Notify Owner",
+				"send_welcome_email": 0,
+			}
+		).insert(ignore_permissions=True)
+	return email
+
+
 class TestDeployManager(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
@@ -64,19 +93,7 @@ class TestDeployManager(IntegrationTestCase):
 		super().tearDownClass()
 
 	def _fresh_bench(self):
-		frappe.set_user("Administrator")
-		existing = get_instance_id("Administrator", self.lab.name)
-		if frappe.db.exists("Bench Instance", existing):
-			frappe.delete_doc("Bench Instance", existing, force=True, ignore_permissions=True)
-			frappe.db.commit()
-		bench = _make_bench(self.lab.name)
-		self.addCleanup(
-			lambda n=bench.name: frappe.delete_doc("Bench Instance", n, force=True, ignore_permissions=True)
-			if frappe.db.exists("Bench Instance", n)
-			else None
-		)
-		self.addCleanup(frappe.db.commit)
-		return bench
+		return _fresh_bench(self, self.lab.name)
 
 	# --- stop_bench ---
 
@@ -265,3 +282,161 @@ class TestDeployManager(IntegrationTestCase):
 		args = build_linkuser_args(bench, self.lab, settings, "pw")
 
 		self.assertEqual(args[-1], "/bin/bash")
+
+
+class TestTerminalStateNotifications(IntegrationTestCase):
+	"""Phase 3 (#98): every terminal deploy/build state desk-notifies the owner, best-effort."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.lab = _make_lab("test-lab-notify")
+		cls.owner = _ensure_owner("notify-owner@example.com")
+		if not frappe.db.exists("Database Server", "test-db-notify"):
+			frappe.get_doc(
+				{
+					"doctype": "Database Server",
+					"container_name": "test-db-notify",
+					"mariadb_version": "10.6",
+				}
+			).insert(ignore_permissions=True)
+		cls.db_server_name = frappe.db.get_value(
+			"Database Server", {"container_name": "test-db-notify"}, "name"
+		)
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		for name in frappe.get_all("Bench Instance", filters={"lab": cls.lab.name}, pluck="name"):
+			frappe.delete_doc("Bench Instance", name, force=True, ignore_permissions=True)
+		if cls.db_server_name and frappe.db.exists("Database Server", cls.db_server_name):
+			frappe.delete_doc("Database Server", cls.db_server_name, force=True, ignore_permissions=True)
+		cls.lab.delete(ignore_permissions=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def _owned_bench(self):
+		bench = _fresh_bench(self, self.lab.name)
+		frappe.db.set_value("Bench Instance", bench.name, "owner", self.owner)
+		frappe.db.commit()
+		self._cleanup_side_effects(bench_name=bench.name)
+		return bench
+
+	def _cleanup_side_effects(self, bench_name=None, lab_name=None):
+		# deploy/build commit mid-flight, so test-transaction rollback can't
+		# undo these rows — the file's manual-cleanup idiom.
+		def _purge():
+			frappe.db.delete("Notification Log", {"for_user": self.owner})
+			if bench_name:
+				frappe.db.delete("Deploy Log", {"bench": bench_name})
+			if lab_name:
+				frappe.db.delete("Build Log", {"lab": lab_name})
+			frappe.db.commit()
+
+		self.addCleanup(_purge)
+
+	def _owner_notification(self, document_type, document_name):
+		return frappe.db.get_value(
+			"Notification Log",
+			{"for_user": self.owner, "document_type": document_type, "document_name": document_name},
+			["type", "subject"],
+			as_dict=True,
+		)
+
+	@patch("benchpress.deploy_manager.ensure_infrastructure", autospec=True)
+	def test_deploy_failure_notifies_owner(self, mock_infra):
+		from benchpress.deploy_manager import deploy_bench
+
+		bench = self._owned_bench()
+		mock_infra.side_effect = Exception("mariadb container refused to start")
+
+		deploy_bench(bench.name)
+
+		self.assertEqual(frappe.db.get_value("Bench Instance", bench.name, "status"), "Error")
+		notification = self._owner_notification("Bench Instance", bench.name)
+		self.assertIsNotNone(notification)
+		self.assertEqual(notification.type, "Alert")
+		self.assertIn("failed", notification.subject)
+
+	def test_deploy_success_notifies_owner(self):
+		from benchpress import deploy_manager
+
+		bench = self._owned_bench()
+		frappe.db.set_value("Lab", self.lab.name, {"status": "Ready", "image_tag": "benchpress/test:latest"})
+		frappe.db.commit()
+
+		with (
+			patch.object(deploy_manager, "ensure_infrastructure", autospec=True) as mock_infra,
+			patch.object(deploy_manager, "wait_for_mariadb", autospec=True),
+			patch.object(deploy_manager, "_remove_stale_container", autospec=True),
+			patch.object(deploy_manager, "create_bench_container", autospec=True) as mock_create,
+			patch.object(deploy_manager, "start_container", autospec=True),
+			patch.object(deploy_manager, "wait_for_container_running", autospec=True) as mock_wait,
+			patch.object(deploy_manager, "_setup_container_vpn", autospec=True),
+			patch.object(deploy_manager, "write_file_to_container", autospec=True),
+			patch.object(deploy_manager, "exec_in_container", autospec=True) as mock_exec,
+			patch.object(deploy_manager, "create_site_in_container", autospec=True) as mock_site,
+		):
+			mock_infra.return_value = self.db_server_name
+			mock_create.return_value = "cid-notify"
+			mock_wait.return_value = "172.30.0.9"
+			mock_exec.return_value = (0, "")
+			mock_site.return_value = (0, "site created")
+
+			deploy_manager.deploy_bench(bench.name)
+
+		self.assertEqual(frappe.db.get_value("Bench Instance", bench.name, "status"), "Running")
+		notification = self._owner_notification("Bench Instance", bench.name)
+		self.assertIsNotNone(notification)
+		self.assertIn("deployed", notification.subject)
+
+	@patch("benchpress.deploy_manager.build_lab_image", autospec=True)
+	def test_build_lab_success_notifies_lab_owner(self, mock_build):
+		from benchpress.deploy_manager import build_lab
+
+		frappe.db.set_value("Lab", self.lab.name, "owner", self.owner)
+		frappe.db.commit()
+		self._cleanup_side_effects(lab_name=self.lab.name)
+		mock_build.return_value = "benchpress/x:latest"
+
+		build_lab(self.lab.name)
+
+		notification = self._owner_notification("Lab", self.lab.name)
+		self.assertIsNotNone(notification)
+		self.assertEqual(notification.type, "Alert")
+		self.assertIn("complete", notification.subject)
+
+	@patch("benchpress.deploy_manager.build_lab_image", autospec=True)
+	def test_build_lab_failure_notifies_lab_owner(self, mock_build):
+		from benchpress.deploy_manager import build_lab
+
+		frappe.db.set_value("Lab", self.lab.name, "owner", self.owner)
+		frappe.db.commit()
+		self._cleanup_side_effects(lab_name=self.lab.name)
+		mock_build.side_effect = Exception("docker build blew up")
+
+		build_lab(self.lab.name)
+
+		self.assertEqual(frappe.db.get_value("Lab", self.lab.name, "status"), "Error")
+		notification = self._owner_notification("Lab", self.lab.name)
+		self.assertIsNotNone(notification)
+		self.assertIn("failed", notification.subject)
+
+	@patch(
+		"frappe.desk.doctype.notification_log.notification_log.enqueue_create_notification",
+		autospec=True,
+	)
+	@patch("benchpress.deploy_manager.ensure_infrastructure", autospec=True)
+	def test_notification_failure_does_not_break_deploy(self, mock_infra, mock_notify):
+		from benchpress.deploy_manager import deploy_bench
+
+		bench = self._owned_bench()
+		mock_infra.side_effect = Exception("infrastructure down")
+		mock_notify.side_effect = Exception("redis down")
+
+		deploy_bench(bench.name)  # must not raise: _notify_owner swallows the failure
+
+		self.assertEqual(frappe.db.get_value("Bench Instance", bench.name, "status"), "Error")
+		self.assertFalse(frappe.db.exists("Notification Log", {"for_user": self.owner}))

--- a/benchpress/tests/test_diagnostics.py
+++ b/benchpress/tests/test_diagnostics.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+"""run_diagnostics contract: five rows, fixed order, never raises, never mutates."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import docker
+import frappe
+
+from benchpress.diagnostics import run_diagnostics
+
+CHECK_ORDER = ["docker_socket", "docker_network", "mariadb", "redis", "vpn_server"]
+DB_ROW = frappe._dict(name="db-server-1", status="Running", container_name="benchpress-mariadb")
+
+
+def _healthy_client():
+	client = MagicMock()
+	client.containers.get.return_value = MagicMock(status="running")
+	return client
+
+
+class TestDiagnostics(unittest.TestCase):
+	def _run(
+		self,
+		client=None,
+		client_error=None,
+		mariadb_healthy=True,
+		db_rows=None,
+		installed_apps=None,
+		wg_exists=True,
+		wg_key="the-key",
+	):
+		"""Run run_diagnostics with everything healthy unless overridden.
+
+		Returns ({check: row}, ordered rows)."""
+		client = client or _healthy_client()
+		with (
+			patch("benchpress.diagnostics.get_client", side_effect=client_error, return_value=client),
+			patch("benchpress.diagnostics.check_mariadb_health", return_value=mariadb_healthy),
+			patch("benchpress.diagnostics.frappe") as frappe_mock,
+		):
+			frappe_mock.get_all.return_value = [DB_ROW] if db_rows is None else db_rows
+			frappe_mock.get_installed_apps.return_value = installed_apps or [
+				"frappe",
+				"benchpress",
+				"vpn_management",
+			]
+			frappe_mock.db.exists.return_value = wg_exists
+			frappe_mock.db.get_value.return_value = wg_key
+			rows = run_diagnostics()
+		return {row["check"]: row for row in rows}, rows
+
+	def test_all_checks_pass(self):
+		_by_check, rows = self._run()
+		self.assertEqual([row["check"] for row in rows], CHECK_ORDER)
+		for row in rows:
+			self.assertEqual(row["status"], "pass")
+			self.assertEqual(set(row), {"check", "status", "hint"})
+
+	def test_docker_down_marks_docker_checks_failed_without_raising(self):
+		# completing without an exception IS the core assertion
+		by_check, rows = self._run(client_error=Exception("socket unreachable"))
+		self.assertEqual(len(rows), 5)
+		for check in ("docker_socket", "docker_network", "redis"):
+			self.assertEqual(by_check[check]["status"], "fail")
+
+	def test_missing_network_fails_with_hint(self):
+		client = _healthy_client()
+		client.networks.get.side_effect = docker.errors.NotFound("no network")
+		by_check, _rows = self._run(client=client)
+		self.assertEqual(by_check["docker_network"]["status"], "fail")
+		self.assertIn("created automatically on first deploy", by_check["docker_network"]["hint"])
+
+	def test_mariadb_unhealthy_and_missing_server(self):
+		by_check, _rows = self._run(mariadb_healthy=False)
+		self.assertEqual(by_check["mariadb"]["status"], "fail")
+
+		by_check, _rows = self._run(db_rows=[])
+		self.assertEqual(by_check["mariadb"]["status"], "fail")
+		self.assertIn("No Database Server record", by_check["mariadb"]["hint"])
+
+	def test_redis_not_running_fails(self):
+		client = _healthy_client()
+		client.containers.get.return_value = MagicMock(status="exited")
+		by_check, _rows = self._run(client=client)
+		self.assertEqual(by_check["redis"]["status"], "fail")
+		self.assertIn("exited", by_check["redis"]["hint"])
+
+		client = _healthy_client()
+		client.containers.get.side_effect = docker.errors.NotFound("gone")
+		by_check, _rows = self._run(client=client)
+		self.assertEqual(by_check["redis"]["status"], "fail")
+
+	def test_vpn_missing_app_fails(self):
+		by_check, _rows = self._run(installed_apps=["frappe", "benchpress"])
+		self.assertEqual(by_check["vpn_server"]["status"], "fail")
+		self.assertIn("vpn_management", by_check["vpn_server"]["hint"])
+
+	def test_never_calls_mutating_docker_apis(self):
+		client = _healthy_client()
+		client.ping.side_effect = Exception("down")
+		client.networks.get.side_effect = docker.errors.NotFound("no network")
+		client.containers.get.side_effect = docker.errors.NotFound("gone")
+		_by_check, rows = self._run(
+			client=client, mariadb_healthy=False, db_rows=[], installed_apps=["frappe"]
+		)
+		self.assertEqual([row["status"] for row in rows], ["fail"] * 5)
+		client.networks.create.assert_not_called()
+		client.containers.create.assert_not_called()
+		client.containers.run.assert_not_called()

--- a/benchpress/tests/test_docker_manager.py
+++ b/benchpress/tests/test_docker_manager.py
@@ -15,6 +15,7 @@ from benchpress.docker_manager import (
 	DEFAULT_IOPS,
 	DEFAULT_PIDS_LIMIT,
 	get_container_health,
+	wait_for_container_running,
 )
 
 
@@ -41,6 +42,54 @@ class TestContainerHealth(unittest.TestCase):
 		client.containers.get.side_effect = docker.errors.NotFound("no such container")
 		get_client.return_value = client
 		self.assertEqual(get_container_health("gone"), "Unknown")
+
+
+def _reloading_container(states):
+	"""Container mock whose reload() steps through (status, attrs) states."""
+	container = MagicMock()
+	steps = iter(states)
+
+	def advance():
+		container.status, container.attrs = next(steps)
+
+	container.reload.side_effect = advance
+	return container
+
+
+IP_ATTRS = {"NetworkSettings": {"Networks": {"benchpress": {"IPAddress": "172.30.0.5"}}}}
+NO_IP_ATTRS = {"NetworkSettings": {"Networks": {"benchpress": {"IPAddress": ""}}}}
+
+
+class TestWaitForContainerRunning(unittest.TestCase):
+	@patch("benchpress.docker_manager.time.sleep")
+	@patch("benchpress.docker_manager.get_client")
+	def test_returns_ip_when_running_on_third_poll(self, get_client, sleep):
+		container = _reloading_container([("created", {}), ("created", {}), ("running", IP_ATTRS)])
+		get_client.return_value.containers.get.return_value = container
+		self.assertEqual(wait_for_container_running("abc123"), "172.30.0.5")
+		self.assertEqual(container.reload.call_count, 3)
+		self.assertEqual(sleep.call_count, 2)
+		sleep.assert_called_with(2)
+
+	@patch("benchpress.docker_manager.time.sleep")
+	@patch("benchpress.docker_manager.get_client")
+	def test_running_without_ip_keeps_polling(self, get_client, sleep):
+		container = _reloading_container(
+			[("running", NO_IP_ATTRS), ("running", NO_IP_ATTRS), ("running", IP_ATTRS)]
+		)
+		get_client.return_value.containers.get.return_value = container
+		self.assertEqual(wait_for_container_running("abc123"), "172.30.0.5")
+		self.assertEqual(container.reload.call_count, 3)
+
+	@patch("benchpress.docker_manager.time.sleep")
+	@patch("benchpress.docker_manager.get_client")
+	def test_raises_clear_exception_on_timeout(self, get_client, sleep):
+		container = _reloading_container([("created", {})] * 30)
+		get_client.return_value.containers.get.return_value = container
+		with self.assertRaises(Exception) as ctx:
+			wait_for_container_running("abc123")
+		self.assertIn("not running with an IP after 60s", str(ctx.exception))
+		self.assertEqual(sleep.call_count, 30)
 
 
 def _make_lab(lab_id, **extra):


### PR DESCRIPTION
Wave 2 reliability (issue #102), phase 1 of 3 — closes #90.

## What phase one does

Replaces the blind `time.sleep(5)` after `start_container` in `deploy_bench` with a bounded readiness poll:

- New `benchpress.docker_manager.wait_for_container_running(container_id, timeout=60)` — mirrors `wait_for_mariadb`: reload container state every 2s until Docker reports status `running` **and** an IP on the `benchpress` network; raises `Container <id> not running with an IP after 60s` on timeout.
- `deploy_bench` calls it in place of sleep + `get_container_ip`; a timeout flows into the existing broad `except` handler (Bench Instance → `Error`, Deploy Log → `error`, `frappe.log_error`). No handler changes.

**Deliberate semantics change:** a missing container IP was previously tolerated (`if container_ip:` guard); now IP-within-60s is mandatory — a stuck container fails the deploy loudly within ~60s instead of proceeding blind.

Not in scope (later phases): in-container service probes, diagnostics surface (#97, phase 2), completion notifications (#98, phase 3).

## How to verify

```
docker compose exec backend bench --site frontend run-tests --app benchpress --module benchpress.tests.test_docker_manager
docker compose exec backend bench --site frontend run-tests --app benchpress --module benchpress.tests.test_deploy_manager
grep -n "time.sleep" benchpress/deploy_manager.py   # no hits
```

New `TestWaitForContainerRunning` covers: IP returned on 3rd poll (reload cadence + 2s backoff), running-without-IP keeps polling, clear exception + 30 sleeps on timeout. All 6 docker_manager and 9 deploy_manager tests pass; `pre-commit run --all-files` clean.