### PR TITLE
Implemented phase two

### DIFF
--- a/docs/production-safety.md
+++ b/docs/production-safety.md
@@ -22,6 +22,9 @@ environments — not yet for production hosting of customer data. Concretely:
   the shared MariaDB/Redis infrastructure containers, and enables IP forwarding via
   `/etc/sysctl.d`. These are real, persistent changes to the host. (WireGuard is
   brought up by the vpn_management app's wg-agent container, not by `setup.sh`.)
+  Production hosts must also enable
+  [Docker userns-remap](wireguard-setup.md#docker-userns-remap) so in-container
+  root is not host root.
 - **Privileged containers.** Bench containers currently run with elevated Docker
   privileges to support in-container networking. Treat every bench as having host
   reach until that is hardened.

--- a/docs/wireguard-setup.md
+++ b/docs/wireguard-setup.md
@@ -61,6 +61,46 @@ BenchPress only *consumes* the VPN plane through `benchpress/vpn_adapter.py`:
 
 ---
 
+## Docker userns-remap
+
+Lab users get **root inside their bench containers**. `create_bench_container`
+deliberately avoids `privileged`, but without user-namespace remapping,
+in-container UID 0 *is* host UID 0 — a container escape is a host-root escape.
+Enabling `userns-remap` makes the Docker daemon map container root to an
+unprivileged host UID range, the release-blocking defense called out in
+[PRODUCTION_CHECKLIST.md](PRODUCTION_CHECKLIST.md).
+
+### Enable it
+
+1. Add to `/etc/docker/daemon.json` (create the file if it doesn't exist):
+
+   ```json
+   { "userns-remap": "default" }
+   ```
+
+2. Restart Docker: `sudo systemctl restart docker`
+3. Re-run the setup check and confirm the PASS line:
+
+   ```bash
+   bash apps/benchpress/setup.sh <site> --strict
+   ```
+
+> **⚠️ Migration warning — enable this BEFORE your first deploy.**
+> Turning on userns-remap re-roots Docker's storage under a remapped
+> subdirectory of `/var/lib/docker`. The remapped daemon **no longer sees
+> existing containers, images, or volumes** — deployed labs and
+> `benchpress-mariadb-data` included. Nothing is deleted, but everything must
+> be redeployed. If benches already exist, back up their data and plan a
+> redeploy of every bench before flipping the switch.
+
+### Rootless Docker
+
+Running the Docker daemon itself rootless is an accepted alternative: the
+entire daemon runs as an unprivileged user, so container-root ≠ host-root
+holds even more strongly. `setup.sh` reports PASS on rootless hosts.
+
+---
+
 ## Troubleshooting
 
 | Symptom | Check |

--- a/setup.sh
+++ b/setup.sh
@@ -4,10 +4,13 @@
 #
 # Usage:
 #   cd /path/to/frappe-bench
-#   bash apps/benchpress/setup.sh <site-name>
+#   bash apps/benchpress/setup.sh <site-name> [--strict]
 #
 # Example:
 #   bash apps/benchpress/setup.sh sponge.localhost
+#
+# --strict: exit non-zero if Docker userns-remap is absent or unverifiable
+# (production hosts); default is warn-and-continue (dev hosts).
 #
 # VPN note: tunnels, peers and IP allocation are owned by the vpn_management
 # app (wg-agent + VPN Peer / Network Pool DocTypes). This script only prepares
@@ -16,7 +19,6 @@
 set -e
 
 BENCH_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
-SITE_NAME="${1:-}"
 BENCH_USER="$(whoami)"
 
 RED='\033[0;31m'
@@ -30,6 +32,25 @@ success() { echo -e "${GREEN}[✓]${NC} $1"; }
 warn()    { echo -e "${YELLOW}[!]${NC} $1"; }
 error()   { echo -e "${RED}[✗]${NC} $1"; exit 1; }
 
+# --- Parse arguments ---
+
+SITE_NAME=""
+STRICT=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --strict) STRICT=1 ;;
+        -*) error "Unknown option: $arg. Usage: bash apps/benchpress/setup.sh <site-name> [--strict]" ;;
+        *)
+            if [ -z "$SITE_NAME" ]; then
+                SITE_NAME="$arg"
+            else
+                error "Unexpected argument: $arg"
+            fi
+            ;;
+    esac
+done
+
 echo ""
 echo "=============================="
 echo "  BenchPress Setup"
@@ -37,7 +58,7 @@ echo "=============================="
 echo ""
 
 if [ -z "$SITE_NAME" ]; then
-    error "Site name required. Usage: bash apps/benchpress/setup.sh <site-name>"
+    error "Site name required. Usage: bash apps/benchpress/setup.sh <site-name> [--strict]"
 fi
 
 # Every step needs host-level access (docker group, sysctl) — none of it
@@ -61,7 +82,7 @@ echo ""
 
 # --- Step 1: Docker group ---
 
-info "Step 1/3: Docker group"
+info "Step 1/4: Docker group"
 
 if groups "$BENCH_USER" | grep -q '\bdocker\b'; then
     success "User '$BENCH_USER' is already in the docker group"
@@ -82,9 +103,27 @@ fi
 
 echo ""
 
-# --- Step 2: Shared infrastructure (MariaDB + Redis) ---
+# --- Step 2: Docker user-namespace remap (container-root != host-root) ---
 
-info "Step 2/3: Shared infrastructure (MariaDB + Redis)"
+info "Step 2/4: Docker userns-remap"
+if ! docker info &>/dev/null; then
+    MSG="Cannot verify userns-remap — docker socket not accessible (re-login, then re-run)"
+    [ "$STRICT" -eq 1 ] && error "$MSG" || warn "$MSG"
+elif docker info --format '{{join .SecurityOptions ","}}' | grep -qE 'name=(userns|rootless)'; then
+    success "Docker userns-remap (or rootless) is enabled — container root is unprivileged on the host"
+else
+    warn "Docker userns-remap is NOT enabled — in-container root maps to HOST root"
+    warn "Lab users get container root; without remap that is one kernel bug from host root."
+    warn "Enable it: add {\"userns-remap\": \"default\"} to /etc/docker/daemon.json, restart docker."
+    warn "Details and migration caveats: apps/benchpress/docs/wireguard-setup.md#docker-userns-remap"
+    [ "$STRICT" -eq 1 ] && error "--strict: refusing to continue without userns-remap"
+fi
+
+echo ""
+
+# --- Step 3: Shared infrastructure (MariaDB + Redis) ---
+
+info "Step 3/4: Shared infrastructure (MariaDB + Redis)"
 
 COMPOSE_DIR="$BENCH_DIR/apps/benchpress/benchpress/config"
 COMPOSE_FILE="$COMPOSE_DIR/docker-compose.yml"
@@ -154,9 +193,9 @@ fi
 
 echo ""
 
-# --- Step 3: IP forwarding ---
+# --- Step 4: IP forwarding ---
 
-info "Step 3/3: IP forwarding"
+info "Step 4/4: IP forwarding"
 
 SYSCTL_CONF="/etc/sysctl.d/99-benchpress.conf"
 


### PR DESCRIPTION
Phase 1 of specs/in-progress/setup-userns-check (issue #95): `setup.sh` now verifies Docker userns-remap before any mutating step.

**What it does**
- New **Step 2/4: Docker userns-remap** — runs after the docker-group/socket check, before shared-infra `docker compose up`.
- PASS when `docker info` SecurityOptions contains `name=userns` or `name=rootless`.
- Otherwise a loud multi-line WARN: container root maps to host root, how to enable remap in `/etc/docker/daemon.json`, pointer to `docs/wireguard-setup.md#docker-userns-remap` (section lands in phase 2). Default continues (dev hosts).
- `--strict` exits non-zero at Step 2 — also when the docker socket is unreachable (unverifiable = fail-closed). Detect and instruct only; never edits daemon.json.
- Arg loop replaces bare `$1`: first positional = site name, unknown `--*` = usage error; usage strings now show `[--strict]`.

**How to verify** (all run on this dev host, no remap)
1. `bash -n setup.sh` — clean.
2. No site: usage error mentioning `[--strict]`. Unknown flag: `Unknown option: --bogus`.
3. `bash apps/benchpress/setup.sh frontend` — Step 2 WARN block, continues through Steps 3–4, exit 0.
4. `bash apps/benchpress/setup.sh frontend --strict` — exits 1 at Step 2, before `docker compose up`.
5. Branch-logic assert from the spec prints `exit=7` here (unremapped), `PASS`/`exit=0` on remapped/rootless hosts.