### PR TITLE
Implemented phase three

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Added
 
+- Nightly MariaDB dumps are now copied to host disk
+  (`sites/<site>/private/backups/mariadb/`), off the database volume, with 7-day
+  retention enforced on the new location — losing the DB volume no longer loses
+  the backups. A documented, once-verified restore runbook
+  ([`docs/database-backup-restore.md`](docs/database-backup-restore.md)) and a
+  console-only `restore_database_server()` helper close the loop.
+  ([#96](https://github.com/Venkateshvenki404224/benchpress/issues/96))
 - Documented, backup-gated upgrade path for installed instances: a manual
   runbook ([`docs/upgrading.md`](docs/upgrading.md)) and a scripted
   [`upgrade.sh`](upgrade.sh) that chains backup → app update → `bench migrate` →

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@
 - [VPN Device Management](docs/device-management.md) -- Register devices for WireGuard access
 - [WireGuard Setup](docs/wireguard-setup.md) -- Detailed WireGuard configuration
 - [Upgrading a BenchPress Install](docs/upgrading.md) -- Backup-gated upgrade and rollback runbook
+- [Database Backup & Restore](docs/database-backup-restore.md) -- Where nightly MariaDB dumps live and the verified restore runbook
 - [Changelog](CHANGELOG.md) -- Notable changes per release; read before a multi-release upgrade
 
 ---

--- a/benchpress/mariadb_manager.py
+++ b/benchpress/mariadb_manager.py
@@ -366,7 +366,8 @@ def _pull_backup_to_host(container, backup_file: str) -> str:
 	host_path = os.path.join(host_dir, os.path.basename(backup_file))
 	with tarfile.open(fileobj=buffer) as tar:
 		member = tar.extractfile(tar.getmembers()[0])
-		with open(host_path, "wb") as f:
+		# Safe: host_dir is the fixed site backup path, filename passed through basename().
+		with open(host_path, "wb") as f:  # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal  # fmt: skip
 			f.write(member.read())
 	return host_path
 

--- a/benchpress/mariadb_manager.py
+++ b/benchpress/mariadb_manager.py
@@ -3,9 +3,11 @@
 
 import base64
 import hashlib
+import io
 import os
 import secrets
 import subprocess
+import tarfile
 import time
 import uuid
 
@@ -349,8 +351,26 @@ def scheduled_health_check():
 			)
 
 
+def _pull_backup_to_host(container, backup_file: str) -> str:
+	"""Copy an in-container dump to the site's private backup dir. Returns host path."""
+	# ponytail: whole dump buffered in RAM; stream the tar (mode="r|") if dumps outgrow worker memory.
+	stream, _stat = container.get_archive(backup_file)
+	buffer = io.BytesIO(b"".join(stream))
+	host_dir = frappe.get_site_path("private", "backups", "mariadb")
+	os.makedirs(host_dir, exist_ok=True)
+	host_path = os.path.join(host_dir, os.path.basename(backup_file))
+	with tarfile.open(fileobj=buffer) as tar:
+		member = tar.extractfile(tar.getmembers()[0])
+		with open(host_path, "wb") as f:
+			f.write(member.read())
+	return host_path
+
+
 def backup_database_server(db_server_name: str, output_path: str = "/var/lib/mysql/backups") -> str:
-	"""Full backup via mariadb-dump, gzipped. Returns backup filename."""
+	"""Full backup via mariadb-dump, gzipped, pulled to host disk.
+
+	Returns the host path; on pull failure returns the in-container path (dump kept as fallback).
+	"""
 	db_server = frappe.get_doc("Database Server", db_server_name)
 	client = get_client()
 	container = client.containers.get(db_server.container_id)
@@ -370,7 +390,16 @@ def backup_database_server(db_server_name: str, output_path: str = "/var/lib/mys
 	)
 	if exit_code != 0:
 		frappe.throw(_("Backup failed: {0}").format(output.decode()))
-	return backup_file
+	try:
+		host_path = _pull_backup_to_host(container, backup_file)
+	except Exception:
+		frappe.log_error(
+			title=f"Backup host copy failed: {db_server_name}",
+			message=frappe.get_traceback(),
+		)
+		return backup_file
+	container.exec_run(cmd=["rm", "-f", backup_file])
+	return host_path
 
 
 def cleanup_old_backups(

--- a/benchpress/mariadb_manager.py
+++ b/benchpress/mariadb_manager.py
@@ -426,6 +426,33 @@ def cleanup_old_backups(
 		old.unlink()
 
 
+def restore_database_server(db_server_name: str, backup_file: str) -> None:
+	"""DESTRUCTIVE: overwrites ALL databases in the target container with a host-side dump.
+
+	Scratch/recovery use only — never point this at a live tenant DB server.
+	Not whitelisted on purpose; run it from `bench console`.
+	See docs/database-backup-restore.md for the full runbook.
+	"""
+	db_server = frappe.get_doc("Database Server", db_server_name)
+	container = get_client().containers.get(db_server.container_id)
+	root_pw = db_server.get_root_password()
+
+	dump_name = os.path.basename(backup_file)
+	buffer = io.BytesIO()
+	with tarfile.open(fileobj=buffer, mode="w") as tar:
+		tar.add(backup_file, arcname=dump_name)
+	container.put_archive("/tmp", buffer.getvalue())
+	try:
+		exit_code, output = container.exec_run(
+			cmd=["bash", "-c", f"gunzip -c /tmp/{dump_name} | mariadb -u root"],
+			environment={"MYSQL_PWD": root_pw},
+		)
+	finally:
+		container.exec_run(cmd=["rm", "-f", f"/tmp/{dump_name}"])
+	if exit_code != 0:
+		frappe.throw(_("Restore failed: {0}").format(output.decode()))
+
+
 def scheduled_backup():
 	"""Cron job — nightly backup with 7-day retention."""
 	servers = frappe.get_all("Database Server", filters={"status": "Active"}, fields=["name"])

--- a/benchpress/mariadb_manager.py
+++ b/benchpress/mariadb_manager.py
@@ -10,6 +10,7 @@ import subprocess
 import tarfile
 import time
 import uuid
+from pathlib import Path
 
 import frappe
 from frappe import _
@@ -351,12 +352,16 @@ def scheduled_health_check():
 			)
 
 
+def _host_backup_dir() -> str:
+	return frappe.get_site_path("private", "backups", "mariadb")
+
+
 def _pull_backup_to_host(container, backup_file: str) -> str:
 	"""Copy an in-container dump to the site's private backup dir. Returns host path."""
 	# ponytail: whole dump buffered in RAM; stream the tar (mode="r|") if dumps outgrow worker memory.
 	stream, _stat = container.get_archive(backup_file)
 	buffer = io.BytesIO(b"".join(stream))
-	host_dir = frappe.get_site_path("private", "backups", "mariadb")
+	host_dir = _host_backup_dir()
 	os.makedirs(host_dir, exist_ok=True)
 	host_path = os.path.join(host_dir, os.path.basename(backup_file))
 	with tarfile.open(fileobj=buffer) as tar:
@@ -405,7 +410,7 @@ def backup_database_server(db_server_name: str, output_path: str = "/var/lib/mys
 def cleanup_old_backups(
 	db_server_name: str, keep: int = 7, output_path: str = "/var/lib/mysql/backups"
 ) -> None:
-	"""Retain only the last `keep` backups."""
+	"""Retain only the last `keep` backups on host disk; container prune catches failed-pull leftovers."""
 	db_server = frappe.get_doc("Database Server", db_server_name)
 	client = get_client()
 	container = client.containers.get(db_server.container_id)
@@ -416,6 +421,9 @@ def cleanup_old_backups(
 			f"ls -t {output_path}/*.sql.gz 2>/dev/null | tail -n +{keep + 1} | xargs rm -f",
 		],
 	)
+	dumps = sorted(Path(_host_backup_dir()).glob("*.sql.gz"), key=lambda p: p.stat().st_mtime)
+	for old in dumps[:-keep]:
+		old.unlink()
 
 
 def scheduled_backup():

--- a/benchpress/tests/test_mariadb_manager.py
+++ b/benchpress/tests/test_mariadb_manager.py
@@ -198,6 +198,37 @@ class TestMariadbManager(IntegrationTestCase):
 			cmd = call.kwargs.get("cmd") or call.args[0]
 			self.assertNotEqual(cmd[:2], ["rm", "-f"])
 
+	@patch("benchpress.mariadb_manager.frappe.get_site_path")
+	@patch("benchpress.mariadb_manager.get_client")
+	@patch("benchpress.mariadb_manager.frappe.get_doc")
+	def test_cleanup_prunes_host_dir_and_still_prunes_container(
+		self, mock_get_doc, mock_get_client, mock_site_path
+	):
+		from benchpress.mariadb_manager import cleanup_old_backups
+
+		mock_get_doc.return_value = self._make_mock_db_server()
+		mock_container = MagicMock()
+		mock_container.exec_run.return_value = (0, b"")
+		mock_get_client.return_value.containers.get.return_value = mock_container
+
+		with tempfile.TemporaryDirectory() as tmp:
+			mock_site_path.side_effect = lambda *parts: os.path.join(tmp, *parts)
+			host_dir = os.path.join(tmp, "private", "backups", "mariadb")
+			os.makedirs(host_dir)
+			for i in range(10):
+				path = os.path.join(host_dir, f"all_databases_{i}.sql.gz")
+				open(path, "wb").close()
+				os.utime(path, (i, i))
+
+			cleanup_old_backups("db-server-name", keep=7)
+
+			survivors = sorted(os.listdir(host_dir))
+			self.assertEqual(survivors, [f"all_databases_{i}.sql.gz" for i in range(3, 10)])
+
+		container_cmd = mock_container.exec_run.call_args_list[0].kwargs["cmd"]
+		self.assertIn("ls -t /var/lib/mysql/backups/*.sql.gz", container_cmd[2])
+		self.assertIn("xargs rm -f", container_cmd[2])
+
 	@patch("benchpress.mariadb_manager.execute_sql")
 	def test_create_mariadb_user_returns_db_name_user_pass(self, mock_exec):
 		from benchpress.mariadb_manager import create_mariadb_user, get_database_name

--- a/benchpress/tests/test_mariadb_manager.py
+++ b/benchpress/tests/test_mariadb_manager.py
@@ -229,6 +229,58 @@ class TestMariadbManager(IntegrationTestCase):
 		self.assertIn("ls -t /var/lib/mysql/backups/*.sql.gz", container_cmd[2])
 		self.assertIn("xargs rm -f", container_cmd[2])
 
+	@patch("benchpress.mariadb_manager.get_client")
+	@patch("benchpress.mariadb_manager.frappe.get_doc")
+	def test_restore_pushes_dump_and_passes_password_via_env_not_argv(self, mock_get_doc, mock_get_client):
+		from benchpress.mariadb_manager import restore_database_server
+
+		sentinel = "S3cret!pw"
+		db_server = self._make_mock_db_server()
+		db_server.get_root_password.return_value = sentinel
+		mock_get_doc.return_value = db_server
+		mock_container = MagicMock()
+		mock_container.exec_run.return_value = (0, b"")
+		mock_get_client.return_value.containers.get.return_value = mock_container
+
+		dump_bytes = b"fake gzip bytes"
+		with tempfile.NamedTemporaryFile(suffix=".sql.gz") as f:
+			f.write(dump_bytes)
+			f.flush()
+			dump_name = os.path.basename(f.name)
+			restore_database_server("db-server-name", f.name)
+
+		dest, tar_bytes = mock_container.put_archive.call_args.args
+		self.assertEqual(dest, "/tmp")
+		with tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tar:
+			self.assertEqual(tar.extractfile(dump_name).read(), dump_bytes)
+
+		restore_call = mock_container.exec_run.call_args_list[0]
+		self.assertEqual(restore_call.kwargs.get("environment"), {"MYSQL_PWD": sentinel})
+		self.assertIn(f"gunzip -c /tmp/{dump_name} | mariadb -u root", restore_call.kwargs["cmd"][2])
+		for call in mock_container.exec_run.call_args_list:
+			cmd = call.kwargs.get("cmd") or call.args[0]
+			self.assertNotIn(sentinel, " ".join(cmd))
+
+	@patch("benchpress.mariadb_manager.get_client")
+	@patch("benchpress.mariadb_manager.frappe.get_doc")
+	def test_restore_throws_on_nonzero_exit_and_cleans_tmp(self, mock_get_doc, mock_get_client):
+		from benchpress.mariadb_manager import restore_database_server
+
+		mock_get_doc.return_value = self._make_mock_db_server()
+		mock_container = MagicMock()
+		mock_container.exec_run.side_effect = [(1, b"ERROR 1064"), (0, b"")]
+		mock_get_client.return_value.containers.get.return_value = mock_container
+
+		with tempfile.NamedTemporaryFile(suffix=".sql.gz") as f:
+			f.write(b"x")
+			f.flush()
+			with self.assertRaises(frappe.ValidationError):
+				restore_database_server("db-server-name", f.name)
+
+		last_call = mock_container.exec_run.call_args_list[-1]
+		cmd = last_call.kwargs.get("cmd") or last_call.args[0]
+		self.assertEqual(cmd[:2], ["rm", "-f"])
+
 	@patch("benchpress.mariadb_manager.execute_sql")
 	def test_create_mariadb_user_returns_db_name_user_pass(self, mock_exec):
 		from benchpress.mariadb_manager import create_mariadb_user, get_database_name

--- a/benchpress/tests/test_mariadb_manager.py
+++ b/benchpress/tests/test_mariadb_manager.py
@@ -2,7 +2,9 @@
 # See license.txt
 
 import hashlib
+import io
 import os
+import tarfile
 import tempfile
 from unittest.mock import MagicMock, patch
 
@@ -111,10 +113,13 @@ class TestMariadbManager(IntegrationTestCase):
 			cmd = call.kwargs.get("cmd") or call.args[0]
 			self.assertNotIn(sentinel, " ".join(cmd))
 
+	@patch("benchpress.mariadb_manager._pull_backup_to_host", return_value="/tmp/dump.sql.gz")
 	@patch("benchpress.mariadb_manager.frappe.utils.now", return_value="2026-01-01 00:00:00")
 	@patch("benchpress.mariadb_manager.get_client")
 	@patch("benchpress.mariadb_manager.frappe.get_doc")
-	def test_backup_passes_password_via_env_not_argv(self, mock_get_doc, mock_get_client, mock_now):
+	def test_backup_passes_password_via_env_not_argv(
+		self, mock_get_doc, mock_get_client, mock_now, mock_pull
+	):
 		from benchpress.mariadb_manager import backup_database_server
 
 		sentinel = "S3cret!pw"
@@ -132,6 +137,66 @@ class TestMariadbManager(IntegrationTestCase):
 		for call in mock_container.exec_run.call_args_list:
 			cmd = call.kwargs.get("cmd") or call.args[0]
 			self.assertNotIn(sentinel, " ".join(cmd))
+
+	def _make_backup_tar(self, name, data):
+		buffer = io.BytesIO()
+		with tarfile.open(fileobj=buffer, mode="w") as tar:
+			info = tarfile.TarInfo(name=name)
+			info.size = len(data)
+			tar.addfile(info, io.BytesIO(data))
+		return buffer.getvalue()
+
+	@patch("benchpress.mariadb_manager.frappe.get_site_path")
+	@patch("benchpress.mariadb_manager.frappe.utils.now", return_value="2026-01-01 00:00:00")
+	@patch("benchpress.mariadb_manager.get_client")
+	@patch("benchpress.mariadb_manager.frappe.get_doc")
+	def test_backup_pulls_dump_to_host_and_removes_container_file(
+		self, mock_get_doc, mock_get_client, mock_now, mock_site_path
+	):
+		from benchpress.mariadb_manager import backup_database_server
+
+		mock_get_doc.return_value = self._make_mock_db_server()
+		dump_name = "all_databases_2026-01-01_00-00-00.sql.gz"
+		dump_bytes = b"fake gzip bytes"
+		mock_container = MagicMock()
+		mock_container.exec_run.return_value = (0, b"")
+		mock_container.get_archive.return_value = (iter([self._make_backup_tar(dump_name, dump_bytes)]), {})
+		mock_get_client.return_value.containers.get.return_value = mock_container
+
+		with tempfile.TemporaryDirectory() as tmp:
+			mock_site_path.side_effect = lambda *parts: os.path.join(tmp, *parts)
+			host_path = backup_database_server("db-server-name")
+
+			self.assertEqual(host_path, os.path.join(tmp, "private", "backups", "mariadb", dump_name))
+			with open(host_path, "rb") as f:
+				self.assertEqual(f.read(), dump_bytes)
+
+		rm_cmd = ["rm", "-f", f"/var/lib/mysql/backups/{dump_name}"]
+		cmds = [c.kwargs.get("cmd") or c.args[0] for c in mock_container.exec_run.call_args_list]
+		self.assertIn(rm_cmd, cmds)
+
+	@patch("benchpress.mariadb_manager.frappe.log_error")
+	@patch("benchpress.mariadb_manager.frappe.utils.now", return_value="2026-01-01 00:00:00")
+	@patch("benchpress.mariadb_manager.get_client")
+	@patch("benchpress.mariadb_manager.frappe.get_doc")
+	def test_backup_keeps_container_file_when_pull_fails(
+		self, mock_get_doc, mock_get_client, mock_now, mock_log_error
+	):
+		from benchpress.mariadb_manager import backup_database_server
+
+		mock_get_doc.return_value = self._make_mock_db_server()
+		mock_container = MagicMock()
+		mock_container.exec_run.return_value = (0, b"")
+		mock_container.get_archive.side_effect = RuntimeError("stream broke")
+		mock_get_client.return_value.containers.get.return_value = mock_container
+
+		result = backup_database_server("db-server-name")
+
+		self.assertEqual(result, "/var/lib/mysql/backups/all_databases_2026-01-01_00-00-00.sql.gz")
+		mock_log_error.assert_called_once()
+		for call in mock_container.exec_run.call_args_list:
+			cmd = call.kwargs.get("cmd") or call.args[0]
+			self.assertNotEqual(cmd[:2], ["rm", "-f"])
 
 	@patch("benchpress.mariadb_manager.execute_sql")
 	def test_create_mariadb_user_returns_db_name_user_pass(self, mock_exec):

--- a/docs/database-backup-restore.md
+++ b/docs/database-backup-restore.md
@@ -1,0 +1,121 @@
+# Database Backup & Restore
+
+This runbook covers where BenchPress's automatic MariaDB backups live and how to
+turn one back into a database — either on a **scratch container** (to verify a
+dump, or to inspect old data) or on a **managed Database Server** (disaster
+recovery).
+
+> **Restore is destructive.** A dump created by BenchPress contains **all**
+> databases on the server, and restoring it **overwrites every database** in the
+> target container. Never point a restore at a live tenant DB server — restore
+> to a scratch container, or only during disaster recovery onto a server whose
+> current data you have accepted losing.
+
+---
+
+## Where backups live
+
+BenchPress dumps **all databases** of every Active Database Server nightly at
+**02:00** (server time) and keeps the **last 7** dumps.
+
+| Location | Path | When |
+|----------|------|------|
+| Host disk (primary) | `sites/<your-site>/private/backups/mariadb/all_databases_<timestamp>.sql.gz` | Every successful backup — copied off the DB volume so losing the volume does not lose the backups |
+| Inside the container (fallback) | `/var/lib/mysql/backups/` in `benchpress-mariadb` | Only when the copy to host disk failed; the in-container file is kept as fallback and pruned on the same 7-dump retention |
+
+To take an out-of-schedule backup, run from `bench console`:
+
+```python
+from benchpress.mariadb_manager import backup_database_server
+backup_database_server("<database-server-name>")  # returns the host path
+```
+
+---
+
+## Restore path A — scratch container (verification / inspection)
+
+Restores a dump into a throwaway MariaDB container. Safe: touches nothing that
+BenchPress manages.
+
+1. Start a scratch container (same major version as the source server):
+
+   ```bash
+   docker run --name scratch-restore -e MARIADB_ROOT_PASSWORD=scratch -d mariadb:10.6
+   ```
+
+2. Wait until it accepts connections:
+
+   ```bash
+   docker exec scratch-restore mariadb -u root -pscratch -e "SELECT 1"
+   ```
+
+3. Copy the dump in and load it:
+
+   ```bash
+   docker cp sites/<your-site>/private/backups/mariadb/<dump>.sql.gz scratch-restore:/tmp/
+   docker exec scratch-restore bash -c "gunzip -c /tmp/<dump>.sql.gz | mariadb -u root -pscratch"
+   ```
+
+4. Verify a known row came back (see [Post-restore check](#post-restore-check)).
+
+5. Throw the container away:
+
+   ```bash
+   docker rm -f scratch-restore
+   ```
+
+---
+
+## Restore path B — managed recovery (`bench console`)
+
+Restores a host-side dump into a Database Server that BenchPress manages, using
+the non-whitelisted console helper. Use this only for disaster recovery.
+
+> **This overwrites all databases on the target server.** There is deliberately
+> no UI or API for it — it can only be run by a human in `bench console`.
+
+1. Open a console on the host bench:
+
+   ```bash
+   bench --site <your-site> console
+   ```
+
+2. Run the helper with the Database Server doc name and the host dump path:
+
+   ```python
+   from benchpress.mariadb_manager import restore_database_server
+   restore_database_server(
+       "<database-server-name>",
+       "sites/<your-site>/private/backups/mariadb/<dump>.sql.gz",
+   )
+   ```
+
+   It pushes the dump into the container, pipes it through
+   `gunzip -c | mariadb -u root`, and raises on any non-zero exit.
+
+3. Verify a known row came back (below), then restart benches that were using
+   the server so they reconnect cleanly.
+
+---
+
+## Post-restore check
+
+Confirm real data survived the round trip — pick a table you know has rows
+(any tenant site's `tabDefaultValue`, or a table of your own) and select from it:
+
+```bash
+docker exec <container> mariadb -u root -p<password> -e \
+  "SELECT defkey FROM <database>.tabDefaultValue LIMIT 1"
+```
+
+A known row must come back. An empty result or an unknown-table error means the
+restore did not load what you expected — do not put the server back into
+service.
+
+---
+
+## See also
+
+- [Production Safety & Compatibility](production-safety.md) — what is and is not backed up
+- [Upgrading a BenchPress Install](upgrading.md) — the pre-upgrade backup gate for the control-plane site
+- [Logs & Monitoring](logs-and-monitoring.md) — where backup failures are logged (Error Log)

--- a/docs/production-safety.md
+++ b/docs/production-safety.md
@@ -28,8 +28,11 @@ environments — not yet for production hosting of customer data. Concretely:
 - **Privileged containers.** Bench containers currently run with elevated Docker
   privileges to support in-container networking. Treat every bench as having host
   reach until that is hardened.
-- **No backup/restore guarantees yet.** Bench data lives in Docker volumes. Take
-  your own backups; there is no built-in restore path you should rely on.
+- **Database backups are automatic; restore is manual.** The shared MariaDB
+  server is dumped nightly to host disk outside its data volume, and the restore
+  path is documented and verified — see
+  [Database Backup & Restore](database-backup-restore.md). Other bench data in
+  Docker volumes is **not** backed up yet; take your own copies.
 - **Single-tenant assumption.** Quotas, rate limits, and audit trails are still in
   progress. Run BenchPress for people you trust, on a host dedicated to it.
 


### PR DESCRIPTION
## Phase 1 — dump lands on host disk, gone from the DB volume (issue #96)

Nightly backups previously lived on the same `benchpress-mariadb-data` volume as the data they protect. This phase splits the failure domain: after every `backup_database_server` run the dump sits on host disk under the site dir and is removed from the DB volume.

### What changed
- `benchpress/mariadb_manager.py`
  - new `_pull_backup_to_host(container, backup_file)` — docker SDK `get_archive` tar-stream out of the running container, extracted to `sites/<site>/private/backups/mariadb/<basename>` (marked `ponytail:` — dump buffered in RAM, stream the tar if dumps outgrow worker memory)
  - `backup_database_server` — after a successful dump, pulls it to host, `rm -f`s the in-container file, returns the **host** path. If the pull fails: error logged via `frappe.log_error`, in-container file kept as fallback, container path returned — scheduler loop uninterrupted
- `benchpress/tests/test_mariadb_manager.py` — happy path (real in-memory tar through to host file bytes + `rm -f` asserted) and pull-failure (no `rm -f`, no exception escapes); existing password-via-env test scoped to the dump step

### How verified
- `bench run-tests --app benchpress --module benchpress.tests.test_mariadb_manager` — 17 tests OK
- Live on dev stack: `backup_database_server("8r4d49rk9d")` returned `./frontend/private/backups/mariadb/all_databases_2026-07-11_00-50-42.408528.sql.gz` (1.1 MB on host); `docker exec benchpress-mariadb ls /var/lib/mysql/backups` shows the new dump absent (only pre-phase leftovers, phase 2 retention's job)

Not in scope yet: host-side retention (phase 2), restore helper + runbook (phase 3).