### PR TITLE
Implemented phase one

### DIFF
--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -118,16 +118,9 @@ def get_benches() -> list[dict]:
 		order_by="creation desc",
 	)
 
-	from frappe.utils.password import get_decrypted_password
-
 	for bench in benches:
 		bench["app_count"] = frappe.db.count("Bench App", {"parent": bench["name"]})
 		bench["site_count"] = frappe.db.count("Bench Site", {"bench": bench["name"]})
-		for field in ("ssh_password", "admin_password", "code_server_password"):
-			try:
-				bench[field] = get_decrypted_password("Bench Instance", bench["name"], field)
-			except frappe.exceptions.ValidationError:
-				bench[field] = None
 
 	return benches
 
@@ -395,6 +388,20 @@ def get_code_server_credentials(bench_name: str) -> dict:
 
 	password = get_decrypted_password("Bench Instance", bench_name, "code_server_password")
 	return {"url": bench.code_server_url, "password": password}
+
+
+@frappe.whitelist()
+def get_bench_credentials(bench_name: str) -> dict:
+	require_bench_access(bench_name)
+	from frappe.utils.password import get_decrypted_password
+
+	credentials = {}
+	for field in ("ssh_password", "admin_password", "code_server_password"):
+		try:
+			credentials[field] = get_decrypted_password("Bench Instance", bench_name, field)
+		except frappe.exceptions.ValidationError:
+			credentials[field] = None
+	return credentials
 
 
 @frappe.whitelist()

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -166,8 +166,11 @@ class TestApi(IntegrationTestCase):
 		benches, elapsed_ms = _timed(api.get_benches)
 		self.assertIsInstance(benches, list)
 		for bench in benches:
-			for key in ("app_count", "site_count", "ssh_password", "admin_password", "code_server_password"):
+			for key in ("app_count", "site_count", "ssh_username"):
 				self.assertIn(key, bench)
+			# Secrets moved to get_bench_credentials (issue #91).
+			for key in ("ssh_password", "admin_password", "code_server_password"):
+				self.assertNotIn(key, bench)
 		self.assert_within_budget("get_benches", elapsed_ms)
 
 	def test_list_devices_shape_and_timing(self):

--- a/benchpress/tests/test_api_authorization.py
+++ b/benchpress/tests/test_api_authorization.py
@@ -127,6 +127,7 @@ class TestApiAuthorization(IntegrationTestCase):
 		self.assert_denied(lambda: api.bench_action(bench, "start"))
 		self.assert_denied(lambda: api.get_deploy_logs(bench))
 		self.assert_denied(lambda: api.get_code_server_credentials(bench))
+		self.assert_denied(lambda: api.get_bench_credentials(bench))
 		self.assert_denied(lambda: api.restart_code_server(bench))
 
 	# --- Wrong-role (BenchPress User) blocked from admin-only endpoints -------
@@ -165,6 +166,10 @@ class TestApiAuthorization(IntegrationTestCase):
 	def test_cross_user_denied_from_restart_code_server(self):
 		frappe.set_user(self.user_b)
 		self.assert_denied(lambda: api.restart_code_server(self.bench.name))
+
+	def test_cross_user_denied_from_get_bench_credentials(self):
+		frappe.set_user(self.user_b)
+		self.assert_denied(lambda: api.get_bench_credentials(self.bench.name))
 
 	def test_get_benches_hides_other_users_bench(self):
 		frappe.set_user(self.user_b)
@@ -213,6 +218,10 @@ class TestApiAuthorization(IntegrationTestCase):
 	def test_roleless_denied_from_get_benches(self):
 		frappe.set_user(self.norole_user)
 		self.assert_denied(api.get_benches)
+
+	def test_roleless_denied_from_get_bench_credentials(self):
+		frappe.set_user(self.norole_user)
+		self.assert_denied(lambda: api.get_bench_credentials(self.bench.name))
 
 	# --- Positive controls: require_app_user permits a BenchPress User --------
 
@@ -295,6 +304,20 @@ class TestApiAuthorization(IntegrationTestCase):
 		frappe.set_user(self.user_a)
 		names = [bench["name"] for bench in api.get_benches()]
 		self.assertIn(self.bench.name, names)
+
+	def test_get_benches_omits_password_fields(self):
+		# Ponytail check for issue #91: fails if the decrypt loop is reintroduced.
+		frappe.set_user(self.user_a)
+		for bench in api.get_benches():
+			for field in ("ssh_password", "admin_password", "code_server_password"):
+				self.assertNotIn(field, bench)
+
+	def test_owner_reads_own_bench_credentials_via_get_bench_credentials(self):
+		frappe.set_user(self.user_a)
+		creds = api.get_bench_credentials(self.bench.name)
+		self.assertEqual(creds["code_server_password"], "cs-secret")
+		self.assertIn("ssh_password", creds)
+		self.assertIn("admin_password", creds)
 
 	def test_admin_allowed_to_create_lab_from_template(self):
 		frappe.set_user(self.admin_user)

--- a/e2e/pages/BasePage.ts
+++ b/e2e/pages/BasePage.ts
@@ -10,7 +10,8 @@ export class BasePage {
     await this.page.goto("/login");
     await this.page.locator("#login_email").fill(user);
     await this.page.locator("#login_password").fill(password);
-    await this.page.locator(".btn-login").click();
+    // Login page has a second .btn-login for the email-link flow; target the password submit.
+    await this.page.locator("button.btn-login[type=submit]:not(.btn-login-with-email-link)").click();
     await this.page.waitForURL(/\/(app|desk)/, { timeout: 20_000 });
   }
 

--- a/frontend/src/pages/LabDetail.vue
+++ b/frontend/src/pages/LabDetail.vue
@@ -624,10 +624,10 @@ const siteColumns = [
 ];
 
 const sshUsername = computed(() => activeBench.value?.ssh_username || null);
-const sshPassword = computed(() => activeBench.value?.ssh_password || null);
-const adminPassword = computed(() => activeBench.value?.admin_password || null);
+const sshPassword = computed(() => benchCredentials.data?.ssh_password || null);
+const adminPassword = computed(() => benchCredentials.data?.admin_password || null);
 const codeServerUrl = computed(() => activeBench.value?.code_server_url || null);
-const codeServerPassword = computed(() => activeBench.value?.code_server_password || null);
+const codeServerPassword = computed(() => benchCredentials.data?.code_server_password || null);
 const benchIp = computed(
 	() => activeBench.value?.wg_ip || activeBench.value?.container_ip || null
 );
@@ -657,6 +657,19 @@ const activeBench = computed(() => {
 	if (!benches.data) return null;
 	return benches.data.find((b) => b.lab === labId) || null;
 });
+
+const benchCredentials = createResource({
+	url: "benchpress.api.get_bench_credentials",
+});
+
+// Passwords are no longer in get_benches; fetch them per bench once it resolves.
+watch(
+	() => activeBench.value?.name,
+	(name) => {
+		if (name) benchCredentials.submit({ bench_name: name });
+	},
+	{ immediate: true }
+);
 
 const sites = createListResource({
 	doctype: "Bench Site",


### PR DESCRIPTION
## Issue #91 — stop returning decrypted secrets in get_benches()

Phase one (single-phase spec `no-secrets-in-list`): the bench list response no longer carries decrypted passwords; the Lab detail credentials panel fetches them through one new per-bench guarded endpoint.

### What changed
- `get_benches()` — decrypt loop removed; `app_count`/`site_count` enrichment kept; `ssh_username` (non-secret) still in the list.
- New `get_bench_credentials(bench_name)` — first line `require_bench_access(bench_name)` (same guard as `get_code_server_credentials`, which is untouched per issue guardrail); returns `ssh_password` / `admin_password` / `code_server_password`, `None` when unset. No Running-status gate, preserving current UX.
- `LabDetail.vue` — new `createResource` for the endpoint, submitted when `activeBench` resolves; the three password computeds repointed to it. `sshUsername` / `codeServerUrl` still come from the list.
- Tests — `test_get_benches_omits_password_fields` (fails if the decrypt loop is reintroduced) plus guest / roleless / cross-user denials and an owner positive control (`code_server_password == "cs-secret"`) for the new endpoint.
- e2e harness fix — the v16 login page has two `.btn-login` elements; `BasePage.login()` now targets the password submit button. Auth setup was failing before any spec ran.

### Verification (all run)
1. `bench --site frontend run-tests --app benchpress --module benchpress.tests.test_api_authorization` — 38 tests, OK.
2. In-container smoke (throwaway bench, rolled back): `get_benches` row leaked fields `[]`; `get_bench_credentials` returned all three keys with the correct decrypted value.
3. `bench build --app benchpress` + restart backend/frontend — SPA and new bundle serve 200.
4. `cd e2e && npx playwright test bench-instances.spec.ts` — 4 passed.

Per the spec: needs human review before merge (backend + Vue); no autonomous merge.