### PR TITLE
Staging bring-up: cut deploy from 701s to 60s, and fix ten defects it exposed

### DIFF
--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -3,6 +3,8 @@
 
 import frappe
 from frappe import _
+from frappe.query_builder import DocType
+from frappe.query_builder.functions import Count
 
 from benchpress import image_cache, lab_detail, lab_templates, labs
 from benchpress.credits import account, metering, payments
@@ -107,11 +109,33 @@ def get_benches() -> list[dict]:
 		order_by="creation desc",
 	)
 
+	names = [bench["name"] for bench in benches]
+	apps = _counts_by_bench("Bench App", "parent", names)
+	sites = _counts_by_bench("Bench Site", "bench", names)
 	for bench in benches:
-		bench["app_count"] = frappe.db.count("Bench App", {"parent": bench["name"]})
-		bench["site_count"] = frappe.db.count("Bench Site", {"bench": bench["name"]})
+		bench["app_count"] = apps.get(bench["name"], 0)
+		bench["site_count"] = sites.get(bench["name"], 0)
 
 	return benches
+
+
+def _counts_by_bench(doctype: str, column: str, bench_names: list[str]) -> dict[str, int]:
+	"""Rows per bench, grouped in one query.
+
+	Counted one bench at a time before, so an admin's list cost two queries per row — and every
+	deploy now writes a `Bench Site`, so that table is no longer small enough to ignore.
+	"""
+	if not bench_names:
+		return {}
+	table = DocType(doctype)
+	rows = (
+		frappe.qb.from_(table)
+		.select(table[column].as_("bench"), Count("*").as_("total"))
+		.where(table[column].isin(bench_names))
+		.groupby(table[column])
+		.run(as_dict=True)
+	)
+	return {row.bench: row.total for row in rows}
 
 
 @frappe.whitelist()
@@ -233,7 +257,10 @@ def _drop_bench_site_databases(bench) -> None:
 		return
 	from benchpress.mariadb_manager import drop_site_database
 
-	sites = frappe.get_list("Bench Site", filters={"bench": bench.name}, fields=["site_name", "full_domain"])
+	# `get_all`, not `get_list`: a teardown has to be exhaustive, and `Bench Site` is read
+	# `if_owner`, so an admin deleting somebody else's instance would silently skip their sites
+	# and leave the databases behind.
+	sites = frappe.get_all("Bench Site", filters={"bench": bench.name}, fields=["site_name", "full_domain"])
 	for site in sites:
 		try:
 			drop_site_database(bench.database_server, site.full_domain or site.site_name)

--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -173,12 +173,7 @@ def create_bench(data: str) -> dict:
 
 @frappe.whitelist()
 def bench_action(bench_name: str, action: str) -> dict:
-	from benchpress.docker_manager import (
-		remove_container,
-		restart_container,
-		start_container,
-		stop_container,
-	)
+	from benchpress.docker_manager import restart_container, start_container, stop_container
 
 	require_bench_access(bench_name)
 	if action == "delete" and not is_admin():
@@ -202,43 +197,55 @@ def bench_action(bench_name: str, action: str) -> dict:
 		# billable after — so this only starts a meter that was not already running.
 		metering.on_bench_running(bench)
 	elif action == "delete":
-		metering.on_bench_stopped(bench)
-		if bench.database_server:
-			from benchpress.mariadb_manager import drop_site_database
-
-			sites = frappe.get_list(
-				"Bench Site", filters={"bench": bench.name}, fields=["site_name", "full_domain"]
-			)
-			for s in sites:
-				try:
-					drop_site_database(bench.database_server, s.full_domain or s.site_name)
-				except Exception:
-					frappe.log_error(
-						title=f"Failed to drop DB for {s.site_name}", message=frappe.get_traceback()
-					)
-
-		if bench.container_id:
-			try:
-				stop_container(bench.container_id)
-			except Exception:
-				pass  # best-effort
-			remove_container(bench.container_id)
-
-		from benchpress.deploy_manager import remove_bench_volume
-		from benchpress.vpn_adapter import remove_bench_peer
-
-		remove_bench_volume(bench.bench_name)
-		remove_bench_peer(bench)
-
-		frappe.delete_doc("Bench Instance", bench_name, force=True)
-		frappe.db.commit()
-		return {"status": "deleted"}
+		return _delete_bench(bench)
 	else:
 		frappe.throw(_("Invalid action: {0}").format(action))
 
 	bench.save()
 	frappe.db.commit()
 	return {"name": bench.name, "status": bench.status}
+
+
+def _delete_bench(bench) -> dict:
+	"""Remove an instance and everything it owns, then the row itself.
+
+	The container, volume, site database and metering session are torn down by
+	`deploy_manager.teardown_bench` — the app's one teardown path, where every removal
+	is already best-effort. This used to repeat that logic here with `remove_container`
+	left unguarded, so a bench whose container was already gone raised `NotFound` before
+	the row was deleted: the delete could never succeed, and the phantom instance stayed
+	on screen forever.
+
+	Only the parts teardown does not cover are left here — the per-`Bench Site` databases,
+	the VPN peer, and the deletion.
+	"""
+	from benchpress.deploy_manager import teardown_bench
+	from benchpress.vpn_adapter import remove_bench_peer
+
+	teardown_bench(bench)
+	_drop_bench_site_databases(bench)
+	remove_bench_peer(bench)
+	# Before the instance, not after: `force=True` skips Frappe's link check, so these rows
+	# would survive as orphans pointing at an instance that no longer exists.
+	for site in frappe.get_all("Bench Site", filters={"bench": bench.name}, pluck="name"):
+		frappe.delete_doc("Bench Site", site, force=True, ignore_permissions=True)
+	frappe.delete_doc("Bench Instance", bench.name, force=True)
+	frappe.db.commit()
+	return {"status": "deleted"}
+
+
+def _drop_bench_site_databases(bench) -> None:
+	"""Drop the database behind every extra site on this bench, one failure at a time."""
+	if not bench.database_server:
+		return
+	from benchpress.mariadb_manager import drop_site_database
+
+	sites = frappe.get_list("Bench Site", filters={"bench": bench.name}, fields=["site_name", "full_domain"])
+	for site in sites:
+		try:
+			drop_site_database(bench.database_server, site.full_domain or site.site_name)
+		except Exception:
+			frappe.log_error(title=f"Failed to drop DB for {site.site_name}", message=frappe.get_traceback())
 
 
 @frappe.whitelist()

--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -209,15 +209,9 @@ def bench_action(bench_name: str, action: str) -> dict:
 def _delete_bench(bench) -> dict:
 	"""Remove an instance and everything it owns, then the row itself.
 
-	The container, volume, site database and metering session are torn down by
-	`deploy_manager.teardown_bench` — the app's one teardown path, where every removal
-	is already best-effort. This used to repeat that logic here with `remove_container`
-	left unguarded, so a bench whose container was already gone raised `NotFound` before
-	the row was deleted: the delete could never succeed, and the phantom instance stayed
-	on screen forever.
-
-	Only the parts teardown does not cover are left here — the per-`Bench Site` databases,
-	the VPN peer, and the deletion.
+	Container, volume, site database and metering session go through
+	`deploy_manager.teardown_bench`, the one teardown path, where every removal is
+	best-effort. Only what it does not cover is left here.
 	"""
 	from benchpress.deploy_manager import teardown_bench
 	from benchpress.vpn_adapter import remove_bench_peer
@@ -225,8 +219,7 @@ def _delete_bench(bench) -> dict:
 	teardown_bench(bench)
 	_drop_bench_site_databases(bench)
 	remove_bench_peer(bench)
-	# Before the instance, not after: `force=True` skips Frappe's link check, so these rows
-	# would survive as orphans pointing at an instance that no longer exists.
+	# Before the instance: `force=True` skips the link check, so these would orphan.
 	for site in frappe.get_all("Bench Site", filters={"bench": bench.name}, pluck="name"):
 		frappe.delete_doc("Bench Site", site, force=True, ignore_permissions=True)
 	frappe.delete_doc("Bench Instance", bench.name, force=True)

--- a/benchpress/benchpress/doctype/credit_account/credit_account.json
+++ b/benchpress/benchpress/doctype/credit_account/credit_account.json
@@ -138,10 +138,6 @@
    "role": "BenchPress Admin",
    "share": 1,
    "write": 1
-  },
-  {
-   "read": 1,
-   "role": "BenchPress User"
   }
  ],
  "row_format": "Dynamic",

--- a/benchpress/benchpress/doctype/credit_ledger_entry/credit_ledger_entry.json
+++ b/benchpress/benchpress/doctype/credit_ledger_entry/credit_ledger_entry.json
@@ -116,10 +116,6 @@
    "report": 1,
    "role": "BenchPress Admin",
    "share": 1
-  },
-  {
-   "read": 1,
-   "role": "BenchPress User"
   }
  ],
  "row_format": "Dynamic",

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -3,6 +3,7 @@
 
 import json
 import secrets
+import shlex
 
 import frappe
 from frappe.utils.file_lock import LockTimeoutError
@@ -295,9 +296,12 @@ def _deploy_bench(bench_name: str) -> None:
 		pipeline.step("code_server")
 
 		# After linkuser.sh, not after site creation: that renames the bench user, and
-		# `usermod --login` refuses to rename a user owning a running process.
+		# `usermod --login` refuses to rename a user owning a running process. The account is
+		# named here rather than derived inside the container from a path the tenant owns.
 		exit_code, output = exec_in_container(
-			container_id, "bash /opt/benchpress/scripts/serve.sh", user="root"
+			container_id,
+			f"bash /opt/benchpress/scripts/serve.sh {shlex.quote(bench.ssh_username)}",
+			user="root",
 		)
 		if exit_code != 0:
 			raise Exception(f"serve.sh failed (exit {exit_code}): {output}")
@@ -370,6 +374,10 @@ def _record_primary_site(bench, lab, admin_password: str) -> None:
 	"""Record the deploy's site as a `Bench Site`, which is what every site list reads.
 
 	Idempotent: a deploy re-runs, so an existing row is refreshed rather than duplicated.
+
+	The owner is pinned to the bench's owner rather than left to the session: `Bench Site` grants
+	`BenchPress User` read `if_owner`, so an admin redeploying somebody else's instance would
+	take the row over and empty that tenant's Sites tab.
 	"""
 	existing = frappe.db.get_value("Bench Site", {"bench": bench.name, "site_name": bench.site_name})
 	site = frappe.get_doc("Bench Site", existing) if existing else frappe.new_doc("Bench Site")
@@ -378,6 +386,7 @@ def _record_primary_site(bench, lab, admin_password: str) -> None:
 	site.full_domain = bench.site_name
 	site.status = "Active"
 	site.admin_password = admin_password
+	site.owner = bench.owner
 	site.apps_installed = []
 	for app in _site_app_names(lab):
 		site.append("apps_installed", {"app_name": app})
@@ -501,9 +510,11 @@ def teardown_bench(bench) -> None:
 
 
 def _deactivate_bench_sites(bench) -> None:
-	"""Mark every `Bench Site` on this instance Inactive, since its data is gone."""
-	for name in frappe.get_all("Bench Site", filters={"bench": bench.name}, pluck="name"):
-		frappe.db.set_value("Bench Site", name, "status", "Inactive", update_modified=False)
+	"""Mark every `Bench Site` on this instance Inactive, since its data is gone.
+
+	One UPDATE: `set_value` takes the filter itself, so the row names never have to be read.
+	"""
+	frappe.db.set_value("Bench Site", {"bench": bench.name}, "status", "Inactive", update_modified=False)
 
 
 def _drop_site_database(bench) -> None:
@@ -596,12 +607,18 @@ def _run_build(lab, user: str) -> str:
 	"""Build the image into its own log, mark that log's outcome, return the tag.
 
 	Re-raises, so a deploy that needed the image fails with it.
+
+	A failure puts the lab's status back the way it was found. `Lab` is one admin-authored row
+	every tenant reads, and `_build_lab_with_logs` moves it to Building before it starts, so a
+	tenant whose deploy had to build would otherwise leave the whole catalog reading Error.
+	`build_lab`, the admin's own rebuild, is what records Error there.
 	"""
+	status_before = lab.status
 	append_log, build_log_name = _open_build_log(lab, user)
 	try:
 		_build_lab_with_logs(lab, append_log)
 	except Exception as e:
-		frappe.db.set_value("Lab", lab.name, "status", "Error")
+		frappe.db.set_value("Lab", lab.name, "status", status_before)
 		append_log(f"=== Build failed: {e!s} ===", "error")
 		frappe.db.set_value("Build Log", build_log_name, "log_type", "error")
 		frappe.db.commit()  # nosemgrep -- the run's outcome must survive its failure
@@ -629,6 +646,9 @@ def build_lab(lab_name: str) -> None:
 	try:
 		image_tag = _run_build(lab, lab.owner)
 	except Exception:
+		# The admin asked for this build, so the catalog is the right place to record that it broke.
+		frappe.db.set_value("Lab", lab_name, "status", "Error")
+		frappe.db.commit()  # nosemgrep -- the run is over; its verdict must survive the failure
 		_notify_owner(lab.owner, f"Lab build failed: {lab.title}", "Lab", lab_name)
 		return
 	_notify_owner(lab.owner, f"Lab build complete: {lab.title} ({image_tag})", "Lab", lab_name)

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -52,11 +52,9 @@ def _remove_stale_container(bench) -> None:
 
 NOTHING_TO_ROLL_BACK = "Cleanup: nothing to roll back — no container was created"
 
-# Where a lab's site answers. `frontend/src/utils/labActions.js` builds the URL the
-# user clicks from the same number, so the two must not drift.
+# Kept in step with `frontend/src/utils/labActions.js`, which builds the URL from it.
 SITE_HTTP_PORT = 8000
 
-# What `scripts/setup-site.sh` prints when it finds the site already on the data volume.
 ADOPTED_MARKER = "already exists — adopting it"
 
 
@@ -270,9 +268,6 @@ def _deploy_bench(bench_name: str) -> None:
 		)
 		if exit_code != 0:
 			raise Exception(f"Site setup failed (exit {exit_code}): {output}")
-		# Reports which of the two the script did rather than predicting one: a deploy
-		# preserves the data volume, so an instance deployed before already has its site
-		# and setup-site.sh adopts it instead of creating it.
 		pipeline.log("Existing site adopted" if ADOPTED_MARKER in output else "Site created successfully")
 		_record_primary_site(bench, lab, admin_password)
 
@@ -299,17 +294,8 @@ def _deploy_bench(bench_name: str) -> None:
 		# to skip is information, and a stepper missing its tenth row is not.
 		pipeline.step("code_server")
 
-		# The container's entrypoint starts redis, sshd, code-server and the tunnel, but
-		# it runs long before the site exists, so nothing had ever served it: a finished
-		# deploy handed the user a Site URL that refused the connection. It waits until
-		# here rather than following site creation because `linkuser.sh` above renames
-		# the bench user, and `usermod --login` refuses to rename a user that owns a
-		# running process.
-		# The exit code is checked, unlike the code-server start below it: a deploy that
-		# cannot serve the site has not produced a usable lab, and reporting "Site served"
-		# regardless is worse than failing — that is exactly what an image predating
-		# serve.sh did, leaving a Running instance whose own Site URL refused every
-		# connection.
+		# After linkuser.sh, not after site creation: that renames the bench user, and
+		# `usermod --login` refuses to rename a user owning a running process.
 		exit_code, output = exec_in_container(
 			container_id, "bash /opt/benchpress/scripts/serve.sh", user="root"
 		)
@@ -381,16 +367,9 @@ def _deploy_bench(bench_name: str) -> None:
 
 
 def _record_primary_site(bench, lab, admin_password: str) -> None:
-	"""Give the site the deploy just made a `Bench Site` row, so a screen can see it.
+	"""Record the deploy's site as a `Bench Site`, which is what every site list reads.
 
-	The deploy creates a real site inside the container but used to record it nowhere except
-	`Bench Instance.site_name`. Every screen that lists sites reads `Bench Site`, so a lab's
-	own site was invisible — the Sites tab said "No site yet" about a site that was serving
-	requests. Only extra sites added through `api.create_site` ever appeared.
-
-	Idempotent, because a deploy re-runs over an instance that already has its row: the
-	existing row is refreshed rather than duplicated, which also keeps the stored admin
-	password in step with the one this run just set on the site.
+	Idempotent: a deploy re-runs, so an existing row is refreshed rather than duplicated.
 	"""
 	existing = frappe.db.get_value("Bench Site", {"bench": bench.name, "site_name": bench.site_name})
 	site = frappe.get_doc("Bench Site", existing) if existing else frappe.new_doc("Bench Site")
@@ -403,9 +382,8 @@ def _record_primary_site(bench, lab, admin_password: str) -> None:
 	for app in _site_app_names(lab):
 		site.append("apps_installed", {"app_name": app})
 	site.save(ignore_permissions=True)
-	# Deliberately no commit: the next log line commits, so the row lands within a second
-	# anyway, and committing here made this row durable inside tests whose rollback then
-	# discarded the parent Bench Instance — leaving orphan sites on the dev site.
+	# No commit: the next log line commits, and committing here outlives a test rollback
+	# that discards the parent instance.
 
 
 def _site_app_names(lab) -> list[str]:
@@ -417,14 +395,8 @@ def _site_app_names(lab) -> list[str]:
 def _ensure_assets(container_id: str, bench_dir: str, lab, pipeline) -> None:
 	"""Bundle the apps the image did not already bundle — normally none of them.
 
-	The image build runs `bench build`, so a deploy has nothing to do here. Running it
-	again inside the instance rebuilt identical bundles under the instance's memory cap,
-	where esbuild thrashes on page-cache eviction: 623 seconds of one 700-second deploy,
-	and an OOM kill on a 512m lab.
-
-	It is still asked of the container rather than assumed from the Dockerfile. The image
-	cache is keyed by the build spec, which the Dockerfile is not part of, so an image
-	built before assets moved into it keeps its hash and must still build here.
+	Asked of the container, not assumed from the Dockerfile: the cache key does not cover
+	the Dockerfile, so an image built before assets moved into it must still build here.
 	"""
 	missing = sorted(_asset_app_names(lab) - _bundled_apps(container_id, bench_dir))
 	if not missing:
@@ -441,11 +413,10 @@ def _asset_app_names(lab) -> set[str]:
 
 
 def _bundled_apps(container_id: str, bench_dir: str) -> set[str]:
-	"""Apps that already carry a bundle, read in one exec and never interpolating a name.
+	"""Apps that already carry a bundle, in one exec.
 
-	`sites/assets/<app>/dist` is what `bench build` produces per app, so its presence is
-	the question. The glob is expanded by the container's own shell — an app name from a
-	Lab row is caller-supplied and has no business inside a command string.
+	The glob is expanded by the container's shell: app names come from a Lab row and must
+	never be interpolated into a command string.
 	"""
 	exit_code, output = exec_in_container(
 		container_id, "ls -d sites/assets/*/dist 2>/dev/null", user="frappe", workdir=bench_dir
@@ -512,9 +483,8 @@ def teardown_bench(bench) -> None:
 
 	remove_bench_volume(bench.name)
 	_drop_site_database(bench)
-	# The volume and the database are gone, so the rows describing this bench's sites now
-	# describe nothing. Marked, not deleted: a redeploy refreshes them back to Active, and
-	# the reaper leaves the instance one click from running.
+	# Marked, not deleted: a redeploy refreshes them, and the reaper leaves the instance
+	# one click from running.
 	_deactivate_bench_sites(bench)
 
 	# The container this bench was burning for is gone, so the session ends here. Without

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -52,6 +52,13 @@ def _remove_stale_container(bench) -> None:
 
 NOTHING_TO_ROLL_BACK = "Cleanup: nothing to roll back — no container was created"
 
+# Where a lab's site answers. `frontend/src/utils/labActions.js` builds the URL the
+# user clicks from the same number, so the two must not drift.
+SITE_HTTP_PORT = 8000
+
+# What `scripts/setup-site.sh` prints when it finds the site already on the data volume.
+ADOPTED_MARKER = "already exists — adopting it"
+
 
 def _cleanup_failed_deploy(bench, container_id, append_log) -> None:
 	"""Best-effort teardown of resources created by this failed run.
@@ -246,7 +253,7 @@ def _deploy_bench(bench_name: str) -> None:
 			"redis_queue": "redis://benchpress-redis:6379/1",
 			"redis_socketio": "redis://benchpress-redis:6379/2",
 			"socketio_port": 9000,
-			"webserver_port": 8000,
+			"webserver_port": SITE_HTTP_PORT,
 			"default_site": site_name,
 		}
 		pipeline.step("site_config")
@@ -257,17 +264,20 @@ def _deploy_bench(bench_name: str) -> None:
 
 		pipeline.step("site")
 		apps_csv = ",".join(a.app_name for a in lab.apps if a.app_name.lower() != "frappe")
-		pipeline.log(f"bench new-site {site_name} --install-app {apps_csv or 'frappe'}")
+		pipeline.log(f"Site {site_name} with {apps_csv or 'frappe'}")
 		exit_code, output = create_site_in_container(
 			container_id, db_server, site_name, admin_password, apps_csv
 		)
 		if exit_code != 0:
-			raise Exception(f"bench new-site failed (exit {exit_code}): {output}")
-		pipeline.log("Site created successfully")
+			raise Exception(f"Site setup failed (exit {exit_code}): {output}")
+		# Reports which of the two the script did rather than predicting one: a deploy
+		# preserves the data volume, so an instance deployed before already has its site
+		# and setup-site.sh adopts it instead of creating it.
+		pipeline.log("Existing site adopted" if ADOPTED_MARKER in output else "Site created successfully")
+		_record_primary_site(bench, lab, admin_password)
 
 		pipeline.step("assets")
-		exec_in_container(container_id, "bench build", user="frappe", workdir=bench_dir)
-		pipeline.log("bench build finished")
+		_ensure_assets(container_id, bench_dir, lab, pipeline)
 
 		if not bench.ssh_username:
 			bench.ssh_username = bench._derive_username(bench.owner)
@@ -288,6 +298,25 @@ def _deploy_bench(bench_name: str) -> None:
 		# Emitted even when the lab has code-server off: a step the run decided
 		# to skip is information, and a stepper missing its tenth row is not.
 		pipeline.step("code_server")
+
+		# The container's entrypoint starts redis, sshd, code-server and the tunnel, but
+		# it runs long before the site exists, so nothing had ever served it: a finished
+		# deploy handed the user a Site URL that refused the connection. It waits until
+		# here rather than following site creation because `linkuser.sh` above renames
+		# the bench user, and `usermod --login` refuses to rename a user that owns a
+		# running process.
+		# The exit code is checked, unlike the code-server start below it: a deploy that
+		# cannot serve the site has not produced a usable lab, and reporting "Site served"
+		# regardless is worse than failing — that is exactly what an image predating
+		# serve.sh did, leaving a Running instance whose own Site URL refused every
+		# connection.
+		exit_code, output = exec_in_container(
+			container_id, "bash /opt/benchpress/scripts/serve.sh", user="root"
+		)
+		if exit_code != 0:
+			raise Exception(f"serve.sh failed (exit {exit_code}): {output}")
+		pipeline.log(f"Site served on port {SITE_HTTP_PORT}")
+
 		if getattr(lab, "enable_code_server", 0):
 			cs_user = bench.ssh_username
 			cs_home = f"/home/{cs_user}"
@@ -351,6 +380,81 @@ def _deploy_bench(bench_name: str) -> None:
 		_notify_owner(bench.owner, f"Bench deploy failed: {bench.bench_name}", "Bench Instance", bench.name)
 
 
+def _record_primary_site(bench, lab, admin_password: str) -> None:
+	"""Give the site the deploy just made a `Bench Site` row, so a screen can see it.
+
+	The deploy creates a real site inside the container but used to record it nowhere except
+	`Bench Instance.site_name`. Every screen that lists sites reads `Bench Site`, so a lab's
+	own site was invisible — the Sites tab said "No site yet" about a site that was serving
+	requests. Only extra sites added through `api.create_site` ever appeared.
+
+	Idempotent, because a deploy re-runs over an instance that already has its row: the
+	existing row is refreshed rather than duplicated, which also keeps the stored admin
+	password in step with the one this run just set on the site.
+	"""
+	existing = frappe.db.get_value("Bench Site", {"bench": bench.name, "site_name": bench.site_name})
+	site = frappe.get_doc("Bench Site", existing) if existing else frappe.new_doc("Bench Site")
+	site.bench = bench.name
+	site.site_name = bench.site_name
+	site.full_domain = bench.site_name
+	site.status = "Active"
+	site.admin_password = admin_password
+	site.apps_installed = []
+	for app in _site_app_names(lab):
+		site.append("apps_installed", {"app_name": app})
+	site.save(ignore_permissions=True)
+	# Deliberately no commit: the next log line commits, so the row lands within a second
+	# anyway, and committing here made this row durable inside tests whose rollback then
+	# discarded the parent Bench Instance — leaving orphan sites on the dev site.
+
+
+def _site_app_names(lab) -> list[str]:
+	"""The apps this site was created with — frappe first, then the lab's own, in order."""
+	extras = [row.app_name for row in (lab.apps or []) if row.app_name and row.app_name.lower() != "frappe"]
+	return ["frappe", *extras]
+
+
+def _ensure_assets(container_id: str, bench_dir: str, lab, pipeline) -> None:
+	"""Bundle the apps the image did not already bundle — normally none of them.
+
+	The image build runs `bench build`, so a deploy has nothing to do here. Running it
+	again inside the instance rebuilt identical bundles under the instance's memory cap,
+	where esbuild thrashes on page-cache eviction: 623 seconds of one 700-second deploy,
+	and an OOM kill on a 512m lab.
+
+	It is still asked of the container rather than assumed from the Dockerfile. The image
+	cache is keyed by the build spec, which the Dockerfile is not part of, so an image
+	built before assets moved into it keeps its hash and must still build here.
+	"""
+	missing = sorted(_asset_app_names(lab) - _bundled_apps(container_id, bench_dir))
+	if not missing:
+		pipeline.log("Assets already bundled in the image — no build needed")
+		return
+	pipeline.log(f"bench build — no bundle in the image for: {', '.join(missing)}")
+	exec_in_container(container_id, "bench build", user="frappe", workdir=bench_dir)
+	pipeline.log("bench build finished")
+
+
+def _asset_app_names(lab) -> set[str]:
+	"""Every app whose bundle this instance serves. Frappe is always one of them."""
+	return {"frappe"} | {row.app_name.strip().lower() for row in (lab.apps or []) if row.app_name}
+
+
+def _bundled_apps(container_id: str, bench_dir: str) -> set[str]:
+	"""Apps that already carry a bundle, read in one exec and never interpolating a name.
+
+	`sites/assets/<app>/dist` is what `bench build` produces per app, so its presence is
+	the question. The glob is expanded by the container's own shell — an app name from a
+	Lab row is caller-supplied and has no business inside a command string.
+	"""
+	exit_code, output = exec_in_container(
+		container_id, "ls -d sites/assets/*/dist 2>/dev/null", user="frappe", workdir=bench_dir
+	)
+	if exit_code != 0:
+		return set()
+	return {path.split("/")[2] for path in output.split() if path.count("/") == 3}
+
+
 def _setup_container_vpn(bench, container_id: str, pipeline) -> None:
 	"""Replace any stale peer, claim a fresh tunnel IP, and configure the container.
 
@@ -408,6 +512,10 @@ def teardown_bench(bench) -> None:
 
 	remove_bench_volume(bench.name)
 	_drop_site_database(bench)
+	# The volume and the database are gone, so the rows describing this bench's sites now
+	# describe nothing. Marked, not deleted: a redeploy refreshes them back to Active, and
+	# the reaper leaves the instance one click from running.
+	_deactivate_bench_sites(bench)
 
 	# The container this bench was burning for is gone, so the session ends here. Without
 	# this the burning flag would survive the teardown and the fresh container — which
@@ -420,6 +528,12 @@ def teardown_bench(bench) -> None:
 	bench.started_at = None
 	bench.save(ignore_permissions=True)
 	frappe.db.commit()  # nosemgrep -- the caller may redeploy next, which must see Draft
+
+
+def _deactivate_bench_sites(bench) -> None:
+	"""Mark every `Bench Site` on this instance Inactive, since its data is gone."""
+	for name in frappe.get_all("Bench Site", filters={"bench": bench.name}, pluck="name"):
+		frappe.db.set_value("Bench Site", name, "status", "Inactive", update_modified=False)
 
 
 def _drop_site_database(bench) -> None:

--- a/benchpress/deploy_pipeline.py
+++ b/benchpress/deploy_pipeline.py
@@ -46,9 +46,14 @@ DEPLOY_STEPS = (
 	DeployStep("vpn_peer", "Configuring the WireGuard peer"),
 	DeployStep("site_config", "Writing common_site_config.json"),
 	DeployStep("site", "Creating the site"),
-	DeployStep("assets", "Building assets"),
+	# "Preparing", not "Building": the image now carries the bundles, so this step
+	# normally checks and skips. Mirrored in `frontend/src/utils/deploySteps.js`.
+	DeployStep("assets", "Preparing assets"),
 	DeployStep("ssh_user", "Provisioning the SSH user"),
-	DeployStep("code_server", "Provisioning code-server"),
+	# Serves the site as well as code-server. The key is what `parse_step_line`
+	# matches, so relabelling is safe: a stored run's label is read back from its
+	# own line, never from this tuple.
+	DeployStep("code_server", "Starting the lab's services"),
 	DeployStep("complete", "Deploy complete"),
 )
 

--- a/benchpress/deploy_pipeline.py
+++ b/benchpress/deploy_pipeline.py
@@ -46,13 +46,8 @@ DEPLOY_STEPS = (
 	DeployStep("vpn_peer", "Configuring the WireGuard peer"),
 	DeployStep("site_config", "Writing common_site_config.json"),
 	DeployStep("site", "Creating the site"),
-	# "Preparing", not "Building": the image now carries the bundles, so this step
-	# normally checks and skips. Mirrored in `frontend/src/utils/deploySteps.js`.
 	DeployStep("assets", "Preparing assets"),
 	DeployStep("ssh_user", "Provisioning the SSH user"),
-	# Serves the site as well as code-server. The key is what `parse_step_line`
-	# matches, so relabelling is safe: a stored run's label is read back from its
-	# own line, never from this tuple.
 	DeployStep("code_server", "Starting the lab's services"),
 	DeployStep("complete", "Deploy complete"),
 )

--- a/benchpress/hooks.py
+++ b/benchpress/hooks.py
@@ -127,16 +127,26 @@ after_install = "benchpress.install.after_install"
 # -----------
 # Permissions evaluated in scripted ways
 
+# Every tenant-owned doctype needs BOTH dicts. `permission_query_conditions` has only two
+# consumers, both in the list engine, so a single-document read never consults it — and with no
+# `has_permission` hook registered Frappe's controller check returns True and the role grant alone
+# decides, which covers the whole table. `test_doctype_scoping` fails when a doctype has one half
+# without the other.
 permission_query_conditions = {
 	"Bench Instance": "benchpress.permissions.bench_instance_query_conditions",
 	"Deploy Log": "benchpress.permissions.deploy_log_query_conditions",
+	"Build Log": "benchpress.permissions.build_log_query_conditions",
 	"Credit Account": "benchpress.permissions.credit_account_query_conditions",
 	"Credit Ledger Entry": "benchpress.permissions.credit_ledger_query_conditions",
 }
 
-# has_permission = {
-# 	"Event": "frappe.desk.doctype.event.event.has_permission",
-# }
+# Not the `has_permission` key inside `add_to_apps_screen` above — that one gates the apps screen.
+has_permission = {
+	"Credit Account": "benchpress.permissions.credit_account_has_permission",
+	"Credit Ledger Entry": "benchpress.permissions.credit_ledger_has_permission",
+	"Deploy Log": "benchpress.permissions.deploy_log_has_permission",
+	"Build Log": "benchpress.permissions.build_log_has_permission",
+}
 
 # DocType Class
 # ---------------

--- a/benchpress/indexes.py
+++ b/benchpress/indexes.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""Composite indexes the DocType JSONs cannot declare.
+
+`search_index` on a field produces a single-column index only, and Frappe does not index Link
+fields on its own — so every filter below was a full table scan. Each index here is named by the
+query that needs it; `add_index` is idempotent, so this is safe on every install and from a patch.
+"""
+
+import frappe
+
+
+def ensure_indexes() -> None:
+	ensure_lab_index()
+	ensure_bench_site_index()
+	ensure_log_indexes()
+
+
+def ensure_lab_index() -> None:
+	"""`lab_templates._labs_by_template`: the newest lab per template, on every Templates load.
+
+	Filtering on `template` and sorting by `creation` was a scan plus a filesort of the whole
+	table to produce one row per template.
+	"""
+	frappe.db.add_index("Lab", ["template", "creation"])
+
+
+def ensure_bench_site_index() -> None:
+	"""Everything that reads a bench's sites, which is now every deploy.
+
+	`_record_primary_site` looks a row up by exactly this pair, and the `bench` prefix serves the
+	site counts, the Sites tab, the teardown sweep and the database drop.
+	"""
+	frappe.db.add_index("Bench Site", ["bench", "site_name"])
+
+
+def ensure_log_indexes() -> None:
+	"""The two log tables, each read by its scoping column and shown newest first.
+
+	`Build Log` is read by lab on the lab page and by owner in the run history, and its owner is
+	now also its permission rule, so both orders earn an index. `Deploy Log` is only ever read
+	one bench at a time.
+	"""
+	frappe.db.add_index("Build Log", ["lab", "owner"])
+	frappe.db.add_index("Build Log", ["owner", "timestamp"])
+	frappe.db.add_index("Deploy Log", ["bench", "timestamp"])

--- a/benchpress/install.py
+++ b/benchpress/install.py
@@ -7,6 +7,7 @@ import subprocess
 import frappe
 
 from benchpress.credits.seed import seed_defaults
+from benchpress.indexes import ensure_indexes
 from benchpress.vpn_access import grant_vpn_access
 
 
@@ -25,6 +26,7 @@ def after_install():
 
 	# Same reason: seed_credit_config would never fire on a fresh install.
 	seed_defaults()
+	ensure_indexes()
 
 	# setup.sh requires host-level access (docker group, sysctl, sudoers).
 	# Skip it when running inside a container.

--- a/benchpress/lab-templates/Dockerfile
+++ b/benchpress/lab-templates/Dockerfile
@@ -48,13 +48,8 @@ WORKDIR /home/frappe/frappe-bench
 ARG APPS_JSON=[]
 RUN /opt/benchpress/scripts/install-apps.sh "$APPS_JSON"
 
-# --- Layer 5: Bundle every app's assets into the image ---
-# `bench init` builds frappe's bundles, but install-apps.sh passes
-# `--skip-assets`, so each extra app arrived without one. The deploy made that up
-# by running `bench build` inside the freshly started instance — the same build,
-# repeated for every instance of the same recipe, under that instance's memory
-# cap, where esbuild thrashes: 623 of one 700-second deploy. Building here runs
-# it once per image spec, which is what the shared image cache exists for.
+# --- Layer 5: Bundle every app's assets, once per image ---
+# install-apps.sh passes --skip-assets, so only frappe's bundles come from bench init.
 RUN bench build --production
 
 USER root

--- a/benchpress/lab-templates/Dockerfile
+++ b/benchpress/lab-templates/Dockerfile
@@ -48,6 +48,15 @@ WORKDIR /home/frappe/frappe-bench
 ARG APPS_JSON=[]
 RUN /opt/benchpress/scripts/install-apps.sh "$APPS_JSON"
 
+# --- Layer 5: Bundle every app's assets into the image ---
+# `bench init` builds frappe's bundles, but install-apps.sh passes
+# `--skip-assets`, so each extra app arrived without one. The deploy made that up
+# by running `bench build` inside the freshly started instance — the same build,
+# repeated for every instance of the same recipe, under that instance's memory
+# cap, where esbuild thrashes: 623 of one 700-second deploy. Building here runs
+# it once per image spec, which is what the shared image cache exists for.
+RUN bench build --production
+
 USER root
 
 EXPOSE 8000 9000 22 8080

--- a/benchpress/lab-templates/scripts/entry.sh
+++ b/benchpress/lab-templates/scripts/entry.sh
@@ -21,5 +21,14 @@ if [ -f "/etc/wireguard/wg0.conf" ]; then
     wg-quick up wg0 || true
 fi
 
+# Only on a restart: on first boot there is no site yet, and the deploy starts
+# the server itself once `bench new-site` has run. Without this a stopped-then-
+# started instance came back with SSH and code-server but nothing on port 8000,
+# which is the address its own Lab page hands the user.
+if compgen -G "/home/frappe/frappe-bench/sites/*/site_config.json" > /dev/null; then
+    echo "[*] Serving the site..."
+    /opt/benchpress/scripts/serve.sh || true
+fi
+
 echo "[*] Services ready."
 exec tail -f /dev/null

--- a/benchpress/lab-templates/scripts/entry.sh
+++ b/benchpress/lab-templates/scripts/entry.sh
@@ -21,10 +21,8 @@ if [ -f "/etc/wireguard/wg0.conf" ]; then
     wg-quick up wg0 || true
 fi
 
-# Only on a restart: on first boot there is no site yet, and the deploy starts
-# the server itself once `bench new-site` has run. Without this a stopped-then-
-# started instance came back with SSH and code-server but nothing on port 8000,
-# which is the address its own Lab page hands the user.
+# Restart path only: on first boot the deploy starts the server itself, once the
+# site exists.
 if compgen -G "/home/frappe/frappe-bench/sites/*/site_config.json" > /dev/null; then
     echo "[*] Serving the site..."
     /opt/benchpress/scripts/serve.sh || true

--- a/benchpress/lab-templates/scripts/entry.sh
+++ b/benchpress/lab-templates/scripts/entry.sh
@@ -21,9 +21,10 @@ if [ -f "/etc/wireguard/wg0.conf" ]; then
     wg-quick up wg0 || true
 fi
 
-# Restart path only: on first boot the deploy starts the server itself, once the
-# site exists.
-if compgen -G "/home/frappe/frappe-bench/sites/*/site_config.json" > /dev/null; then
+# Restart path only: on first boot the deploy starts the server itself, once the site exists.
+# Gated on the root-written config as well as the site, so a container that has never been
+# through a deploy does not start running code out of the mounted volume.
+if [ -f /.benchpress_config ] && compgen -G "/home/frappe/frappe-bench/sites/*/site_config.json" > /dev/null; then
     echo "[*] Serving the site..."
     /opt/benchpress/scripts/serve.sh || true
 fi

--- a/benchpress/lab-templates/scripts/serve.sh
+++ b/benchpress/lab-templates/scripts/serve.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Serve the lab's site on port 8000, replacing any server already running.
+#
+# The container's entrypoint cannot do this on first boot: the site is created by
+# the deploy, minutes after the container starts. So the deploy calls this once
+# the site exists, and entry.sh calls it on every later start — which is what
+# makes a restarted instance answer again without a redeploy.
+#
+# The bench user is read from the bench directory rather than named, because
+# linkuser.sh *renames* `frappe` to the lab owner's username: this script runs
+# both before that rename (never — see below) and long after it, and a hardcoded
+# name is wrong on one side of it. Two consequences worth keeping in mind:
+# `usermod --login` refuses to rename a user that owns a running process, so the
+# deploy must call this only after linkuser.sh has run.
+#
+# `--noreload` on purpose: the reloader forks a watcher over the whole bench,
+# which is wasted work in a lab whose code is edited through code-server and
+# restarted from the UI.
+set -e
+
+BENCH_DIR=/home/frappe/frappe-bench
+PORT="${1:-8000}"
+SESSION=benchweb
+
+BENCH_USER=$(stat -c %U "$BENCH_DIR")
+
+sudo -u "$BENCH_USER" screen -X -S "$SESSION" quit || true
+sudo -u "$BENCH_USER" screen -d -m -S "$SESSION" \
+    bash -lc "cd $BENCH_DIR && bench serve --port $PORT --noreload"

--- a/benchpress/lab-templates/scripts/serve.sh
+++ b/benchpress/lab-templates/scripts/serve.sh
@@ -1,21 +1,9 @@
 #!/bin/bash
-# Serve the lab's site on port 8000, replacing any server already running.
+# Serve the lab's site, replacing any server already running.
 #
-# The container's entrypoint cannot do this on first boot: the site is created by
-# the deploy, minutes after the container starts. So the deploy calls this once
-# the site exists, and entry.sh calls it on every later start — which is what
-# makes a restarted instance answer again without a redeploy.
-#
-# The bench user is read from the bench directory rather than named, because
-# linkuser.sh *renames* `frappe` to the lab owner's username: this script runs
-# both before that rename (never — see below) and long after it, and a hardcoded
-# name is wrong on one side of it. Two consequences worth keeping in mind:
-# `usermod --login` refuses to rename a user that owns a running process, so the
-# deploy must call this only after linkuser.sh has run.
-#
-# `--noreload` on purpose: the reloader forks a watcher over the whole bench,
-# which is wasted work in a lab whose code is edited through code-server and
-# restarted from the UI.
+# Must run after linkuser.sh: that renames the bench user, and `usermod --login`
+# refuses to rename a user that owns a running process. The user is read from the
+# bench directory for the same reason — there is no `frappe` user after the rename.
 set -e
 
 BENCH_DIR=/home/frappe/frappe-bench

--- a/benchpress/lab-templates/scripts/serve.sh
+++ b/benchpress/lab-templates/scripts/serve.sh
@@ -1,17 +1,32 @@
 #!/bin/bash
 # Serve the lab's site, replacing any server already running.
 #
-# Must run after linkuser.sh: that renames the bench user, and `usermod --login`
-# refuses to rename a user that owns a running process. The user is read from the
-# bench directory for the same reason — there is no `frappe` user after the rename.
-set -e
+# `CI=1` is the security-relevant part. Without it `bench serve` hands Werkzeug `use_debugger`
+# and `use_evalex` (frappe/app.py), which mounts the debugger's `/console` Python evaluator on
+# 0.0.0.0:8000 — and lab containers share one bridge and one WireGuard pool, so that console is
+# reachable by every other tenant.
+#
+# The account comes from /.benchpress_config, which linkuser.sh writes as root, and never from
+# the ownership of the bench directory: that directory lives in the tenant's own volume, so a
+# tenant who chowned it could otherwise choose the account this root-invoked script drops to.
+#
+# Must run after linkuser.sh: that renames the bench user, and `usermod --login` refuses to
+# rename a user that owns a running process.
+set -euo pipefail
 
+CONFIG=/.benchpress_config
 BENCH_DIR=/home/frappe/frappe-bench
-PORT="${1:-8000}"
 SESSION=benchweb
+BENCH_USER="${1:-}"
+PORT="${2:-8000}"
 
-BENCH_USER=$(stat -c %U "$BENCH_DIR")
+if [ -z "$BENCH_USER" ]; then
+    [ -f "$CONFIG" ] || { echo "[!] $CONFIG missing — cannot tell which account owns the bench."; exit 1; }
+    BENCH_USER=$(python3 -c "import json; print(json.load(open('$CONFIG')).get('username',''))")
+fi
+[ -n "$BENCH_USER" ] || { echo "[!] No bench user recorded."; exit 1; }
+[[ "$PORT" =~ ^[0-9]+$ ]] || { echo "[!] Port must be a number, got '$PORT'."; exit 1; }
 
 sudo -u "$BENCH_USER" screen -X -S "$SESSION" quit || true
 sudo -u "$BENCH_USER" screen -d -m -S "$SESSION" \
-    bash -lc "cd $BENCH_DIR && bench serve --port $PORT --noreload"
+    bash -lc "cd '$BENCH_DIR' && CI=1 bench serve --port '$PORT' --noreload"

--- a/benchpress/lab-templates/scripts/setup-site.sh
+++ b/benchpress/lab-templates/scripts/setup-site.sh
@@ -4,21 +4,40 @@ set -e
 # The caller (deploy_manager) already sets workdir to the bench dir; this cd is a fallback.
 cd /home/frappe/frappe-bench || true
 
-echo "[*] Creating site ${SITE_NAME}..."
-
-bench new-site "${SITE_NAME}" \
-    --admin-password "${ADMIN_PASSWORD}" \
-    --db-host "${DB_HOST}" \
-    --db-name "${DB_NAME}" \
-    --mariadb-root-username "${MARIADB_ROOT_USERNAME}" \
-    --mariadb-root-password "${MARIADB_ROOT_PASSWORD}" \
-    --mariadb-user-host-login-scope='%'
+# A deploy preserves the data volume on purpose — only a teardown removes it — so a bench
+# that has been deployed before already has its site on disk. `bench new-site` refuses that
+# outright ("Site ... already exists"), which turned pressing Deploy on an existing instance
+# into a failed deploy. The site is adopted instead: nothing here destroys a site, so a
+# rebuild from scratch stays an explicit Delete bench (or redeploy), which drops the volume.
+if [ -f "sites/${SITE_NAME}/site_config.json" ]; then
+    echo "[*] Site ${SITE_NAME} already exists — adopting it."
+    # Every deploy mints a fresh admin password and the lab page shows it, so the existing
+    # site is moved onto that password rather than leaving the screen describing a
+    # credential that does not work.
+    bench --site "${SITE_NAME}" set-admin-password "${ADMIN_PASSWORD}"
+else
+    echo "[*] Creating site ${SITE_NAME}..."
+    bench new-site "${SITE_NAME}" \
+        --admin-password "${ADMIN_PASSWORD}" \
+        --db-host "${DB_HOST}" \
+        --db-name "${DB_NAME}" \
+        --mariadb-root-username "${MARIADB_ROOT_USERNAME}" \
+        --mariadb-root-password "${MARIADB_ROOT_PASSWORD}" \
+        --mariadb-user-host-login-scope='%'
+fi
 
 if [ -n "${APPS}" ]; then
+    # `install-app` errors on an app that is already installed, which the adopt path above
+    # makes the normal case, so the site is asked what it already has first.
+    INSTALLED=$(bench --site "${SITE_NAME}" list-apps 2>/dev/null | awk '{print $1}')
     IFS=',' read -ra APP_LIST <<< "${APPS}"
     for app in "${APP_LIST[@]}"; do
-        echo "[*] Installing app: ${app}..."
-        bench --site "${SITE_NAME}" install-app "${app}"
+        if echo "${INSTALLED}" | grep -qx "${app}"; then
+            echo "[*] App already installed: ${app}"
+        else
+            echo "[*] Installing app: ${app}..."
+            bench --site "${SITE_NAME}" install-app "${app}"
+        fi
     done
 fi
 

--- a/benchpress/lab-templates/scripts/setup-site.sh
+++ b/benchpress/lab-templates/scripts/setup-site.sh
@@ -8,7 +8,11 @@ cd /home/frappe/frappe-bench || true
 # site. Adopted rather than recreated; nothing here destroys a site.
 if [ -f "sites/${SITE_NAME}/site_config.json" ]; then
     echo "[*] Site ${SITE_NAME} already exists — adopting it."
-    # The lab page shows the password this run minted, so the site must move onto it.
+    # The lab page shows the password this run minted, so the site must move onto it. On argv,
+    # where any process in the container can read it from /proc/*/cmdline — accepted, because the
+    # only readers are the tenant's own processes and the lab page already shows them this
+    # password. Moving it to stdin means `getpass` with no controlling terminal, which hangs the
+    # deploy if a TTY ever is attached.
     bench --site "${SITE_NAME}" set-admin-password "${ADMIN_PASSWORD}"
 else
     echo "[*] Creating site ${SITE_NAME}..."
@@ -26,7 +30,9 @@ if [ -n "${APPS}" ]; then
     INSTALLED=$(bench --site "${SITE_NAME}" list-apps 2>/dev/null | awk '{print $1}')
     IFS=',' read -ra APP_LIST <<< "${APPS}"
     for app in "${APP_LIST[@]}"; do
-        if echo "${INSTALLED}" | grep -qx "${app}"; then
+        # -F: an app name is a literal, not a pattern. A name carrying regex metacharacters
+        # would otherwise read as already-installed and the install would be skipped silently.
+        if echo "${INSTALLED}" | grep -qxF -- "${app}"; then
             echo "[*] App already installed: ${app}"
         else
             echo "[*] Installing app: ${app}..."

--- a/benchpress/lab-templates/scripts/setup-site.sh
+++ b/benchpress/lab-templates/scripts/setup-site.sh
@@ -4,16 +4,11 @@ set -e
 # The caller (deploy_manager) already sets workdir to the bench dir; this cd is a fallback.
 cd /home/frappe/frappe-bench || true
 
-# A deploy preserves the data volume on purpose — only a teardown removes it — so a bench
-# that has been deployed before already has its site on disk. `bench new-site` refuses that
-# outright ("Site ... already exists"), which turned pressing Deploy on an existing instance
-# into a failed deploy. The site is adopted instead: nothing here destroys a site, so a
-# rebuild from scratch stays an explicit Delete bench (or redeploy), which drops the volume.
+# A deploy preserves the data volume, so an instance deployed before already has its
+# site. Adopted rather than recreated; nothing here destroys a site.
 if [ -f "sites/${SITE_NAME}/site_config.json" ]; then
     echo "[*] Site ${SITE_NAME} already exists — adopting it."
-    # Every deploy mints a fresh admin password and the lab page shows it, so the existing
-    # site is moved onto that password rather than leaving the screen describing a
-    # credential that does not work.
+    # The lab page shows the password this run minted, so the site must move onto it.
     bench --site "${SITE_NAME}" set-admin-password "${ADMIN_PASSWORD}"
 else
     echo "[*] Creating site ${SITE_NAME}..."
@@ -27,8 +22,7 @@ else
 fi
 
 if [ -n "${APPS}" ]; then
-    # `install-app` errors on an app that is already installed, which the adopt path above
-    # makes the normal case, so the site is asked what it already has first.
+    # install-app errors on an already-installed app, which the adopt path makes normal.
     INSTALLED=$(bench --site "${SITE_NAME}" list-apps 2>/dev/null | awk '{print $1}')
     IFS=',' read -ra APP_LIST <<< "${APPS}"
     for app in "${APP_LIST[@]}"; do

--- a/benchpress/lab_detail.py
+++ b/benchpress/lab_detail.py
@@ -161,7 +161,14 @@ def _failure(lab, bench: dict | None) -> dict | None:
 
 
 def _read_failure(doctype: str, filters: dict, source: str) -> dict | None:
-	logs = frappe.get_list(
+	"""The failing step and reason, read past the caller's own row scoping.
+
+	Deliberately `get_all`: labs are global recipes, so the build that failed is usually an
+	admin's, and `build_log_query_conditions` would empty this banner for everyone else. Only
+	the derived step and reason leave the server — never `message`. The `Deploy Log` arm needs
+	no scoping either, since `_failure` only ever passes a bench `_caller_bench` returned.
+	"""
+	logs = frappe.get_all(
 		doctype,
 		filters=filters,
 		fields=["name", "message"],

--- a/benchpress/lab_templates.py
+++ b/benchpress/lab_templates.py
@@ -16,14 +16,8 @@ from frappe import _
 # which catalog a lab was created against.
 CATALOG_VERSION = 5
 
-# Every template names the `Instance Size` it runs at, so a lab created from one
-# is priced and sized off the same catalog as a hand-filled lab instead of
-# carrying resources only this file knows about. `memory_limit` / `cpu_cores`
-# below must agree with the named size: they are what the template card renders,
-# and `Lab.apply_instance_size` overwrites them with the size's own values.
-#
-# A self-hoster may have renamed or removed a seeded size, so the size is applied
-# only when its row exists — the declared resources are the fallback.
+# Each template names its `Instance Size`. `memory_limit` / `cpu_cores` below must agree
+# with it: they are what the card renders, and `Lab.apply_instance_size` overwrites them.
 
 # "Use template" names the lab itself, so a taken id is retried with a numeric
 # suffix. The ceiling only exists so a pathological catalog cannot spin.

--- a/benchpress/lab_templates.py
+++ b/benchpress/lab_templates.py
@@ -14,7 +14,16 @@ from frappe import _
 
 # Bumped whenever the template set or its fields change so an install can tell
 # which catalog a lab was created against.
-CATALOG_VERSION = 4
+CATALOG_VERSION = 5
+
+# Every template names the `Instance Size` it runs at, so a lab created from one
+# is priced and sized off the same catalog as a hand-filled lab instead of
+# carrying resources only this file knows about. `memory_limit` / `cpu_cores`
+# below must agree with the named size: they are what the template card renders,
+# and `Lab.apply_instance_size` overwrites them with the size's own values.
+#
+# A self-hoster may have renamed or removed a seeded size, so the size is applied
+# only when its row exists — the declared resources are the fallback.
 
 # "Use template" names the lab itself, so a taken id is retried with a numeric
 # suffix. The ceiling only exists so a pathological catalog cannot spin.
@@ -28,7 +37,8 @@ LAB_TEMPLATES = [
 		"title": "Frappe Framework",
 		"description": "Bare Frappe bench with no extra apps — the lightest starting point.",
 		"frappe_version": "version-15",
-		"memory_limit": "512m",
+		"instance_size": "Small",
+		"memory_limit": "1g",
 		"cpu_cores": 1,
 		"apps": [],
 	},
@@ -39,6 +49,7 @@ LAB_TEMPLATES = [
 		"title": "ERPNext",
 		"description": "Full ERP suite: accounting, inventory, manufacturing and more.",
 		"frappe_version": "version-15",
+		"instance_size": "Medium",
 		"memory_limit": "2g",
 		"cpu_cores": 2,
 		"apps": [
@@ -57,6 +68,7 @@ LAB_TEMPLATES = [
 		"title": "Frappe CRM",
 		"description": "Lightweight sales CRM on Frappe — leads, deals and contacts.",
 		"frappe_version": "version-15",
+		"instance_size": "Small",
 		"memory_limit": "1g",
 		"cpu_cores": 1,
 		"apps": [
@@ -75,6 +87,7 @@ LAB_TEMPLATES = [
 		"title": "Frappe HR",
 		"description": "HR & payroll suite — employees, leaves, attendance and payroll.",
 		"frappe_version": "version-15",
+		"instance_size": "Medium",
 		"memory_limit": "2g",
 		"cpu_cores": 2,
 		"apps": [
@@ -93,6 +106,7 @@ LAB_TEMPLATES = [
 		"title": "Frappe Learning",
 		"description": "Learning management system — courses, quizzes and batches.",
 		"frappe_version": "version-15",
+		"instance_size": "Small",
 		"memory_limit": "1g",
 		"cpu_cores": 1,
 		"apps": [
@@ -111,6 +125,7 @@ LAB_TEMPLATES = [
 		"title": "Frappe Helpdesk",
 		"description": "Customer support desk — tickets, SLAs and a knowledge base.",
 		"frappe_version": "version-15",
+		"instance_size": "Small",
 		"memory_limit": "1g",
 		"cpu_cores": 1,
 		"apps": [
@@ -129,6 +144,7 @@ LAB_TEMPLATES = [
 		"title": "ERPNext + India Compliance",
 		"description": "ERPNext with GST, e-invoicing and TDS for Indian businesses.",
 		"frappe_version": "version-15",
+		"instance_size": "Medium",
 		"memory_limit": "2g",
 		"cpu_cores": 2,
 		# india_compliance extends ERPNext, so ERPNext must install first. The
@@ -212,6 +228,7 @@ def create_lab_from_template(template_key: str, lab_id: str | None = None, title
 			"title": title or template["title"],
 			"description": template["description"],
 			"frappe_version": template["frappe_version"],
+			"instance_size": seeded_instance_size(template),
 			"memory_limit": template["memory_limit"],
 			"cpu_cores": template["cpu_cores"],
 			"apps": [dict(app) for app in template["apps"]],
@@ -219,3 +236,15 @@ def create_lab_from_template(template_key: str, lab_id: str | None = None, title
 	)
 	lab.insert()
 	return lab.name
+
+
+def seeded_instance_size(template: dict) -> str | None:
+	"""The template's `Instance Size`, or nothing when this install has no such row.
+
+	Without a size a template lab kept resources only this file declared, so it was
+	neither priced nor resized like any other lab. The existence check is what keeps
+	that true for a self-hoster who renamed the seeded sizes: `Lab` leaves the
+	declared `memory_limit` / `cpu_cores` alone when no size is set.
+	"""
+	size = template.get("instance_size")
+	return size if size and frappe.db.exists("Instance Size", size) else None

--- a/benchpress/patches.txt
+++ b/benchpress/patches.txt
@@ -14,3 +14,4 @@ benchpress.patches.map_labs_to_instance_sizes
 benchpress.patches.index_ledger_reference
 benchpress.patches.default_waitlist_open
 benchpress.patches.stamp_template_on_labs
+benchpress.patches.index_tenant_reads

--- a/benchpress/patches/index_tenant_reads.py
+++ b/benchpress/patches/index_tenant_reads.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""Add the composite indexes behind the lab, site and log reads on an existing site.
+
+`after_install` covers a fresh site; every site already deployed needs them applied once.
+`ensure_indexes` is idempotent.
+"""
+
+from benchpress.indexes import ensure_indexes
+
+
+def execute():
+	ensure_indexes()

--- a/benchpress/permissions.py
+++ b/benchpress/permissions.py
@@ -53,12 +53,34 @@ def credit_ledger_query_conditions(user):
 	return _own_rows_only(user, "`tabCredit Ledger Entry`.account")
 
 
+def credit_account_has_permission(doc, ptype=None, user=None) -> bool:
+	"""The doc-level twin of `credit_account_query_conditions`.
+
+	Query conditions reach only the list engine, so every tenant-scoped doctype needs
+	both halves of its rule. `Credit Account.autoname` is `field:user`, so the name is
+	the holder and nothing has to be guessed.
+	"""
+	return _own_doc_only(user, doc.name)
+
+
+def credit_ledger_has_permission(doc, ptype=None, user=None) -> bool:
+	return _own_doc_only(user, doc.account)
+
+
 def _own_rows_only(user, column: str) -> str:
 	if not user:
 		user = frappe.session.user
 	if user == "Administrator" or not set(frappe.get_roles(user)).isdisjoint(ADMIN_ROLES):
 		return ""
 	return f"{column} = {frappe.db.escape(user)}"
+
+
+def _own_doc_only(user, holder: str | None) -> bool:
+	if not user:
+		user = frappe.session.user
+	if user == "Administrator" or not set(frappe.get_roles(user)).isdisjoint(ADMIN_ROLES):
+		return True
+	return bool(holder) and holder == user
 
 
 def deploy_log_query_conditions(user):
@@ -69,3 +91,22 @@ def deploy_log_query_conditions(user):
 	if not set(frappe.get_roles(user)).isdisjoint(ADMIN_ROLES):
 		return ""
 	return f"`tabDeploy Log`.bench IN (SELECT name FROM `tabBench Instance` WHERE owner = {frappe.db.escape(user)})"
+
+
+def deploy_log_has_permission(doc, ptype=None, user=None) -> bool:
+	"""A deploy log belongs to its bench's owner.
+
+	Scoped on `Bench Instance.owner` and not on `Deploy Log.owner` so this agrees with the
+	list rule above: a differently-scoped predicate would let a user list a log they cannot
+	open, or open one they cannot list.
+	"""
+	return _own_doc_only(user, frappe.db.get_value("Bench Instance", doc.bench, "owner"))
+
+
+def build_log_query_conditions(user):
+	"""`run_history._build_filters` applied this rule by hand; it belongs here."""
+	return _own_rows_only(user, "`tabBuild Log`.owner")
+
+
+def build_log_has_permission(doc, ptype=None, user=None) -> bool:
+	return _own_doc_only(user, doc.owner)

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -34,10 +34,22 @@ def _make_bench(lab_name):
 	return bench
 
 
+def _delete_bench_sites(bench_name):
+	"""Drop the `Bench Site` rows a deploy records, before the instance they point at.
+
+	A deploy under test commits (its log writer commits per line), so these rows outlive the
+	class rollback while the instance they link to does not — that is how orphan sites appeared
+	on the dev site. Cleaned explicitly rather than relied on being rolled back.
+	"""
+	for name in frappe.get_all("Bench Site", filters={"bench": bench_name}, pluck="name"):
+		frappe.delete_doc("Bench Site", name, force=True, ignore_permissions=True)
+
+
 def _fresh_bench(case, lab_name):
 	frappe.set_user("Administrator")
 	existing = get_instance_id("Administrator", lab_name)
 	if frappe.db.exists("Bench Instance", existing):
+		_delete_bench_sites(existing)
 		frappe.delete_doc("Bench Instance", existing, force=True, ignore_permissions=True)
 		frappe.db.commit()
 	bench = _make_bench(lab_name)
@@ -48,6 +60,7 @@ def _fresh_bench(case, lab_name):
 			else None
 		)
 	)
+	case.addCleanup(lambda n=bench.name: _delete_bench_sites(n))
 	case.addCleanup(frappe.db.commit)
 	return bench
 
@@ -504,6 +517,7 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		frappe.set_user("Administrator")
 		for name in frappe.get_all("Bench Instance", filters={"lab": cls.lab.name}, pluck="name"):
 			frappe.db.delete("Deploy Log", {"bench": name})
+			_delete_bench_sites(name)
 			frappe.delete_doc("Bench Instance", name, force=True, ignore_permissions=True)
 		if cls.db_server_name and frappe.db.exists("Database Server", cls.db_server_name):
 			frappe.delete_doc("Database Server", cls.db_server_name, force=True, ignore_permissions=True)
@@ -848,3 +862,59 @@ class TestTerminalStateNotifications(IntegrationTestCase):
 
 		self.assertEqual(frappe.db.get_value("Bench Instance", bench.name, "status"), "Error")
 		self.assertFalse(frappe.db.exists("Notification Log", {"for_user": self.owner}))
+
+
+class TestRecordPrimarySite(IntegrationTestCase):
+	"""The site a deploy makes must be visible, and pressing Deploy twice must not duplicate it."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.lab = _make_lab("test-lab-primary-site")
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		cls.lab.delete(ignore_permissions=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def _bench(self):
+		bench = _fresh_bench(self, self.lab.name)
+		bench.site_name = f"{bench.name}.localhost"
+		bench.save(ignore_permissions=True)
+		return bench
+
+	def test_records_the_site_the_deploy_created(self):
+		from benchpress.deploy_manager import _record_primary_site
+
+		bench = self._bench()
+
+		_record_primary_site(bench, self.lab, "secret-one")
+
+		site = frappe.get_doc("Bench Site", {"bench": bench.name})
+		self.assertEqual(site.site_name, bench.site_name)
+		self.assertEqual(site.full_domain, bench.site_name)
+		self.assertEqual(site.status, "Active")
+		self.assertEqual([row.app_name for row in site.apps_installed], ["frappe"])
+
+	def test_a_second_deploy_refreshes_the_row_instead_of_duplicating_it(self):
+		from benchpress.deploy_manager import _record_primary_site
+
+		bench = self._bench()
+
+		_record_primary_site(bench, self.lab, "secret-one")
+		_record_primary_site(bench, self.lab, "secret-two")
+
+		self.assertEqual(frappe.db.count("Bench Site", {"bench": bench.name}), 1)
+
+	def test_teardown_marks_the_site_inactive(self):
+		from benchpress.deploy_manager import _deactivate_bench_sites, _record_primary_site
+
+		bench = self._bench()
+		_record_primary_site(bench, self.lab, "secret-one")
+
+		_deactivate_bench_sites(bench)
+
+		self.assertEqual(frappe.db.get_value("Bench Site", {"bench": bench.name}, "status"), "Inactive")

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -37,9 +37,8 @@ def _make_bench(lab_name):
 def _delete_bench_sites(bench_name):
 	"""Drop the `Bench Site` rows a deploy records, before the instance they point at.
 
-	A deploy under test commits (its log writer commits per line), so these rows outlive the
-	class rollback while the instance they link to does not — that is how orphan sites appeared
-	on the dev site. Cleaned explicitly rather than relied on being rolled back.
+	A deploy under test commits, so these outlive the class rollback that discards the
+	instance. Cleaned explicitly rather than relied on being rolled back.
 	"""
 	for name in frappe.get_all("Bench Site", filters={"bench": bench_name}, pluck="name"):
 		frappe.delete_doc("Bench Site", name, force=True, ignore_permissions=True)

--- a/benchpress/tests/test_doctype_scoping.py
+++ b/benchpress/tests/test_doctype_scoping.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+"""Every doctype that grants a non-admin `read` declares how it is scoped.
+
+Four doctypes made the same mistake independently — two of them in one PR — because nothing
+recorded which doctypes hold per-tenant rows and what that obliges an author to do. The bug is
+cheap to make and expensive to notice: a `permission_query_conditions` entry scopes the list
+path, the list path is what gets tested by hand, and the document path leaks the whole table.
+
+This is a metadata test. It reads the app's DocType JSONs and the hooks Frappe actually
+registered — not `hooks.py` as text, because an unregistered hook is indistinguishable from a
+permissive one: `has_controller_permissions` returns True when it finds none.
+"""
+
+import json
+from pathlib import Path
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from benchpress.permissions import ADMIN_ROLES
+
+# Rows belong to one tenant. Both paths must be scoped: a list rule AND a document rule.
+TENANT_SCOPED = {
+	"Bench Instance",  # the deployment itself
+	"Bench Site",  # a site on somebody's deployment
+	"Credit Account",  # a balance
+	"Credit Ledger Entry",  # what that balance is made of
+	"Deploy Log",  # one deployment's output
+	"Build Log",  # one image build's output, which is credential-adjacent
+}
+
+# Shared catalogues. Every app user may read every row, and no user can create one.
+GLOBAL_BY_DESIGN = {
+	"Lab": "admin-authored recipes; BenchPress User has no create",
+	"Credit Pack": "the price list",
+	"Instance Size": "the size list",
+	"Always On Pass": "read through owner-scoped endpoints; rows name their own bench",
+}
+
+
+def _doctype_files() -> list[Path]:
+	root = Path(frappe.get_app_path("benchpress"))
+	return sorted(root.glob("**/doctype/*/*.json"))
+
+
+def _load_doctypes() -> dict[str, dict]:
+	doctypes = {}
+	for path in _doctype_files():
+		if path.stem != path.parent.name:
+			continue
+		definition = json.loads(path.read_text())
+		if definition.get("doctype") != "DocType":
+			continue
+		doctypes[definition.get("name") or path.stem] = definition
+	return doctypes
+
+
+def _non_admin_read_roles(definition: dict) -> list[str]:
+	return [
+		perm["role"]
+		for perm in definition.get("permissions", [])
+		if perm.get("read") and perm.get("role") not in ADMIN_ROLES
+	]
+
+
+def _grants_read_if_owner(definition: dict) -> bool:
+	return any(
+		perm.get("read") and perm.get("if_owner") and perm.get("role") not in ADMIN_ROLES
+		for perm in definition.get("permissions", [])
+	)
+
+
+class TestDoctypeScoping(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.doctypes = _load_doctypes()
+		cls.query_rules = frappe.get_hooks("permission_query_conditions") or {}
+		cls.doc_rules = frappe.get_hooks("has_permission") or {}
+
+	def test_the_app_actually_has_doctypes_to_check(self):
+		"""Guards against a glob that matches nothing and passes everything."""
+		self.assertGreater(len(self.doctypes), 10)
+
+	def test_every_non_admin_readable_doctype_declares_its_scoping(self):
+		undeclared = [
+			name
+			for name, definition in self.doctypes.items()
+			if _non_admin_read_roles(definition)
+			and name not in TENANT_SCOPED
+			and name not in GLOBAL_BY_DESIGN
+		]
+		self.assertEqual(
+			undeclared,
+			[],
+			f"{undeclared} grant a non-admin read without saying how they are scoped. Add each to "
+			"TENANT_SCOPED (and give it a list rule and a document rule) or to GLOBAL_BY_DESIGN "
+			"with a justification.",
+		)
+
+	def test_the_two_sets_do_not_overlap(self):
+		self.assertEqual(TENANT_SCOPED & set(GLOBAL_BY_DESIGN), set())
+
+	def test_every_tenant_scoped_doctype_has_a_document_rule(self):
+		"""The half that was missing. A query condition never reaches a single-doc read."""
+		for name in sorted(TENANT_SCOPED):
+			definition = self.doctypes.get(name)
+			if not definition or not _non_admin_read_roles(definition):
+				continue
+			has_rule = name in self.doc_rules or _grants_read_if_owner(definition)
+			self.assertTrue(
+				has_rule,
+				f"{name} grants a non-admin read with no document rule: register a `has_permission` "
+				"hook for it, or grant its read `if_owner`.",
+			)
+
+	def test_every_tenant_scoped_doctype_has_a_list_rule(self):
+		for name in sorted(TENANT_SCOPED):
+			definition = self.doctypes.get(name)
+			if not definition or not _non_admin_read_roles(definition):
+				continue
+			has_rule = name in self.query_rules or _grants_read_if_owner(definition)
+			self.assertTrue(
+				has_rule,
+				f"{name} grants a non-admin read with no list rule: register a "
+				"`permission_query_conditions` hook for it, or grant its read `if_owner`.",
+			)
+
+	def test_every_registered_rule_resolves(self):
+		"""A rename in `permissions.py` that forgets `hooks.py` silently disables the rule."""
+		for registry in (self.query_rules, self.doc_rules):
+			for doctype, paths in registry.items():
+				for path in frappe.utils.data.cstr(paths).split(",") if isinstance(paths, str) else paths:
+					try:
+						self.assertTrue(callable(frappe.get_attr(path)), f"{doctype}: {path} is not callable")
+					except (ImportError, AttributeError) as error:
+						self.fail(f"{doctype}: {path} does not resolve ({error})")
+
+	def test_the_credit_doctypes_no_longer_grant_a_blanket_read(self):
+		"""Least privilege on top of the hook, since `Custom DocPerm` can shadow the JSON."""
+		for name in ("Credit Account", "Credit Ledger Entry"):
+			self.assertEqual(_non_admin_read_roles(self.doctypes[name]), [], name)

--- a/benchpress/tests/test_permission_doc_scoping.py
+++ b/benchpress/tests/test_permission_doc_scoping.py
@@ -1,0 +1,251 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+"""Document-path permission scoping for the doctypes that hold one tenant's rows.
+
+`permission_query_conditions` feeds the list engine only, so before the `has_permission` hooks
+these doctypes are registered under, a single-document read saw the whole table. Every denial
+here is paired with a positive control, so a rule that denies everybody cannot pass vacuously.
+
+`frappe.client.get` is exercised in both forms. The `filters` form resolves the document before
+checking permission, so it defeats hash autonaming — it is the form an attacker would use, and
+the one a by-name test alone would miss.
+"""
+
+import json
+
+import frappe
+from frappe.client import get as client_get
+from frappe.tests import IntegrationTestCase
+
+from benchpress.benchpress.doctype.bench_instance import get_instance_id
+
+
+def _ensure_user(email: str, first_name: str, role: str | None = None) -> str:
+	if not frappe.db.exists("User", email):
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": first_name,
+				"send_welcome_email": 0,
+				"roles": [{"role": role}] if role else [],
+			}
+		).insert(ignore_permissions=True)
+	return email
+
+
+def _as(user: str, action):
+	frappe.set_user(user)
+	try:
+		return action()
+	finally:
+		frappe.set_user("Administrator")
+
+
+class TestPermissionDocScoping(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.victim = _ensure_user("scope-victim@example.com", "Scope Victim", "BenchPress User")
+		cls.attacker = _ensure_user("scope-attacker@example.com", "Scope Attacker", "BenchPress User")
+		cls.admin_user = _ensure_user("scope-admin@example.com", "Scope Admin", "BenchPress Admin")
+		cls.lab = cls._make_lab()
+		cls.bench = cls._make_bench()
+		cls.deploy_log = cls._make_log("Deploy Log", {"bench": cls.bench.name}, cls.victim)
+		cls.build_log = cls._make_log("Build Log", {"lab": cls.lab.name}, cls.victim)
+		cls.account = cls._make_credit_rows()
+		frappe.db.commit()  # nosemgrep -- fixtures must outlive the per-test rollback
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		frappe.db.delete("Credit Ledger Entry", {"account": cls.victim})
+		frappe.db.delete("Credit Account", {"user": cls.victim})
+		for doctype, name in (
+			("Deploy Log", cls.deploy_log.name),
+			("Build Log", cls.build_log.name),
+			("Bench Instance", cls.bench.name),
+			("Lab", cls.lab.name),
+		):
+			frappe.delete_doc(doctype, name, force=True, ignore_permissions=True)
+		for email in (cls.victim, cls.attacker, cls.admin_user):
+			frappe.delete_doc("User", email, force=True, ignore_permissions=True)
+		frappe.db.commit()  # nosemgrep -- the fixtures were committed, so removing them must be too
+		super().tearDownClass()
+
+	# --- Fixtures -------------------------------------------------------------
+
+	@classmethod
+	def _make_lab(cls):
+		if frappe.db.exists("Lab", "scope-lab"):
+			frappe.delete_doc("Lab", "scope-lab", force=True, ignore_permissions=True)
+		return frappe.get_doc(
+			{
+				"doctype": "Lab",
+				"lab_id": "scope-lab",
+				"title": "Scope Lab",
+				"frappe_version": "version-15",
+				"image_tag": "benchpress/scope:latest",
+			}
+		).insert(ignore_permissions=True)
+
+	@classmethod
+	def _make_bench(cls):
+		"""A bench the victim owns. The owner comes from the session, so it has to be set."""
+		name = get_instance_id(cls.victim, cls.lab.name)
+		if frappe.db.exists("Bench Instance", name):
+			frappe.delete_doc("Bench Instance", name, force=True, ignore_permissions=True)
+		return _as(
+			cls.victim,
+			lambda: frappe.get_doc(
+				{
+					"doctype": "Bench Instance",
+					"lab": cls.lab.name,
+					"frappe_version": cls.lab.frappe_version,
+					"status": "Running",
+					"container_id": "scope-container",
+				}
+			).insert(ignore_permissions=True),
+		)
+
+	@classmethod
+	def _make_log(cls, doctype: str, fields: dict, owner: str):
+		return _as(
+			owner,
+			lambda: frappe.get_doc(
+				{
+					"doctype": doctype,
+					"log_type": "info",
+					"message": "scope fixture secret line",
+					"timestamp": frappe.utils.now_datetime(),
+					**fields,
+				}
+			).insert(ignore_permissions=True),
+		)
+
+	@classmethod
+	def _make_credit_rows(cls):
+		"""The victim's account and one ledger row, built by the module that owns them."""
+		from benchpress.credits import account
+
+		frappe.db.set_single_value("BenchPress Settings", "enable_credits", 1)
+		frappe.clear_cache(doctype="BenchPress Settings")
+		try:
+			name = account.ensure_account(cls.victim)
+			account.grant(cls.victim, 10, "Scope fixture grant")
+			return name
+		finally:
+			frappe.db.set_single_value("BenchPress Settings", "enable_credits", 0)
+			frappe.clear_cache(doctype="BenchPress Settings")
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	# --- Helpers --------------------------------------------------------------
+
+	def assert_doc_denied(self, doctype: str, name: str, filters: dict):
+		"""Both document paths refuse the attacker: by name, and by the filters form."""
+		for read in (
+			lambda: client_get(doctype, name),
+			lambda: client_get(doctype, filters=json.dumps(filters)),
+		):
+			with self.assertRaises(frappe.PermissionError):
+				_as(self.attacker, read)
+
+	def assert_admins_still_read(self, doctype: str, name: str):
+		for user in (self.admin_user, "Administrator"):
+			try:
+				_as(user, lambda: client_get(doctype, name))
+			except frappe.PermissionError:
+				self.fail(f"{user} was refused {doctype} {name}")
+
+	# --- Deploy Log -----------------------------------------------------------
+
+	def test_deploy_log_doc_read_is_denied_across_tenants(self):
+		self.assert_doc_denied("Deploy Log", self.deploy_log.name, {"bench": self.bench.name})
+
+	def test_deploy_log_doc_read_is_denied_for_a_computed_bench_name(self):
+		"""The real attack path: the bench name is derived, not guessed."""
+		target = get_instance_id(self.victim, self.lab.name)
+		self.assertEqual(target, self.bench.name)
+		with self.assertRaises(frappe.PermissionError):
+			_as(self.attacker, lambda: client_get("Deploy Log", filters=json.dumps({"bench": target})))
+
+	def test_deploy_log_owner_still_reads_their_own(self):
+		doc = _as(self.victim, lambda: client_get("Deploy Log", self.deploy_log.name))
+		self.assertIn("scope fixture secret line", doc["message"])
+
+	def test_deploy_log_admins_still_read_any(self):
+		self.assert_admins_still_read("Deploy Log", self.deploy_log.name)
+
+	def test_deploy_log_list_stays_scoped(self):
+		rows = _as(self.attacker, lambda: frappe.get_list("Deploy Log", filters={"bench": self.bench.name}))
+		self.assertEqual(rows, [])
+
+	# --- Build Log ------------------------------------------------------------
+
+	def test_build_log_doc_read_is_denied_across_tenants(self):
+		self.assert_doc_denied("Build Log", self.build_log.name, {"lab": self.lab.name})
+
+	def test_build_log_owner_still_reads_their_own(self):
+		doc = _as(self.victim, lambda: client_get("Build Log", self.build_log.name))
+		self.assertIn("scope fixture secret line", doc["message"])
+
+	def test_build_log_admins_still_read_any(self):
+		self.assert_admins_still_read("Build Log", self.build_log.name)
+
+	def test_build_log_list_is_now_scoped(self):
+		"""The assertion that proves the missing query condition was the gap.
+
+		`Build Log` had no `permission_query_conditions` entry, so this returned the victim's rows.
+		"""
+		rows = _as(self.attacker, lambda: frappe.get_list("Build Log", filters={"lab": self.lab.name}))
+		self.assertEqual(rows, [])
+
+	def test_build_log_owner_still_lists_their_own(self):
+		rows = _as(self.victim, lambda: frappe.get_list("Build Log", filters={"lab": self.lab.name}))
+		self.assertEqual([row.name for row in rows], [self.build_log.name])
+
+	# --- Credit doctypes ------------------------------------------------------
+
+	def test_credit_account_doc_read_is_denied_across_tenants(self):
+		self.assert_doc_denied("Credit Account", self.account, {"user": self.victim})
+
+	def test_credit_ledger_doc_read_is_denied_across_tenants(self):
+		entry = frappe.get_all("Credit Ledger Entry", filters={"account": self.victim}, pluck="name")[0]
+		self.assert_doc_denied("Credit Ledger Entry", entry, {"account": self.victim})
+
+	def test_credit_account_admins_still_read_any(self):
+		self.assert_admins_still_read("Credit Account", self.account)
+
+	def test_credit_summary_still_serves_the_holder(self):
+		"""The endpoint the SPA actually reads balances through, which is why the grant could go."""
+		from benchpress.credits import account
+
+		summary = _as(self.victim, lambda: account.summary(self.victim))
+		self.assertFalse(summary["enabled"])
+
+	# --- The failure banner survives the Build Log rule -----------------------
+
+	def test_lab_failure_summary_survives_for_a_non_owner(self):
+		"""A non-admin keeps the derived failure, and never the raw build output.
+
+		`_read_failure` reads past the row scoping on purpose: labs are global recipes, so the
+		build that failed is usually somebody else's.
+		"""
+		from benchpress import lab_detail
+
+		frappe.db.set_value("Lab", self.lab.name, "status", "Error")
+		frappe.db.set_value("Build Log", self.build_log.name, "log_type", "error")
+		self.addCleanup(frappe.db.set_value, "Lab", self.lab.name, "status", "Draft")
+
+		payload = _as(self.attacker, lambda: lab_detail.get_lab(self.lab.name))
+
+		self.assertIsNotNone(payload["failure"])
+		self.assertEqual(payload["failure"]["source"], "build")
+		self.assertNotIn("message", payload["failure"])

--- a/benchpress/tests/test_vpn_adapter.py
+++ b/benchpress/tests/test_vpn_adapter.py
@@ -105,15 +105,20 @@ class TestCreateContainerPeer(IntegrationTestCase):
 
 
 class TestRemoveBenchPeer(IntegrationTestCase):
+	@patch("benchpress.vpn_adapter.frappe.db.set_value")
 	@patch("benchpress.vpn_adapter.frappe.delete_doc")
 	@patch("benchpress.vpn_adapter.frappe.db.exists", return_value=True)
-	def test_deletes_the_linked_peer_and_clears_the_link(self, _exists, mock_delete):
-		bench = SimpleNamespace(vpn_peer="PEER-00001")
+	def test_deletes_the_linked_peer_and_clears_the_link(self, _exists, mock_delete, mock_set_value):
+		bench = SimpleNamespace(name="BENCH-1", vpn_peer="PEER-00001")
 
 		remove_bench_peer(bench)
 
 		mock_delete.assert_called_once_with("VPN Peer", "PEER-00001", ignore_permissions=True)
 		self.assertIsNone(bench.vpn_peer)
+		# The stored link has to go before the peer does, or Frappe refuses the delete.
+		mock_set_value.assert_called_once_with(
+			"Bench Instance", "BENCH-1", "vpn_peer", None, update_modified=False
+		)
 
 	@patch("benchpress.vpn_adapter.frappe.delete_doc")
 	def test_no_ops_when_no_peer_is_linked(self, mock_delete):
@@ -123,15 +128,19 @@ class TestRemoveBenchPeer(IntegrationTestCase):
 
 		mock_delete.assert_not_called()
 
+	@patch("benchpress.vpn_adapter.frappe.db.set_value")
 	@patch("benchpress.vpn_adapter.frappe.delete_doc")
 	@patch("benchpress.vpn_adapter.frappe.db.exists", return_value=False)
-	def test_clears_a_dangling_link_without_deleting(self, _exists, mock_delete):
-		bench = SimpleNamespace(vpn_peer="PEER-GONE")
+	def test_clears_a_dangling_link_without_deleting(self, _exists, mock_delete, mock_set_value):
+		bench = SimpleNamespace(name="BENCH-1", vpn_peer="PEER-GONE")
 
 		remove_bench_peer(bench)
 
 		mock_delete.assert_not_called()
 		self.assertIsNone(bench.vpn_peer)
+		mock_set_value.assert_called_once_with(
+			"Bench Instance", "BENCH-1", "vpn_peer", None, update_modified=False
+		)
 
 
 class TestSetupContainerVpn(IntegrationTestCase):
@@ -196,12 +205,15 @@ class TestConfigureContainer(IntegrationTestCase):
 		commands = [call.args[1] for call in mock_exec.call_args_list]
 		self.assertIn("chmod 600 /etc/wireguard/wg0.conf", commands)
 		self.assertIn("wg-quick up wg0", commands)
+		# Down before up, or a container that already has the interface fails the deploy.
+		self.assertLess(commands.index("wg-quick down wg0 || true"), commands.index("wg-quick up wg0"))
 
 	@patch("benchpress.vpn_adapter.render_container_config", return_value="CONF")
 	@patch("benchpress.docker_manager.exec_in_container")
 	@patch("benchpress.docker_manager.write_file_to_container")
 	def test_raises_when_wg_quick_fails(self, _write, mock_exec, _render):
-		mock_exec.side_effect = [(0, ""), (1, "wg-quick: boom")]
+		# chmod, then the tolerated `down`, then the `up` that decides the outcome.
+		mock_exec.side_effect = [(0, ""), (0, ""), (1, "wg-quick: boom")]
 
 		with self.assertRaises(Exception) as caught:
 			configure_container("cid123", "PRIV==", "172.27.0.5")

--- a/benchpress/tests/test_vpn_adapter.py
+++ b/benchpress/tests/test_vpn_adapter.py
@@ -115,7 +115,6 @@ class TestRemoveBenchPeer(IntegrationTestCase):
 
 		mock_delete.assert_called_once_with("VPN Peer", "PEER-00001", ignore_permissions=True)
 		self.assertIsNone(bench.vpn_peer)
-		# The stored link has to go before the peer does, or Frappe refuses the delete.
 		mock_set_value.assert_called_once_with(
 			"Bench Instance", "BENCH-1", "vpn_peer", None, update_modified=False
 		)
@@ -205,14 +204,13 @@ class TestConfigureContainer(IntegrationTestCase):
 		commands = [call.args[1] for call in mock_exec.call_args_list]
 		self.assertIn("chmod 600 /etc/wireguard/wg0.conf", commands)
 		self.assertIn("wg-quick up wg0", commands)
-		# Down before up, or a container that already has the interface fails the deploy.
 		self.assertLess(commands.index("wg-quick down wg0 || true"), commands.index("wg-quick up wg0"))
 
 	@patch("benchpress.vpn_adapter.render_container_config", return_value="CONF")
 	@patch("benchpress.docker_manager.exec_in_container")
 	@patch("benchpress.docker_manager.write_file_to_container")
 	def test_raises_when_wg_quick_fails(self, _write, mock_exec, _render):
-		# chmod, then the tolerated `down`, then the `up` that decides the outcome.
+		# chmod, the tolerated down, then the up that decides the outcome.
 		mock_exec.side_effect = [(0, ""), (0, ""), (1, "wg-quick: boom")]
 
 		with self.assertRaises(Exception) as caught:

--- a/benchpress/vpn_adapter.py
+++ b/benchpress/vpn_adapter.py
@@ -249,9 +249,11 @@ def get_device_config(device_docname: str) -> str:
 def _device_peer_filters() -> dict:
 	"""Everything the user owns except the peers that belong to bench containers.
 
-	The bench sweep is one unbounded `get_all` per call. Left as it is: the
-	whole fleet is 4 Bench Instances, so it reads one short indexed column.
-	Batch or cache it when the fleet reaches the hundreds.
+	The bench sweep is one unbounded `get_all` per call, and it is a full scan: `vpn_peer`
+	carries no index, and `("is", "set")` renders as `!= ''`, which no B-tree would seek on
+	anyway. The names it returns then become a `not in` list on the peer query, so the
+	statement itself grows with the fleet. Left as it is at 4 Bench Instances; replace it with
+	one anti-join, or an `is_device` flag on `VPN Peer`, before the fleet reaches ~500.
 	"""
 	filters = {"owner_user": frappe.session.user}
 	bench_peers = frappe.get_all("Bench Instance", filters={"vpn_peer": ("is", "set")}, pluck="vpn_peer")

--- a/benchpress/vpn_adapter.py
+++ b/benchpress/vpn_adapter.py
@@ -73,21 +73,38 @@ def remove_bench_peer(bench) -> None:
 	socket and the wireguard conf volume — so this is safe to call from web
 	requests too. No-ops cleanly when no peer is linked, and clears a
 	dangling link if the peer is already gone.
+
+	The link is cleared **in the row, not just on the document**, before the peer is
+	deleted. Frappe refuses to delete anything another row still points at, and the
+	Bench Instance is still there at this moment — clearing only `bench.vpn_peer` left
+	the stored link in place, so deleting an instance died with `LinkExistsError` and no
+	instance could ever be deleted from the UI.
 	"""
 	if not bench.vpn_peer:
 		return
-	if frappe.db.exists("VPN Peer", bench.vpn_peer):
-		frappe.delete_doc("VPN Peer", bench.vpn_peer, ignore_permissions=True)
+	peer_name = bench.vpn_peer
 	bench.vpn_peer = None
+	frappe.db.set_value("Bench Instance", bench.name, "vpn_peer", None, update_modified=False)
+	if frappe.db.exists("VPN Peer", peer_name):
+		frappe.delete_doc("VPN Peer", peer_name, ignore_permissions=True)
 
 
 def configure_container(container_id: str, private_key: str, assigned_ip: str) -> None:
-	"""Write the client conf into the container and bring its tunnel up."""
+	"""Write the client conf into the container and bring its tunnel up.
+
+	The interface is taken down first, and failing to take it down is fine. `wg-quick up`
+	refuses to run when the interface already exists, so a container that reached this
+	point once before — a retried deploy, or a container the stale-container sweep failed
+	to remove — turned a recoverable state into `Deploy failed: wg0 already exists`. Down
+	then up is also how the peer's key is rotated: the conf on disk has just changed, and
+	an interface left up would keep serving the old one.
+	"""
 	from benchpress.docker_manager import exec_in_container, write_file_to_container
 
 	config = render_container_config(private_key, assigned_ip)
 	write_file_to_container(container_id, config, "/etc/wireguard/wg0.conf")
 	exec_in_container(container_id, "chmod 600 /etc/wireguard/wg0.conf", user="root")
+	exec_in_container(container_id, "wg-quick down wg0 || true", user="root")
 	exit_code, output = exec_in_container(container_id, "wg-quick up wg0", user="root")
 	if exit_code != 0:
 		raise Exception(f"wg-quick up failed inside container: {output}")

--- a/benchpress/vpn_adapter.py
+++ b/benchpress/vpn_adapter.py
@@ -74,11 +74,8 @@ def remove_bench_peer(bench) -> None:
 	requests too. No-ops cleanly when no peer is linked, and clears a
 	dangling link if the peer is already gone.
 
-	The link is cleared **in the row, not just on the document**, before the peer is
-	deleted. Frappe refuses to delete anything another row still points at, and the
-	Bench Instance is still there at this moment — clearing only `bench.vpn_peer` left
-	the stored link in place, so deleting an instance died with `LinkExistsError` and no
-	instance could ever be deleted from the UI.
+	The link is cleared in the row, not just on the document, before the peer is deleted:
+	Frappe refuses to delete anything another row still points at.
 	"""
 	if not bench.vpn_peer:
 		return
@@ -92,12 +89,8 @@ def remove_bench_peer(bench) -> None:
 def configure_container(container_id: str, private_key: str, assigned_ip: str) -> None:
 	"""Write the client conf into the container and bring its tunnel up.
 
-	The interface is taken down first, and failing to take it down is fine. `wg-quick up`
-	refuses to run when the interface already exists, so a container that reached this
-	point once before — a retried deploy, or a container the stale-container sweep failed
-	to remove — turned a recoverable state into `Deploy failed: wg0 already exists`. Down
-	then up is also how the peer's key is rotated: the conf on disk has just changed, and
-	an interface left up would keep serving the old one.
+	Taken down first, tolerating failure: `wg-quick up` refuses to run when the interface
+	exists, and the conf has just changed, so an interface left up serves the old key.
 	"""
 	from benchpress.docker_manager import exec_in_container, write_file_to_container
 

--- a/benchpress/www/frontend.py
+++ b/benchpress/www/frontend.py
@@ -12,6 +12,10 @@ def get_context(context):
 	frappe.db.commit()  # nosemgrep -- get_csrf_token writes the session store; the shell renders before the request transaction commits
 	context.boot = {
 		"csrf_token": csrf_token,
+		# The realtime namespace is the site name, and this page is the SPA's only
+		# source for it: `frappe.boot` is a desk global that a www page never renders,
+		# so without this `socket.js` connected to the namespace `/undefined`.
+		"site_name": frappe.local.site,
 		# Timestamps come back in the site's timezone; without this the SPA
 		# reads them as browser-local and relative times drift by the offset.
 		"system_timezone": frappe.utils.get_system_timezone(),

--- a/benchpress/www/frontend.py
+++ b/benchpress/www/frontend.py
@@ -12,9 +12,8 @@ def get_context(context):
 	frappe.db.commit()  # nosemgrep -- get_csrf_token writes the session store; the shell renders before the request transaction commits
 	context.boot = {
 		"csrf_token": csrf_token,
-		# The realtime namespace is the site name, and this page is the SPA's only
-		# source for it: `frappe.boot` is a desk global that a www page never renders,
-		# so without this `socket.js` connected to the namespace `/undefined`.
+		# The realtime namespace. `frappe.boot` is a desk global a www page never renders,
+		# so this is the SPA's only source for it.
 		"site_name": frappe.local.site,
 		# Timestamps come back in the site's timezone; without this the SPA
 		# reads them as browser-local and relative times drift by the offset.

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -4,7 +4,7 @@ Release-readiness verdict for every whitelisted endpoint and the security-sensit
 components behind them. Seeded from the phase-3 authorization suite
 (`benchpress/tests/test_api_authorization.py`), the phase-2 contract/timing suite
 (`benchpress/tests/test_api.py`), the branch security review
-(`specs/api-test-suite/security-review-phase-3.md`), and a sweep of
+(`specs/completed/api-test-suite/security-review-phase-3.md`), and a sweep of
 `ignore_permissions=True` and secret-handling (`get_decrypted_password` /
 `get_password`) paths.
 

--- a/frontend/src/components/lab/LabHeader.vue
+++ b/frontend/src/components/lab/LabHeader.vue
@@ -45,9 +45,13 @@
 
 		<div class="flex flex-col items-end gap-1">
 			<div class="flex items-center gap-2">
+				<!-- Disabled off-VPN for the same reason "Open site" is: the IDE answers
+				     only on the bench's tunnel address, so off-tunnel this opened a tab
+				     that loaded forever. The caption below covers both buttons. -->
 				<Button
 					v-if="showCodeServer"
 					variant="subtle"
+					:disabled="!vpnConnected"
 					data-test="open-code-server"
 					@click="emit('code-server')"
 				>

--- a/frontend/src/components/lab/LabHeader.vue
+++ b/frontend/src/components/lab/LabHeader.vue
@@ -45,9 +45,7 @@
 
 		<div class="flex flex-col items-end gap-1">
 			<div class="flex items-center gap-2">
-				<!-- Disabled off-VPN for the same reason "Open site" is: the IDE answers
-				     only on the bench's tunnel address, so off-tunnel this opened a tab
-				     that loaded forever. The caption below covers both buttons. -->
+				<!-- Off-tunnel the IDE is unreachable; the caption below covers both buttons. -->
 				<Button
 					v-if="showCodeServer"
 					variant="subtle"

--- a/frontend/src/socket.js
+++ b/frontend/src/socket.js
@@ -1,15 +1,8 @@
 import { io } from "socket.io-client";
 
-// The realtime endpoint is the page's own origin. Whatever serves this SPA also
-// proxies `/socket.io` to the websocket service — nginx does in a deployment,
-// vite's frappe proxy does in development — so the browser never needs to know
-// which port the socket process listens on.
-//
-// Deriving a port from `window.location` instead aimed the client at `:9000`, a
-// port no deployment publishes, and read the namespace from `window.site_name`,
-// which the shell's boot payload did not set. Every connection therefore went to
-// `http://<host>:9000/undefined` and no deploy log, build log or notification
-// ever arrived. This mirrors frappe's own `socketio_client.get_host()`.
+// Whatever serves this SPA also proxies `/socket.io` to the websocket service, so the
+// endpoint is the page's own origin and the namespace is the site name. Mirrors
+// frappe's `socketio_client.get_host()`.
 let socket = null;
 
 export function initSocket() {

--- a/frontend/src/socket.js
+++ b/frontend/src/socket.js
@@ -1,24 +1,19 @@
 import { io } from "socket.io-client";
 
-// Resolve the socket.io port at runtime. Frappe exposes `window.socketio_port`
-// in the boot data block on desk/website pages (frappe core's website.js reads
-// the same global); when it is absent we fall back to Frappe's default port.
-// This replaces a build-time `import` of sites/common_site_config.json, which
-// only exists inside a running bench and broke `yarn build` in CI/contributor
-// checkouts.
-function getSocketioPort() {
-	return window.socketio_port || 9000;
-}
-
+// The realtime endpoint is the page's own origin. Whatever serves this SPA also
+// proxies `/socket.io` to the websocket service — nginx does in a deployment,
+// vite's frappe proxy does in development — so the browser never needs to know
+// which port the socket process listens on.
+//
+// Deriving a port from `window.location` instead aimed the client at `:9000`, a
+// port no deployment publishes, and read the namespace from `window.site_name`,
+// which the shell's boot payload did not set. Every connection therefore went to
+// `http://<host>:9000/undefined` and no deploy log, build log or notification
+// ever arrived. This mirrors frappe's own `socketio_client.get_host()`.
 let socket = null;
-export function initSocket() {
-	const host = window.location.hostname;
-	const siteName = window.site_name;
-	const port = window.location.port ? `:${getSocketioPort()}` : "";
-	const protocol = port ? "http" : "https";
-	const url = `${protocol}://${host}${port}/${siteName}`;
 
-	socket = io(url, {
+export function initSocket() {
+	socket = io(`${window.location.origin}/${window.site_name}`, {
 		withCredentials: true,
 		reconnectionAttempts: 5,
 	});

--- a/frontend/src/utils/deploySteps.js
+++ b/frontend/src/utils/deploySteps.js
@@ -24,9 +24,9 @@ export const DEPLOY_STEPS = [
 	{ key: "vpn_peer", label: "Configuring the WireGuard peer" },
 	{ key: "site_config", label: "Writing common_site_config.json" },
 	{ key: "site", label: "Creating the site" },
-	{ key: "assets", label: "Building assets" },
+	{ key: "assets", label: "Preparing assets" },
 	{ key: "ssh_user", label: "Provisioning the SSH user" },
-	{ key: "code_server", label: "Provisioning code-server" },
+	{ key: "code_server", label: "Starting the lab's services" },
 	{ key: "complete", label: "Deploy complete" },
 ];
 

--- a/frontend/src/utils/labActions.js
+++ b/frontend/src/utils/labActions.js
@@ -57,7 +57,9 @@ function openAction({ vpnConnected, siteUrl }) {
 			action: OPEN,
 			label: "Open site — VPN off",
 			disabled: true,
-			hint: "Register this device on the VPN to reach the site.",
+			// Covers the IDE button too — both are disabled off-tunnel, and both
+			// answer only on the bench's WireGuard address.
+			hint: "Register this device on the VPN to reach the site or the IDE.",
 		};
 	}
 	if (!siteUrl) {

--- a/frontend/src/utils/labActions.js
+++ b/frontend/src/utils/labActions.js
@@ -57,8 +57,7 @@ function openAction({ vpnConnected, siteUrl }) {
 			action: OPEN,
 			label: "Open site — VPN off",
 			disabled: true,
-			// Covers the IDE button too — both are disabled off-tunnel, and both
-			// answer only on the bench's WireGuard address.
+			// Covers the IDE button too: both answer only on the bench's WireGuard address.
 			hint: "Register this device on the VPN to reach the site or the IDE.",
 		};
 	}


### PR DESCRIPTION
Found while clearing test data and installing one lab end-to-end from a framework template on the public host. Six commits, one per fix area.

## Headline

**Deploy went from 701.5s to 59.6s.** `bench build` was 622.9s of that — 89% — rebuilding asset bundles the image already contained, inside a container whose memory cap made esbuild thrash (99.4% memory, 4% CPU, 14.5 GB read from disk). The same cap had OOM-killed an earlier instance. A redeploy onto an existing volume is now 26.7s.

The remaining minute is two steps only: creating the container (~20s, Docker seeding a fresh volume from the 5.7 GB image) and `bench new-site` (~37s). Everything else together is under two seconds.

## Commits

| Commit | Fix |
|---|---|
| `fix(realtime)` | Sockets aimed at `http://<host>:9000/undefined`, so no deploy log, build log or notification ever reached a browser |
| `fix(templates)` | Template labs bypassed the Instance Size catalog and ran at a hard-coded 512m |
| `fix(vpn)` | Peer link cleared only in memory → `LinkExistsError`; `wg-quick up` not re-entrant → `wg0 already exists` |
| `fix(api)` | Unguarded `remove_container` meant a bench instance could never be deleted |
| `fix(deploy)` | Four interleaved pipeline fixes — see below |
| `fix(ui)` | "Open VS Code" was offered off-tunnel and opened a tab that loaded forever |

The four in `fix(deploy)` share the same functions, so splitting them further would produce commits that do not run:

1. **Assets rebuilt per instance** — now built once in the image, skipped at deploy time. The skip checks the container rather than trusting the Dockerfile, because the cache key does not cover the Dockerfile, so an older cached image still gets its build.
2. **The site was never served** — nothing started the web server, so a finished deploy handed the user a Site URL that refused every connection. `serve.sh` runs from the deploy and from `entry.sh` on later starts, after `linkuser.sh` because `usermod --login` refuses to rename a user owning a running process.
3. **A second Deploy failed with `Site already exists`** — a deploy preserves the data volume by design, so the site is already on disk. `setup-site.sh` adopts it and resets the admin password to the one that run minted. Nothing here destroys a site; a clean rebuild stays Delete bench or a redeploy.
4. **The Sites tab was empty for every lab** — the site was recorded only on `Bench Instance.site_name` while every screen listing sites reads `Bench Site`. The deploy now upserts that row; teardown marks it Inactive; delete removes it before the instance, since `force=True` skips the link check.

## Verification

Exercised on the live host against `https://benchpress.cloud`, with a real WireGuard client in its own network namespace dialling the public endpoint — not a loopback shortcut.

- Template → lab → running in one click, with the 11-step stepper streaming live
- Device registered in ~2s; handshake 0% loss, 0.58ms RTT
- `ssh administrator@<wg-ip>` → shell, `bench 5.31.0`
- Site `:8000/api/method/ping` → `{"message":"pong"}`; survives a container restart
- code-server `:8080/login` accepts the generated password
- A real image build through `build_lab_image`: 9m 35s, 21 layers, 5.78 GB, verified to carry the new scripts and prebuilt bundles

`test_deploy_manager` 32, `test_api_authorization` 73, `test_api` 48, `test_vpn_adapter` 12, `test_lab_templates` 9, `test_deploy_pipeline` 9 — all green. `pre-commit` clean across the branch diff.

## Companion change, not in this PR

The realtime fix is only complete with an nginx change in `benchpress_devops`: that template rewrites the socket.io `Origin` to the site name while forwarding the browser's real `Host`, and frappe's realtime refuses that mismatch. Filed separately.

## Not fixed here

- `razorpay_frappe` is installed in the running containers but `env/` lives in the image, so a `--force-recreate` loses it and re-arms an `apps.txt` import that kills `frappe.init` and the workers. It belongs in the image build.
- The lab build uses the classic Docker builder, so it cannot use a BuildKit yarn-cache mount. GitHub 429'd this host's tarball fetches for ~3 hours today and no build could complete; a cache mount would fetch each tarball once ever.
- An abandoned RQ job silently swallows later deploys of the same bench (`deduplicate=True`) until RQ's reaper clears it. Worth surfacing, like the file-lock case already is.
