### PR TITLE
Implemented phase two

### DIFF
--- a/benchpress/mariadb_manager.py
+++ b/benchpress/mariadb_manager.py
@@ -303,7 +303,8 @@ def wait_for_mariadb(
 	for _attempt in range(timeout // 2):
 		if direct:
 			exit_code, _output = container.exec_run(
-				cmd=["mariadb", "-u", "root", f"-p{root_pw}", "-e", "SELECT 1"],
+				cmd=["mariadb", "-u", "root", "-e", "SELECT 1"],
+				environment={"MYSQL_PWD": root_pw},
 			)
 			healthy = exit_code == 0
 		else:
@@ -363,8 +364,9 @@ def backup_database_server(db_server_name: str, output_path: str = "/var/lib/mys
 		cmd=[
 			"bash",
 			"-c",
-			f"mariadb-dump -u root -p'{root_pw}' --all-databases | gzip > {backup_file}",
+			f"mariadb-dump -u root --all-databases | gzip > {backup_file}",
 		],
+		environment={"MYSQL_PWD": root_pw},
 	)
 	if exit_code != 0:
 		frappe.throw(_("Backup failed: {0}").format(output.decode()))

--- a/benchpress/mariadb_manager.py
+++ b/benchpress/mariadb_manager.py
@@ -65,7 +65,8 @@ def execute_sql(db_server_name: str, sql: str) -> tuple[int, str]:
 	try:
 		container.exec_run(cmd=["bash", "-c", f"echo '{encoded}' | base64 -d > {tmp}"])
 		exit_code, output = container.exec_run(
-			cmd=["bash", "-c", f"mariadb -u root -p'{root_pw}' < {tmp}"],
+			cmd=["bash", "-c", f"mariadb -u root < {tmp}"],
+			environment={"MYSQL_PWD": root_pw},
 		)
 	finally:
 		container.exec_run(cmd=["rm", "-f", tmp])

--- a/benchpress/tests/test_mariadb_manager.py
+++ b/benchpress/tests/test_mariadb_manager.py
@@ -111,6 +111,28 @@ class TestMariadbManager(IntegrationTestCase):
 			cmd = call.kwargs.get("cmd") or call.args[0]
 			self.assertNotIn(sentinel, " ".join(cmd))
 
+	@patch("benchpress.mariadb_manager.frappe.utils.now", return_value="2026-01-01 00:00:00")
+	@patch("benchpress.mariadb_manager.get_client")
+	@patch("benchpress.mariadb_manager.frappe.get_doc")
+	def test_backup_passes_password_via_env_not_argv(self, mock_get_doc, mock_get_client, mock_now):
+		from benchpress.mariadb_manager import backup_database_server
+
+		sentinel = "S3cret!pw"
+		db_server = self._make_mock_db_server()
+		db_server.get_root_password.return_value = sentinel
+		mock_get_doc.return_value = db_server
+		mock_container = MagicMock()
+		mock_container.exec_run.return_value = (0, b"")
+		mock_get_client.return_value.containers.get.return_value = mock_container
+
+		backup_database_server("db-server-name")
+
+		dump_call = mock_container.exec_run.call_args_list[1]
+		self.assertEqual(dump_call.kwargs.get("environment"), {"MYSQL_PWD": sentinel})
+		for call in mock_container.exec_run.call_args_list:
+			cmd = call.kwargs.get("cmd") or call.args[0]
+			self.assertNotIn(sentinel, " ".join(cmd))
+
 	@patch("benchpress.mariadb_manager.execute_sql")
 	def test_create_mariadb_user_returns_db_name_user_pass(self, mock_exec):
 		from benchpress.mariadb_manager import create_mariadb_user, get_database_name

--- a/benchpress/tests/test_mariadb_manager.py
+++ b/benchpress/tests/test_mariadb_manager.py
@@ -90,6 +90,27 @@ class TestMariadbManager(IntegrationTestCase):
 		cmd = last_call[1].get("cmd") or last_call[0][0]
 		self.assertIn("rm", cmd)
 
+	@patch("benchpress.mariadb_manager.get_client")
+	@patch("benchpress.mariadb_manager.frappe.get_doc")
+	def test_execute_sql_passes_password_via_env_not_argv(self, mock_get_doc, mock_get_client):
+		from benchpress.mariadb_manager import execute_sql
+
+		sentinel = "S3cret!pw"
+		db_server = self._make_mock_db_server()
+		db_server.get_root_password.return_value = sentinel
+		mock_get_doc.return_value = db_server
+		mock_container = MagicMock()
+		mock_container.exec_run.return_value = (0, b"ok")
+		mock_get_client.return_value.containers.get.return_value = mock_container
+
+		execute_sql("db-server-name", "SELECT 1")
+
+		sql_call = mock_container.exec_run.call_args_list[1]
+		self.assertEqual(sql_call.kwargs.get("environment"), {"MYSQL_PWD": sentinel})
+		for call in mock_container.exec_run.call_args_list:
+			cmd = call.kwargs.get("cmd") or call.args[0]
+			self.assertNotIn(sentinel, " ".join(cmd))
+
 	@patch("benchpress.mariadb_manager.execute_sql")
 	def test_create_mariadb_user_returns_db_name_user_pass(self, mock_exec):
 		from benchpress.mariadb_manager import create_mariadb_user, get_database_name


### PR DESCRIPTION
Phase one of issue #94 (`mariadb-pw-not-in-argv` spec): `execute_sql` — the seam all SQL routes through (`create_mariadb_user`, `drop_mariadb_user`, `drop_site_database`, `check_mariadb_health`) — now authenticates via `exec_run(environment={"MYSQL_PWD": root_pw})` instead of interpolating the root password into the argv string. Base64 temp-file scheme untouched.

**Verified live:**
- Smoke: `docker exec -e MYSQL_PWD=... benchpress_db mariadb -u root -e "SELECT 1"` returns 1 on mariadb:10.6.
- Full path: `SELECT SLEEP(8)` through `execute_sql` against managed `benchpress-mariadb`; concurrent `ps -ef` inside the container shows `mariadb -u root` with **no password in argv**; query exit 0.
- Regression test `test_execute_sql_passes_password_via_env_not_argv` asserts the sentinel password appears in no `exec_run` cmd and the SQL call carries `environment={"MYSQL_PWD": ...}`. Full `test_mariadb_manager` suite: 14/14 pass.

`backup_database_server` and `wait_for_mariadb` still use argv — phase 2 converts them.

**Needs human review before merge** (issue mandate: human verifies auth against real MariaDB).