### PR TITLE
Drop a site's database by every name it may carry

### DIFF
--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -252,7 +252,15 @@ def _delete_bench(bench) -> dict:
 
 
 def _drop_bench_site_databases(bench) -> None:
-	"""Drop the database behind every extra site on this bench, one failure at a time."""
+	"""Drop the database behind every site on this bench, one failure at a time.
+
+	`full_domain` is recomputed from the editable `Bench Instance.domain` on every `Bench Site`
+	save (`BenchSite.compute_full_domain`), so it drifts from the name a site's database was
+	actually created under — and `get_database_name` hashes that name, so a drifted value drops a
+	hash that never existed and orphans the real database. Both candidate names are dropped, which
+	the idempotent `DROP DATABASE IF EXISTS` makes safe: whichever one keyed the database dies, the
+	other is a no-op.
+	"""
 	if not bench.database_server:
 		return
 	from benchpress.mariadb_manager import drop_site_database
@@ -261,11 +269,11 @@ def _drop_bench_site_databases(bench) -> None:
 	# `if_owner`, so an admin deleting somebody else's instance would silently skip their sites
 	# and leave the databases behind.
 	sites = frappe.get_all("Bench Site", filters={"bench": bench.name}, fields=["site_name", "full_domain"])
-	for site in sites:
+	for name in {n for site in sites for n in (site.site_name, site.full_domain) if n}:
 		try:
-			drop_site_database(bench.database_server, site.full_domain or site.site_name)
+			drop_site_database(bench.database_server, name)
 		except Exception:
-			frappe.log_error(title=f"Failed to drop DB for {site.site_name}", message=frappe.get_traceback())
+			frappe.log_error(title=f"Failed to drop DB for {name}", message=frappe.get_traceback())
 
 
 @frappe.whitelist()

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -917,3 +917,27 @@ class TestRecordPrimarySite(IntegrationTestCase):
 		_deactivate_bench_sites(bench)
 
 		self.assertEqual(frappe.db.get_value("Bench Site", {"bench": bench.name}, "status"), "Inactive")
+
+	@patch("benchpress.mariadb_manager.drop_site_database")
+	def test_teardown_drops_the_real_db_when_the_domain_has_drifted(self, mock_drop):
+		"""`full_domain` is recomputed from the editable `Bench Instance.domain`, so it drifts from
+		the name a site's database was created under. Teardown must still drop the real database."""
+		from benchpress.api import _drop_bench_site_databases
+		from benchpress.deploy_manager import _record_primary_site
+
+		bench = self._bench()
+		# The database is created under the bare site_name (deploy passes `bench.site_name`).
+		frappe.db.set_value("Bench Instance", bench.name, "domain", "example.com")
+		_record_primary_site(bench, self.lab, "secret-one")
+
+		site = frappe.get_doc("Bench Site", {"bench": bench.name})
+		# The controller rewrote full_domain, drifting it from the created name.
+		self.assertEqual(site.full_domain, f"{bench.site_name}.example.com")
+
+		bench.database_server = "db-any"
+		_drop_bench_site_databases(bench)
+
+		dropped = {call.args[1] for call in mock_drop.call_args_list}
+		# The name the database was actually created under must be among those dropped.
+		self.assertIn(bench.site_name, dropped)
+		self.assertIn(site.full_domain, dropped)


### PR DESCRIPTION
**Data-loss on teardown of a bench with a domain set.**

A site's MariaDB database is named `get_database_name(<site name>)` — a SHA1 of the name string. Teardown (`api._drop_bench_site_databases`) keyed the drop on `full_domain or site_name`, but `BenchSite.compute_full_domain` recomputes `full_domain` from the freely-editable `Bench Instance.domain` on **every** `Bench Site` save. Once a domain is set, `full_domain` becomes `{site_name}.{domain}` and drifts from the name the database was actually created under, so the drop hashes a string that never existed and the real database survives the delete.

The existing `_record_primary_site` test only passed because its fixture left `domain` empty (asserted `full_domain == site_name`).

Fix: drop every candidate name per site (`site_name` and `full_domain`), deduped. `DROP DATABASE IF EXISTS` makes the non-matching one a no-op. New test `test_teardown_drops_the_real_db_when_the_domain_has_drifted` sets a domain, asserts the drift, and asserts the real name is among those dropped — verified failing on the old code, passing on the new.

Found by a peer session reviewing the merged #123 teardown path. Left untouched: the create-path naming (`_create_site_on_bench` keys extra sites on `full_domain or site_name`) sits in the contested Sites-tab area (#126/#131) and is a separate decision.