### PR TITLE
Implemented phase two

### DIFF
--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -3,8 +3,11 @@
 
 import json
 import secrets
+import time
 
 import frappe
+from frappe.query_builder import DocType
+from frappe.query_builder.functions import Coalesce, Concat
 from frappe.utils.file_lock import LockTimeoutError
 from frappe.utils.synchronization import filelock
 
@@ -100,18 +103,75 @@ def build_linkuser_args(bench, lab, settings, ssh_password: str) -> list[str]:
 	]
 
 
-def _make_log_appender(doctype: str, log_name: str, event: str, context: dict):
-	def append_log(line: str, log_type: str = "info") -> None:
+class LogStream:
+	"""Buffered appender for a Deploy Log / Build Log ``message`` field.
+
+	Writing one line at a time meant a read-modify-write per line, which is
+	O(n²) in bytes for n lines: every append re-transferred the whole
+	accumulated ``longtext`` in both directions. Buffering in memory and
+	concatenating DB-side moves persistence to O(n) bytes in roughly
+	``n / flush_every`` writes. A Frappe image build emits 2,000-8,000 lines,
+	so this is the difference between gigabytes and megabytes of traffic.
+
+	Callable, so every existing ``append_log(line, log_type)`` call site keeps
+	working unchanged.
+	"""
+
+	FLUSH_INTERVAL = 2.0
+	TERMINAL_TYPES = ("success", "error")
+
+	def __init__(self, doctype: str, log_name: str, event: str, context: dict, flush_every: int = 50) -> None:
+		self.doctype = doctype
+		self.log_name = log_name
+		self.event = event
+		self.context = context
+		self.flush_every = flush_every
+		self.pending: list[str] = []
+		self.last_flush = time.monotonic()
+
+	def __call__(self, line: str, log_type: str = "info") -> None:
+		self.pending.append(line + "\n")
+		if self._should_flush(log_type):
+			self.flush()
+		# Publish last, after the write has landed. On a "success"/"error" line
+		# the SPA reloads the persisted log (frontend/src/pages/LabDetail.vue:829-832),
+		# so publishing first would race the flush and show a truncated tail.
 		frappe.publish_realtime(  # nosemgrep -- the SPA listens via raw socket.io without doc-room subscription; room-scoping would drop its events
-			event=event,
-			message={**context, "log": line, "type": log_type},
+			event=self.event,
+			message={**self.context, "log": line, "type": log_type},
 			after_commit=False,
 		)
-		current = frappe.db.get_value(doctype, log_name, "message") or ""
-		frappe.db.set_value(doctype, log_name, "message", current + line + "\n", update_modified=False)
-		frappe.db.commit()
 
-	return append_log
+	def _should_flush(self, log_type: str) -> bool:
+		"""True on a terminal line, a full buffer, or a stale buffer.
+
+		The elapsed-time trigger is durability, not throughput: the bare
+		``except Exception`` in ``_deploy_bench`` cannot catch a worker SIGTERM
+		or the 1800s job timeout, so without it a killed build would lose its
+		entire unflushed tail instead of just the last couple of seconds.
+		"""
+		if log_type in self.TERMINAL_TYPES:
+			return True
+		if len(self.pending) >= self.flush_every:
+			return True
+		return time.monotonic() - self.last_flush >= self.FLUSH_INTERVAL
+
+	def flush(self) -> None:
+		"""Append the buffered chunk in one write, with no read-back.
+
+		``Coalesce`` is required: MariaDB ``CONCAT(NULL, x)`` returns NULL, so a
+		log whose ``message`` is NULL would silently discard every line.
+		"""
+		if not self.pending:
+			return
+		chunk = "".join(self.pending)
+		self.pending.clear()
+		table = DocType(self.doctype)
+		frappe.qb.update(table).set(table.message, Concat(Coalesce(table.message, ""), chunk)).where(
+			table.name == self.log_name
+		).run()
+		frappe.db.commit()
+		self.last_flush = time.monotonic()
 
 
 def _notify_owner(user: str, subject: str, document_type: str, document_name: str) -> None:
@@ -208,7 +268,7 @@ def _deploy_bench(bench_name: str) -> None:
 	frappe.db.commit()
 	deploy_log_name = deploy_log.name
 
-	append_log = _make_log_appender(
+	append_log = LogStream(
 		"Deploy Log",
 		deploy_log_name,
 		"bench_deploy_log",
@@ -452,7 +512,7 @@ def build_lab(lab_name: str) -> None:
 	frappe.db.commit()
 	build_log_name = build_log.name
 
-	append_log = _make_log_appender(
+	append_log = LogStream(
 		"Build Log", build_log_name, "lab_build_log", {"lab": lab_name, "build_log": build_log_name}
 	)
 

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -28,6 +28,27 @@ from benchpress.mariadb_manager import (
 	wait_for_mariadb,
 )
 
+MAX_LOG_LINE_BYTES = 8 * 1024
+MAX_LOG_BYTES = 512 * 1024
+TRUNCATION_MARKER = "=== log truncated ===\n"
+ELISION_MARKER = "...[line truncated]... "
+
+
+def _tail(text: str, max_bytes: int) -> str:
+	"""The last ``max_bytes`` of ``text``, marked when it actually truncated.
+
+	Tails rather than heads because the end of a command's output is where the
+	failure is. The marker is charged against the budget, so the result never
+	exceeds ``max_bytes``.
+	"""
+	encoded = text.encode("utf-8", errors="replace")
+	if len(encoded) <= max_bytes:
+		return text
+	keep = max_bytes - len(ELISION_MARKER)
+	if keep <= 0:
+		return ELISION_MARKER[:max_bytes]
+	return ELISION_MARKER + encoded[-keep:].decode("utf-8", errors="ignore")
+
 
 def _remove_stale_container(bench) -> None:
 	"""Remove any existing container, preserving the data volume."""
@@ -113,6 +134,11 @@ class LogStream:
 	``n / flush_every`` writes. A Frappe image build emits 2,000-8,000 lines,
 	so this is the difference between gigabytes and megabytes of traffic.
 
+	Every line passes through the per-line cap here rather than at each call
+	site, so no caller can write an unbounded line however the output was
+	produced, and the whole document stops at ``max_bytes``. The cap bounds the
+	stored audit trail only — dropped lines are still published live.
+
 	Callable, so every existing ``append_log(line, log_type)`` call site keeps
 	working unchanged.
 	"""
@@ -120,17 +146,29 @@ class LogStream:
 	FLUSH_INTERVAL = 2.0
 	TERMINAL_TYPES = ("success", "error")
 
-	def __init__(self, doctype: str, log_name: str, event: str, context: dict, flush_every: int = 50) -> None:
+	def __init__(
+		self,
+		doctype: str,
+		log_name: str,
+		event: str,
+		context: dict,
+		flush_every: int = 50,
+		max_bytes: int = MAX_LOG_BYTES,
+	) -> None:
 		self.doctype = doctype
 		self.log_name = log_name
 		self.event = event
 		self.context = context
 		self.flush_every = flush_every
+		self.max_bytes = max_bytes
 		self.pending: list[str] = []
+		self.written_bytes = 0
+		self.truncated = False
 		self.last_flush = time.monotonic()
 
 	def __call__(self, line: str, log_type: str = "info") -> None:
-		self.pending.append(line + "\n")
+		line = _tail(line, MAX_LOG_LINE_BYTES)
+		self._buffer(line)
 		if self._should_flush(log_type):
 			self.flush()
 		# Publish last, after the write has landed. On a "success"/"error" line
@@ -141,6 +179,25 @@ class LogStream:
 			message={**self.context, "log": line, "type": log_type},
 			after_commit=False,
 		)
+
+	def _buffer(self, line: str) -> None:
+		"""Buffer the line until the ceiling, then one truncation marker.
+
+		``written_bytes`` is exact without any read-back: the stream owns the
+		document from creation, so it already knows everything it has written.
+		Reading the stored size back per line would reintroduce the O(n²) cost
+		this class exists to remove.
+		"""
+		if self.truncated:
+			return
+		entry = line + "\n"
+		size = len(entry.encode("utf-8"))
+		if self.written_bytes + size > self.max_bytes:
+			self.pending.append(TRUNCATION_MARKER)
+			self.truncated = True
+			return
+		self.written_bytes += size
+		self.pending.append(entry)
 
 	def _should_flush(self, log_type: str) -> bool:
 		"""True on a terminal line, a full buffer, or a stale buffer.
@@ -343,11 +400,15 @@ def _deploy_bench(bench_name: str) -> None:
 			container_id, db_server, site_name, admin_password, apps_csv
 		)
 		if exit_code != 0:
-			raise Exception(f"bench new-site failed (exit {exit_code}): {output}")
+			raise Exception(f"bench new-site failed (exit {exit_code}): {_tail(output, MAX_LOG_LINE_BYTES)}")
 		append_log("Site created successfully")
 
 		append_log("Building assets...")
-		exec_in_container(container_id, "bench build", user="frappe", workdir=bench_dir)
+		exit_code, output = exec_in_container(container_id, "bench build", user="frappe", workdir=bench_dir)
+		if output:
+			append_log(_tail(output.strip(), MAX_LOG_LINE_BYTES))
+		if exit_code != 0:
+			raise Exception(f"bench build failed (exit {exit_code}): {_tail(output, MAX_LOG_LINE_BYTES)}")
 
 		if not bench.ssh_username:
 			bench.ssh_username = bench._derive_username(bench.owner)
@@ -358,9 +419,9 @@ def _deploy_bench(bench_name: str) -> None:
 		linkuser_cmd = "bash /opt/benchpress/scripts/linkuser.sh " + " ".join(f"'{a}'" for a in linkuser_args)
 		exit_code, output = exec_in_container(container_id, linkuser_cmd, user="root")
 		if output:
-			append_log(output.strip())
+			append_log(_tail(output.strip(), MAX_LOG_LINE_BYTES))
 		if exit_code != 0:
-			raise Exception(f"linkuser.sh failed (exit {exit_code}): {output}")
+			raise Exception(f"linkuser.sh failed (exit {exit_code}): {_tail(output, MAX_LOG_LINE_BYTES)}")
 
 		bench.ssh_password = ssh_password
 

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -340,6 +340,91 @@ class TestDeployManager(IntegrationTestCase):
 		self.assertEqual(bench.container_ip, "172.30.0.50")
 		self.assertEqual(bench.wg_ip, "10.8.0.20")
 
+	# --- LogStream batching (deploy-pipeline-performance phase 1) ---
+
+	def _new_deploy_log(self, bench_name):
+		"""An empty Deploy Log, cleaned up the way the rest of this file does it."""
+		self._cleanup_deploy_logs(bench_name)
+		log = frappe.get_doc(
+			{
+				"doctype": "Deploy Log",
+				"bench": bench_name,
+				"log_type": "info",
+				"timestamp": frappe.utils.now_datetime(),
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+		return log.name
+
+	def _log_stream(self, log_name, bench_name, flush_every=50):
+		"""LogStream with the elapsed-time trigger pinned far out of reach, so
+		write-count assertions measure the line-count and terminal triggers only.
+		"""
+		from benchpress.deploy_manager import LogStream
+
+		stream = LogStream(
+			"Deploy Log",
+			log_name,
+			"bench_deploy_log",
+			{"bench": bench_name, "deploy_log": log_name},
+			flush_every=flush_every,
+		)
+		stream.FLUSH_INTERVAL = 3600
+		return stream
+
+	@patch("frappe.publish_realtime")
+	def test_log_stream_batches_writes(self, mock_publish):
+		"""The O(n²) regression guard: assert the write count AND the content.
+
+		Either assertion alone passes for a broken writer — a no-op writer hits
+		the count, and the old read-modify-write appender hits the content.
+		"""
+		bench = self._fresh_bench()
+		log_name = self._new_deploy_log(bench.name)
+		# A NULL message exercises the Coalesce in flush(): CONCAT(NULL, x) is NULL.
+		frappe.db.set_value("Deploy Log", log_name, "message", None, update_modified=False)
+		frappe.db.commit()
+		stream = self._log_stream(log_name, bench.name)
+
+		with patch.object(stream, "flush", wraps=stream.flush) as flush_spy:
+			for index in range(200):
+				stream(f"line {index}")
+
+		self.assertEqual(flush_spy.call_count, 4)  # 200 lines at flush_every=50
+		message = frappe.db.get_value("Deploy Log", log_name, "message")
+		self.assertEqual(message.splitlines(), [f"line {index}" for index in range(200)])
+		# The realtime contract is unchanged: still one event per line, batching or not.
+		# Count only our event — frappe.db.commit() publishes its own events too.
+		line_events = [c for c in mock_publish.call_args_list if c.kwargs.get("event") == "bench_deploy_log"]
+		self.assertEqual(len(line_events), 200)
+
+	@patch("frappe.publish_realtime")
+	def test_log_stream_flushes_on_terminal_type(self, mock_publish):
+		bench = self._fresh_bench()
+		log_name = self._new_deploy_log(bench.name)
+		stream = self._log_stream(log_name, bench.name)
+
+		for index in range(3):
+			stream(f"line {index}")
+		self.assertFalse(frappe.db.get_value("Deploy Log", log_name, "message"))
+
+		stream("=== Deploy complete ===", "success")
+
+		message = frappe.db.get_value("Deploy Log", log_name, "message")
+		self.assertEqual(message.splitlines(), ["line 0", "line 1", "line 2", "=== Deploy complete ==="])
+
+	@patch("frappe.publish_realtime")
+	def test_log_stream_flushes_stale_buffer(self, mock_publish):
+		"""A SIGTERM'd or timed-out build keeps everything but the last seconds."""
+		bench = self._fresh_bench()
+		log_name = self._new_deploy_log(bench.name)
+		stream = self._log_stream(log_name, bench.name)
+		stream.FLUSH_INTERVAL = 0  # every buffer counts as stale
+
+		stream("line 0")
+
+		self.assertEqual(frappe.db.get_value("Deploy Log", log_name, "message"), "line 0\n")
+
 	# --- enqueue-time dedupe (issue #92 phase 2) ---
 
 	@patch("frappe.enqueue")

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -356,11 +356,11 @@ class TestDeployManager(IntegrationTestCase):
 		frappe.db.commit()
 		return log.name
 
-	def _log_stream(self, log_name, bench_name, flush_every=50):
+	def _log_stream(self, log_name, bench_name, flush_every=50, max_bytes=None):
 		"""LogStream with the elapsed-time trigger pinned far out of reach, so
 		write-count assertions measure the line-count and terminal triggers only.
 		"""
-		from benchpress.deploy_manager import LogStream
+		from benchpress.deploy_manager import MAX_LOG_BYTES, LogStream
 
 		stream = LogStream(
 			"Deploy Log",
@@ -368,6 +368,7 @@ class TestDeployManager(IntegrationTestCase):
 			"bench_deploy_log",
 			{"bench": bench_name, "deploy_log": log_name},
 			flush_every=flush_every,
+			max_bytes=max_bytes or MAX_LOG_BYTES,
 		)
 		stream.FLUSH_INTERVAL = 3600
 		return stream
@@ -424,6 +425,96 @@ class TestDeployManager(IntegrationTestCase):
 		stream("line 0")
 
 		self.assertEqual(frappe.db.get_value("Deploy Log", log_name, "message"), "line 0\n")
+
+	# --- LogStream bounding (deploy-pipeline-performance phase 2) ---
+
+	@patch("frappe.publish_realtime")
+	def test_log_stream_caps_total_size(self, mock_publish):
+		"""A runaway build stops growing the stored log, and says so exactly once."""
+		from benchpress.deploy_manager import TRUNCATION_MARKER
+
+		bench = self._fresh_bench()
+		log_name = self._new_deploy_log(bench.name)
+		cap = 2048
+		stream = self._log_stream(log_name, bench.name, flush_every=10, max_bytes=cap)
+		line = "x" * 200
+
+		for _ in range(40):  # 40 * 201 bytes, ~4x the cap
+			stream(line)
+		stream.flush()
+		message_at_cap = frappe.db.get_value("Deploy Log", log_name, "message")
+
+		for _ in range(200):  # far past the cap: nothing more may be stored
+			stream(line)
+		stream("=== Deploy complete ===", "success")
+
+		message = frappe.db.get_value("Deploy Log", log_name, "message")
+		self.assertEqual(message, message_at_cap)
+		self.assertLessEqual(len(message.encode("utf-8")), cap + len(TRUNCATION_MARKER))
+		self.assertEqual(message.count(TRUNCATION_MARKER), 1)
+		# The cap bounds persistence only — every line still reaches the SPA.
+		line_events = [c for c in mock_publish.call_args_list if c.kwargs.get("event") == "bench_deploy_log"]
+		self.assertEqual(len(line_events), 241)
+
+	@patch("frappe.publish_realtime")
+	def test_log_stream_tails_long_line(self, mock_publish):
+		"""One pathological line (a base64 blob, a minified traceback) cannot flood the log."""
+		from benchpress.deploy_manager import MAX_LOG_LINE_BYTES
+
+		bench = self._fresh_bench()
+		log_name = self._new_deploy_log(bench.name)
+		stream = self._log_stream(log_name, bench.name, flush_every=1)
+
+		stream("head" + "y" * (MAX_LOG_LINE_BYTES * 2) + "tail")
+
+		stored = frappe.db.get_value("Deploy Log", log_name, "message").splitlines()[0]
+		self.assertLessEqual(len(stored.encode("utf-8")), MAX_LOG_LINE_BYTES)
+		self.assertTrue(stored.endswith("tail"))  # the tail is what a failure message carries
+		self.assertNotIn("head", stored)
+
+	# --- bench build failure visibility (deploy-pipeline-performance phase 2) ---
+
+	def test_deploy_fails_when_bench_build_fails(self):
+		"""A non-zero `bench build` must fail the deploy, not report Running."""
+		from benchpress import deploy_manager
+
+		bench = self._fresh_bench()
+		self._cleanup_deploy_logs(bench.name)
+		frappe.db.set_value("Lab", self.lab.name, {"status": "Ready", "image_tag": "benchpress/test:latest"})
+		frappe.db.commit()
+
+		def exec_result(container_id, command, **kwargs):
+			if "bench build" in command:
+				return (1, "asset build failed: node heap out of memory")
+			return (0, "")
+
+		with (
+			patch.object(deploy_manager, "ensure_infrastructure", autospec=True) as mock_infra,
+			patch.object(deploy_manager, "wait_for_mariadb", autospec=True),
+			patch.object(deploy_manager, "_remove_stale_container", autospec=True),
+			patch.object(deploy_manager, "create_bench_container", autospec=True) as mock_create,
+			patch.object(deploy_manager, "start_container", autospec=True),
+			patch.object(deploy_manager, "wait_for_container_running", autospec=True) as mock_wait,
+			patch.object(deploy_manager, "_setup_container_vpn", autospec=True),
+			patch.object(deploy_manager, "write_file_to_container", autospec=True),
+			patch.object(deploy_manager, "exec_in_container", autospec=True) as mock_exec,
+			patch.object(deploy_manager, "create_site_in_container", autospec=True) as mock_site,
+			patch.object(deploy_manager, "remove_container", autospec=True),
+			patch.object(deploy_manager, "_notify_owner", autospec=True),
+			patch("benchpress.vpn_adapter.remove_bench_peer", autospec=True),
+		):
+			mock_infra.return_value = self.db_server_name
+			mock_create.return_value = "cid-build-fail"
+			mock_wait.return_value = "172.30.0.11"
+			mock_exec.side_effect = exec_result
+			mock_site.return_value = (0, "site created")
+
+			deploy_manager.deploy_bench(bench.name)
+
+		bench.reload()
+		self.assertEqual(bench.status, "Error")
+		message = frappe.db.get_value("Deploy Log", {"bench": bench.name, "log_type": "error"}, "message")
+		self.assertIn("asset build failed", message)
 
 	# --- enqueue-time dedupe (issue #92 phase 2) ---
 


### PR DESCRIPTION
Rolling PR for the **deploy pipeline performance hardening** feature (`specs/in-progress/deploy-pipeline-performance/`, 5 phases). Phases one and two are in.

## Phase one — batch deploy and build log writes via `LogStream` (5decff7)

The log appender did a read-modify-write per line: O(n²) in bytes for n lines, since every append re-transferred the whole accumulated `longtext` in both directions. A Frappe image build emits 2,000–8,000 lines, so log persistence dominated build wall time.

`LogStream` replaces the appender closure — it buffers lines in memory and flushes them in one query-builder update that concatenates DB-side with no read-back. Flush triggers: 50 buffered lines, 2 seconds elapsed, or a terminal (`success`/`error`) line. The elapsed-time trigger is durability, not throughput: the bare `except` in `_deploy_bench` cannot catch a worker SIGTERM or the 1800s job timeout, so without it a killed build would lose its whole unflushed tail. The realtime publish moved after the persistence write, because the SPA reloads the persisted log when it sees a terminal line and would otherwise race the flush.

Measured on 3,000 lines: **61 writes instead of 9,000 round trips, 0.45s instead of 9.55s (21x)**.

## Phase two — bound log sizes and surface `bench build` failures (497d268)

See the phase-two comment below.

## Verification

- `bench --site frontend run-tests --app benchpress` → 222 tests green.
- `ruff check` / `ruff format --check` clean, `pre-commit run --all-files` 12/12.
- No DocType JSON changes in either phase, so no `bench migrate` needed. No frontend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)