### PR TITLE
fix(ui): send build output to the build log, and flag used templates

### DIFF
--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -46,7 +46,7 @@ def get_lab_form_options() -> dict:
 @frappe.whitelist()
 def get_lab_templates() -> list[dict]:
 	require_app_user()
-	return lab_templates.get_templates()
+	return lab_templates.get_catalog()
 
 
 @frappe.whitelist()

--- a/benchpress/benchpress/doctype/lab/lab.json
+++ b/benchpress/benchpress/doctype/lab/lab.json
@@ -12,6 +12,7 @@
   "column_break_basic",
   "frappe_version",
   "status",
+  "template",
   "description",
   "apps_section",
   "apps",
@@ -65,6 +66,13 @@
    "in_list_view": 1,
    "label": "Status",
    "options": "Draft\nBuilding\nReady\nError"
+  },
+  {
+   "description": "Set when the lab was created from a catalog template; blank for hand-written labs.",
+   "fieldname": "template",
+   "fieldtype": "Data",
+   "label": "Template",
+   "read_only": 1
   },
   {
    "fieldname": "description",

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -215,7 +215,7 @@ def _deploy_bench(bench_name: str) -> None:
 		# One step whichever way it goes: the run either builds the image or
 		# adopts a cached one, and the detail line says which.
 		pipeline.step("image")
-		_prepare_lab_image(lab, pipeline)
+		_prepare_lab_image(lab, pipeline, bench.owner)
 
 		_remove_stale_container(bench)
 		pipeline.step("container")
@@ -433,18 +433,22 @@ def _drop_site_database(bench) -> None:
 		pass  # best-effort
 
 
-def _prepare_lab_image(lab, pipeline) -> None:
+def _prepare_lab_image(lab, pipeline, user: str) -> None:
 	"""Adopt the shared image for this lab's spec, or build it if nobody has yet.
 
 	The cache is keyed by the build spec rather than by the lab, so the second user to deploy a
 	given template performs no build at all. It also closes a staleness hole in the old
 	`status == "Ready"` check: editing a Ready lab's apps changed what should be built but kept
 	pointing at the image built from the previous recipe.
+
+	A build started here writes a `Build Log`, as an explicit rebuild does; the deploy log
+	keeps the step and a pointer to it.
 	"""
 	tag, hit = image_cache.resolve(lab)
 	if not hit:
-		pipeline.log(f"Building lab image for {lab.title}")
-		_build_lab_with_logs(lab, pipeline.log)
+		pipeline.log(f"Building lab image for {lab.title} — output goes to the build log")
+		image_tag = _run_build(lab, user)
+		pipeline.log(f"Lab image ready: {image_tag}")
 		return
 	pipeline.log(f"Cache hit: reusing shared image {tag} — no build needed")
 	_adopt_cached_image(lab, tag)
@@ -480,6 +484,55 @@ def _build_lab_with_logs(lab, log_fn) -> None:
 		log_fn(f"Lab image ready: {image_tag}")
 
 
+def _open_build_log(lab, user: str) -> tuple[DeployLogWriter, str]:
+	"""A fresh `Build Log` for this lab, and the writer that streams it to `user` alone."""
+	build_log = frappe.get_doc(
+		{
+			"doctype": "Build Log",
+			"lab": lab.name,
+			"message": "=== Build started ===\n",
+			"log_type": "info",
+			"timestamp": frappe.utils.now_datetime(),
+		}
+	)
+	build_log.insert(ignore_permissions=True)
+	frappe.db.commit()
+
+	writer = DeployLogWriter(
+		"Build Log",
+		build_log.name,
+		"lab_build_log",
+		{"lab": lab.name, "build_log": build_log.name},
+		user,
+	)
+	return writer, build_log.name
+
+
+def _run_build(lab, user: str) -> str:
+	"""Build the image into its own log, mark that log's outcome, return the tag.
+
+	Re-raises, so a deploy that needed the image fails with it.
+	"""
+	append_log, build_log_name = _open_build_log(lab, user)
+	try:
+		_build_lab_with_logs(lab, append_log)
+	except Exception as e:
+		frappe.db.set_value("Lab", lab.name, "status", "Error")
+		append_log(f"=== Build failed: {e!s} ===", "error")
+		frappe.db.set_value("Build Log", build_log_name, "log_type", "error")
+		frappe.db.commit()  # nosemgrep -- the run's outcome must survive its failure
+		frappe.log_error(
+			title=f"Lab image build failed: {lab.name}",
+			message=frappe.get_traceback(),
+		)
+		raise
+
+	append_log(f"=== Build complete: {lab.image_tag} ===", "success")
+	frappe.db.set_value("Build Log", build_log_name, "log_type", "success")
+	frappe.db.commit()  # nosemgrep -- the log records a finished run
+	return lab.image_tag
+
+
 def build_lab(lab_name: str) -> None:
 	"""Build a lab image as a background job with realtime log streaming.
 
@@ -489,50 +542,12 @@ def build_lab(lab_name: str) -> None:
 	`no_cache=True` for a true from-scratch rebuild.
 	"""
 	lab = frappe.get_doc("Lab", lab_name)
-
-	build_log = frappe.get_doc(
-		{
-			"doctype": "Build Log",
-			"lab": lab_name,
-			"message": "=== Build started ===\n",
-			"log_type": "info",
-			"timestamp": frappe.utils.now_datetime(),
-		}
-	)
-	build_log.insert(ignore_permissions=True)
-	frappe.db.commit()
-	build_log_name = build_log.name
-
-	# A standalone image build is the lab owner's run, so it goes to the lab
-	# owner's socket only — same scoping rule as a deploy.
-	append_log = DeployLogWriter(
-		"Build Log",
-		build_log_name,
-		"lab_build_log",
-		{"lab": lab_name, "build_log": build_log_name},
-		lab.owner,
-	)
-
 	try:
-		_build_lab_with_logs(lab, append_log)
-
-		append_log(f"=== Build complete: {lab.image_tag} ===", "success")
-		frappe.db.set_value("Build Log", build_log_name, "log_type", "success")
-		frappe.db.commit()
-		_notify_owner(lab.owner, f"Lab build complete: {lab.title} ({lab.image_tag})", "Lab", lab_name)
-
-	except Exception as e:
-		frappe.db.set_value("Lab", lab_name, "status", "Error")
-		frappe.db.commit()
-
-		append_log(f"=== Build failed: {e!s} ===", "error")
-		frappe.db.set_value("Build Log", build_log_name, "log_type", "error")
-		frappe.db.commit()
-		frappe.log_error(
-			title=f"Lab image build failed: {lab_name}",
-			message=frappe.get_traceback(),
-		)
+		image_tag = _run_build(lab, lab.owner)
+	except Exception:
 		_notify_owner(lab.owner, f"Lab build failed: {lab.title}", "Lab", lab_name)
+		return
+	_notify_owner(lab.owner, f"Lab build complete: {lab.title} ({image_tag})", "Lab", lab_name)
 
 
 def stop_bench(bench_name: str) -> None:

--- a/benchpress/lab_templates.py
+++ b/benchpress/lab_templates.py
@@ -156,6 +156,27 @@ def get_templates() -> list[dict]:
 	return LAB_TEMPLATES
 
 
+def get_catalog() -> list[dict]:
+	"""The catalog as the Templates page reads it: each template and the lab it built."""
+	built = _labs_by_template()
+	return [{**template, "lab": built.get(template["key"])} for template in LAB_TEMPLATES]
+
+
+def _labs_by_template() -> dict[str, dict]:
+	"""The newest lab built from each template, of the labs the caller may see."""
+	labs = frappe.get_list(
+		"Lab",
+		filters={"template": ("in", [template["key"] for template in LAB_TEMPLATES])},
+		fields=["name", "title", "status", "template"],
+		order_by="creation desc",
+		limit_page_length=0,
+	)
+	newest: dict[str, dict] = {}
+	for lab in labs:
+		newest.setdefault(lab.template, lab)
+	return newest
+
+
 def get_template(key: str) -> dict:
 	"""Return a single template by key, or throw if it is unknown."""
 	for template in LAB_TEMPLATES:
@@ -187,6 +208,7 @@ def create_lab_from_template(template_key: str, lab_id: str | None = None, title
 		{
 			"doctype": "Lab",
 			"lab_id": lab_id or available_lab_id(template_key),
+			"template": template_key,
 			"title": title or template["title"],
 			"description": template["description"],
 			"frappe_version": template["frappe_version"],

--- a/benchpress/patches.txt
+++ b/benchpress/patches.txt
@@ -13,3 +13,4 @@ benchpress.patches.index_credit_ledger
 benchpress.patches.map_labs_to_instance_sizes
 benchpress.patches.index_ledger_reference
 benchpress.patches.default_waitlist_open
+benchpress.patches.stamp_template_on_labs

--- a/benchpress/patches/stamp_template_on_labs.py
+++ b/benchpress/patches/stamp_template_on_labs.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""Name the template every existing lab was created from.
+
+`Lab.template` is new, so labs built before it carry nothing and the Templates page cannot tell
+they exist. "Use template" names a lab after the template key, suffixing only on collision, so
+an id of `key` or `key-2` identifies its template. Hand-named labs are left alone.
+"""
+
+import re
+
+import frappe
+
+from benchpress.lab_templates import get_templates
+
+
+def execute():
+	for template in get_templates():
+		key = template["key"]
+		for name in _labs_from(key):
+			frappe.db.set_value("Lab", name, "template", key, update_modified=False)
+
+
+def _labs_from(key: str) -> list[str]:
+	"""Labs whose id reads as one "Use template" click on this key."""
+	suffixed = re.compile(rf"^{re.escape(key)}(-\d+)?$")
+	labs = frappe.get_all(
+		"Lab",
+		filters={"lab_id": ("like", f"{key}%"), "template": ("in", ["", None])},
+		fields=["name", "lab_id"],
+	)
+	return [lab.name for lab in labs if suffixed.match(lab.lab_id)]

--- a/benchpress/tests/test_credits.py
+++ b/benchpress/tests/test_credits.py
@@ -124,6 +124,12 @@ class TestCredits(IntegrationTestCase):
 		self.wipe_credits()
 		self.reset_bench()
 
+	@staticmethod
+	def purge_build_logs(lab_name: str) -> None:
+		"""A build commits every line it writes, so no rollback removes its log."""
+		frappe.db.delete("Build Log", {"lab": lab_name})
+		frappe.db.commit()  # nosemgrep -- undoing a committed row takes a commit
+
 	# --- The switch off means the feature does not exist ----------------------
 
 	def test_this_module_leaves_the_switch_where_it_found_it(self):
@@ -319,7 +325,7 @@ class TestCredits(IntegrationTestCase):
 		self.enable_credits()
 		lab = frappe.get_doc("Lab", self.lab.name)
 		with patch.object(deploy_manager.image_cache, "resolve", return_value=("cached:tag", True)):
-			deploy_manager._prepare_lab_image(lab, MagicMock())
+			deploy_manager._prepare_lab_image(lab, MagicMock(), frappe.session.user)
 		self.assertEqual(self.entry_count(), 0)
 
 	def test_a_cache_miss_build_writes_exactly_one_usage_row(self):
@@ -329,7 +335,8 @@ class TestCredits(IntegrationTestCase):
 			patch.object(deploy_manager.image_cache, "resolve", return_value=("fresh:tag", False)),
 			patch.object(deploy_manager, "build_lab_image", return_value="fresh:tag"),
 		):
-			deploy_manager._prepare_lab_image(lab, MagicMock())
+			deploy_manager._prepare_lab_image(lab, MagicMock(), frappe.session.user)
+		self.addCleanup(self.purge_build_logs, lab.name)
 
 		entries = [entry for entry in self.entries() if entry.entry_type == "Usage"]
 		self.assertEqual(len(entries), 1)

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026, Venkatesh and Contributors
 # See license.txt
 
+from contextlib import nullcontext
 from unittest.mock import MagicMock, patch
 
 import frappe
@@ -516,12 +517,15 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		self.addCleanup(lambda name=bench.name: frappe.db.delete("Deploy Log", {"bench": name}))
 		return bench
 
-	def _run_deploy(self, bench, site_result=(0, "site created")):
-		"""A whole deploy with every side effect mocked but the log itself."""
+	def _run_deploy(self, bench, site_result=(0, "site created"), cache_hit=True):
+		"""A whole deploy with every side effect mocked but the log itself.
+
+		`cache_hit=False` leaves the image step to the caller, so it has to build.
+		"""
 		from benchpress import deploy_manager
 
 		with (
-			_cached_image(),
+			_cached_image() if cache_hit else nullcontext(),
 			patch.object(deploy_manager, "ensure_infrastructure", autospec=True) as mock_infra,
 			patch.object(deploy_manager, "wait_for_mariadb", autospec=True),
 			patch.object(deploy_manager, "_remove_stale_container", autospec=True),
@@ -641,6 +645,38 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		self.assertEqual({call["user"] for call in published}, {"Administrator"})
 		# A room would broadcast past the user scoping the leak fix relies on.
 		self.assertFalse(any(call.get("room") for call in published))
+
+	def test_a_build_inside_a_deploy_writes_the_build_log_not_the_deploy_log(self):
+		"""The image step's Docker output belongs to the Build log tab."""
+		from benchpress import deploy_manager
+
+		bench = self._bench()
+		self.addCleanup(frappe.db.delete, "Build Log", {"lab": self.lab.name})
+
+		def fake_build(lab, log_fn=None, **kwargs):
+			log_fn("Compiling translations for hrms")
+			return "benchpress/steps:built"
+
+		with (
+			patch.object(deploy_manager.image_cache, "resolve", return_value=("fresh:tag", False)),
+			patch.object(deploy_manager, "build_lab_image", side_effect=fake_build),
+		):
+			self._run_deploy(bench, cache_hit=False)
+
+		deploy_log = self._log(bench.name)
+		self.assertIn("output goes to the build log", deploy_log)
+		self.assertNotIn("Compiling translations for hrms", deploy_log)
+
+		build_log = frappe.get_all(
+			"Build Log",
+			filters={"lab": self.lab.name},
+			fields=["message", "log_type"],
+			order_by="creation desc",
+			limit_page_length=1,
+		)[0]
+		self.assertIn("Compiling translations for hrms", build_log.message)
+		self.assertIn("=== Build complete: benchpress/steps:built ===", build_log.message)
+		self.assertEqual(build_log.log_type, "success")
 
 	def test_step_lines_are_published_as_the_step_type(self):
 		bench = self._bench()

--- a/benchpress/tests/test_lab_templates.py
+++ b/benchpress/tests/test_lab_templates.py
@@ -78,3 +78,27 @@ class TestLabTemplates(IntegrationTestCase):
 	def test_create_lab_from_template_unknown_throws(self):
 		with self.assertRaises(frappe.ValidationError):
 			lab_templates.create_lab_from_template("nope", "tmpl-nope-test")
+
+	def test_created_lab_names_the_template_it_came_from(self):
+		lab = self._make_lab("erpnext", "tmpl-erpnext-stamp")
+		self.assertEqual(lab.template, "erpnext")
+
+	def test_catalog_points_a_used_template_at_the_lab_it_built(self):
+		lab = self._make_lab("hrms", "tmpl-hrms-used")
+		catalog = {template["key"]: template for template in lab_templates.get_catalog()}
+
+		self.assertEqual(catalog["hrms"]["lab"]["name"], lab.name)
+		self.assertEqual(catalog["hrms"]["lab"]["status"], lab.status)
+
+	def test_catalog_reports_a_lab_only_where_one_was_built(self):
+		for template in lab_templates.get_catalog():
+			built = bool(frappe.db.exists("Lab", {"template": template["key"]}))
+			self.assertEqual(bool(template["lab"]), built, template["key"])
+
+	def test_catalog_carries_every_template_field(self):
+		for template in lab_templates.get_catalog():
+			self.assertTrue(REQUIRED_FIELDS.issubset(template))
+
+	def test_catalog_does_not_mutate_the_module_catalog(self):
+		lab_templates.get_catalog()
+		self.assertFalse(any("lab" in template for template in lab_templates.get_templates()))

--- a/frontend/src/pages/LabDetail.vue
+++ b/frontend/src/pages/LabDetail.vue
@@ -125,7 +125,7 @@ const TERMINAL_LOG_TYPES = ["success", "error"];
 
 const LOG_EMPTY = {
 	deploy: "No deploy has run yet — deploying this lab streams its log here.",
-	build: "No image build has run yet — rebuilding this lab streams its log here.",
+	build: "No image build has run yet — a rebuild, or a deploy with no cached image, streams its log here.",
 };
 
 const route = useRoute();
@@ -135,6 +135,9 @@ const labId = route.params.labId;
 const activeTab = ref(0);
 const liveDeployLog = ref("");
 const liveBuildLog = ref("");
+// The stored document each live buffer belongs to.
+const liveDeployRun = ref("");
+const liveBuildRun = ref("");
 // True from the click, before the enqueued worker has flipped the lab to
 // Building in the database — without it the button races the background job.
 const building = ref(false);
@@ -197,16 +200,23 @@ const tabs = computed(() => {
 		{ key: "sites", label: "Sites" },
 		{ key: "deploy", label: "Deploy log" },
 	];
-	if (userContext.isAdmin) list.push({ key: "build", label: "Build log" });
+	// A deploy that misses the image cache builds too, so the tab follows the log, not the role.
+	if (userContext.isAdmin || buildText.value) list.push({ key: "build", label: "Build log" });
 	return list;
 });
 
 // The stored log and the live stream are one run: a page opened mid-deploy
 // reads the lines it missed from the document and appends the rest as they
 // arrive. Reading only the live stream would restart the stepper at step one
-// on every reload.
-const deployText = computed(() => (deployLogs.data?.[0]?.message ?? "") + liveDeployLog.value);
-const buildText = computed(() => (buildLogs.data?.[0]?.message ?? "") + liveBuildLog.value);
+// on every reload, and reading another run's document would show its outcome above step one.
+const deployText = computed(() => runText(deployLogs.data?.[0], liveDeployRun, liveDeployLog));
+const buildText = computed(() => runText(buildLogs.data?.[0], liveBuildRun, liveBuildLog));
+
+function runText(stored, liveRun, liveLog) {
+	if (!liveRun.value) return stored?.message ?? "";
+	const base = stored?.name === liveRun.value ? stored.message : "";
+	return base + liveLog.value;
+}
 
 // Credentials and deploy history belong to a bench, so both follow its identity.
 watch(
@@ -228,14 +238,14 @@ watch(
 );
 
 async function deployLab() {
-	liveDeployLog.value = "";
+	endRun(liveDeployRun, liveDeployLog);
 	const bench = await deployAction.submit({ data: JSON.stringify({ lab: labId }) });
 	if (deployAction.error || !bench?.name) return;
 	openDeployRun({ labId, benchName: bench.name });
 }
 
 function buildImage() {
-	liveBuildLog.value = "";
+	endRun(liveBuildRun, liveBuildLog);
 	building.value = true;
 	buildAction.submit({ lab_name: labId });
 }
@@ -290,20 +300,33 @@ const socket = useSocket();
 // any earlier would flash the previous run.
 async function onDeployLog(data) {
 	if (!bench.value || data.bench !== bench.value.name) return;
+	startRun(liveDeployRun, liveDeployLog, data.deploy_log);
 	liveDeployLog.value += `${data.log}\n`;
 	if (!TERMINAL_LOG_TYPES.includes(data.type)) return;
 	refresh();
 	await deployLogs.reload();
-	liveDeployLog.value = "";
+	endRun(liveDeployRun, liveDeployLog);
 }
 
 async function onBuildLog(data) {
 	if (data.lab !== labId) return;
+	startRun(liveBuildRun, liveBuildLog, data.build_log);
 	liveBuildLog.value += `${data.log}\n`;
 	if (!TERMINAL_LOG_TYPES.includes(data.type)) return;
 	refresh();
 	await buildLogs.reload();
-	liveBuildLog.value = "";
+	endRun(liveBuildRun, liveBuildLog);
+}
+
+function startRun(liveRun, liveLog, logName) {
+	if (!logName || liveRun.value === logName) return;
+	liveRun.value = logName;
+	liveLog.value = "";
+}
+
+function endRun(liveRun, liveLog) {
+	liveRun.value = "";
+	liveLog.value = "";
 }
 
 onMounted(() => {

--- a/frontend/src/pages/LabTemplates.vue
+++ b/frontend/src/pages/LabTemplates.vue
@@ -63,11 +63,25 @@
 				</div>
 
 				<div class="mt-auto flex items-center gap-2 border-t border-outline-gray-1 pt-2.5">
-					<span class="text-meta text-ink-gray-4">{{
-						etaLabel(template.eta_minutes)
-					}}</span>
+					<span
+						class="min-w-0 truncate text-meta"
+						:class="template.lab ? 'text-ink-gray-6' : 'text-ink-gray-4'"
+						:data-test="`template-footnote-${template.key}`"
+					>
+						{{ footnote(template) }}
+					</span>
 					<Button
-						class="ml-auto"
+						v-if="template.lab"
+						class="ml-auto flex-none"
+						variant="solid"
+						:data-test="`open-lab-${template.key}`"
+						@click="router.push(`/labs/${template.lab.name}`)"
+					>
+						Go to lab
+					</Button>
+					<Button
+						v-else
+						class="ml-auto flex-none"
 						variant="solid"
 						:loading="pendingKey === template.key"
 						:disabled="Boolean(pendingKey)"
@@ -112,6 +126,13 @@ import { useRouter } from "vue-router";
 const router = useRouter();
 const pendingKey = ref("");
 
+const LAB_STATES = {
+	Draft: "not built yet",
+	Building: "building now",
+	Ready: "ready",
+	Error: "build failed",
+};
+
 const templates = createResource({ url: "benchpress.api.get_lab_templates", auto: true });
 
 const rows = computed(() => templates.data ?? []);
@@ -132,6 +153,12 @@ function markFor(template) {
 
 function resourceChips(template) {
 	return [memoryLabel(template.memory_limit), cpuLabel(template.cpu_cores)];
+}
+
+function footnote(template) {
+	if (!template.lab) return etaLabel(template.eta_minutes);
+	const status = template.lab.status || "";
+	return `Already used — ${LAB_STATES[status] || status.toLowerCase() || "created"}`;
 }
 
 /**


### PR DESCRIPTION
## Build output landed in the Deploy log

A deploy that misses the image cache builds the image inline, and `_prepare_lab_image` passed the deploy pipeline's writer straight into the build — so Docker's output was written to the Deploy Log. On screen, a lab that was *building* read as a deploy stuck on step 2 ("Preparing the lab image").

- `_prepare_lab_image` now opens a real `Build Log` for that build and streams into it; the deploy log keeps the step marker plus two pointer lines.
- Extracted `_open_build_log` / `_run_build`, so a rebuild click and a deploy-triggered build take one path — same document, same `lab_build_log` event, same success/error marking. `_run_build` re-raises so a broken build still fails the deploy; `build_lab` swallows it as before.
- The stream is scoped to the deployer for a deploy, the lab owner for a rebuild.
- Build log tab was admin-only; it now appears whenever the lab has a build to show, since any user's deploy can trigger one.
- Related: each tab concatenated the *previous* run's stored document with the new live stream. Live lines now carry their run's document name, and stored text is used only for that same run.

## A used template still said "Use template"

Clicking it again quietly created a second lab with a suffixed id.

- New read-only `Lab.template`, stamped by `create_lab_from_template`.
- Patch `stamp_template_on_labs` backfills existing labs from their id.
- `lab_templates.get_catalog()` attaches the lab each template built; `api.get_lab_templates` returns it.
- The card reads `Already used — building now / ready / build failed` and offers **Go to lab**.

## Tests

`test_a_build_inside_a_deploy_writes_the_build_log_not_the_deploy_log` pins the split; 5 new template/catalog tests cover the stamp and the catalog. `test_deploy_manager` (33), `test_lab_templates` (14), `test_credits` (28), `test_api` (48), `test_api_authorization` (73) pass; pre-commit clean.

Verified on the dev site: migrate backfilled both existing labs, the Templates page shows "Already used — ready" with **Go to lab** routing to `/labs/hrms`, and both log tabs render.
