### PR TITLE
chore(license): relicense to AGPL-3.0-only

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -1,0 +1,102 @@
+# BenchPress Contributor License Agreement
+
+Thank you for contributing to BenchPress.
+
+This agreement clarifies the intellectual property licence granted with
+contributions from any person or entity. It is required before we can merge your
+first contribution. **You keep the copyright in your work** — this is a licence
+grant, not an assignment.
+
+By signing, you accept and agree to the following terms for your present and
+future Contributions to BenchPress.
+
+## 1. Definitions
+
+**"You"** means the copyright owner, or the legal entity authorised by the
+copyright owner, entering into this agreement.
+
+**"Contribution"** means any original work of authorship — including
+modifications to existing work — that You intentionally submit to this project
+for inclusion in it. "Submit" means any form of electronic or written
+communication sent to the project or its maintainers, including pull requests,
+issues, and patches, but excluding anything You conspicuously mark in writing as
+`Not a Contribution`.
+
+**"Project"** means the BenchPress software and any repository maintained by the
+Project Owner as part of it.
+
+**"Project Owner"** means Venkatesh, and its successors and assigns.
+
+## 2. Copyright licence
+
+You grant to the Project Owner, and to recipients of software distributed by the
+Project Owner, a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright licence to reproduce, prepare derivative works of,
+publicly display, publicly perform, sublicense, and distribute Your
+Contributions and such derivative works.
+
+**This licence is sublicensable.** The Project Owner may distribute Your
+Contribution under the AGPL-3.0-only licence that governs the Project today, and
+may also distribute it under other licence terms — including a commercial
+licence — as part of the Project. This is what makes it possible to offer
+commercial exceptions and to change the Project's licence in the future without
+having to track down and re-license every contributor's work.
+
+## 3. Patent licence
+
+You grant to the Project Owner and to recipients of software distributed by the
+Project Owner a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent licence to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Contribution,
+where such licence applies only to those patent claims licensable by You that
+are necessarily infringed by Your Contribution alone or by combination of Your
+Contribution with the Project.
+
+If any entity institutes patent litigation against You or any other entity
+alleging that Your Contribution, or the Project to which You contributed,
+constitutes direct or contributory patent infringement, then any patent licences
+granted to that entity under this agreement for that Contribution or Project
+terminate as of the date such litigation is filed.
+
+## 4. Your representations
+
+You represent that:
+
+1. You are legally entitled to grant the above licences.
+2. Each Contribution is Your original creation, or You have identified in the
+   Contribution any third-party work it contains, together with its licence and
+   any restrictions You are aware of.
+3. If Your employer has rights to intellectual property You create, You have
+   received permission to make Contributions on behalf of that employer, or Your
+   employer has waived such rights, or Your employer has signed this agreement.
+
+You are not expected to provide support for Your Contributions. Except as
+required by applicable law or agreed in writing, You provide Your Contributions
+**"AS IS", without warranties or conditions of any kind**, either express or
+implied, including any warranty of title, non-infringement, merchantability, or
+fitness for a particular purpose.
+
+## 5. Notice of change
+
+You agree to notify the Project Owner if any of the representations above become
+inaccurate.
+
+---
+
+## How to sign
+
+Signing is automated. Open a pull request; the CLA Assistant bot comments with a
+link, and you sign in-thread with your GitHub account. One signature covers all
+of your future contributions.
+
+If you are contributing on behalf of a company, have someone authorised to bind
+the company sign instead.
+
+## Why a CLA and not a DCO
+
+A Developer Certificate of Origin certifies provenance but grants no
+sublicensing right. Under a DCO, every file an outside contributor touches would
+become permanently un-relicensable — which would foreclose offering commercial
+licence exceptions for the project, and would make any future licence change
+impossible. The grant above is the narrowest thing that keeps those options open
+while leaving your copyright with you.

--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,6 @@ jspm_packages/
 # Aider AI Chat
 .aider*
 CLAUDE.md
-.claudebenchpress/public/node_modules/
 .mcp.json
 everything-claude-code/
 .claude
@@ -62,6 +61,12 @@ everything-claude-code/
 # Frontend build output
 benchpress/public/frontend/
 benchpress/www/frontend.html
+# bench build symlinks this into the app; it is not source
+benchpress/public/node_modules
+
+# Design handoffs and other binary drops land here while a phase is in flight;
+# they are not part of the published repository.
+*.zip
 
 # Local tooling artifacts (knowledge graph + scratch specs)
 graphify-out/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,21 @@
 
 Thanks for your interest in contributing to BenchPress! This guide will help you get started.
 
+## Licence and the CLA
+
+BenchPress is licensed under the **GNU Affero General Public License v3.0 only**
+([license.txt](license.txt)). Contributions are accepted under the same licence.
+
+Before your first pull request can be merged you must sign the
+[Contributor License Agreement](.github/CLA.md). It is a one-time, in-thread
+signature: open a PR, and a bot comments with the document and a line to reply
+with. **You keep the copyright in your work** — the CLA is a broad, sublicensable
+licence grant, not an assignment. [.github/CLA.md](.github/CLA.md) explains why a
+CLA rather than a DCO.
+
+The BenchPress name and logo are *not* covered by the AGPL grant — see
+[TRADEMARKS.md](TRADEMARKS.md).
+
 ## Development Setup
 
 ```bash
@@ -18,6 +33,10 @@ cd apps/benchpress/frontend
 yarn install
 yarn dev
 ```
+
+BenchPress declares `required_apps = ["vpn_management"]` and will not install
+without it; `bench get-app` resolves it automatically from
+[Venkateshvenki404224/vpn_management](https://github.com/Venkateshvenki404224/vpn_management).
 
 ## Branch Strategy
 
@@ -46,19 +65,40 @@ perf(stats): cache container stats in Redis
 
 Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `perf`
 
-## Code Style
+## Verification before you push
 
-**Python:**
+Run these three, in this order. Together they are what CI checks.
+
+**1. Formatting and linting — everything, Python and frontend:**
+
 ```bash
-cd apps/benchpress
-python -m ruff check .
-python -m ruff format .
+uvx pre-commit@4.3.0 run --all-files
 ```
 
-**JavaScript/Vue:**
+This is the formatter of record: ruff for Python, prettier and eslint for
+JavaScript and Vue. **Do not run `yarn lint`** — it runs biome with a different
+style than the repo has ever used and will rewrite every frontend file.
+
+**2. Backend tests:**
+
 ```bash
-cd apps/benchpress/frontend
-npx prettier --write src/
+bench --site <your-site> run-tests --app benchpress
+```
+
+**3. Frontend unit tests:**
+
+```bash
+cd frontend && yarn test:run
+```
+
+End-to-end tests are optional locally, and must be run from `e2e/` — invoking
+Playwright from the app root resolves no config and every test fails
+unauthenticated:
+
+```bash
+cd e2e && FRAPPE_BASE_URL=http://localhost:8080 \
+  FRAPPE_ADMIN_USER=administrator FRAPPE_ADMIN_PASSWORD=<password> \
+  npx playwright test
 ```
 
 ## Key Rules
@@ -69,14 +109,31 @@ npx prettier --write src/
 - No `console.log` in production JS code
 - No hardcoded credentials or API keys
 
+## Dependencies
+
+Adding, removing, or upgrading a dependency means the notices file is stale.
+Regenerate it in the same PR:
+
+```bash
+docker compose exec backend bash -lc \
+  'cd apps/benchpress && ./scripts/generate-third-party-notices.sh'
+```
+
+Do not hand-edit [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md).
+
+Prefer dependencies under permissive or GPL-compatible licences. A dependency
+under a licence incompatible with AGPL-3.0 (SSPL, BUSL, or anything
+source-available with a commercial-use restriction) cannot be merged.
+
 ## Pull Requests
 
 1. Create a branch from `develop`
 2. Make your changes with conventional commit messages
-3. Run linters before pushing
+3. Run the three verification commands above before pushing
 4. Open a PR targeting `develop`
 5. Describe **what** changed and **why** in the PR description
 6. Link any related issues
+7. Sign the CLA when the bot asks
 
 ## Reporting Bugs
 
@@ -85,3 +142,5 @@ Open an issue with:
 - Expected vs actual behavior
 - Frappe version and environment details
 - Screenshots if applicable
+
+**Security bugs do not go in issues** — see [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![CI](https://github.com/Venkateshvenki404224/benchpress/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/Venkateshvenki404224/benchpress/actions/workflows/ci.yml)
 [![Linters](https://github.com/Venkateshvenki404224/benchpress/actions/workflows/linter.yml/badge.svg)](https://github.com/Venkateshvenki404224/benchpress/actions/workflows/linter.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-green.svg)](license.txt)
 [![Frappe Framework](https://img.shields.io/badge/Built%20on-Frappe%20v16-blue)](https://frappeframework.com)
 [![FOSS Hack 2026](https://img.shields.io/badge/FOSS%20Hack-2026-orange)](https://fossunited.org)
 [![Python 3.14+](https://img.shields.io/badge/Python-3.14+-3776AB.svg)](https://python.org)
@@ -24,13 +24,69 @@
 
 ## What is BenchPress?
 
+Spinning up a Frappe bench to try an app, reproduce a bug, or hand a client a demo
+usually means an afternoon of Docker, nginx, and database setup — repeated for every
+new environment, on a machine you then have to keep tidy.
+
+BenchPress turns that into a form. Describe a **Lab** — a Frappe version and the list
+of apps you want — and it builds a Docker image, deploys a container, gives it a
+private WireGuard IP, and hands you an SSH command and a working site URL. When you
+are done with the environment, you delete it.
+
+It is a self-hosted alternative to Frappe Cloud, and it is itself a Frappe app: the
+whole thing installs onto a bench you already run, with a Vue 3 SPA on the front and
+`frappe.qb` and background jobs on the back.
+
+**What you get per Lab:** a reproducible image, a running bench container, a private
+VPN address reachable from your laptop, SSH access, code-server, and per-site
+management — with build and deploy output streamed live into the browser.
+
+![Labs List](docs/images/labs-list.png)
+
 [![Watch the video](https://img.youtube.com/vi/DzTNwA39PqA/maxresdefault.jpg)](https://www.youtube.com/watch?v=DzTNwA39PqA)
+
+> **Disposable sandboxes, not production hosting.** A Lab is a throwaway development
+> environment with credentials shown in the UI. See
+> [Production Safety & Compatibility](docs/production-safety.md) before pointing
+> anything important at it.
+
+---
+
+## Quickstart
+
+You need a Linux host with Docker, a Frappe v16 bench, and IP forwarding enabled —
+the full list is under [Prerequisites](#prerequisites).
+
+```bash
+cd /path/to/your/frappe-bench
+
+bench get-app https://github.com/Venkateshvenki404224/benchpress --branch develop
+bench pip install docker
+bench --site your-site.localhost install-app benchpress
+bench --site your-site.localhost migrate
+bash apps/benchpress/setup.sh your-site.localhost
+bench build --app benchpress
+```
+
+Then open `http://your-site.localhost:8000/frontend` and create your first Lab.
+[Installation](#installation) covers each step, and
+[docs/getting-started.md](docs/getting-started.md) walks through it slowly.
+
+---
+
+## Licence
+
+BenchPress is free software under the **GNU Affero General Public License v3.0 only**.
+If you run a modified version as a network service, the AGPL requires you to offer its
+users the corresponding source. See [License](#license) for the notice, and
+[TRADEMARKS.md](TRADEMARKS.md) for what the licence does *not* cover.
 
 ---
 
 ## Table of Contents
 
 - [What is BenchPress?](#what-is-benchpress)
+- [Quickstart](#quickstart)
 - [The Problem](#the-problem)
 - [The Solution](#the-solution)
 - [Architecture](#architecture)
@@ -51,6 +107,10 @@
 - [Configuration Reference](#configuration-reference)
 - [Contributing](#contributing)
 - [License](#license)
+- [Trademarks](TRADEMARKS.md)
+- [Third-party notices](THIRD-PARTY-NOTICES.md)
+- [Integration notices](docs/integration-notices.md)
+- [Security policy](SECURITY.md)
 
 ### Detailed Guides
 
@@ -829,13 +889,20 @@ Device management is backed by the **VPN Peer** DocType in the vpn_management ap
 
 ## Contributing
 
+Contributions are welcome. [CONTRIBUTING.md](CONTRIBUTING.md) is the full guide —
+setup, the verification commands CI actually runs, and the dependency policy.
+
 1. Fork the repository
 2. Create a feature branch from `develop`: `git checkout -b feature/my-feature`
 3. Make your changes following Frappe coding conventions
 4. Run tests: `bench --site your-site.localhost run-tests --app benchpress`
-5. Run linters: `cd apps/benchpress && python -m ruff check . && python -m ruff format .`
+5. Run every linter and formatter: `uvx pre-commit@4.3.0 run --all-files`
 6. Commit using Conventional Commits: `feat(lab): add batch deploy support`
 7. Push and open a Pull Request against `develop`
+8. Sign the [Contributor License Agreement](.github/CLA.md) when the bot asks —
+   once, and it covers everything you contribute afterwards
+
+Security issues go through [SECURITY.md](SECURITY.md), never a public issue.
 
 ### Commit Format
 
@@ -854,7 +921,43 @@ chore(deps):   bump frappe-ui to 0.1.192
 
 ## License
 
-MIT License. See [LICENSE](license.txt) for details.
+```
+Copyright (C) 2026 Venkatesh
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>.
+```
+
+The full text is in [license.txt](license.txt). The SPDX identifier is
+`AGPL-3.0-only`.
+
+**What the AGPL means here in practice.** You may run, study, modify, and
+redistribute BenchPress freely. Section 13 adds one obligation beyond the GPL: if
+you modify BenchPress and let other people use it over a network, you must offer
+those users the corresponding source of your modified version. Running an
+unmodified copy, or a modified copy only you use, triggers nothing.
+
+Benches that BenchPress provisions are **not** derivative works of BenchPress.
+Whatever you build inside a Lab is yours, under whatever licence you choose.
+
+The VPN plane lives in
+[vpn_management](https://github.com/Venkateshvenki404224/vpn_management), a required
+dependency, under the same licence.
+
+Third-party components are listed in
+[THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md), each under its own licence, and the
+Frappe apps BenchPress integrates with in
+[docs/integration-notices.md](docs/integration-notices.md). The
+BenchPress name and logo are trademarks and are **not** covered by the AGPL grant —
+see [TRADEMARKS.md](TRADEMARKS.md).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,9 +11,13 @@
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
-Instead, please report them via email:
+Report privately through GitHub Security Advisories:
 
-**Email:** venkateshvenki404224@gmail.com
+**[Report a vulnerability](https://github.com/Venkateshvenki404224/benchpress/security/advisories/new)**
+— or open the repository's **Security** tab and choose *Report a vulnerability*.
+
+The report stays private between you and the maintainers until a fix ships, and
+you are credited on the published advisory unless you ask otherwise.
 
 Include:
 - Description of the vulnerability
@@ -32,5 +36,18 @@ Include:
 This policy covers the BenchPress Frappe app, including:
 - API endpoints (`benchpress/api.py`)
 - Docker container management
-- WireGuard VPN configuration
+- WireGuard VPN configuration (see also the
+  [vpn_management](https://github.com/Venkateshvenki404224/vpn_management) repository)
 - Frontend authentication and authorization
+
+Out of scope: vulnerabilities in the Frappe Framework itself (report those to
+[frappe/frappe](https://github.com/frappe/frappe/security)), and findings that
+require an attacker to already hold administrator credentials on the host.
+
+## A note on what BenchPress is
+
+BenchPress provisions **disposable development sandboxes**. Each Lab is a
+throwaway Frappe bench, reachable over WireGuard, with credentials shown in the
+UI. It is not hardened for production workloads or untrusted tenants, and a
+finding that amounts to "a Lab owner can reach their own Lab's data" is expected
+behaviour rather than a vulnerability.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,62 +1,491 @@
 # Third-party notices
 
-Third-party components BenchPress integrates with directly, and what our exposure to each one is.
-This covers Frappe apps and services BenchPress calls into — not the transitive Python and npm
-dependency trees, which are declared in [pyproject.toml](pyproject.toml) and
-[package.json](package.json) and carry their own licences.
+BenchPress is distributed under the GNU Affero General Public License v3.0 only
+(see [license.txt](license.txt)). It bundles and redistributes the third-party
+components listed below, each under its own license.
 
-## razorpay_frappe — optional
+**This file is generated — do not edit it by hand.** Regenerate it with
+`./scripts/generate-third-party-notices.sh` whenever a dependency is added,
+removed, or upgraded.
 
-| | |
-|---|---|
-| Source | <https://github.com/bwhtech/razorpay_frappe> |
-| Licence | MIT |
-| Used by | [benchpress/credits/payments.py](benchpress/credits/payments.py) |
-| Required | **No.** Deliberately absent from `required_apps` in [hooks.py](benchpress/hooks.py). |
+The full license text of every component is shipped alongside the component
+itself: Python packages carry theirs in `env/lib/python*/site-packages/*.dist-info/`
+inside the published container image, and JavaScript packages carry theirs in
+`node_modules/*/LICENSE`. To produce a single bundle of the full texts, run
+`pip-licenses --format=markdown --with-license-file` in the bench virtualenv.
 
-Provides the `Razorpay Order` and `Razorpay Settings` DocTypes, order creation, the checkout
-success/failure callbacks and webhook signature verification. BenchPress uses **Razorpay Orders
-only** — no Payment Links, no Subscriptions. Frappe v16 ships nothing of its own here: every
-built-in payment gateway was removed in v14 by
-`frappe/patches/v14_0/delete_payment_gateways.py`.
+Frappe apps BenchPress integrates with — razorpay_frappe, vpn_management — are not dependency
+metadata and are documented by hand in
+[docs/integration-notices.md](docs/integration-notices.md).
 
-### Why it is optional
+## Python dependencies
 
-A self-hoster running BenchPress on their own hardware must never be made to install a payment
-processor to use it. The integration is gated on `payments.payments_available()`, which asks
-`frappe.get_installed_apps()`, and the only coupling is one `doc_events` entry on a DocType that
-simply does not exist on a site without the app — an inert hook rather than a broken one.
+| Name                     | Version     | License                                                                                                                                        | URL                                                                                           |
+|--------------------------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
+| protobuf                 | 7.35.1      | 3-Clause BSD License                                                                                                                           | https://developers.google.com/protocol-buffers/                                               |
+| asttokens                | 3.0.2       | Apache 2.0                                                                                                                                     | https://github.com/gristlabs/asttokens                                                        |
+| PyPika                   | 0.48.9      | Apache Software License                                                                                                                        | https://github.com/kayak/pypika                                                               |
+| bleach                   | 6.3.0       | Apache Software License                                                                                                                        | https://github.com/mozilla/bleach                                                             |
+| distro                   | 1.9.0       | Apache Software License                                                                                                                        | https://github.com/python-distro/distro                                                       |
+| google-api-core          | 2.33.0      | Apache Software License                                                                                                                        | https://github.com/googleapis/google-cloud-python/tree/main/packages/google-api-core          |
+| google-api-python-client | 2.188.0     | Apache Software License                                                                                                                        | https://github.com/googleapis/google-api-python-client/                                       |
+| google-auth              | 2.48.0      | Apache Software License                                                                                                                        | https://github.com/googleapis/google-auth-library-python                                      |
+| google-auth-httplib2     | 0.4.0       | Apache Software License                                                                                                                        | https://github.com/googleapis/google-cloud-python/packages/google-auth-httplib2               |
+| google-auth-oauthlib     | 1.2.4       | Apache Software License                                                                                                                        | https://github.com/GoogleCloudPlatform/google-auth-library-python-oauthlib                    |
+| googleapis-common-protos | 1.75.0      | Apache Software License                                                                                                                        | https://github.com/googleapis/google-cloud-python/tree/main/packages/googleapis-common-protos |
+| proto-plus               | 1.28.2      | Apache Software License                                                                                                                        | https://github.com/googleapis/google-cloud-python/tree/main/packages/proto-plus               |
+| pyOpenSSL                | 26.0.0      | Apache Software License                                                                                                                        | https://pyopenssl.org/                                                                        |
+| requests                 | 2.33.1      | Apache Software License                                                                                                                        | https://github.com/psf/requests                                                               |
+| rsa                      | 4.9.1       | Apache Software License                                                                                                                        | https://stuvel.eu/rsa                                                                         |
+| tenacity                 | 9.1.4       | Apache Software License                                                                                                                        | https://github.com/jd/tenacity                                                                |
+| vobject                  | 0.9.9       | Apache Software License                                                                                                                        | UNKNOWN                                                                                       |
+| zopfli                   | 0.4.3       | Apache Software License                                                                                                                        | https://github.com/fonttools/py-zopfli                                                        |
+| python-dateutil          | 2.9.0.post0 | Apache Software License; BSD License                                                                                                           | https://github.com/dateutil/dateutil                                                          |
+| docker                   | 7.2.0       | Apache-2.0                                                                                                                                     | https://github.com/docker/docker-py                                                           |
+| phonenumbers             | 9.0.35      | Apache-2.0                                                                                                                                     | https://github.com/daviddrysdale/python-phonenumbers                                          |
+| packaging                | 26.2        | Apache-2.0 OR BSD-2-Clause                                                                                                                     | https://github.com/pypa/packaging                                                             |
+| cryptography             | 46.0.7      | Apache-2.0 OR BSD-3-Clause                                                                                                                     | https://github.com/pyca/cryptography                                                          |
+| passlib                  | 1.7.4       | BSD                                                                                                                                            | https://passlib.readthedocs.io                                                                |
+| uritemplate              | 4.2.0       | BSD 3-Clause OR Apache-2.0                                                                                                                     | https://uritemplate.readthedocs.org                                                           |
+| Jinja2                   | 3.1.6       | BSD License                                                                                                                                    | https://github.com/pallets/jinja/                                                             |
+| PyQRCode                 | 1.2.1       | BSD License                                                                                                                                    | https://github.com/mnooner256/pyqrcode                                                        |
+| Whoosh                   | 2.7.4       | BSD License                                                                                                                                    | http://bitbucket.org/mchaput/whoosh                                                           |
+| babel                    | 2.16.0      | BSD License                                                                                                                                    | https://babel.pocoo.org/                                                                      |
+| bleach-allowlist         | 1.0.3       | BSD License                                                                                                                                    | https://github.com/yourcelf/bleach-allowlist.git                                              |
+| cssselect2               | 0.9.0       | BSD License                                                                                                                                    | https://doc.courtbouillon.org/cssselect2/                                                     |
+| gitdb                    | 4.0.12      | BSD License                                                                                                                                    | https://github.com/gitpython-developers/gitdb                                                 |
+| ipython                  | 8.37.0      | BSD License                                                                                                                                    | https://ipython.org                                                                           |
+| prompt_toolkit           | 3.0.52      | BSD License                                                                                                                                    | https://github.com/prompt-toolkit/python-prompt-toolkit                                       |
+| psutil                   | 7.0.0       | BSD License                                                                                                                                    | https://github.com/giampaolo/psutil                                                           |
+| pyasn1_modules           | 0.4.2       | BSD License                                                                                                                                    | https://github.com/pyasn1/pyasn1-modules                                                      |
+| pydyf                    | 0.12.1      | BSD License                                                                                                                                    | https://www.courtbouillon.org/pydyf                                                           |
+| requests-oauthlib        | 2.0.0       | BSD License                                                                                                                                    | https://github.com/requests/requests-oauthlib                                                 |
+| semantic-version         | 2.10.0      | BSD License                                                                                                                                    | https://github.com/rbarrois/python-semanticversion                                            |
+| sentry-sdk               | 1.45.1      | BSD License                                                                                                                                    | https://github.com/getsentry/sentry-python                                                    |
+| smmap                    | 5.0.3       | BSD License                                                                                                                                    | https://github.com/gitpython-developers/smmap                                                 |
+| sqlparse                 | 0.5.5       | BSD License                                                                                                                                    | https://github.com/andialbrecht/sqlparse                                                      |
+| tinycss2                 | 1.5.1       | BSD License                                                                                                                                    | https://www.courtbouillon.org/tinycss2                                                        |
+| traitlets                | 5.15.1      | BSD License                                                                                                                                    | https://github.com/ipython/traitlets                                                          |
+| weasyprint               | 68.0        | BSD License                                                                                                                                    | https://weasyprint.org/                                                                       |
+| webencodings             | 0.5.1       | BSD License                                                                                                                                    | https://github.com/SimonSapin/python-webencodings                                             |
+| websockets               | 15.0.1      | BSD License                                                                                                                                    | https://github.com/python-websockets/websockets                                               |
+| xlrd                     | 2.0.2       | BSD License                                                                                                                                    | http://www.python-excel.org/                                                                  |
+| xlsxwriter               | 3.2.9       | BSD License                                                                                                                                    | https://github.com/jmcnamara/XlsxWriter                                                       |
+| qrcode                   | 8.2         | BSD License; Other/Proprietary License                                                                                                         | https://github.com/lincolnloop/python-qrcode                                                  |
+| Pygments                 | 2.20.0      | BSD-2-Clause                                                                                                                                   | https://pygments.org                                                                          |
+| decorator                | 5.3.1       | BSD-2-Clause                                                                                                                                   | UNKNOWN                                                                                       |
+| pyasn1                   | 0.6.4       | BSD-2-Clause                                                                                                                                   | https://github.com/pyasn1/pyasn1                                                              |
+| rq                       | 2.6.1       | BSD-2-Clause                                                                                                                                   | https://python-rq.org/                                                                        |
+| GitPython                | 3.1.57      | BSD-3-Clause                                                                                                                                   | https://github.com/gitpython-developers/GitPython                                             |
+| MarkupSafe               | 3.0.3       | BSD-3-Clause                                                                                                                                   | https://github.com/pallets/markupsafe/                                                        |
+| Werkzeug                 | 3.1.6       | BSD-3-Clause                                                                                                                                   | https://github.com/pallets/werkzeug/                                                          |
+| click                    | 8.3.3       | BSD-3-Clause                                                                                                                                   | https://github.com/pallets/click/                                                             |
+| cssselect                | 1.4.0       | BSD-3-Clause                                                                                                                                   | https://github.com/scrapy/cssselect                                                           |
+| idna                     | 3.18        | BSD-3-Clause                                                                                                                                   | https://github.com/kjd/idna                                                                   |
+| lxml                     | 6.1.1       | BSD-3-Clause                                                                                                                                   | https://lxml.de/                                                                              |
+| matplotlib-inline        | 0.2.2       | BSD-3-Clause                                                                                                                                   | https://github.com/ipython/matplotlib-inline                                                  |
+| oauthlib                 | 3.3.1       | BSD-3-Clause                                                                                                                                   | https://github.com/oauthlib/oauthlib                                                          |
+| pycparser                | 3.0         | BSD-3-Clause                                                                                                                                   | https://github.com/eliben/pycparser                                                           |
+| pypdf                    | 6.13.3      | BSD-3-Clause                                                                                                                                   | https://github.com/py-pdf/pypdf                                                               |
+| mysqlclient              | 2.2.7       | GNU General Public License v2 or later (GPLv2+)                                                                                                | https://mysqlclient.readthedocs.io/                                                           |
+| pyphen                   | 0.17.2      | GNU General Public License v2 or later (GPLv2+); GNU Lesser General Public License v2 or later (LGPLv2+); Mozilla Public License 1.1 (MPL 1.1) | https://www.courtbouillon.org/pyphen                                                          |
+| pycountry                | 24.6.1      | GNU Lesser General Public License v2 (LGPLv2)                                                                                                  | https://github.com/flyingcircusio/pycountry                                                   |
+| chardet                  | 5.2.0       | GNU Lesser General Public License v2 or later (LGPLv2+)                                                                                        | https://github.com/chardet/chardet                                                            |
+| ldap3                    | 2.9.1       | GNU Lesser General Public License v3 (LGPLv3)                                                                                                  | https://github.com/cannatag/ldap3                                                             |
+| cssutils                 | 2.11.1      | GNU Library or Lesser General Public License (LGPL)                                                                                            | https://github.com/jaraco/cssutils                                                            |
+| num2words                | 0.5.14      | GNU Library or Lesser General Public License (LGPL)                                                                                            | https://github.com/savoirfairelinux/num2words                                                 |
+| psycopg2-binary          | 2.9.12      | GNU Library or Lesser General Public License (LGPL)                                                                                            | https://psycopg.org/                                                                          |
+| pexpect                  | 4.9.0       | ISC License (ISCL)                                                                                                                             | https://pexpect.readthedocs.io/                                                               |
+| ptyprocess               | 0.7.0       | ISC License (ISCL)                                                                                                                             | https://github.com/pexpect/ptyprocess                                                         |
+| PyJWT                    | 2.13.0      | MIT                                                                                                                                            | https://github.com/jpadilla/pyjwt                                                             |
+| PyMySQL                  | 1.1.2       | MIT                                                                                                                                            | https://github.com/PyMySQL/PyMySQL/blob/main/CHANGELOG.md                                     |
+| annotated-types          | 0.8.0       | MIT                                                                                                                                            | https://github.com/annotated-types/annotated-types                                            |
+| brotli                   | 1.2.0       | MIT                                                                                                                                            | https://github.com/google/brotli                                                              |
+| cachetools               | 7.1.6       | MIT                                                                                                                                            | https://github.com/tkem/cachetools/                                                           |
+| charset-normalizer       | 3.4.9       | MIT                                                                                                                                            | https://github.com/jawah/charset_normalizer/blob/master/CHANGELOG.md                          |
+| email-reply-parser       | 0.5.12      | MIT                                                                                                                                            | https://github.com/zapier/email-reply-parser                                                  |
+| fonttools                | 4.63.0      | MIT                                                                                                                                            | http://github.com/fonttools/fonttools                                                         |
+| markdown2                | 2.5.5       | MIT                                                                                                                                            | https://github.com/trentm/python-markdown2                                                    |
+| more-itertools           | 11.1.0      | MIT                                                                                                                                            | https://github.com/more-itertools/more-itertools                                              |
+| nh3                      | 0.3.6       | MIT                                                                                                                                            | UNKNOWN                                                                                       |
+| pdfkit                   | 1.0.0       | MIT                                                                                                                                            | UNKNOWN                                                                                       |
+| pydantic                 | 2.12.5      | MIT                                                                                                                                            | https://github.com/pydantic/pydantic                                                          |
+| pydantic_core            | 2.41.5      | MIT                                                                                                                                            | https://github.com/pydantic/pydantic-core                                                     |
+| pyparsing                | 3.3.2       | MIT                                                                                                                                            | https://github.com/pyparsing/pyparsing/                                                       |
+| redis                    | 7.1.1       | MIT                                                                                                                                            | https://github.com/redis/redis-py                                                             |
+| soupsieve                | 2.9.1       | MIT                                                                                                                                            | https://github.com/facelessuser/soupsieve                                                     |
+| typing-inspection        | 0.4.2       | MIT                                                                                                                                            | https://github.com/pydantic/typing-inspection                                                 |
+| urllib3                  | 2.7.0       | MIT                                                                                                                                            | https://github.com/urllib3/urllib3/blob/main/CHANGES.rst                                      |
+| PyYAML                   | 6.0.3       | MIT License                                                                                                                                    | https://pyyaml.org/                                                                           |
+| beautifulsoup4           | 4.13.5      | MIT License                                                                                                                                    | https://www.crummy.com/software/BeautifulSoup/bs4/                                            |
+| croniter                 | 6.0.0       | MIT License                                                                                                                                    | http://github.com/kiorky/croniter                                                             |
+| docopt                   | 0.6.2       | MIT License                                                                                                                                    | http://docopt.org                                                                             |
+| duckdb                   | 1.4.5       | MIT License                                                                                                                                    | https://github.com/duckdb/duckdb-python                                                       |
+| et_xmlfile               | 2.0.0       | MIT License                                                                                                                                    | https://foss.heptapod.net/openpyxl/et_xmlfile                                                 |
+| executing                | 2.2.1       | MIT License                                                                                                                                    | https://github.com/alexmojaki/executing                                                       |
+| filetype                 | 1.2.0       | MIT License                                                                                                                                    | https://github.com/h2non/filetype.py                                                          |
+| gunicorn                 | 23.0.0      | MIT License                                                                                                                                    | https://gunicorn.org                                                                          |
+| hiredis                  | 3.3.1       | MIT License                                                                                                                                    | https://github.com/redis/hiredis-py                                                           |
+| html5lib                 | 1.1         | MIT License                                                                                                                                    | https://github.com/html5lib/html5lib-python                                                   |
+| httplib2                 | 0.32.0      | MIT License                                                                                                                                    | https://github.com/httplib2/httplib2                                                          |
+| jedi                     | 0.20.0      | MIT License                                                                                                                                    | https://github.com/davidhalter/jedi                                                           |
+| markdownify              | 1.2.3       | MIT License                                                                                                                                    | http://github.com/matthewwithanm/python-markdownify                                           |
+| openpyxl                 | 3.1.5       | MIT License                                                                                                                                    | https://openpyxl.readthedocs.io                                                               |
+| parso                    | 0.8.7       | MIT License                                                                                                                                    | https://github.com/davidhalter/parso                                                          |
+| pure_eval                | 0.2.3       | MIT License                                                                                                                                    | http://github.com/alexmojaki/pure_eval                                                        |
+| pyotp                    | 2.9.0       | MIT License                                                                                                                                    | https://github.com/pyotp/pyotp                                                                |
+| pytz                     | 2025.2      | MIT License                                                                                                                                    | http://pythonhosted.org/pytz                                                                  |
+| rauth                    | 0.7.3       | MIT License                                                                                                                                    | https://github.com/litl/rauth                                                                 |
+| six                      | 1.17.0      | MIT License                                                                                                                                    | https://github.com/benjaminp/six                                                              |
+| sql_metadata             | 2.19.0      | MIT License                                                                                                                                    | https://github.com/macbre/sql-metadata                                                        |
+| stack-data               | 0.6.3       | MIT License                                                                                                                                    | http://github.com/alexmojaki/stack_data                                                       |
+| terminaltables           | 3.1.10      | MIT License                                                                                                                                    | https://github.com/matthewdeanmartin/terminaltables                                           |
+| tinyhtml5                | 2.1.0       | MIT License                                                                                                                                    | https://github.com/CourtBouillon/tinyhtml5                                                    |
+| traceback-with-variables | 2.2.1       | MIT License                                                                                                                                    | https://github.com/andy-landy/traceback_with_variables                                        |
+| zxcvbn                   | 4.5.0       | MIT License                                                                                                                                    | https://github.com/dwolfhub/zxcvbn-python                                                     |
+| cffi                     | 2.1.0       | MIT-0                                                                                                                                          | https://cffi.readthedocs.io/en/latest/whatsnew.html                                           |
+| pillow                   | 12.2.0      | MIT-CMU                                                                                                                                        | https://python-pillow.github.io                                                               |
+| orjson                   | 3.11.9      | MPL-2.0 AND (Apache-2.0 OR MIT)                                                                                                                | https://github.com/ijl/orjson                                                                 |
+| certifi                  | 2026.7.22   | Mozilla Public License 2.0 (MPL 2.0)                                                                                                           | https://github.com/certifi/python-certifi                                                     |
+| typing_extensions        | 4.16.0      | PSF-2.0                                                                                                                                        | https://github.com/python/typing_extensions                                                   |
+| premailer                | 3.10.0      | Python Software Foundation License                                                                                                             | http://github.com/peterbe/premailer                                                           |
+| frappe                   | 16.28.0     | UNKNOWN                                                                                                                                        | https://frappe.io/framework                                                                   |
+| filelock                 | 3.20.4      | Unlicense                                                                                                                                      | https://github.com/tox-dev/py-filelock                                                        |
+| RestrictedPython         | 8.4         | ZPL-2.1                                                                                                                                        | https://github.com/zopefoundation/RestrictedPython                                            |
 
-### Maintenance exposure
+## JavaScript dependencies (frontend, production only)
 
-It is a small project (roughly a dozen stars and under a hundred commits at the time of writing)
-maintained by one author. That risk is accepted for a specific reason: the licence is MIT, so if
-it stops being maintained we may fork or vendor it outright without relicensing anything.
+- [@alloc/quick-lru@5.2.0](https://github.com/sindresorhus/quick-lru) - MIT
+- [@antfu/install-pkg@1.1.0](https://github.com/antfu/install-pkg) - MIT
+- [@babel/helper-string-parser@7.27.1](https://github.com/babel/babel) - MIT
+- [@babel/helper-validator-identifier@7.28.5](https://github.com/babel/babel) - MIT
+- [@babel/parser@7.29.2](https://github.com/babel/babel) - MIT
+- [@babel/types@7.29.0](https://github.com/babel/babel) - MIT
+- [@floating-ui/core@1.7.5](https://github.com/floating-ui/floating-ui) - MIT
+- [@floating-ui/dom@1.7.6](https://github.com/floating-ui/floating-ui) - MIT
+- [@floating-ui/utils@0.2.11](https://github.com/floating-ui/floating-ui) - MIT
+- [@floating-ui/vue@1.1.11](https://github.com/floating-ui/floating-ui) - MIT
+- [@headlessui/vue@1.7.23](https://github.com/tailwindlabs/headlessui) - MIT
+- [@iconify/types@2.0.0](https://github.com/iconify/iconify) - MIT
+- [@iconify/utils@3.1.0](https://github.com/iconify/iconify) - MIT
+- [@interactjs/types@1.10.27](https://github.com/taye/interact.js) - MIT
+- [@internationalized/date@3.12.0](https://github.com/adobe/react-spectrum.git#main) - Apache-2.0
+- [@internationalized/number@3.6.5](https://github.com/adobe/react-spectrum) - Apache-2.0
+- [@jridgewell/gen-mapping@0.3.13](https://github.com/jridgewell/sourcemaps) - MIT
+- [@jridgewell/remapping@2.3.5](https://github.com/jridgewell/sourcemaps) - MIT
+- [@jridgewell/resolve-uri@3.1.2](https://github.com/jridgewell/resolve-uri) - MIT
+- [@jridgewell/sourcemap-codec@1.5.5](https://github.com/jridgewell/sourcemaps) - MIT
+- [@jridgewell/trace-mapping@0.3.31](https://github.com/jridgewell/sourcemaps) - MIT
+- [@juggle/resize-observer@3.4.0](https://github.com/juggle/resize-observer) - Apache-2.0
+- [@nodelib/fs.scandir@2.1.5](https://github.com/nodelib/nodelib.git#master) - MIT
+- [@nodelib/fs.stat@2.0.5](https://github.com/nodelib/nodelib.git#master) - MIT
+- [@nodelib/fs.walk@1.2.8](https://github.com/nodelib/nodelib.git#master) - MIT
+- [@popperjs/core@2.11.8](https://github.com/popperjs/popper-core) - MIT
+- [@remirror/core-constants@3.0.0](https://github.com/remirror/remirror) - MIT
+- [@socket.io/component-emitter@3.1.2](https://github.com/socketio/emitter) - MIT
+- [@swc/helpers@0.5.19](https://github.com/swc-project/swc) - Apache-2.0
+- [@tailwindcss/forms@0.5.11](https://github.com/tailwindlabs/tailwindcss-forms) - MIT
+- [@tailwindcss/line-clamp@0.4.4](https://github.com/tailwindlabs/tailwindcss-line-clamp) - MIT
+- [@tailwindcss/typography@0.5.19](https://github.com/tailwindlabs/tailwindcss-typography) - MIT
+- [@tanstack/virtual-core@3.13.23](https://github.com/TanStack/virtual) - MIT
+- [@tanstack/vue-virtual@3.13.23](https://github.com/TanStack/virtual) - MIT
+- [@tiptap/core@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-blockquote@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-bold@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-bubble-menu@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-bullet-list@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-code-block-lowlight@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-code-block@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-code@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-color@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-document@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-dropcursor@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-floating-menu@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-gapcursor@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-hard-break@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-heading@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-highlight@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-horizontal-rule@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-image@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-italic@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-link@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-list-item@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-list-keymap@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-list@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-mention@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-node-range@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-ordered-list@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-paragraph@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-placeholder@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-strike@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-table@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-task-item@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-task-list@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-text-align@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-text-style@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-text@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-typography@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extension-underline@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/extensions@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/pm@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/starter-kit@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/suggestion@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@tiptap/vue-3@3.20.5](https://github.com/ueberdosis/tiptap) - MIT
+- [@types/estree@1.0.8](https://github.com/DefinitelyTyped/DefinitelyTyped) - MIT
+- [@types/hast@3.0.4](https://github.com/DefinitelyTyped/DefinitelyTyped) - MIT
+- [@types/linkify-it@5.0.0](https://github.com/DefinitelyTyped/DefinitelyTyped) - MIT
+- [@types/markdown-it@14.1.2](https://github.com/DefinitelyTyped/DefinitelyTyped) - MIT
+- [@types/mdurl@2.0.0](https://github.com/DefinitelyTyped/DefinitelyTyped) - MIT
+- [@types/trusted-types@2.0.7](https://github.com/DefinitelyTyped/DefinitelyTyped) - MIT
+- [@types/unist@3.0.3](https://github.com/DefinitelyTyped/DefinitelyTyped) - MIT
+- [@types/web-bluetooth@0.0.20](https://github.com/DefinitelyTyped/DefinitelyTyped) - MIT
+- [@types/web-bluetooth@0.0.21](https://github.com/DefinitelyTyped/DefinitelyTyped) - MIT
+- [@vexip-ui/hooks@2.9.3](https://github.com/vexip-ui/vexip-ui) - MIT
+- [@vexip-ui/utils@2.16.4](https://github.com/vexip-ui/vexip-ui) - MIT
+- [@vue/compiler-core@3.5.31](https://github.com/vuejs/core) - MIT
+- [@vue/compiler-dom@3.5.31](https://github.com/vuejs/core) - MIT
+- [@vue/compiler-sfc@3.5.31](https://github.com/vuejs/core) - MIT
+- [@vue/compiler-ssr@3.5.31](https://github.com/vuejs/core) - MIT
+- [@vue/devtools-api@6.6.4](https://github.com/vuejs/vue-devtools) - MIT
+- [@vue/reactivity@3.5.31](https://github.com/vuejs/core) - MIT
+- [@vue/runtime-core@3.5.31](https://github.com/vuejs/core) - MIT
+- [@vue/runtime-dom@3.5.31](https://github.com/vuejs/core) - MIT
+- [@vue/server-renderer@3.5.31](https://github.com/vuejs/core) - MIT
+- [@vue/shared@3.5.31](https://github.com/vuejs/core) - MIT
+- [@vueuse/core@10.11.1](https://github.com/vueuse/vueuse) - MIT
+- [@vueuse/core@14.2.1](https://github.com/vueuse/vueuse) - MIT
+- [@vueuse/metadata@10.11.1](https://github.com/vueuse/vueuse) - MIT
+- [@vueuse/metadata@14.2.1](https://github.com/vueuse/vueuse) - MIT
+- [@vueuse/shared@10.11.1](https://github.com/vueuse/vueuse) - MIT
+- [@vueuse/shared@14.2.1](https://github.com/vueuse/vueuse) - MIT
+- [acorn@8.16.0](https://github.com/acornjs/acorn) - MIT
+- [ansi-regex@5.0.1](https://github.com/chalk/ansi-regex) - MIT
+- [ansi-styles@4.3.0](https://github.com/chalk/ansi-styles) - MIT
+- [any-promise@1.3.0](https://github.com/kevinbeaty/any-promise) - MIT
+- [anymatch@3.1.3](https://github.com/micromatch/anymatch) - ISC
+- [arg@5.0.2](https://github.com/vercel/arg) - MIT
+- [argparse@2.0.1](https://github.com/nodeca/argparse) - Python-2.0
+- [aria-hidden@1.2.6](https://github.com/theKashey/aria-hidden) - MIT
+- [base64-js@1.5.1](https://github.com/beatgammit/base64-js) - MIT
+- [binary-extensions@2.3.0](https://github.com/sindresorhus/binary-extensions) - MIT
+- [bl@4.1.0](https://github.com/rvagg/bl) - MIT
+- [braces@3.0.3](https://github.com/micromatch/braces) - MIT
+- [buffer@5.7.1](https://github.com/feross/buffer) - MIT
+- [camelcase-css@2.0.1](https://github.com/stevenvachon/camelcase-css) - MIT
+- [camelcase@5.3.1](https://github.com/sindresorhus/camelcase) - MIT
+- [chalk@4.1.2](https://github.com/chalk/chalk) - MIT
+- [chokidar@3.6.0](https://github.com/paulmillr/chokidar) - MIT
+- [classnames@2.5.1](https://github.com/JedWatson/classnames) - MIT
+- [cli-cursor@3.1.0](https://github.com/sindresorhus/cli-cursor) - MIT
+- [cli-spinners@2.9.2](https://github.com/sindresorhus/cli-spinners) - MIT
+- [cliui@6.0.0](https://github.com/yargs/cliui) - ISC
+- [clone@1.0.4](https://github.com/pvorb/node-clone) - MIT
+- [color-convert@2.0.1](https://github.com/Qix-/color-convert) - MIT
+- [color-name@1.1.4](https://github.com/colorjs/color-name) - MIT
+- [commander@4.1.1](https://github.com/tj/commander.js) - MIT
+- [confbox@0.1.8](https://github.com/unjs/confbox) - MIT
+- [confbox@0.2.4](https://github.com/unjs/confbox) - MIT
+- [core-js@3.49.0](https://github.com/zloirock/core-js) - MIT
+- [crelt@1.0.6](https://github.com/marijnh/crelt) - MIT
+- [cssesc@3.0.0](https://github.com/mathiasbynens/cssesc) - MIT
+- [csstype@3.2.3](https://github.com/frenic/csstype) - MIT
+- [dayjs@1.11.20](https://github.com/iamkun/dayjs) - MIT
+- [debug@4.4.3](https://github.com/debug-js/debug) - MIT
+- [decamelize@1.2.0](https://github.com/sindresorhus/decamelize) - MIT
+- [defaults@1.0.4](https://github.com/sindresorhus/node-defaults) - MIT
+- [defu@6.1.4](https://github.com/unjs/defu) - MIT
+- [dequal@2.0.3](https://github.com/lukeed/dequal) - MIT
+- [devlop@1.1.0](https://github.com/wooorm/devlop) - MIT
+- [didyoumean@1.2.2](https://github.com/dcporter/didyoumean.js) - Apache-2.0
+- [dijkstrajs@1.0.3](https://github.com/tcort/dijkstrajs) - MIT
+- [dlv@1.1.3](https://github.com/developit/dlv) - MIT
+- [dompurify@3.3.3](https://github.com/cure53/DOMPurify) - (MPL-2.0 OR Apache-2.0)
+- [echarts@5.6.0](https://github.com/apache/echarts) - Apache-2.0
+- [emoji-regex@8.0.0](https://github.com/mathiasbynens/emoji-regex) - MIT
+- [engine.io-client@6.6.4](https://github.com/socketio/socket.io) - MIT
+- [engine.io-parser@5.2.3](https://github.com/socketio/socket.io) - MIT
+- [entities@4.5.0](https://github.com/fb55/entities) - BSD-2-Clause
+- [entities@7.0.1](https://github.com/fb55/entities) - BSD-2-Clause
+- [escape-string-regexp@4.0.0](https://github.com/sindresorhus/escape-string-regexp) - MIT
+- [escape-string-regexp@5.0.0](https://github.com/sindresorhus/escape-string-regexp) - MIT
+- [estree-walker@2.0.2](https://github.com/Rich-Harris/estree-walker) - MIT
+- [estree-walker@3.0.3](https://github.com/Rich-Harris/estree-walker) - MIT
+- [exsolve@1.0.8](https://github.com/unjs/exsolve) - MIT
+- [fast-deep-equal@3.1.3](https://github.com/epoberezkin/fast-deep-equal) - MIT
+- [fast-glob@3.3.3](https://github.com/mrmlnc/fast-glob) - MIT
+- [fastq@1.20.1](https://github.com/mcollina/fastq) - ISC
+- [fdir@6.5.0](https://github.com/thecodrr/fdir) - MIT
+- [feather-icons@4.29.2](https://github.com/feathericons/feather) - MIT
+- [fill-range@7.1.1](https://github.com/jonschlinkert/fill-range) - MIT
+- [find-up@4.1.0](https://github.com/sindresorhus/find-up) - MIT
+- [frappe-ui@0.1.278](https://github.com/frappe/frappe-ui) - MIT
+- [function-bind@1.1.2](https://github.com/Raynos/function-bind) - MIT
+- [get-caller-file@2.0.5](https://github.com/stefanpenner/get-caller-file) - ISC
+- [glob-parent@5.1.2](https://github.com/gulpjs/glob-parent) - ISC
+- [glob-parent@6.0.2](https://github.com/gulpjs/glob-parent) - ISC
+- [grid-layout-plus@1.1.1](undefined) - MIT
+- [has-flag@4.0.0](https://github.com/sindresorhus/has-flag) - MIT
+- [hasown@2.0.2](https://github.com/inspect-js/hasOwn) - MIT
+- [highlight.js@11.11.1](https://github.com/highlightjs/highlight.js) - BSD-3-Clause
+- [idb-keyval@6.2.2](https://github.com/jakearchibald/idb-keyval) - Apache-2.0
+- [ieee754@1.2.1](https://github.com/feross/ieee754) - BSD-3-Clause
+- [inherits@2.0.4](https://github.com/isaacs/inherits) - ISC
+- [interactjs@1.10.27](https://github.com/taye/interact.js) - MIT
+- [is-binary-path@2.1.0](https://github.com/sindresorhus/is-binary-path) - MIT
+- [is-core-module@2.16.1](https://github.com/inspect-js/is-core-module) - MIT
+- [is-extglob@2.1.1](https://github.com/jonschlinkert/is-extglob) - MIT
+- [is-fullwidth-code-point@3.0.0](https://github.com/sindresorhus/is-fullwidth-code-point) - MIT
+- [is-glob@4.0.3](https://github.com/micromatch/is-glob) - MIT
+- [is-interactive@1.0.0](https://github.com/sindresorhus/is-interactive) - MIT
+- [is-number@7.0.0](https://github.com/jonschlinkert/is-number) - MIT
+- [is-unicode-supported@0.1.0](https://github.com/sindresorhus/is-unicode-supported) - MIT
+- [jiti@1.21.7](https://github.com/unjs/jiti) - MIT
+- [js-tokens@9.0.1](https://github.com/lydell/js-tokens) - MIT
+- [lilconfig@3.1.3](https://github.com/antonk52/lilconfig) - MIT
+- [lines-and-columns@1.2.4](https://github.com/eventualbuddha/lines-and-columns) - MIT
+- [linkify-it@5.0.0](https://github.com/markdown-it/linkify-it) - MIT
+- [linkifyjs@4.3.2](https://github.com/nfrasser/linkifyjs) - MIT
+- [local-pkg@1.1.2](https://github.com/antfu-collective/local-pkg) - MIT
+- [locate-path@5.0.0](https://github.com/sindresorhus/locate-path) - MIT
+- [log-symbols@4.1.0](https://github.com/sindresorhus/log-symbols) - MIT
+- [lowlight@3.3.0](https://github.com/wooorm/lowlight) - MIT
+- [lucide-static@0.545.0](https://github.com/lucide-icons/lucide) - ISC
+- [magic-string@0.30.21](https://github.com/Rich-Harris/magic-string) - MIT
+- [markdown-it@14.1.1](https://github.com/markdown-it/markdown-it) - MIT
+- [marked@15.0.12](https://github.com/markedjs/marked) - MIT
+- [mdurl@2.0.0](https://github.com/markdown-it/mdurl) - MIT
+- [merge2@1.4.1](https://github.com/teambition/merge2) - MIT
+- [micromatch@4.0.8](https://github.com/micromatch/micromatch) - MIT
+- [mimic-fn@2.1.0](https://github.com/sindresorhus/mimic-fn) - MIT
+- [mini-svg-data-uri@1.4.4](https://github.com/tigt/mini-svg-data-uri) - MIT
+- [mlly@1.8.2](https://github.com/unjs/mlly) - MIT
+- [ms@2.1.3](https://github.com/vercel/ms) - MIT
+- [mz@2.7.0](https://github.com/normalize/mz) - MIT
+- [nanoid@3.3.11](https://github.com/ai/nanoid) - MIT
+- [nanoid@5.1.7](https://github.com/ai/nanoid) - MIT
+- [normalize-path@3.0.0](https://github.com/jonschlinkert/normalize-path) - MIT
+- [object-assign@4.1.1](https://github.com/sindresorhus/object-assign) - MIT
+- [object-hash@3.0.0](https://github.com/puleos/object-hash) - MIT
+- [ohash@2.0.11](https://github.com/unjs/ohash) - MIT
+- [onetime@5.1.2](https://github.com/sindresorhus/onetime) - MIT
+- [ora@5.4.1](https://github.com/sindresorhus/ora) - MIT
+- [orderedmap@2.1.1](https://github.com/marijnh/orderedmap) - MIT
+- [p-limit@2.3.0](https://github.com/sindresorhus/p-limit) - MIT
+- [p-locate@4.1.0](https://github.com/sindresorhus/p-locate) - MIT
+- [p-try@2.2.0](https://github.com/sindresorhus/p-try) - MIT
+- [package-manager-detector@1.6.0](https://github.com/antfu-collective/package-manager-detector) - MIT
+- [path-exists@4.0.0](https://github.com/sindresorhus/path-exists) - MIT
+- [path-parse@1.0.7](https://github.com/jbgutierrez/path-parse) - MIT
+- [pathe@2.0.3](https://github.com/unjs/pathe) - MIT
+- [picocolors@1.1.1](https://github.com/alexeyraspopov/picocolors) - ISC
+- [picomatch@2.3.2](https://github.com/micromatch/picomatch) - MIT
+- [picomatch@4.0.4](https://github.com/micromatch/picomatch) - MIT
+- [pify@2.3.0](https://github.com/sindresorhus/pify) - MIT
+- [pirates@4.0.7](https://github.com/danez/pirates) - MIT
+- [pkg-types@1.3.1](https://github.com/unjs/pkg-types) - MIT
+- [pkg-types@2.3.0](https://github.com/unjs/pkg-types) - MIT
+- [pngjs@5.0.0](https://github.com/lukeapage/pngjs) - MIT
+- [postcss-import@15.1.0](https://github.com/postcss/postcss-import) - MIT
+- [postcss-js@4.1.0](https://github.com/postcss/postcss-js) - MIT
+- [postcss-load-config@6.0.1](https://github.com/postcss/postcss-load-config) - MIT
+- [postcss-nested@6.2.0](https://github.com/postcss/postcss-nested) - MIT
+- [postcss-selector-parser@6.0.10](https://github.com/postcss/postcss-selector-parser) - MIT
+- [postcss-selector-parser@6.1.2](https://github.com/postcss/postcss-selector-parser) - MIT
+- [postcss-value-parser@4.2.0](https://github.com/TrySound/postcss-value-parser) - MIT
+- [postcss@8.5.8](https://github.com/postcss/postcss) - MIT
+- [prettier@3.8.1](https://github.com/prettier/prettier) - MIT
+- [prosemirror-changeset@2.4.0](https://github.com/prosemirror/prosemirror-changeset) - MIT
+- [prosemirror-collab@1.3.1](https://github.com/prosemirror/prosemirror-collab) - MIT
+- [prosemirror-commands@1.7.1](https://github.com/prosemirror/prosemirror-commands) - MIT
+- [prosemirror-dropcursor@1.8.2](https://github.com/prosemirror/prosemirror-dropcursor) - MIT
+- [prosemirror-gapcursor@1.4.1](https://github.com/prosemirror/prosemirror-gapcursor) - MIT
+- [prosemirror-history@1.5.0](https://github.com/prosemirror/prosemirror-history) - MIT
+- [prosemirror-inputrules@1.5.1](https://github.com/prosemirror/prosemirror-inputrules) - MIT
+- [prosemirror-keymap@1.2.3](https://github.com/prosemirror/prosemirror-keymap) - MIT
+- [prosemirror-markdown@1.13.4](https://github.com/prosemirror/prosemirror-markdown) - MIT
+- [prosemirror-menu@1.3.0](https://github.com/prosemirror/prosemirror-menu) - MIT
+- [prosemirror-model@1.25.4](https://github.com/prosemirror/prosemirror-model) - MIT
+- [prosemirror-schema-basic@1.2.4](https://github.com/prosemirror/prosemirror-schema-basic) - MIT
+- [prosemirror-schema-list@1.5.1](https://github.com/prosemirror/prosemirror-schema-list) - MIT
+- [prosemirror-state@1.4.4](https://github.com/prosemirror/prosemirror-state) - MIT
+- [prosemirror-tables@1.8.5](https://github.com/ProseMirror/prosemirror-tables) - MIT
+- [prosemirror-trailing-node@3.0.0](https://github.com/remirror/remirror) - MIT
+- [prosemirror-transform@1.11.0](https://github.com/prosemirror/prosemirror-transform) - MIT
+- [prosemirror-view@1.41.7](https://github.com/prosemirror/prosemirror-view) - MIT
+- [punycode.js@2.3.1](https://github.com/mathiasbynens/punycode.js) - MIT
+- [qrcode@1.5.4](https://github.com/soldair/node-qrcode) - MIT
+- [quansync@0.2.11](https://github.com/quansync-dev/quansync) - MIT
+- [queue-microtask@1.2.3](https://github.com/feross/queue-microtask) - MIT
+- [radix-vue@1.9.17](https://github.com/unovue/radix-vue) - MIT
+- [read-cache@1.0.0](https://github.com/TrySound/read-cache) - MIT
+- [readable-stream@3.6.2](https://github.com/nodejs/readable-stream) - MIT
+- [readdirp@3.6.0](https://github.com/paulmillr/readdirp) - MIT
+- [reka-ui@2.9.2](https://github.com/unovue/reka-ui) - MIT
+- [require-directory@2.1.1](https://github.com/troygoode/node-require-directory) - MIT
+- [require-main-filename@2.0.0](https://github.com/yargs/require-main-filename) - ISC
+- [resolve@1.22.11](https://github.com/browserify/resolve) - MIT
+- [restore-cursor@3.1.0](https://github.com/sindresorhus/restore-cursor) - MIT
+- [reusify@1.1.0](https://github.com/mcollina/reusify) - MIT
+- [rope-sequence@1.3.4](https://github.com/marijnh/rope-sequence) - MIT
+- [run-parallel@1.2.0](https://github.com/feross/run-parallel) - MIT
+- [safe-buffer@5.2.1](https://github.com/feross/safe-buffer) - MIT
+- [scule@1.3.0](https://github.com/unjs/scule) - MIT
+- [set-blocking@2.0.0](https://github.com/yargs/set-blocking) - ISC
+- [signal-exit@3.0.7](https://github.com/tapjs/signal-exit) - ISC
+- [slugify@1.6.8](https://github.com/simov/slugify) - MIT
+- [socket.io-client@4.8.3](https://github.com/socketio/socket.io) - MIT
+- [socket.io-parser@4.2.6](https://github.com/socketio/socket.io) - MIT
+- [source-map-js@1.2.1](https://github.com/7rulnik/source-map-js) - BSD-3-Clause
+- [string-width@4.2.3](https://github.com/sindresorhus/string-width) - MIT
+- [string_decoder@1.3.0](https://github.com/nodejs/string_decoder) - MIT
+- [strip-ansi@6.0.1](https://github.com/chalk/strip-ansi) - MIT
+- [strip-literal@3.1.0](https://github.com/antfu/strip-literal) - MIT
+- [sucrase@3.35.1](https://github.com/alangpierce/sucrase) - MIT
+- [supports-color@7.2.0](https://github.com/chalk/supports-color) - MIT
+- [supports-preserve-symlinks-flag@1.0.0](https://github.com/inspect-js/node-supports-preserve-symlinks-flag) - MIT
+- [tailwindcss@3.4.19](https://github.com/tailwindlabs/tailwindcss.git#v3) - MIT
+- [thenify-all@1.6.0](https://github.com/thenables/thenify-all) - MIT
+- [thenify@3.3.1](https://github.com/thenables/thenify) - MIT
+- [tinyexec@1.0.4](https://github.com/tinylibs/tinyexec) - MIT
+- [tinyglobby@0.2.15](https://github.com/SuperchupuDev/tinyglobby) - MIT
+- [tippy.js@6.3.7](https://github.com/atomiks/tippyjs) - MIT
+- [to-regex-range@5.0.1](https://github.com/micromatch/to-regex-range) - MIT
+- [ts-interface-checker@0.1.13](https://github.com/gristlabs/ts-interface-checker) - Apache-2.0
+- [tslib@2.3.0](https://github.com/Microsoft/tslib) - 0BSD
+- [tslib@2.8.1](https://github.com/Microsoft/tslib) - 0BSD
+- [typescript@5.9.3](https://github.com/microsoft/TypeScript) - Apache-2.0
+- [uc.micro@2.1.0](https://github.com/markdown-it/uc.micro) - MIT
+- [ufo@1.6.3](https://github.com/unjs/ufo) - MIT
+- [unimport@4.2.0](https://github.com/unjs/unimport) - MIT
+- [unplugin-auto-import@19.3.0](https://github.com/unplugin/unplugin-auto-import) - MIT
+- [unplugin-icons@22.5.0](https://github.com/unplugin/unplugin-icons) - MIT
+- [unplugin-utils@0.2.5](https://github.com/sxzz/unplugin-utils) - MIT
+- [unplugin-vue-components@28.8.0](https://github.com/unplugin/unplugin-vue-components) - MIT
+- [unplugin@2.3.11](https://github.com/unjs/unplugin) - MIT
+- [util-deprecate@1.0.2](https://github.com/TooTallNate/util-deprecate) - MIT
+- [vue-demi@0.14.10](https://github.com/antfu/vue-demi) - MIT
+- [vue-router@4.6.4](https://github.com/vuejs/router) - MIT
+- [vue@3.5.31](https://github.com/vuejs/core) - MIT
+- [w3c-keyname@2.2.8](https://github.com/marijnh/w3c-keyname) - MIT
+- [wcwidth@1.0.1](https://github.com/timoxley/wcwidth) - MIT
+- [webpack-virtual-modules@0.6.2](https://github.com/sysgears/webpack-virtual-modules) - MIT
+- [which-module@2.0.1](https://github.com/nexdrew/which-module) - ISC
+- [wrap-ansi@6.2.0](https://github.com/chalk/wrap-ansi) - MIT
+- [ws@8.18.3](https://github.com/websockets/ws) - MIT
+- [xmlhttprequest-ssl@2.1.2](https://github.com/mjwwit/node-XMLHttpRequest) - MIT
+- [y18n@4.0.3](https://github.com/yargs/y18n) - ISC
+- [yargs-parser@18.1.3](https://github.com/yargs/yargs-parser) - ISC
+- [yargs@15.4.1](https://github.com/yargs/yargs) - MIT
+- [zrender@5.6.1](https://github.com/ecomfe/zrender) - BSD-3-Clause
 
-Two properties keep that option cheap, and both should survive any future change here:
 
-- **The seam is one doc event.** `Razorpay Order.on_update` is the entire contract BenchPress
-  depends on. A fork, a vendored copy or a replacement gateway only has to keep a document whose
-  status becomes `Paid`.
-- **BenchPress does not trust its numbers.** `razorpay_frappe` exposes an open
-  `/razorpay-api/initiate-order` endpoint on which any logged-in caller names their own amount and
-  metadata, so settlement re-reads every price from BenchPress's own `Credit Pack` and
-  `Credit Settings` records and credits nothing unless the rupees paid match. Swapping the gateway
-  changes where a payment is confirmed, never what it is worth.
+## Metadata corrections
 
-### Transitive
+The tables above report what each package publishes in its own metadata. Two
+upstreams publish something incomplete or misleading; the authoritative license
+is the one in the license file each of them actually ships.
 
-`razorpay_frappe` depends on the official [`razorpay`](https://github.com/razorpay/razorpay-python)
-Python SDK (MIT). BenchPress never imports it directly.
-
-## vpn_management — required
-
-| | |
-|---|---|
-| Source | <https://github.com/Venkateshvenki404224/vpn_management> |
-| Licence | Same as BenchPress |
-| Required | Yes — listed in `required_apps`. |
-
-The entire VPN plane (peers, IP allocation, `wg-agent`) is delegated to it. Maintained alongside
-BenchPress, so it is a sibling rather than a third party in the usual sense; it is listed here
-because it is a separate installable app with its own repository.
+| Package | Reported above | Actual license | Source |
+|---|---|---|---|
+| `frappe` | UNKNOWN — publishes no license metadata | MIT | `apps/frappe/LICENSE` |
+| `qrcode` | `BSD License; Other/Proprietary License` | BSD 3-Clause | `qrcode-*.dist-info/LICENSE` |

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,52 @@
+# Trademark policy
+
+BenchPress is licensed under the GNU Affero General Public License v3.0 only. The
+AGPL is a **copyright** licence. It grants no rights in trademarks, and unlike
+Apache-2.0 §6 it contains no express trademark carve-out — so this file states
+the position explicitly rather than leaving it to be inferred.
+
+## Our marks
+
+The name **"BenchPress"**, the BenchPress logo, and the BenchPress wordmark
+(the "BenchPress Marks") are trademarks of Venkatesh. They are **not** licensed
+under the AGPL, and receiving a copy of this software grants you no right to use
+them.
+
+### What you may do without asking
+
+- Say truthfully that your product is built on, forked from, derived from,
+  compatible with, or integrates with BenchPress.
+- Use "BenchPress" in prose, documentation, blog posts, talks, and comparisons.
+- Keep the marks in place when you redistribute BenchPress **unmodified**.
+
+### What requires written permission
+
+- Using "BenchPress" (or a confusingly similar name) as the name of your
+  product, service, company, app, or hosted offering.
+- Using the BenchPress Marks in a domain name, social media handle, or paid
+  advertising.
+- Using the marks in a way that suggests your fork is the official BenchPress,
+  or that we endorse, sponsor, or maintain it.
+
+If you fork and modify BenchPress, the AGPL gives you every right to the code.
+Please give the result its own name.
+
+To request permission, open a discussion on the repository.
+
+## Frappe and ERPNext marks
+
+BenchPress builds on the Frappe Framework and provisions Frappe benches. It is
+an independent project. **"Frappe", "ERPNext", and the Frappe and ERPNext logos
+are trademarks of Frappe Technologies Pvt. Ltd.**, used here referentially to
+describe what this software does. BenchPress is not affiliated with, endorsed
+by, or sponsored by Frappe Technologies Pvt. Ltd.
+
+Per Frappe's trademark policy, this project therefore does not use "Frappe" or
+"ERPNext" in its product name, its domain names, or any paid advertising, and
+uses them only to state accurately what BenchPress runs.
+
+## Third-party marks
+
+All other product names, logos, and brands referenced in this repository or in
+[THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md) are the property of their
+respective owners.

--- a/benchpress/hooks.py
+++ b/benchpress/hooks.py
@@ -3,7 +3,7 @@ app_title = "BenchPress"
 app_publisher = "Venkatesh"
 app_description = "Press a button. Get a Frappe bench. Self-hosted, Docker-powered, VPN-secured."
 app_email = "venkateshvenki404224@gmail.com"
-app_license = "mit"
+app_license = "AGPL-3.0-only"
 app_logo_url = "/assets/benchpress/images/logo/favicon.svg"
 app_home = "/desk/benchpress"
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -597,7 +597,7 @@
   <div class="container">
     <div class="cta-card reveal">
       <h2>Ready to deploy?</h2>
-      <p>BenchPress is open source, MIT licensed, and built for the Frappe community.</p>
+      <p>BenchPress is free software, AGPL-3.0 licensed, and built for the Frappe community.</p>
       <div style="display:flex;gap:12px;justify-content:center;flex-wrap:wrap;">
         <a href="https://github.com/Venkateshvenki404224/benchpress" target="_blank" class="btn btn-primary">View on GitHub</a>
         <a href="https://github.com/Venkateshvenki404224/benchpress" target="_blank" class="btn btn-ghost">

--- a/docs/integration-notices.md
+++ b/docs/integration-notices.md
@@ -1,0 +1,63 @@
+# Integration notices
+
+Frappe apps and services BenchPress integrates with directly, and what our exposure to each one
+is. Hand-maintained, because it records judgement rather than metadata.
+
+The redistributed Python and npm dependency trees are a separate, generated list —
+[THIRD-PARTY-NOTICES.md](../THIRD-PARTY-NOTICES.md).
+
+## razorpay_frappe — optional
+
+| | |
+|---|---|
+| Source | <https://github.com/bwhtech/razorpay_frappe> |
+| Licence | MIT |
+| Used by | [benchpress/credits/payments.py](benchpress/credits/payments.py) |
+| Required | **No.** Deliberately absent from `required_apps` in [hooks.py](benchpress/hooks.py). |
+
+Provides the `Razorpay Order` and `Razorpay Settings` DocTypes, order creation, the checkout
+success/failure callbacks and webhook signature verification. BenchPress uses **Razorpay Orders
+only** — no Payment Links, no Subscriptions. Frappe v16 ships nothing of its own here: every
+built-in payment gateway was removed in v14 by
+`frappe/patches/v14_0/delete_payment_gateways.py`.
+
+### Why it is optional
+
+A self-hoster running BenchPress on their own hardware must never be made to install a payment
+processor to use it. The integration is gated on `payments.payments_available()`, which asks
+`frappe.get_installed_apps()`, and the only coupling is one `doc_events` entry on a DocType that
+simply does not exist on a site without the app — an inert hook rather than a broken one.
+
+### Maintenance exposure
+
+It is a small project (roughly a dozen stars and under a hundred commits at the time of writing)
+maintained by one author. That risk is accepted for a specific reason: the licence is MIT, so if
+it stops being maintained we may fork or vendor it outright without relicensing anything.
+
+Two properties keep that option cheap, and both should survive any future change here:
+
+- **The seam is one doc event.** `Razorpay Order.on_update` is the entire contract BenchPress
+  depends on. A fork, a vendored copy or a replacement gateway only has to keep a document whose
+  status becomes `Paid`.
+- **BenchPress does not trust its numbers.** `razorpay_frappe` exposes an open
+  `/razorpay-api/initiate-order` endpoint on which any logged-in caller names their own amount and
+  metadata, so settlement re-reads every price from BenchPress's own `Credit Pack` and
+  `Credit Settings` records and credits nothing unless the rupees paid match. Swapping the gateway
+  changes where a payment is confirmed, never what it is worth.
+
+### Transitive
+
+`razorpay_frappe` depends on the official [`razorpay`](https://github.com/razorpay/razorpay-python)
+Python SDK (MIT). BenchPress never imports it directly.
+
+## vpn_management — required
+
+| | |
+|---|---|
+| Source | <https://github.com/Venkateshvenki404224/vpn_management> |
+| Licence | Same as BenchPress |
+| Required | Yes — listed in `required_apps`. |
+
+The entire VPN plane (peers, IP allocation, `wg-agent`) is delegated to it. Maintained alongside
+BenchPress, so it is a sibling rather than a third party in the usual sense; it is listed here
+because it is a separate installable app with its own repository.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "frappe-ui-frontend",
+  "name": "benchpress-frontend",
   "private": true,
   "version": "0.0.0",
+  "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/license.txt
+++ b/license.txt
@@ -1,21 +1,661 @@
-MIT License
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Copyright (c) [year] [fullname]
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "benchpress",
       "version": "1.0.0",
       "hasInstallScript": true,
-      "license": "ISC",
+      "license": "AGPL-3.0-only",
       "devDependencies": {
         "@playwright/test": "^1.58.2"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "benchpress",
   "version": "1.0.0",
-  "description": "<div align=\"center\">",
+  "description": "Press a button. Get a Frappe bench. Self-hosted, Docker-powered, VPN-secured.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -14,8 +14,8 @@
     "url": "git+https://github.com/Venkateshvenki404224/benchpress.git"
   },
   "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "author": "Venkatesh",
+  "license": "AGPL-3.0-only",
   "type": "commonjs",
   "bugs": {
     "url": "https://github.com/Venkateshvenki404224/benchpress/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ authors = [
 description = "Press a button. Get a Frappe bench. Self-hosted, Docker-powered, VPN-secured."
 requires-python = ">=3.14"
 readme = "README.md"
+license = "AGPL-3.0-only"
+license-files = ["license.txt"]
 dynamic = ["version"]
 dependencies = [
     # "frappe~=16.0.0" # Installed and managed by bench.

--- a/scripts/generate-third-party-notices.sh
+++ b/scripts/generate-third-party-notices.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# Regenerates THIRD-PARTY-NOTICES.md from the installed dependency tree.
+#
+# The file is generated, never hand-edited: the published container image
+# redistributes third-party Python wheels and the built frontend bundle inlines
+# third-party JavaScript, so the notice list has to track what is actually
+# shipped rather than what someone remembered to write down.
+#
+# Run it inside the bench (the Python side reads the bench virtualenv):
+#
+#   docker compose exec backend bash -lc \
+#     'cd apps/benchpress && ./scripts/generate-third-party-notices.sh'
+#
+set -euo pipefail
+
+APP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT="${APP_DIR}/THIRD-PARTY-NOTICES.md"
+
+# Standard bench layout: apps/<app>/../../env is the bench virtualenv.
+BENCH_PYTHON="${BENCH_PYTHON:-${APP_DIR}/../../env/bin/python}"
+
+# pip-licenses and prettytable are reporting tooling, not shipped dependencies.
+REPORTING_ONLY="pip-licenses prettytable"
+
+# The apps themselves are covered by license.txt, not by a third-party notice.
+FIRST_PARTY="benchpress vpn_management"
+
+require_bench_python() {
+	if [ ! -x "${BENCH_PYTHON}" ]; then
+		echo "No bench virtualenv at ${BENCH_PYTHON}." >&2
+		echo "Run this inside the bench, or set BENCH_PYTHON." >&2
+		exit 1
+	fi
+}
+
+python_notices() {
+	"${BENCH_PYTHON}" -m pip install --quiet pip-licenses
+	"${BENCH_PYTHON}" -m piplicenses \
+		--format=markdown \
+		--order=license \
+		--with-urls \
+		--ignore-packages ${REPORTING_ONLY} ${FIRST_PARTY}
+	"${BENCH_PYTHON}" -m pip uninstall --quiet --yes ${REPORTING_ONLY}
+}
+
+# Frappe's container images install node through nvm, which a non-interactive
+# shell does not put on PATH.
+load_node() {
+	if ! command -v npx >/dev/null && [ -s "${HOME}/.nvm/nvm.sh" ]; then
+		# shellcheck disable=SC1091
+		. "${HOME}/.nvm/nvm.sh"
+	fi
+}
+
+javascript_notices() {
+	load_node
+	# --excludePrivatePackages drops our own frontend package, which is the only
+	# private one in a production tree.
+	(cd "${APP_DIR}/frontend" &&
+		npx --yes license-checker-rseidelsohn --production --markdown --excludePrivatePackages)
+}
+
+write_header() {
+	cat <<'HEADER'
+# Third-party notices
+
+BenchPress is distributed under the GNU Affero General Public License v3.0 only
+(see [license.txt](license.txt)). It bundles and redistributes the third-party
+components listed below, each under its own license.
+
+**This file is generated — do not edit it by hand.** Regenerate it with
+`./scripts/generate-third-party-notices.sh` whenever a dependency is added,
+removed, or upgraded.
+
+The full license text of every component is shipped alongside the component
+itself: Python packages carry theirs in `env/lib/python*/site-packages/*.dist-info/`
+inside the published container image, and JavaScript packages carry theirs in
+`node_modules/*/LICENSE`. To produce a single bundle of the full texts, run
+`pip-licenses --format=markdown --with-license-file` in the bench virtualenv.
+
+Frappe apps BenchPress integrates with — razorpay_frappe, vpn_management — are not dependency
+metadata and are documented by hand in
+[docs/integration-notices.md](docs/integration-notices.md).
+
+HEADER
+}
+
+# A handful of upstreams publish no license metadata, or publish a stray extra
+# classifier, so the generated tables above report the wrong thing for them.
+# Each correction below was read out of the shipped license file itself.
+write_corrections() {
+	cat <<'CORRECTIONS'
+
+## Metadata corrections
+
+The tables above report what each package publishes in its own metadata. Two
+upstreams publish something incomplete or misleading; the authoritative license
+is the one in the license file each of them actually ships.
+
+| Package | Reported above | Actual license | Source |
+|---|---|---|---|
+| `frappe` | UNKNOWN — publishes no license metadata | MIT | `apps/frappe/LICENSE` |
+| `qrcode` | `BSD License; Other/Proprietary License` | BSD 3-Clause | `qrcode-*.dist-info/LICENSE` |
+CORRECTIONS
+}
+
+require_bench_python
+
+{
+	write_header
+	echo "## Python dependencies"
+	echo
+	python_notices
+	echo
+	echo "## JavaScript dependencies (frontend, production only)"
+	echo
+	javascript_notices
+	write_corrections
+} >"${OUTPUT}"
+
+echo "Wrote ${OUTPUT}"


### PR DESCRIPTION
Phase 0 of the hosted-credits-and-landing plan. It was written first but never merged — PR #121 is titled *"phases zero to seven"* and its squash carried phases 1–7 only, so `version-16` still ships an unfilled MIT template and GitHub still reports the repository as **MIT**.

## What changes

| File | Change |
|---|---|
| `license.txt` | Complete verbatim AGPL v3 text, replacing an MIT template that still said `[year] [fullname]` |
| `benchpress/hooks.py` | `app_license = "AGPL-3.0-only"` |
| `pyproject.toml` | PEP 639 `license` + `license-files` (previously declared nothing) |
| `package.json`, `frontend/package.json` | `AGPL-3.0-only` (root claimed ISC, frontend claimed nothing) |
| `README.md`, `docs/index.html` | Badge and copy no longer say MIT |
| `THIRD-PARTY-NOTICES.md` | Generated dependency inventory, from the new `scripts/generate-third-party-notices.sh` |
| `docs/integration-notices.md` | **New.** The hand-written razorpay_frappe / vpn_management notes PR #121 put under the `THIRD-PARTY-NOTICES.md` name, moved so the generator can own its own output |
| `TRADEMARKS.md` | **New.** AGPL has no Apache-2.0 §6 trademark carve-out, so the position on the marks has to be stated |
| `.github/CLA.md` | **New.** A DCO grants no sublicensing right, so any file an outside contributor touched would become permanently un-relicensable |
| `.gitignore` | A missing newline had fused `.claude` and `benchpress/public/node_modules/` into one dead pattern |

## Held back

The CLA Assistant workflow and the fork-friendly CI deploy-key fallback from the original phase-0 commit are on `chore/relicense-agpl-full`. Pushing `.github/workflows/` needs a token with the `workflow` scope; run `gh auth refresh -h github.com -s workflow` and they can follow in a second PR.

## vpn_management

Relicensed separately in its own open PR — Venkateshvenki404224/vpn_management#14, checks green. That repo also carries a stray GPL-3 `LICENSE` next to `license.txt`; GitHub's detector prefers `LICENSE`, so it needs deleting or the badge will read GPL-3.0.

## Verified

`pre-commit run --from-ref 7c6f837 --to-ref HEAD` clean. No behaviour changes — no Python or Vue source is touched.