### PR TITLE
fix(lab-access): the access surface stops claiming what it has not verified

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -185,14 +185,18 @@ Layer 5: Create site (create-site.sh)
 
 | Component | Purpose |
 |-----------|---------|
-| **LogViewer** | Parses raw logs into collapsible steps |
+| **DeployPipeline** | The eleven deploy steps, their state and their durations, derived from the log |
+| **DeployStepRow** | One deploy step with its status and elapsed time |
+| **RawLogPanel** | The unparsed deploy log, with a download |
+| **LogViewer** | Parses raw logs into collapsible steps (build logs, which have no steps of ours) |
 | **LogStep** | Single log step with status indicator |
+| **CodeServerDialog** | The IDE password, surfaced at the moment the IDE tab is opened |
 
 ### Real-Time Communication
 
 The frontend listens for WebSocket events published by the backend:
 
-- **`bench_deploy_log`** — During deployment, streamed to DeployPage's Terminal component
+- **`bench_deploy_log`** — During deployment, appended to LabDetail's live buffer and rendered by `DeployPipeline` / `DeployStepRow` / `RawLogPanel`
 - **`lab_build_log`** — During image build, triggers LabsPage refresh
 
 Pattern:
@@ -206,6 +210,25 @@ this.$socket.on("bench_deploy_log", (data) => { this.logs.push(data) })
 ```
 
 ---
+
+## Shell Access — Where the Terminal Actually Is
+
+There is **no web terminal in this app**: no `ttyd`, no `xterm.js`, no PTY endpoint. A user gets a shell
+in exactly two ways, both over the WireGuard tunnel:
+
+1. **SSH** — `ssh <ssh_username>@<wg_ip>` with the SSH password from Connection details. `linkuser.sh`
+   renames the image's `frappe` user to the lab's own username, sets the password, grants passwordless
+   `sudo` for `bench`/`supervisord`/`supervisorctl`/`service` only, and appends the nvm node path plus
+   `frappe-bench/env/bin` to its `.bashrc` — so `bench` resolves on login with no PATH fix.
+2. **The terminal inside code-server** — `restart.sh` launches code-server against
+   `/home/<ssh_username>/frappe-bench`, so its integrated terminal opens in the bench directory as the
+   same user, with the same PATH.
+
+The deploy log is not a terminal either. It is a stored `Deploy Log` document plus a `bench_deploy_log`
+socket stream, rendered by the components in the table above.
+
+The terminal windows in [docs/index.html](docs/index.html) and `www/home.html` are **marketing mockups** —
+static markup of a session that is not running anywhere.
 
 ## Complete Workflow: Lab → Bench → SSH
 
@@ -282,5 +305,10 @@ this.$socket.on("bench_deploy_log", (data) => { this.logs.push(data) })
 
 - **Docker network**: `benchpress` (172.30.0.0/24)
 - **VPN pool**: 172.27.0.0/16 (vpn_management Network Pool `pool-wg0`), WireGuard port 44556, owned by the vpn_management app
-- **VPN access**: direct tunnel to the container's `wg0` — ports 22 (SSH), 8000 (Frappe web), 9000 (Frappe WebSocket)
+- **VPN access**: direct tunnel to the container's `wg0` — ports 22 (SSH), 8000 (Frappe web), 8080 (code-server), 9000 (Frappe WebSocket)
+- **code-server binds `0.0.0.0:8080` with `cert: false`** (`deploy_manager._start_code_server`), so it is
+  plaintext HTTP on every interface of the container — including the shared `benchpress` bridge, not only
+  the WireGuard address. Its password is the only control. That holds while WireGuard is the sole ingress;
+  it is a prerequisite to fix before [#129](https://github.com/Venkateshvenki404224/benchpress/issues/129)
+  puts a public hostname in front of it.
 - **Container volumes**: `benchpress-{bench_name}-data` → `/home/frappe`

--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -13,7 +13,6 @@ from benchpress.credits.guard import (
 	cap_builds_per_day,
 	cap_concurrent_instances,
 	cap_devices,
-	cap_sites_per_instance,
 	payload_runway,
 	requires_credits,
 )
@@ -344,85 +343,6 @@ def get_device_wg_config(device_name: str) -> str:
 	from benchpress.vpn_adapter import get_device_config
 
 	return get_device_config(device_name)
-
-
-@frappe.whitelist()
-@requires_credits(caps=(cap_sites_per_instance,))
-def create_site(data: str) -> dict:
-	require_app_user()
-	data = frappe.parse_json(data)
-
-	bench_name = data.get("bench")
-	if bench_name:
-		require_bench_access(bench_name)
-
-	doc = frappe.get_doc(
-		{
-			"doctype": "Bench Site",
-			"site_name": data.get("site_name"),
-			"bench": bench_name,
-		}
-	)
-
-	for app in data.get("apps", []):
-		doc.append(
-			"apps_installed",
-			{
-				"app_name": app.get("name"),
-				"app_label": app.get("label", app.get("name")),
-			},
-		)
-
-	doc.insert()
-
-	frappe.enqueue(
-		"benchpress.api._create_site_on_bench",
-		site_doc_name=doc.name,
-		queue="long",
-		timeout=600,
-		enqueue_after_commit=True,
-	)
-
-	return {"name": doc.name, "status": "Creating"}
-
-
-def _create_site_on_bench(site_doc_name: str) -> None:
-	from benchpress.deploy_manager import create_site_in_container
-
-	site = frappe.get_doc("Bench Site", site_doc_name)
-	bench = frappe.get_doc("Bench Instance", site.bench)
-	db_server = frappe.get_doc("Database Server", bench.database_server)
-
-	try:
-		admin_password = bench.get_password("admin_password")
-		site.admin_password = admin_password
-		site_name = site.full_domain or site.site_name
-		apps_csv = ",".join(a.app_name for a in site.apps_installed if a.app_name.lower() != "frappe")
-
-		exit_code, output = create_site_in_container(
-			bench.container_id, db_server, site_name, admin_password, apps_csv
-		)
-
-		if exit_code != 0:
-			site.status = "Error"
-			site.save(ignore_permissions=True)
-			frappe.db.commit()
-			frappe.log_error(title=f"Site creation failed: {site_name}", message=output[:500])
-			return
-
-		site.status = "Active"
-		site.save(ignore_permissions=True)
-		frappe.db.commit()
-
-	except Exception:
-		site.reload()
-		site.status = "Error"
-		site.save(ignore_permissions=True)
-		frappe.db.commit()
-		frappe.log_error(
-			title=f"Site creation failed: {site_doc_name}",
-			message=frappe.get_traceback(),
-		)
 
 
 @frappe.whitelist()

--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -196,7 +196,7 @@ def create_bench(data: str) -> dict:
 
 @frappe.whitelist()
 def bench_action(bench_name: str, action: str) -> dict:
-	from benchpress.docker_manager import restart_container, start_container, stop_container
+	from benchpress.docker_manager import restart_container, start_container
 
 	require_bench_access(bench_name)
 	if action == "delete" and not is_admin():
@@ -204,29 +204,49 @@ def bench_action(bench_name: str, action: str) -> dict:
 
 	bench = frappe.get_doc("Bench Instance", bench_name)
 
-	if action == "start":
-		start_container(bench.container_id)
-		bench.status = "Running"
-		bench.started_at = frappe.utils.now_datetime()
-		metering.on_bench_running(bench)
-	elif action == "stop":
-		stop_container(bench.container_id)
-		bench.status = "Stopped"
-		metering.on_bench_stopped(bench)
-	elif action == "restart":
-		restart_container(bench.container_id)
-		bench.status = "Running"
-		# A restart does not interrupt the session — the instance was billable before and is
-		# billable after — so this only starts a meter that was not already running.
-		metering.on_bench_running(bench)
-	elif action == "delete":
+	if action == "delete":
 		return _delete_bench(bench)
-	else:
+	if action == "stop":
+		return _stop_bench(bench)
+
+	if action not in ("start", "restart"):
 		frappe.throw(_("Invalid action: {0}").format(action))
 
+	_require_container(bench)
+	if action == "start":
+		start_container(bench.container_id)
+		bench.started_at = frappe.utils.now_datetime()
+	else:
+		restart_container(bench.container_id)
+
+	bench.status = "Running"
+	# A restart does not interrupt the session — the instance was billable before and is
+	# billable after — so this only starts a meter that was not already running.
+	metering.on_bench_running(bench)
 	bench.save()
 	frappe.db.commit()
 	return {"name": bench.name, "status": bench.status}
+
+
+def _require_container(bench) -> None:
+	"""Refuse a container action on an instance that has no container.
+
+	A `Draft` instance has never been deployed and a reaped one has had its container removed,
+	so handing Docker an empty id raises its own error at the user, naming nothing they can act
+	on. `Bench Instance.enqueue_start` makes the same check; one message covers every action
+	because the remedy is the same one.
+	"""
+	if not bench.container_id:
+		frappe.throw(_("This instance has no container — deploy it first."))
+
+
+def _stop_bench(bench) -> dict:
+	"""Stop through `deploy_manager.stop_bench`, the one path that also deactivates the sites."""
+	from benchpress.deploy_manager import stop_bench
+
+	_require_container(bench)
+	stop_bench(bench.name)
+	return {"name": bench.name, "status": "Stopped"}
 
 
 def _delete_bench(bench) -> dict:

--- a/benchpress/benchpress/doctype/bench_site/bench_site.json
+++ b/benchpress/benchpress/doctype/bench_site/bench_site.json
@@ -98,7 +98,6 @@
    "write": 1
   },
   {
-   "create": 1,
    "if_owner": 1,
    "read": 1,
    "report": 1,

--- a/benchpress/benchpress/doctype/bench_site/bench_site.py
+++ b/benchpress/benchpress/doctype/bench_site/bench_site.py
@@ -10,8 +10,12 @@ class BenchSite(Document):
 		self.compute_full_domain()
 
 	def compute_full_domain(self):
-		"""Compute full_domain from site_name and bench domain."""
-		if self.bench:
-			bench_domain = frappe.db.get_value("Bench Instance", self.bench, "domain")
-			if bench_domain:
-				self.full_domain = f"{self.site_name}.{bench_domain}"
+		"""Derive the site's display name — a label, never a routable address.
+
+		Nothing resolves `full_domain`: the site is served by the container itself on its
+		WireGuard address, and `Bench Instance.domain` is free text on the desk form, so this
+		value drifts whenever an admin edits it. This controller is its only writer; anything
+		that needs the name the site actually exists under reads `site_name`.
+		"""
+		domain = frappe.db.get_value("Bench Instance", self.bench, "domain") if self.bench else None
+		self.full_domain = f"{self.site_name}.{domain}" if domain else self.site_name

--- a/benchpress/credits/guard.py
+++ b/benchpress/credits/guard.py
@@ -147,7 +147,7 @@ def cap_sites_per_instance(**call) -> None:
 	if frappe.db.count(SITE, {"bench": bench_name}) >= limit:
 		frappe.throw(
 			_(
-				"This instance already has the {0} sites its size allows. Remove a site, or deploy the lab at a larger size."
+				"This instance already has the {0} sites its size allows. Deploy the lab at a larger size, or ask an admin to remove this instance."
 			).format(limit)
 		)
 

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -654,7 +654,13 @@ def build_lab(lab_name: str) -> None:
 
 
 def stop_bench(bench_name: str) -> None:
-	"""Stop a bench container. VPN stops automatically with the container."""
+	"""Stop a bench container, and with it every site the container was serving.
+
+	VPN stops automatically with the container. The sites do not: nothing answers on a stopped
+	container, so a row left `Active` is the page telling the user to open an address that has
+	gone quiet. This is the one stop path — `api.bench_action("stop")` routes here too — so the
+	deactivation cannot be missed by a second caller.
+	"""
 	bench = frappe.get_doc("Bench Instance", bench_name)
 
 	if bench.container_id:
@@ -663,4 +669,5 @@ def stop_bench(bench_name: str) -> None:
 	bench.status = "Stopped"
 	metering.on_bench_stopped(bench)
 	bench.save(ignore_permissions=True)
+	_deactivate_bench_sites(bench)
 	frappe.db.commit()  # nosemgrep -- intentional commit to persist status before response

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -383,7 +383,6 @@ def _record_primary_site(bench, lab, admin_password: str) -> None:
 	site = frappe.get_doc("Bench Site", existing) if existing else frappe.new_doc("Bench Site")
 	site.bench = bench.name
 	site.site_name = bench.site_name
-	site.full_domain = bench.site_name
 	site.status = "Active"
 	site.admin_password = admin_password
 	site.owner = bench.owner

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -308,26 +308,7 @@ def _deploy_bench(bench_name: str) -> None:
 		pipeline.log(f"Site served on port {SITE_HTTP_PORT}")
 
 		if getattr(lab, "enable_code_server", 0):
-			cs_user = bench.ssh_username
-			cs_home = f"/home/{cs_user}"
-			code_server_password = secrets.token_urlsafe(16)
-			config_yaml = (
-				f"bind-addr: 0.0.0.0:8080\nauth: password\npassword: {code_server_password}\ncert: false\n"
-			)
-			write_file_to_container(
-				container_id,
-				config_yaml,
-				f"{cs_home}/.config/code-server/config.yaml",
-			)
-			exec_in_container(
-				container_id,
-				f"chown -R {cs_user}:{cs_user} {cs_home}/.config && chmod 600 {cs_home}/.config/code-server/config.yaml",
-				user="root",
-			)
-			exec_in_container(container_id, "bash /opt/benchpress/scripts/restart.sh", user="root")
-			bench.code_server_password = code_server_password
-			bench.code_server_url = f"http://{bench.wg_ip or bench.container_ip or '127.0.0.1'}:8080/"
-			pipeline.log(f"code-server ready at {bench.code_server_url}")
+			_start_code_server(bench, container_id, pipeline)
 		else:
 			pipeline.log("Code server is disabled for this lab — skipped")
 
@@ -368,6 +349,55 @@ def _deploy_bench(bench_name: str) -> None:
 			message=frappe.get_traceback(),
 		)
 		_notify_owner(bench.owner, f"Bench deploy failed: {bench.bench_name}", "Bench Instance", bench.name)
+
+
+def _start_code_server(bench, container_id: str, pipeline) -> None:
+	"""Configure code-server, launch it, and only then claim it is up.
+
+	Every exec is checked. The config write decides whether code-server can authenticate at
+	all, the `chown`/`chmod` decides whether it reads that file or leaks the password to every
+	account in the container, and `restart.sh` is what actually launches it — a deploy that
+	reports a `code_server_url` answering nothing is worse than one that fails here.
+
+	The address is cleared before the attempt and stored after it, so a failed launch leaves
+	the field empty and `LabHeader.showCodeServer` hides the button instead of offering a
+	dead link.
+	"""
+	_forget_code_server_url(bench)
+	cs_user = bench.ssh_username
+	cs_home = f"/home/{cs_user}"
+	code_server_password = secrets.token_urlsafe(16)
+	config_yaml = f"bind-addr: 0.0.0.0:8080\nauth: password\npassword: {code_server_password}\ncert: false\n"
+	config_path = f"{cs_home}/.config/code-server/config.yaml"
+
+	write_file_to_container(container_id, config_yaml, config_path)
+	_checked_exec(
+		container_id,
+		f"chown -R {cs_user}:{cs_user} {cs_home}/.config && chmod 600 {config_path}",
+		"Securing the code-server config",
+	)
+	_checked_exec(container_id, "bash /opt/benchpress/scripts/restart.sh", "restart.sh")
+
+	bench.code_server_password = code_server_password
+	bench.code_server_url = f"http://{bench.wg_ip or bench.container_ip or '127.0.0.1'}:8080/"
+	pipeline.log(f"code-server ready at {bench.code_server_url}")
+
+
+def _forget_code_server_url(bench) -> None:
+	"""Drop the address a previous deploy proved, in the row as well as in memory.
+
+	The failure path reloads the instance before saving it, so an in-memory clear alone would
+	be discarded and a redeploy that broke at this step would keep serving the old link.
+	"""
+	bench.code_server_url = None
+	frappe.db.set_value("Bench Instance", bench.name, "code_server_url", None, update_modified=False)
+
+
+def _checked_exec(container_id: str, command: str, what: str) -> None:
+	"""Run a command in the container as root, raising with its output when it fails."""
+	exit_code, output = exec_in_container(container_id, command, user="root")
+	if exit_code != 0:
+		raise Exception(f"{what} failed (exit {exit_code}): {output}")
 
 
 def _record_primary_site(bench, lab, admin_password: str) -> None:
@@ -411,7 +441,16 @@ def _ensure_assets(container_id: str, bench_dir: str, lab, pipeline) -> None:
 		pipeline.log("Assets already bundled in the image — no build needed")
 		return
 	pipeline.log(f"bench build — no bundle in the image for: {', '.join(missing)}")
-	exec_in_container(container_id, "bench build", user="frappe", workdir=bench_dir)
+	exit_code, output = exec_in_container(container_id, "bench build", user="frappe", workdir=bench_dir)
+	if exit_code != 0:
+		# The one step in this pipeline that logs instead of raising, deliberately: a site with
+		# stale or missing bundles still loads and the user can rebuild from the IDE, so losing
+		# an otherwise-good deploy over asset bundling costs more than it saves. The captured
+		# output goes into the line so the warning is actionable. Do not "fix" this into a raise.
+		pipeline.log(
+			f"bench build failed (exit {exit_code}) — assets may be stale: {output.strip()}", "warning"
+		)
+		return
 	pipeline.log("bench build finished")
 
 

--- a/benchpress/deploy_pipeline.py
+++ b/benchpress/deploy_pipeline.py
@@ -65,11 +65,14 @@ FAILED_MARKER = re.compile(r"^===\s*(?:Deploy|Build) failed:\s*(.*?)\s*===$")
 PLAIN_MARKER = re.compile(r"^===\s*(.*?)\s*===$")
 
 
+def step_label(key: str) -> str:
+	"""One step's human label — what `scan_log` reports, so readers can match on it."""
+	return DEPLOY_STEPS[STEP_INDEX[key] - 1].label
+
+
 def format_step_line(key: str, elapsed_seconds: float) -> str:
 	"""The human sentence first, the machine fields second, both in one line."""
-	index = STEP_INDEX[key]
-	step = DEPLOY_STEPS[index - 1]
-	return f"=== Step {index}/{STEP_TOTAL}: {step.label} [{step.key} @{elapsed_seconds:.1f}s] ==="
+	return f"=== Step {STEP_INDEX[key]}/{STEP_TOTAL}: {step_label(key)} [{key} @{elapsed_seconds:.1f}s] ==="
 
 
 def parse_step_line(line: str) -> dict | None:

--- a/benchpress/docker_manager.py
+++ b/benchpress/docker_manager.py
@@ -249,18 +249,34 @@ def exec_in_container(
 		workdir=workdir,
 		environment=environment,
 	)
-	return exit_code, output.decode("utf-8", errors="replace")
+	return exit_code, _decoded(output)
 
 
 def write_file_to_container(container_id: str, content: str, path: str) -> None:
-	"""Write a file into a running container using docker exec."""
+	"""Write a file into a running container using docker exec, raising when it did not land.
+
+	The exec result used to be discarded, which made a failed write invisible: every caller
+	writes a file something later depends on — `common_site_config.json`, `wg0.conf`, the
+	code-server config — so a silent failure surfaced as a site that cannot find redis, a
+	tunnel serving the wrong key, or an IDE that never starts, long after the deploy said
+	it was fine.
+	"""
 	client = get_client()
 	container = client.containers.get(container_id)
 	escaped = content.replace("'", "'\\''")
-	container.exec_run(
+	exit_code, output = container.exec_run(
 		cmd=["bash", "-c", f"mkdir -p $(dirname {path}) && cat > {path} << 'WGEOF'\n{escaped}\nWGEOF"],
 		user="root",
 	)
+	if exit_code != 0:
+		raise Exception(f"Writing {path} failed (exit {exit_code}): {_decoded(output)}")
+
+
+def _decoded(output) -> str:
+	"""Docker's exec output as text, whether it came back as bytes or not at all."""
+	if isinstance(output, bytes):
+		return output.decode("utf-8", errors="replace")
+	return "" if output is None else str(output)
 
 
 def get_container_health(container_id: str) -> str:

--- a/benchpress/lab_detail.py
+++ b/benchpress/lab_detail.py
@@ -19,7 +19,7 @@ output — still only have `=== … ===` markers, so both are read.
 import frappe
 
 from benchpress.credits import config, passes
-from benchpress.deploy_pipeline import scan_log
+from benchpress.deploy_pipeline import scan_log, step_label
 
 BENCH_FIELDS = [
 	"name",
@@ -41,6 +41,9 @@ BENCH_FIELDS = [
 ]
 
 SITE_FIELDS = ["name", "site_name", "full_domain", "status"]
+
+# The step a deploy is inside when it builds the image, as `scan_log` reports it.
+IMAGE_STEP = step_label("image")
 
 
 def get_lab(name: str) -> dict:
@@ -156,29 +159,75 @@ def _failure(lab, bench: dict | None) -> dict | None:
 	if lab.status == "Error":
 		return _read_failure("Build Log", {"lab": lab.name}, "build")
 	if bench and bench.status == "Error":
-		return _read_failure("Deploy Log", {"bench": bench.name}, "deploy")
+		return _deploy_failure(lab.name, bench["name"])
 	return None
 
 
+def _deploy_failure(lab_name: str, bench_name: str) -> dict | None:
+	"""The last deploy's failure — attributed to the image build when that is what broke.
+
+	A deploy that misses the image cache builds, and `deploy_manager._run_build` puts
+	`Lab.status` back the way it found it so one tenant's failed build does not mark the
+	catalog entry every other tenant reads. That is why the `Lab.status` arm above never
+	fires here: without this, the banner would blame the deploy and show its tail, while the
+	Docker output that actually explains the failure sat in a `Build Log` nothing pointed at.
+	"""
+	log = _latest_log("Deploy Log", {"bench": bench_name})
+	if not log:
+		return None
+	if _broke_preparing_the_image(log.message):
+		build = _build_failure_since(lab_name, log.timestamp)
+		if build:
+			return build
+	return _failure_payload(log, "deploy")
+
+
+def _broke_preparing_the_image(message: str) -> bool:
+	"""Did the run die inside the step that resolves or builds the image?"""
+	return scan_log(message or "").step == IMAGE_STEP
+
+
+def _build_failure_since(lab_name: str, deploy_started) -> dict | None:
+	"""The failed build this deploy ran, if it ran one.
+
+	Bounded by the deploy's own log timestamp so an older failed build — somebody else's, or
+	one since fixed — cannot be blamed for this run. The image step can also fail without any
+	build at all (cache resolution, adopting a tag), and then there is nothing here to find.
+	"""
+	log = _latest_log(
+		"Build Log", {"lab": lab_name, "log_type": "error", "timestamp": (">=", deploy_started)}
+	)
+	return _failure_payload(log, "build") if log else None
+
+
 def _read_failure(doctype: str, filters: dict, source: str) -> dict | None:
-	"""The failing step and reason, read past the caller's own row scoping.
+	"""The failing step and reason of the newest matching log, or ``None``."""
+	log = _latest_log(doctype, filters)
+	return _failure_payload(log, source) if log else None
+
+
+def _latest_log(doctype: str, filters: dict) -> dict | None:
+	"""The newest matching run log, read past the caller's own row scoping.
 
 	Deliberately `get_all`: labs are global recipes, so the build that failed is usually an
-	admin's, and `build_log_query_conditions` would empty this banner for everyone else. Only
-	the derived step and reason leave the server — never `message`. The `Deploy Log` arm needs
-	no scoping either, since `_failure` only ever passes a bench `_caller_bench` returned.
+	admin's, and `build_log_query_conditions` would empty this banner for everyone else. The
+	`Deploy Log` arm needs no scoping either, since `_failure` only ever passes a bench
+	`_caller_bench` returned.
 	"""
 	logs = frappe.get_all(
 		doctype,
 		filters=filters,
-		fields=["name", "message"],
+		fields=["name", "message", "timestamp"],
 		order_by="timestamp desc",
 		limit_page_length=1,
 	)
-	if not logs:
-		return None
-	step, reason = _parse_failure(logs[0].message or "")
-	return {"source": source, "log": logs[0].name, "step": step, "reason": reason}
+	return logs[0] if logs else None
+
+
+def _failure_payload(log: dict, source: str) -> dict:
+	"""What the banner renders. Only the derived step and reason leave the server — never `message`."""
+	step, reason = _parse_failure(log.message or "")
+	return {"source": source, "log": log.name, "step": step, "reason": reason}
 
 
 def _parse_failure(message: str) -> tuple[str, str]:

--- a/benchpress/patches.txt
+++ b/benchpress/patches.txt
@@ -15,3 +15,4 @@ benchpress.patches.index_ledger_reference
 benchpress.patches.default_waitlist_open
 benchpress.patches.stamp_template_on_labs
 benchpress.patches.index_tenant_reads
+benchpress.patches.retire_orphaned_creating_sites

--- a/benchpress/patches/retire_orphaned_creating_sites.py
+++ b/benchpress/patches/retire_orphaned_creating_sites.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""Retire the `Bench Site` rows the removed create path could strand in `Creating`.
+
+`api.create_site` inserted a row as `Creating` and handed the site build to a worker, so a worker
+that died between the insert and the job left the row claiming a site was still on its way — and
+nothing ever moved it again. That endpoint is gone, so no new row can reach this state, but the
+rows it already made are on existing sites and would sit there forever.
+
+`Creating` means "a job is working on this". No job is. A site nobody is building is Inactive —
+the same state a stop leaves behind, and the state the Sites tab already refuses to open.
+"""
+
+import frappe
+
+
+def execute():
+	frappe.db.set_value(
+		"Bench Site", {"status": "Creating"}, "status", "Inactive", update_modified=False
+	)

--- a/benchpress/patches/retire_orphaned_creating_sites.py
+++ b/benchpress/patches/retire_orphaned_creating_sites.py
@@ -16,6 +16,4 @@ import frappe
 
 
 def execute():
-	frappe.db.set_value(
-		"Bench Site", {"status": "Creating"}, "status", "Inactive", update_modified=False
-	)
+	frappe.db.set_value("Bench Site", {"status": "Creating"}, "status", "Inactive", update_modified=False)

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -526,6 +526,27 @@ class TestApi(IntegrationTestCase):
 		self.assertEqual(creds["password"], "cs-secret")
 		self.assert_within_budget("get_code_server_credentials", elapsed_ms)
 
+	# The IDE button now calls this endpoint at the moment it is clicked, so its two
+	# guards are what a user reads when the IDE cannot answer — not an assumption.
+	def test_get_code_server_credentials_refuses_a_bench_that_is_not_running(self):
+		with self.assertRaises(frappe.ValidationError):
+			api.get_code_server_credentials(self.action_bench.name)
+
+	def test_get_code_server_credentials_refuses_a_bench_with_no_address(self):
+		# A failed code-server step clears the address, and this class rolls back
+		# only once, so the fixture is put back for its siblings.
+		self.addCleanup(self._restore_code_server_url, self.bench.code_server_url)
+		self._set_code_server_url("")
+		with self.assertRaises(frappe.ValidationError):
+			api.get_code_server_credentials(self.bench.name)
+
+	def _restore_code_server_url(self, url):
+		self._set_code_server_url(url)
+
+	def _set_code_server_url(self, url):
+		frappe.db.set_value("Bench Instance", self.bench.name, "code_server_url", url)
+		frappe.clear_document_cache("Bench Instance", self.bench.name)
+
 	# --- Enqueue endpoints (patch frappe.enqueue, assert contract) -----------
 
 	def test_create_lab_from_template_contract_and_timing(self):

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -26,7 +26,6 @@ BUDGETS_MS = {
 	"build_lab_image": 300,
 	"prewarm_catalog": 300,
 	"create_bench": 1500,
-	"create_site": 1500,
 	"bench_action": 800,
 	"get_deploy_logs": 400,
 	"add_device": 400,
@@ -564,16 +563,6 @@ class TestApi(IntegrationTestCase):
 		self.assertEqual(result["status"], "Deploying")
 		self.assertTrue(frappe.db.exists("Bench Instance", result["name"]))
 		self.assert_within_budget("create_bench", elapsed_ms)
-
-	def test_create_site_contract_and_timing(self):
-		data = frappe.as_json({"bench": self.bench.name, "site_name": "cli-site", "apps": []})
-		with patch("frappe.enqueue") as enqueue:
-			result, elapsed_ms = _timed(lambda: api.create_site(data))
-		self.addCleanup(frappe.delete_doc, "Bench Site", result["name"], force=True, ignore_permissions=True)
-		enqueue.assert_called_once()
-		self.assertTrue(enqueue.call_args.kwargs["enqueue_after_commit"])
-		self.assertEqual(result["status"], "Creating")
-		self.assert_within_budget("create_site", elapsed_ms)
 
 	# --- Docker / manager side effects (patch module functions) --------------
 

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -569,7 +569,9 @@ class TestApi(IntegrationTestCase):
 	def test_bench_action_start_stop_restart_and_timing(self):
 		with (
 			patch("benchpress.docker_manager.start_container"),
-			patch("benchpress.docker_manager.stop_container"),
+			# Stop routes through `deploy_manager.stop_bench`, which bound its Docker call at
+			# import — so the patch has to land on that module, not on `docker_manager`.
+			patch("benchpress.deploy_manager.stop_container"),
 			patch("benchpress.docker_manager.restart_container"),
 			patch("benchpress.docker_manager.remove_container"),
 		):
@@ -578,6 +580,46 @@ class TestApi(IntegrationTestCase):
 				self.assertEqual(result["name"], self.action_bench.name)
 				self.assertEqual(result["status"], expected)
 				self.assert_within_budget("bench_action", elapsed_ms)
+
+	def test_bench_action_stop_deactivates_the_sites(self):
+		"""The SPA's Stop and the worker's stop are one path, so neither can skip the rows."""
+		site = frappe.get_doc(
+			{
+				"doctype": "Bench Site",
+				"bench": self.action_bench.name,
+				"site_name": "stop-path.localhost",
+				"status": "Active",
+			}
+		).insert(ignore_permissions=True)
+		self.addCleanup(frappe.delete_doc, "Bench Site", site.name, force=True, ignore_permissions=True)
+		self.addCleanup(frappe.db.commit)
+
+		with patch("benchpress.deploy_manager.stop_container"):
+			api.bench_action(self.action_bench.name, "stop")
+
+		self.assertEqual(frappe.db.get_value("Bench Site", site.name, "status"), "Inactive")
+
+	def test_bench_action_on_an_instance_with_no_container_never_reaches_docker(self):
+		"""A Draft or reaped instance has no container id; Docker's own error names nothing
+		the user can act on, so the guard has to fire before the call."""
+		lab = _ensure_lab("api-timing-no-container-lab")
+		bench = _ensure_bench(lab, status="Draft")
+		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
+		self.addCleanup(frappe.delete_doc, "Bench Instance", bench.name, force=True, ignore_permissions=True)
+
+		for action in ("start", "stop", "restart"):
+			with (
+				self.subTest(action=action),
+				patch("benchpress.docker_manager.start_container") as start,
+				patch("benchpress.deploy_manager.stop_container") as stop,
+				patch("benchpress.docker_manager.restart_container") as restart,
+			):
+				with self.assertRaises(frappe.ValidationError) as caught:
+					api.bench_action(bench.name, action)
+				self.assertIn("deploy it first", str(caught.exception))
+				start.assert_not_called()
+				stop.assert_not_called()
+				restart.assert_not_called()
 
 	def test_restart_code_server_contract_and_timing(self):
 		with patch("benchpress.docker_manager.exec_in_container", return_value=(0, "ok")):

--- a/benchpress/tests/test_api_authorization.py
+++ b/benchpress/tests/test_api_authorization.py
@@ -353,10 +353,6 @@ class TestApiAuthorization(IntegrationTestCase):
 		frappe.set_user(self.norole_user)
 		self.assert_denied(lambda: api.create_bench("{}"))
 
-	def test_roleless_denied_from_create_site(self):
-		frappe.set_user(self.norole_user)
-		self.assert_denied(lambda: api.create_site("{}"))
-
 	def test_roleless_denied_from_add_device(self):
 		frappe.set_user(self.norole_user)
 		self.assert_denied(lambda: api.add_device("authz-dev", "laptop"))
@@ -398,7 +394,6 @@ class TestApiAuthorization(IntegrationTestCase):
 		self.with_credits_armed()
 		frappe.set_user(self.norole_user)
 		self.assert_denied(lambda: api.create_bench(json.dumps({"lab": self.lab.name})))
-		self.assert_denied(lambda: api.create_site(json.dumps({"bench": self.bench.name})))
 		self.assert_denied(lambda: api.add_device("authz-dev", "Laptop"))
 		frappe.set_user("Administrator")
 		self.assertFalse(frappe.db.exists("Credit Account", self.norole_user))
@@ -580,21 +575,16 @@ class TestApiAuthorization(IntegrationTestCase):
 			frappe.db.set_value("Bench Instance", self.bench.name, "status", "Running")
 			frappe.db.commit()
 
-	def test_app_user_allowed_to_create_site(self):
+	def test_creating_a_site_is_not_a_capability_this_api_offers(self):
+		"""The Sites tab is read-only, so neither the endpoint nor the perm behind it may return.
+
+		`frappe.client.insert` is whitelisted, so a leftover `create` DocPerm would be a second
+		way to make exactly the site the deploy cannot serve.
+		"""
+		self.assertFalse(hasattr(api, "create_site"))
+		self.assertNotIn("create_site", {method.__name__ for method in frappe.whitelisted})
 		frappe.set_user(self.user_a)
-		result = None
-		try:
-			with patch("frappe.enqueue") as enqueue:
-				result = api.create_site(
-					frappe.as_json({"site_name": "authz-site", "bench": self.bench.name})
-				)
-			enqueue.assert_called_once()
-			self.assertEqual(result["status"], "Creating")
-		finally:
-			frappe.set_user("Administrator")
-			if result and frappe.db.exists("Bench Site", result["name"]):
-				frappe.delete_doc("Bench Site", result["name"], force=True, ignore_permissions=True)
-			frappe.db.commit()
+		self.assertFalse(frappe.has_permission("Bench Site", "create"))
 
 	def test_app_user_allowed_to_add_device(self):
 		frappe.set_user(self.user_a)

--- a/benchpress/tests/test_credit_guard.py
+++ b/benchpress/tests/test_credit_guard.py
@@ -294,15 +294,14 @@ class TestCreditGuard(IntegrationTestCase):
 		self.add_sites(MAX_SITES)
 		frappe.set_user(self.user)
 		with self.assertRaises(frappe.ValidationError) as refusal:
-			api.create_site(json.dumps({"bench": self.bench.name, "site_name": "one-too-many"}))
+			guard.cap_sites_per_instance(data=json.dumps({"bench": self.bench.name}))
 		self.assertIn("sites its size allows", str(refusal.exception))
 
 	def test_the_site_cap_allows_one_under(self):
 		self.enable_credits()
 		self.add_sites(MAX_SITES - 1)
 		frappe.set_user(self.user)
-		with patch("frappe.enqueue"):
-			api.create_site(json.dumps({"bench": self.bench.name, "site_name": "room-for-this"}))
+		guard.cap_sites_per_instance(data=json.dumps({"bench": self.bench.name}))
 
 	def test_zero_max_sites_means_unlimited(self):
 		self.enable_credits()

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -44,6 +44,18 @@ def _delete_bench_sites(bench_name):
 		frappe.delete_doc("Bench Site", name, force=True, ignore_permissions=True)
 
 
+def _make_bench_site(bench_name, site_name, status="Active"):
+	"""A `Bench Site` row a deploy would have recorded, for tests about what happens to it."""
+	return frappe.get_doc(
+		{
+			"doctype": "Bench Site",
+			"bench": bench_name,
+			"site_name": site_name,
+			"status": status,
+		}
+	).insert(ignore_permissions=True)
+
+
 def _fresh_bench(case, lab_name):
 	frappe.set_user("Administrator")
 	existing = get_instance_id("Administrator", lab_name)
@@ -164,6 +176,25 @@ class TestDeployManager(IntegrationTestCase):
 		mock_stop.assert_not_called()
 		bench.reload()
 		self.assertEqual(bench.status, "Stopped")
+
+	@patch("benchpress.deploy_manager.stop_container")
+	def test_stop_bench_deactivates_every_site_on_the_bench(self, mock_stop):
+		"""Nothing answers inside a stopped container, so no row may stay Active."""
+		from benchpress.deploy_manager import stop_bench
+
+		bench = self._fresh_bench()
+		bench.container_id = "container-stop-sites"
+		bench.status = "Running"
+		bench.save(ignore_permissions=True)
+		_make_bench_site(bench.name, "one.localhost")
+		_make_bench_site(bench.name, "two.localhost")
+		frappe.db.commit()
+
+		stop_bench(bench.name)
+		stop_bench(bench.name)  # a second stop is a no-op, not an error
+
+		statuses = frappe.get_all("Bench Site", filters={"bench": bench.name}, pluck="status")
+		self.assertEqual(statuses, ["Inactive", "Inactive"])
 
 	@patch("benchpress.deploy_manager._deploy_bench")
 	@patch("benchpress.deploy_manager.remove_container")
@@ -890,6 +921,26 @@ class TestRecordPrimarySite(IntegrationTestCase):
 		_deactivate_bench_sites(bench)
 
 		self.assertEqual(frappe.db.get_value("Bench Site", {"bench": bench.name}, "status"), "Inactive")
+
+	@patch("benchpress.deploy_manager.stop_container")
+	def test_a_deploy_returns_a_stopped_site_to_active(self, mock_stop):
+		"""The round trip, which needs no code of its own: `_record_primary_site` already writes
+		`Active`, so a stop followed by a deploy must land back where it started."""
+		from benchpress.deploy_manager import _record_primary_site, stop_bench
+
+		bench = self._bench()
+		bench.container_id = "container-round-trip"
+		bench.save(ignore_permissions=True)
+		_record_primary_site(bench, self.lab, "secret-one")
+		frappe.db.commit()
+
+		stop_bench(bench.name)
+		self.assertEqual(frappe.db.get_value("Bench Site", {"bench": bench.name}, "status"), "Inactive")
+
+		bench.reload()
+		_record_primary_site(bench, self.lab, "secret-one")
+
+		self.assertEqual(frappe.db.get_value("Bench Site", {"bench": bench.name}, "status"), "Active")
 
 	@patch("benchpress.mariadb_manager.drop_site_database")
 	def test_teardown_drops_the_real_db_when_the_domain_has_drifted(self, mock_drop):

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -410,54 +410,6 @@ class TestDeployManager(IntegrationTestCase):
 		for call in mock_msgprint.call_args_list:
 			self.assertIn("already in progress", str(call.args[0]))
 
-	# --- _create_site_on_bench (add-site path) ---
-
-	def _make_bench_site(self, bench):
-		site = frappe.get_doc(
-			{
-				"doctype": "Bench Site",
-				"site_name": "arity-test-site",
-				"bench": bench.name,
-				"status": "Creating",
-				"apps_installed": [{"app_name": "benchpress", "app_label": "BenchPress"}],
-			}
-		).insert(ignore_permissions=True)
-		frappe.db.commit()
-		self.addCleanup(
-			lambda n=site.name: (
-				frappe.delete_doc("Bench Site", n, force=True, ignore_permissions=True)
-				if frappe.db.exists("Bench Site", n)
-				else None
-			)
-		)
-		return site
-
-	@patch("benchpress.deploy_manager.create_site_in_container", autospec=True)
-	def test_create_site_on_bench_matches_signature_and_activates_site(self, mock_create):
-		from benchpress.api import _create_site_on_bench
-
-		bench = self._fresh_bench()
-		bench.database_server = self.db_server_name
-		bench.container_id = "container-arity-test"
-		bench.admin_password = "test-admin-pw"
-		bench.save(ignore_permissions=True)
-		frappe.db.commit()
-
-		site = self._make_bench_site(bench)
-		# autospec enforces the real 5-arg signature: a stale 6-arg call raises
-		# TypeError inside the except block, which would leave status = Error.
-		mock_create.return_value = (0, "site created")
-
-		_create_site_on_bench(site.name)
-
-		site.reload()
-		self.assertEqual(site.status, "Active")
-		mock_create.assert_called_once()
-		args = mock_create.call_args.args
-		self.assertEqual(args[0], "container-arity-test")
-		self.assertEqual(args[2], "arity-test-site")
-		self.assertEqual(args[4], "benchpress")
-
 	# --- build_linkuser_args (Lab.shell wiring) ---
 
 	def test_build_linkuser_args_includes_lab_shell(self):
@@ -897,6 +849,27 @@ class TestRecordPrimarySite(IntegrationTestCase):
 		self.assertEqual(site.full_domain, bench.site_name)
 		self.assertEqual(site.status, "Active")
 		self.assertEqual([row.app_name for row in site.apps_installed], ["frappe"])
+
+	def test_the_controller_alone_owns_full_domain(self):
+		"""Two writers meant the label could name a site that does not exist.
+
+		`_record_primary_site` no longer stamps `full_domain`; the controller derives it from the
+		editable `Bench Instance.domain`. The name the site was created under is `site_name`, and
+		relabelling the instance must never move it.
+		"""
+		from benchpress.deploy_manager import _record_primary_site
+
+		bench = self._bench()
+		_record_primary_site(bench, self.lab, "secret-one")
+		created = frappe.db.get_value("Bench Site", {"bench": bench.name}, "full_domain")
+		self.assertEqual(created, bench.site_name)
+
+		frappe.db.set_value("Bench Instance", bench.name, "domain", "relabelled.example")
+		_record_primary_site(bench, self.lab, "secret-one")
+
+		site = frappe.get_doc("Bench Site", {"bench": bench.name})
+		self.assertEqual(site.site_name, bench.site_name)
+		self.assertEqual(site.full_domain, f"{bench.site_name}.relabelled.example")
 
 	def test_a_second_deploy_refreshes_the_row_instead_of_duplicating_it(self):
 		from benchpress.deploy_manager import _record_primary_site

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -102,6 +102,18 @@ def _ensure_owner(email):
 	return email
 
 
+def _exec_results(failures: dict | None):
+	"""An `exec_in_container` stand-in that fails only the commands a test named."""
+
+	def run(container_id, command, *args, **kwargs):
+		for fragment, result in (failures or {}).items():
+			if fragment in command:
+				return result
+		return (0, "")
+
+	return run
+
+
 class TestDeployManager(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
@@ -513,10 +525,15 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		self.addCleanup(lambda name=bench.name: frappe.db.delete("Deploy Log", {"bench": name}))
 		return bench
 
-	def _run_deploy(self, bench, site_result=(0, "site created"), cache_hit=True):
+	def _run_deploy(
+		self, bench, site_result=(0, "site created"), cache_hit=True, exec_failures=None, write_error=None
+	):
 		"""A whole deploy with every side effect mocked but the log itself.
 
 		`cache_hit=False` leaves the image step to the caller, so it has to build.
+		`exec_failures` maps a fragment of a container command to the result that command
+		returns, so one exec can fail while the rest of the run succeeds. `write_error` makes
+		every `write_file_to_container` raise, the way a read-only target path would.
 		"""
 		from benchpress import deploy_manager
 
@@ -528,7 +545,7 @@ class TestDeployStepMarkers(IntegrationTestCase):
 			patch.object(deploy_manager, "create_bench_container", autospec=True) as mock_create,
 			patch.object(deploy_manager, "start_container", autospec=True),
 			patch.object(deploy_manager, "wait_for_container_running", autospec=True) as mock_wait,
-			patch.object(deploy_manager, "write_file_to_container", autospec=True),
+			patch.object(deploy_manager, "write_file_to_container", autospec=True) as mock_write,
 			patch.object(deploy_manager, "exec_in_container", autospec=True) as mock_exec,
 			patch.object(deploy_manager, "create_site_in_container", autospec=True) as mock_site,
 			patch.object(deploy_manager, "remove_container", autospec=True),
@@ -540,7 +557,9 @@ class TestDeployStepMarkers(IntegrationTestCase):
 			mock_infra.return_value = self.db_server_name
 			mock_create.return_value = "cid-steps"
 			mock_wait.return_value = "172.30.0.11"
-			mock_exec.return_value = (0, "")
+			mock_exec.side_effect = _exec_results(exec_failures)
+			if write_error:
+				mock_write.side_effect = Exception(write_error)
 			mock_peer.return_value = {
 				"peer": "peer-steps",
 				"assigned_ip": "172.27.0.11",
@@ -673,6 +692,134 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		self.assertIn("Compiling translations for hrms", build_log.message)
 		self.assertIn("=== Build complete: benchpress/steps:built ===", build_log.message)
 		self.assertEqual(build_log.log_type, "success")
+
+	# --- Phase 3: a command the run does not check is a claim it cannot make ---
+
+	def _enable_code_server(self):
+		before = frappe.db.get_value("Lab", self.lab.name, "enable_code_server")
+		frappe.db.set_value("Lab", self.lab.name, "enable_code_server", 1)
+		self.addCleanup(frappe.db.set_value, "Lab", self.lab.name, "enable_code_server", before)
+		frappe.db.commit()
+
+	def _bench_field(self, bench, field):
+		return frappe.db.get_value("Bench Instance", bench.name, field)
+
+	def test_a_failed_restart_fails_step_ten_and_stores_no_ide_address(self):
+		"""An address that answers nothing is worse than a deploy that admits it broke."""
+		bench = self._bench()
+		self._enable_code_server()
+		frappe.db.set_value("Bench Instance", bench.name, "code_server_url", "http://stale:8080/")
+		frappe.db.commit()
+
+		self._run_deploy(bench, exec_failures={"restart.sh": (1, "code-server: no such unit")})
+
+		log = self._log(bench.name)
+		self.assertIn("restart.sh failed (exit 1): code-server: no such unit", log)
+		self.assertNotIn("code-server ready at", log)
+		self.assertEqual(self._bench_field(bench, "status"), "Error")
+		# The empty field is the contract: `LabHeader.showCodeServer` reads it to hide the button.
+		self.assertFalse(self._bench_field(bench, "code_server_url"))
+
+	def test_a_failed_config_permission_fix_fails_step_ten(self):
+		"""A config code-server cannot read, or that every account can, is not a working IDE."""
+		bench = self._bench()
+		self._enable_code_server()
+
+		self._run_deploy(bench, exec_failures={"chmod 600": (1, "Operation not permitted")})
+
+		log = self._log(bench.name)
+		self.assertIn("Securing the code-server config failed (exit 1)", log)
+		self.assertNotIn("code-server ready at", log)
+		self.assertFalse(self._bench_field(bench, "code_server_url"))
+
+	def test_a_working_step_ten_stores_the_address_and_says_ready_once(self):
+		bench = self._bench()
+		self._enable_code_server()
+
+		self._run_deploy(bench)
+
+		log = self._log(bench.name)
+		self.assertEqual(log.count("code-server ready at"), 1)
+		self.assertEqual(self._bench_field(bench, "code_server_url"), "http://172.27.0.11:8080/")
+		self.assertEqual(self._bench_field(bench, "status"), "Running")
+
+	def test_a_failed_file_write_fails_the_deploy_at_the_step_that_wrote_it(self):
+		"""Hole 4: a silently unwritten `common_site_config.json` is a site that cannot find redis."""
+		bench = self._bench()
+
+		self._run_deploy(bench, write_error="Writing common_site_config.json failed (exit 1): read-only")
+
+		keys = [step["step_key"] for step in self._emitted_steps(bench.name)]
+		self.assertEqual(keys[-1], "site_config")
+		self.assertIn("common_site_config.json failed", self._log(bench.name))
+		self.assertEqual(self._bench_field(bench, "status"), "Error")
+
+	def test_a_failed_asset_build_warns_and_the_deploy_still_finishes(self):
+		"""The one deliberate asymmetry: stale assets are recoverable, a killed deploy is not."""
+		bench = self._bench()
+
+		self._run_deploy(bench, exec_failures={"bench build": (1, "esbuild: hrms bundle exploded")})
+
+		log = self._log(bench.name)
+		self.assertIn("bench build failed (exit 1)", log)
+		self.assertIn("esbuild: hrms bundle exploded", log)
+		self.assertEqual(self._bench_field(bench, "status"), "Running")
+		self.assertIn("Step 11/11", log)
+
+	def test_a_clean_deploy_writes_no_warning_lines(self):
+		"""The checks above must not turn a healthy run into a noisy one."""
+		bench = self._bench()
+		self._enable_code_server()
+
+		self._run_deploy(bench)
+
+		self.assertNotIn("failed", self._log(bench.name))
+
+	def test_a_build_failure_inside_a_deploy_is_attributed_to_the_build(self):
+		"""Hole 6: the banner must name the build and point at the log holding Docker's error."""
+		from benchpress import deploy_manager, lab_detail
+
+		bench = self._bench()
+		self.addCleanup(frappe.db.delete, "Build Log", {"lab": self.lab.name})
+		status_before = frappe.db.get_value("Lab", self.lab.name, "status")
+
+		def exploding_build(lab, log_fn=None, **kwargs):
+			log_fn("Step 3/8 : RUN bench get-app --branch nope hrms")
+			raise Exception("branch 'nope' not found in upstream origin")
+
+		with (
+			patch.object(deploy_manager.image_cache, "resolve", return_value=("fresh:tag", False)),
+			patch.object(deploy_manager, "build_lab_image", side_effect=exploding_build),
+		):
+			self._run_deploy(bench, cache_hit=False)
+
+		# `_run_build` restores the lab, which is exactly why `Lab.status` cannot carry this.
+		self.assertEqual(frappe.db.get_value("Lab", self.lab.name, "status"), status_before)
+
+		failure = lab_detail.get_lab(self.lab.name)["failure"]
+		self.assertEqual(failure["source"], "build")
+		self.assertIn("branch 'nope' not found", failure["reason"])
+		self.assertEqual(
+			failure["log"],
+			frappe.get_all(
+				"Build Log",
+				filters={"lab": self.lab.name},
+				order_by="timestamp desc",
+				limit_page_length=1,
+				pluck="name",
+			)[0],
+		)
+
+	def test_a_deploy_that_broke_after_the_image_still_blames_the_deploy(self):
+		"""The redirect is bounded to the image step, so an unrelated failure keeps its own log."""
+		from benchpress import lab_detail
+
+		bench = self._bench()
+		self._run_deploy(bench, site_result=Exception("bench new-site exploded"))
+
+		failure = lab_detail.get_lab(self.lab.name)["failure"]
+		self.assertEqual(failure["source"], "deploy")
+		self.assertIn("bench new-site exploded", failure["reason"])
 
 	def test_step_lines_are_published_as_the_step_type(self):
 		bench = self._bench()

--- a/benchpress/tests/test_docker_manager.py
+++ b/benchpress/tests/test_docker_manager.py
@@ -60,6 +60,31 @@ IP_ATTRS = {"NetworkSettings": {"Networks": {"benchpress": {"IPAddress": "172.30
 NO_IP_ATTRS = {"NetworkSettings": {"Networks": {"benchpress": {"IPAddress": ""}}}}
 
 
+class TestWriteFileToContainer(unittest.TestCase):
+	"""The exec result used to be discarded, so a file that never landed looked written."""
+
+	def _client_exec_returning(self, result):
+		client = MagicMock()
+		client.containers.get.return_value.exec_run.return_value = result
+		return client
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_a_zero_exit_returns_without_complaint(self, get_client):
+		get_client.return_value = self._client_exec_returning((0, b""))
+
+		docker_manager.write_file_to_container("cid", "hello", "/etc/wireguard/wg0.conf")
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_a_non_zero_exit_raises_naming_the_path_and_the_output(self, get_client):
+		get_client.return_value = self._client_exec_returning((1, b"Read-only file system"))
+
+		with self.assertRaises(Exception) as caught:
+			docker_manager.write_file_to_container("cid", "hello", "/etc/wireguard/wg0.conf")
+
+		self.assertIn("/etc/wireguard/wg0.conf", str(caught.exception))
+		self.assertIn("Read-only file system", str(caught.exception))
+
+
 class TestWaitForContainerRunning(unittest.TestCase):
 	@patch("benchpress.docker_manager.time.sleep")
 	@patch("benchpress.docker_manager.get_client")

--- a/benchpress/tests/test_patches.py
+++ b/benchpress/tests/test_patches.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from benchpress.patches.retire_orphaned_creating_sites import execute as retire_creating_sites
+
+
+class TestRetireOrphanedCreatingSites(IntegrationTestCase):
+	"""`Creating` used to be a state a dead worker could leave a site in forever."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.lab = frappe.get_doc(
+			{
+				"doctype": "Lab",
+				"lab_id": "test-lab-creating-sites",
+				"title": "Test Lab (Creating Sites)",
+				"frappe_version": "version-15",
+			}
+		).insert(ignore_permissions=True)
+		cls.bench = frappe.get_doc({"doctype": "Bench Instance", "lab": cls.lab.name}).insert(
+			ignore_permissions=True
+		)
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		for name in frappe.get_all("Bench Site", filters={"bench": cls.bench.name}, pluck="name"):
+			frappe.delete_doc("Bench Site", name, force=True, ignore_permissions=True)
+		frappe.delete_doc("Bench Instance", cls.bench.name, force=True, ignore_permissions=True)
+		frappe.delete_doc("Lab", cls.lab.name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def _site(self, site_name, status):
+		site = frappe.get_doc(
+			{
+				"doctype": "Bench Site",
+				"bench": self.bench.name,
+				"site_name": site_name,
+				"status": status,
+			}
+		).insert(ignore_permissions=True)
+		self.addCleanup(frappe.delete_doc, "Bench Site", site.name, force=True, ignore_permissions=True)
+		return site
+
+	def test_a_stranded_creating_row_becomes_inactive(self):
+		stranded = self._site("stranded.localhost", "Creating")
+
+		retire_creating_sites()
+
+		self.assertEqual(frappe.db.get_value("Bench Site", stranded.name, "status"), "Inactive")
+
+	def test_rows_in_any_other_state_are_left_alone(self):
+		"""A running site and a failed one both mean something; only `Creating` is a lie."""
+		untouched = [self._site("live.localhost", "Active"), self._site("broken.localhost", "Error")]
+
+		retire_creating_sites()
+
+		statuses = [frappe.db.get_value("Bench Site", site.name, "status") for site in untouched]
+		self.assertEqual(statuses, ["Active", "Error"])

--- a/benchpress/tests/test_vpn_adapter.py
+++ b/benchpress/tests/test_vpn_adapter.py
@@ -209,6 +209,32 @@ class TestConfigureContainer(IntegrationTestCase):
 	@patch("benchpress.vpn_adapter.render_container_config", return_value="CONF")
 	@patch("benchpress.docker_manager.exec_in_container")
 	@patch("benchpress.docker_manager.write_file_to_container")
+	def test_a_failing_wg_quick_down_is_still_tolerated(self, _write, mock_exec, _render):
+		"""Hardening the other execs here must not harden the one that is meant to fail.
+
+		The interface is legitimately absent on a first deploy, and `|| true` is what makes
+		that tolerance visible rather than a discarded exit code.
+		"""
+		# chmod, a down that reports the interface was never there, then a good up.
+		mock_exec.side_effect = [(0, ""), (1, "wg-quick: `wg0' is not a WireGuard interface"), (0, "")]
+
+		configure_container("cid123", "PRIV==", "172.27.0.5")
+
+	@patch("benchpress.vpn_adapter.render_container_config", return_value="CONF")
+	@patch("benchpress.docker_manager.exec_in_container")
+	@patch("benchpress.docker_manager.write_file_to_container")
+	def test_raises_when_the_conf_cannot_be_secured(self, _write, mock_exec, _render):
+		"""A world-readable wg0.conf hands the tunnel's private key to every account in the box."""
+		mock_exec.side_effect = [(1, "chmod: Operation not permitted")]
+
+		with self.assertRaises(Exception) as caught:
+			configure_container("cid123", "PRIV==", "172.27.0.5")
+
+		self.assertIn("Securing wg0.conf failed", str(caught.exception))
+
+	@patch("benchpress.vpn_adapter.render_container_config", return_value="CONF")
+	@patch("benchpress.docker_manager.exec_in_container")
+	@patch("benchpress.docker_manager.write_file_to_container")
 	def test_raises_when_wg_quick_fails(self, _write, mock_exec, _render):
 		# chmod, the tolerated down, then the up that decides the outcome.
 		mock_exec.side_effect = [(0, ""), (0, ""), (1, "wg-quick: boom")]

--- a/benchpress/vpn_adapter.py
+++ b/benchpress/vpn_adapter.py
@@ -96,7 +96,11 @@ def configure_container(container_id: str, private_key: str, assigned_ip: str) -
 
 	config = render_container_config(private_key, assigned_ip)
 	write_file_to_container(container_id, config, "/etc/wireguard/wg0.conf")
-	exec_in_container(container_id, "chmod 600 /etc/wireguard/wg0.conf", user="root")
+	exit_code, output = exec_in_container(container_id, "chmod 600 /etc/wireguard/wg0.conf", user="root")
+	if exit_code != 0:
+		raise Exception(f"Securing wg0.conf failed inside container: {output}")
+	# The one tolerated exec here: the interface may legitimately be down already, and
+	# `|| true` is what makes that tolerance visible rather than a discarded exit code.
 	exec_in_container(container_id, "wg-quick down wg0 || true", user="root")
 	exit_code, output = exec_in_container(container_id, "wg-quick up wg0", user="root")
 	if exit_code != 0:

--- a/docs/lab-access-acceptance.md
+++ b/docs/lab-access-acceptance.md
@@ -1,0 +1,163 @@
+# Lab Access Acceptance Run
+
+A numbered checklist to repeat after any change to the deploy pipeline, the lab image, or the access
+surface. It answers one question: **can a user reach the lab they were just told is ready?**
+
+Run it against a lab deployed from a template, with a WireGuard tunnel up on the machine you run it
+from. Record the result of every step — a step that was not exercised is reported as not exercised, never
+as a pass.
+
+Shell access in this product is SSH over WireGuard, or the terminal inside code-server. There is no web
+terminal; see [ARCHITECTURE.md](../ARCHITECTURE.md) § Shell Access.
+
+---
+
+## 0. Prerequisites
+
+| Need | How |
+|------|-----|
+| A running lab | Deploy one from the Labs page, or reuse one whose bench is `Running` |
+| A registered device | Devices → **Add device**, import the `.conf`, bring the tunnel up |
+| The bench's addresses and secrets | Lab detail → **Connection details** (secrets behind **Reveal secrets**) |
+
+Throughout, `<wg_ip>` is the bench's WireGuard IP, `<user>` its SSH username and `<site>` its site name —
+all three are on that card.
+
+---
+
+## 1. The deploy is genuinely green
+
+Lab detail → **Deploy log**. All eleven steps show `success` in the stepper, and the raw log holds no
+`[warn]` line. A build that ran inside the deploy has its own tab; a warning there is a real finding
+even when the deploy is green (`_ensure_assets` degrades to a warning on purpose — stale bundles still
+serve, a killed deploy does not).
+
+> A deploy of a cached image lands in ~30 s. Minutes mean the image cache missed.
+
+## 2. The site loads and the admin password works
+
+Click **Open site**. The site answers on `http://<wg_ip>:8000`, and `administrator` with the **Admin
+password** from Connection details logs in.
+
+Headless equivalent, from a machine on the tunnel:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' http://<wg_ip>:8000/          # 200
+curl -s -X POST http://<wg_ip>:8000/api/method/login \
+     -d "usr=Administrator&pwd=<admin_password>"                        # {"message":"Logged In"}
+```
+
+## 3. The IDE opens, with the password in hand
+
+Click **Open VS Code**. Two things must happen:
+
+1. A new tab opens `http://<wg_ip>:8080/`.
+2. A **code-server password** dialog appears on the lab page with the password and a copy button. The
+   password is never in the URL — a query parameter would land in browser history, in the container's
+   access log and in every proxy between.
+
+Paste it into code-server. The window opens on the bench directory: the file tree shows `apps/`,
+`sites/`, `env/`, and the URL carries `?folder=/home/<user>/frappe-bench`.
+
+Headless equivalent:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' http://<wg_ip>:8080/          # 302 (login)
+COOKIE=$(curl -s -i -X POST http://<wg_ip>:8080/login \
+         -d "password=<code_server_password>&base=." |
+         grep -i '^set-cookie' | sed 's/Set-Cookie: //;s/;.*//')
+curl -s -i -H "Cookie: $COOKIE" http://<wg_ip>:8080/ | grep -i '^location'
+# Location: ./?folder=/home/<user>/frappe-bench
+```
+
+If code-server does not answer at all, `benchpress.api.restart_code_server` relaunches it without a
+redeploy. It has no button yet — wire one into the overflow menu the day this step starts needing it.
+
+## 4. The integrated terminal is a real bench shell
+
+Open a terminal inside code-server and run:
+
+```bash
+whoami                                  # the lab's ssh_username, not frappe
+pwd                                     # /home/<user>/frappe-bench
+bench --site <site> list-apps           # the resolved app list
+bench version
+```
+
+All four must work with no `sudo` and no PATH fix — `linkuser.sh` appends the nvm node path and
+`frappe-bench/env/bin` to the user's `.bashrc`, and points the shell at the bench directory. A failure
+here is that block.
+
+> `/home/<user>` is a symlink to `/home/frappe`, so a tool that resolves symlinks may print
+> `/home/frappe/frappe-bench`. Same directory.
+
+## 5. SSH does the same from your own machine
+
+Copy the SSH line from Connection details and run it with the SSH password:
+
+```bash
+ssh <user>@<wg_ip>
+# whoami → <user>, pwd → /home/<user>/frappe-bench, bench --site <site> list-apps works
+```
+
+**A one-shot command is not a login shell.** `ssh <user>@<wg_ip> "bench --site <site> list-apps"` runs a
+non-interactive shell, and Debian's `.bashrc` returns before the bench block for those — so it starts in
+the home directory and `bench` reports *"Command not being executed in bench directory"*. Name the
+directory when scripting:
+
+```bash
+ssh <user>@<wg_ip> "cd frappe-bench && bench --site <site> list-apps"
+```
+
+## 6. Off the tunnel, the UI is honest
+
+Disconnect the tunnel and reload nothing — return to the browser tab.
+
+- **Open site** and **Open VS Code** are disabled and say why ("Register this device on the VPN…").
+- Each site row reads `Unreachable` with its own reason, distinct from a stopped container's.
+- Reconnecting the tunnel re-enables them on the next focus of the tab — the VPN status is re-read on
+  window focus and on page mount, so no hard reload is needed.
+- Nothing spins forever.
+
+## 7. With the bench stopped, nothing offers a dead address
+
+Stop the bench from the overflow menu.
+
+- The **Open VS Code** button is gone (`code_server_url` is cleared, and the button follows it).
+- The site row reads `Inactive`, its Open button is disabled and says the container is stopped.
+- The primary action is **Deploy**, not **Open site**.
+
+Deploy again to bring it back — there is no start-a-stopped-instance path yet
+([#127](https://github.com/Venkateshvenki404224/benchpress/issues/127)).
+
+## 8. A failed deploy names its own cause
+
+Point a Lab App row at a branch that does not exist and deploy.
+
+- The banner names the **image build** failure, not the deploy's log tail.
+- Its button opens the **Build log** tab, and the build log holds the git error.
+
+---
+
+## What to record
+
+For each numbered step: pass, fail, or not exercised — with the reason for the last one. A run that
+skipped the tunnel is a run that did not test the tunnel.
+
+Two known intermittents, neither a defect of the step they break:
+
+- `wg-quick up wg0` can report *"wg0 already exists"* at step 5 when the container's own entrypoint won
+  the race. Retry the deploy.
+- `codeload.github.com` rate-limits this host in bursts. A 429 during an image build is retryable.
+
+## When the public hostname lands
+
+[#129](https://github.com/Venkateshvenki404224/benchpress/issues/129) gives every instance a public
+`<instance-id>.benchpress.cloud` name, and [#130](https://github.com/Venkateshvenki404224/benchpress/issues/130)
+points the open actions at it. This checklist is then re-run with `<wg_ip>` replaced by that hostname and
+step 6 inverted — off the tunnel becomes the normal case, which is
+[#133](https://github.com/Venkateshvenki404224/benchpress/issues/133).
+
+Before that lands, fix the exposure it uncovers: code-server binds `0.0.0.0:8080` with `cert: false`, so
+it is plaintext HTTP on every interface of the container, with its password as the only control. That is
+acceptable while WireGuard is the sole ingress and unacceptable the moment a public hostname points at it.

--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -17,6 +17,7 @@ declare module 'vue' {
     AppSearch: typeof import('./src/components/AppSearch.vue')['default']
     BackLink: typeof import('./src/components/BackLink.vue')['default']
     CheckList: typeof import('./src/components/CheckList.vue')['default']
+    CodeServerDialog: typeof import('./src/components/lab/CodeServerDialog.vue')['default']
     ConnectionCard: typeof import('./src/components/lab/ConnectionCard.vue')['default']
     ConnectionDetails: typeof import('./src/components/lab/ConnectionDetails.vue')['default']
     ConnectionTestCard: typeof import('./src/components/device/ConnectionTestCard.vue')['default']

--- a/frontend/src/components/lab/CodeServerDialog.vue
+++ b/frontend/src/components/lab/CodeServerDialog.vue
@@ -1,0 +1,92 @@
+<template>
+	<Dialog
+		v-model="isOpen"
+		:options="{ title: 'code-server password', size: 'sm' }"
+		data-test="code-server-dialog"
+	>
+		<template #body-content>
+			<p class="text-body text-ink-gray-6" data-test="code-server-message">
+				{{ prompt.message }}
+			</p>
+
+			<div v-if="prompt.status === PROMPT_READY" class="mt-3 flex items-center gap-2">
+				<!-- Shown, not masked: this dialog exists to be read and pasted
+				     into the tab that just opened. -->
+				<FormControl
+					class="min-w-0 flex-1"
+					type="text"
+					:model-value="prompt.password"
+					readonly
+					data-test="code-server-password"
+				/>
+				<Tooltip :text="copied ? 'Copied' : 'Copy'">
+					<Button
+						variant="subtle"
+						aria-label="Copy the code-server password"
+						data-test="copy-code-server-password"
+						@click="copy"
+					>
+						<!-- A tooltip closes on the click that opens it, so the
+						     icon carries the confirmation too. -->
+						<template #icon>
+							<component
+								:is="copied ? CheckIcon : CopyIcon"
+								class="size-3.5"
+								:class="copied ? 'text-ink-green-3' : ''"
+							/>
+						</template>
+					</Button>
+				</Tooltip>
+			</div>
+
+			<ErrorMessage class="mt-3" :message="prompt.error" />
+		</template>
+	</Dialog>
+</template>
+
+<script setup>
+// The password for the IDE tab the click just opened. `get_code_server_credentials`
+// was written for exactly this and had no caller until now; it guards on the bench
+// running and on a stored address, so a dead IDE says so here rather than after a
+// login attempt.
+import { PROMPT_READY, codeServerPrompt } from "@/utils/labActions";
+import { Button, Dialog, ErrorMessage, FormControl, Tooltip } from "frappe-ui";
+import { computed, ref } from "vue";
+
+import CheckIcon from "~icons/lucide/check";
+import CopyIcon from "~icons/lucide/copy";
+
+const COPIED_FEEDBACK_MS = 2000;
+
+const props = defineProps({
+	modelValue: { type: Boolean, default: false },
+	loading: { type: Boolean, default: false },
+	error: { type: [String, Object], default: "" },
+	password: { type: String, default: "" },
+});
+
+const emit = defineEmits(["update:modelValue"]);
+
+const isOpen = computed({
+	get: () => props.modelValue,
+	set: (value) => emit("update:modelValue", value),
+});
+
+const prompt = computed(() =>
+	codeServerPrompt({ loading: props.loading, error: props.error, password: props.password })
+);
+
+const copied = ref(false);
+let copiedTimer = null;
+
+async function copy() {
+	try {
+		await navigator.clipboard.writeText(prompt.value.password);
+	} catch (error) {
+		return;
+	}
+	copied.value = true;
+	clearTimeout(copiedTimer);
+	copiedTimer = setTimeout(() => (copied.value = false), COPIED_FEEDBACK_MS);
+}
+</script>

--- a/frontend/src/components/lab/ConnectionDetails.vue
+++ b/frontend/src/components/lab/ConnectionDetails.vue
@@ -79,6 +79,7 @@
 // re-masks. Copy feedback is a tooltip on the button that was pressed, which
 // replaces the teleported page-corner alert the old screen used.
 import SectionCard from "@/components/SectionCard.vue";
+import { ideUrl } from "@/utils/labActions";
 import { Button, FormControl, Tooltip } from "frappe-ui";
 import { computed, ref } from "vue";
 
@@ -136,7 +137,8 @@ const rows = computed(() =>
 
 function codeServerRow() {
 	if (!props.lab.enable_code_server) return null;
-	return { key: "code-server", label: "code-server", value: props.bench.code_server_url };
+	// Through the same helper the IDE button uses, so what is shown is what opens.
+	return { key: "code-server", label: "code-server", value: ideUrl(props.bench) };
 }
 
 function codeServerPasswordRow() {

--- a/frontend/src/components/lab/LabErrorBanner.vue
+++ b/frontend/src/components/lab/LabErrorBanner.vue
@@ -28,7 +28,7 @@
 						data-test="view-failing-log"
 						@click="emit('view-log')"
 					>
-						View failing log lines
+						{{ logButtonLabel }}
 					</Button>
 				</div>
 			</div>
@@ -47,6 +47,14 @@ import AlertIcon from "~icons/lucide/circle-alert";
 
 const RUN_LABEL = { build: "Image build failed", deploy: "Deploy failed" };
 
+// A build failure inside a deploy is reported against the build (`lab_detail._deploy_failure`),
+// so the button has to name the tab that actually holds the Docker output — the deploy log's
+// tail only says the build broke.
+const LOG_BUTTON_LABEL = {
+	build: "Open the Build log",
+	deploy: "View failing log lines",
+};
+
 const props = defineProps({
 	// The `failure` object `benchpress.api.get_lab` returns.
 	failure: { type: Object, required: true },
@@ -55,8 +63,16 @@ const props = defineProps({
 
 const emit = defineEmits(["edit", "view-log"]);
 
+// A build log carries no steps — `_build_lab_with_logs` writes one opening marker and
+// Docker's own "Step 17/23" lines are not markers — so a build's step is always the word
+// "started" dressed up as information. Only a deploy names a step worth reading.
 const headline = computed(() => {
 	const run = RUN_LABEL[props.failure.source] ?? "Last run failed";
-	return props.failure.step ? `${run} at: ${props.failure.step}` : run;
+	const step = props.failure.source === "build" ? "" : props.failure.step;
+	return step ? `${run} at: ${step}` : run;
 });
+
+const logButtonLabel = computed(
+	() => LOG_BUTTON_LABEL[props.failure.source] ?? "View failing log lines"
+);
 </script>

--- a/frontend/src/components/lab/SitesCard.vue
+++ b/frontend/src/components/lab/SitesCard.vue
@@ -1,8 +1,8 @@
 <template>
-	<SectionCard title="Sites" :padded="!sites.length" data-test="sites-card">
-		<ul v-if="sites.length" class="divide-y divide-outline-gray-1">
+	<SectionCard title="Sites" :padded="!rows.length" data-test="sites-card">
+		<ul v-if="rows.length" class="divide-y divide-outline-gray-1">
 			<li
-				v-for="site in sites"
+				v-for="site in rows"
 				:key="site.name"
 				class="flex flex-wrap items-center gap-3 px-4 py-3"
 				:data-test="`site-${site.name}`"
@@ -17,16 +17,25 @@
 							Bare site
 						</span>
 					</div>
+					<!-- A disabled button emits no hover events, so the reason is a
+					     caption under the row and never a tooltip. -->
+					<p
+						v-if="site.open.hint"
+						class="mt-1 text-2xs text-ink-gray-5"
+						:data-test="`site-hint-${site.name}`"
+					>
+						{{ site.open.hint }}
+					</p>
 				</div>
 				<StatusBadge :status="site.status" />
 				<Button
 					variant="subtle"
 					size="sm"
-					:disabled="!openable(site)"
+					:disabled="site.open.disabled"
 					:data-test="`open-site-${site.name}`"
 					@click="emit('open', site)"
 				>
-					{{ openable(site) ? "Open" : "Unreachable" }}
+					{{ site.open.label }}
 				</Button>
 			</li>
 		</ul>
@@ -40,14 +49,17 @@
 
 <script setup>
 // The sites a bench serves, and nothing more: a site is created by the deploy,
-// so there is no create path to offer here. A site that cannot be reached is
-// never hidden — its button stays, disabled, and says "Unreachable" so the
-// tunnel, or a site nothing serves, is the obvious suspect.
+// so there is no create path to offer here. A site that cannot be opened is
+// never hidden — its button stays, disabled, and names which of the two
+// reasons applies, because a stopped container and a down tunnel send the user
+// somewhere different.
 import AppChip from "@/components/AppChip.vue";
 import EmptyState from "@/components/EmptyState.vue";
 import SectionCard from "@/components/SectionCard.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
+import { siteOpenAction } from "@/utils/labActions";
 import { Button } from "frappe-ui";
+import { computed } from "vue";
 
 const props = defineProps({
 	// Each site as `get_lab` returned it, plus the `url` its Open button opens.
@@ -57,7 +69,16 @@ const props = defineProps({
 
 const emit = defineEmits(["open"]);
 
-function openable(site) {
-	return props.reachable && !!site.url;
-}
+// The card renders what it is handed: the address comes from the page, and the
+// button's state from one pure function, so neither is decided in a template.
+const rows = computed(() =>
+	props.sites.map((site) => ({
+		...site,
+		open: siteOpenAction({
+			status: site.status,
+			url: site.url,
+			vpnConnected: props.reachable,
+		}),
+	}))
+);
 </script>

--- a/frontend/src/components/lab/SitesCard.vue
+++ b/frontend/src/components/lab/SitesCard.vue
@@ -1,18 +1,5 @@
 <template>
 	<SectionCard title="Sites" :padded="!sites.length" data-test="sites-card">
-		<template #action>
-			<Button
-				v-if="canCreate"
-				variant="subtle"
-				size="sm"
-				data-test="new-site"
-				@click="showDialog = true"
-			>
-				<template #prefix><PlusIcon class="size-3.5" /></template>
-				New site
-			</Button>
-		</template>
-
 		<ul v-if="sites.length" class="divide-y divide-outline-gray-1">
 			<li
 				v-for="site in sites"
@@ -35,11 +22,11 @@
 				<Button
 					variant="subtle"
 					size="sm"
-					:disabled="!reachable"
+					:disabled="!openable(site)"
 					:data-test="`open-site-${site.name}`"
 					@click="emit('open', site)"
 				>
-					{{ reachable ? "Open" : "Unreachable" }}
+					{{ openable(site) ? "Open" : "Unreachable" }}
 				</Button>
 			</li>
 		</ul>
@@ -48,100 +35,29 @@
 			v-else
 			message="No site yet — one is created automatically when this lab is deployed."
 		/>
-
-		<Dialog v-model="showDialog" :options="{ title: 'Create a site', size: 'sm' }">
-			<template #body-content>
-				<div class="space-y-4">
-					<FormControl
-						v-model="siteName"
-						label="Site name"
-						type="text"
-						placeholder="e.g. mysite"
-						data-test="site-name-input"
-					/>
-					<div v-if="labApps.length">
-						<p class="mb-2 text-2xs font-medium text-ink-gray-6">Apps to install</p>
-						<div class="flex flex-wrap gap-2">
-							<label
-								v-for="app in labApps"
-								:key="app.app_name"
-								class="flex cursor-pointer items-center gap-2 rounded-control border border-outline-gray-1 px-2.5 py-1.5 text-2xs text-ink-gray-7"
-								:class="
-									selectedApps.includes(app.app_name) ? 'bg-surface-gray-2' : ''
-								"
-							>
-								<input
-									v-model="selectedApps"
-									type="checkbox"
-									:value="app.app_name"
-									:data-test="`site-app-${app.app_name}`"
-								/>
-								{{ app.app_label || app.app_name }}
-							</label>
-						</div>
-					</div>
-					<ErrorMessage :message="createError" />
-				</div>
-			</template>
-			<template #actions>
-				<Button
-					class="w-full"
-					variant="solid"
-					:loading="creating"
-					:disabled="!siteName.trim()"
-					data-test="create-site"
-					@click="submit"
-				>
-					Create site
-				</Button>
-			</template>
-		</Dialog>
 	</SectionCard>
 </template>
 
 <script setup>
-// The sites a bench serves, and the only place one is created. A site that
-// cannot be reached is never hidden — its button stays, disabled, and says
-// "Unreachable" so the tunnel is the obvious suspect.
+// The sites a bench serves, and nothing more: a site is created by the deploy,
+// so there is no create path to offer here. A site that cannot be reached is
+// never hidden — its button stays, disabled, and says "Unreachable" so the
+// tunnel, or a site nothing serves, is the obvious suspect.
 import AppChip from "@/components/AppChip.vue";
 import EmptyState from "@/components/EmptyState.vue";
 import SectionCard from "@/components/SectionCard.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
-import { Button, Dialog, ErrorMessage, FormControl } from "frappe-ui";
-import { computed, ref, watch } from "vue";
-
-import PlusIcon from "~icons/lucide/plus";
+import { Button } from "frappe-ui";
 
 const props = defineProps({
+	// Each site as `get_lab` returned it, plus the `url` its Open button opens.
 	sites: { type: Array, default: () => [] },
-	// The lab's apps, offered as the checklist when creating a site.
-	labApps: { type: Array, default: () => [] },
-	canCreate: { type: Boolean, default: false },
 	reachable: { type: Boolean, default: false },
-	creating: { type: Boolean, default: false },
-	createError: { type: String, default: "" },
 });
 
-const emit = defineEmits(["create", "open"]);
+const emit = defineEmits(["open"]);
 
-const showDialog = ref(false);
-const siteName = ref("");
-const selectedApps = ref([]);
-
-const created = computed(() => props.sites.length);
-
-// The dialog closes when the create lands — the site list is what confirms it.
-watch(created, () => {
-	showDialog.value = false;
-});
-
-watch(showDialog, (open) => {
-	if (!open) return;
-	siteName.value = "";
-	selectedApps.value = props.labApps.map((app) => app.app_name);
-});
-
-function submit() {
-	emit("create", { siteName: siteName.value.trim(), apps: [...selectedApps.value] });
+function openable(site) {
+	return props.reachable && !!site.url;
 }
 </script>

--- a/frontend/src/data/vpnStatus.js
+++ b/frontend/src/data/vpnStatus.js
@@ -31,3 +31,18 @@ const vpnStatusResource = createResource({
 export async function reloadVpnStatus() {
 	await vpnStatusResource.reload();
 }
+
+/**
+ * Refresh on a real signal rather than on a timer.
+ *
+ * The tunnel is brought up outside this app, in the WireGuard client, so nothing
+ * here can be told when it happens. Fetching once per boot meant a user who
+ * connected while sitting on a lab page watched "Open site" and "Open VS Code"
+ * stay disabled until a hard reload, which reads as a broken button rather than
+ * a stale one. Coming back to the tab is exactly when that is most likely to
+ * have just changed, and it costs one request — so this stays an event, not the
+ * poll this codebase avoids everywhere else.
+ */
+if (typeof window !== "undefined") {
+	window.addEventListener("focus", reloadVpnStatus);
+}

--- a/frontend/src/pages/LabDetail.vue
+++ b/frontend/src/pages/LabDetail.vue
@@ -87,6 +87,13 @@
 					</div>
 				</template>
 			</Tabs>
+
+			<CodeServerDialog
+				v-model="showCodeServerPassword"
+				:loading="codeServerCredentials.loading"
+				:error="codeServerCredentials.error"
+				:password="codeServerCredentials.data?.password ?? ''"
+			/>
 		</template>
 	</div>
 </template>
@@ -101,6 +108,7 @@ import EmptyState from "@/components/EmptyState.vue";
 import LogViewer from "@/components/LogViewer.vue";
 import SectionCard from "@/components/SectionCard.vue";
 import DeployPipeline from "@/components/deploy/DeployPipeline.vue";
+import CodeServerDialog from "@/components/lab/CodeServerDialog.vue";
 import ConnectionCard from "@/components/lab/ConnectionCard.vue";
 import ConnectionDetails from "@/components/lab/ConnectionDetails.vue";
 import ContainerStatusCard from "@/components/lab/ContainerStatusCard.vue";
@@ -139,6 +147,12 @@ const building = ref(false);
 
 const lab = createResource({ url: "benchpress.api.get_lab", params: { name: labId }, auto: true });
 const credentials = createResource({ url: "benchpress.api.get_bench_credentials" });
+// Fetched at the moment the IDE is opened, never on page load: a password on
+// screen nobody asked for is a password on a screenshot.
+const codeServerCredentials = createResource({
+	url: "benchpress.api.get_code_server_credentials",
+});
+const showCodeServerPassword = ref(false);
 const deployLogs = createResource({ url: "benchpress.api.get_deploy_logs" });
 const buildLogs = createListResource({
 	doctype: "Build Log",
@@ -261,9 +275,27 @@ function openSite(site = null) {
 	if (address) window.open(address, "_blank");
 }
 
+// The tab is opened by the click itself — a `window.open` after an awaited fetch
+// is a popup, not a navigation, and browsers block it. The password follows into
+// the dialog, so the user reads it beside the login form instead of hunting for
+// it behind "Reveal secrets".
+//
+// `restart_code_server` is the other endpoint with no caller. It belongs in the
+// overflow menu the day an acceptance run shows code-server needs a nudge; until
+// then it would be a button for a problem nobody has had.
 function openCodeServer() {
 	const address = ideUrl(bench.value);
-	if (address) window.open(address, "_blank");
+	if (!address || !bench.value) return;
+	window.open(address, "_blank");
+	// The address opened is the helper's, not the one the endpoint returns:
+	// issue #130 repoints `ideUrl` alone. The call is for the password, and for
+	// the guards it already carries — bench Running, and an address the deploy
+	// actually stored.
+	codeServerCredentials.reset();
+	showCodeServerPassword.value = true;
+	// The dialog is where a failure is read, so the rejection is swallowed here
+	// rather than reported twice.
+	codeServerCredentials.submit({ bench_name: bench.value.name }).catch(() => {});
 }
 
 /** Lab recipes are edited on the desk form; the SPA has no editor yet. */

--- a/frontend/src/pages/LabDetail.vue
+++ b/frontend/src/pages/LabDetail.vue
@@ -60,17 +60,12 @@
 								:connected="vpnStatus.connected"
 								@register="router.push('/devices')"
 							/>
-							<SitesCard v-bind="sitesProps" :can-create="false" @open="openSite" />
+							<SitesCard v-bind="sitesProps" @open="openSite" />
 						</div>
 					</div>
 
 					<div v-else-if="tab.key === 'sites'" class="pt-4">
-						<SitesCard
-							v-bind="sitesProps"
-							:can-create="!!bench"
-							@create="createSite"
-							@open="openSite"
-						/>
+						<SitesCard v-bind="sitesProps" @open="openSite" />
 					</div>
 
 					<div v-else class="pt-4">
@@ -115,7 +110,7 @@ import SitesCard from "@/components/lab/SitesCard.vue";
 import { openDeployRun } from "@/data/deployRun";
 import { userContext } from "@/data/userContext";
 import { vpnStatus } from "@/data/vpnStatus";
-import { siteUrl } from "@/utils/labActions";
+import { ideUrl, siteUrl } from "@/utils/labActions";
 import { useSocket } from "@/socket";
 import { ErrorMessage, Tabs, createListResource, createResource, dayjsLocal } from "frappe-ui";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
@@ -163,7 +158,6 @@ const buildAction = createResource({
 });
 const deployAction = createResource({ url: "benchpress.api.create_bench", onSuccess: refresh });
 const benchAction = createResource({ url: "benchpress.api.bench_action", onSuccess: refresh });
-const createSiteAction = createResource({ url: "benchpress.api.create_site", onSuccess: refresh });
 
 const bench = computed(() => lab.data?.bench ?? null);
 const sites = computed(() => lab.data?.sites ?? []);
@@ -178,12 +172,11 @@ const actionError = computed(
 // The lab as the header should read it, including the optimistic build state.
 const labView = computed(() => (building.value ? { ...lab.data, status: "Building" } : lab.data));
 
+// Each row carries the address its own Open button opens, resolved through the
+// one URL helper — the card renders what it is handed and resolves nothing.
 const sitesProps = computed(() => ({
-	sites: sites.value,
-	labApps: lab.data?.apps ?? [],
+	sites: sites.value.map((site) => ({ ...site, url: siteUrl(bench.value, site) })),
 	reachable: vpnStatus.connected,
-	creating: createSiteAction.loading,
-	createError: createSiteAction.error || "",
 }));
 
 /** Age of the health reading in seconds; null when the bench was never polled. */
@@ -261,22 +254,16 @@ async function deleteBench() {
 	router.push("/labs");
 }
 
-function createSite({ siteName, apps }) {
-	createSiteAction.submit({
-		data: JSON.stringify({
-			site_name: siteName,
-			bench: bench.value?.name,
-			apps: apps.map((name) => ({ name })),
-		}),
-	});
-}
-
-function openSite() {
-	if (siteAddress.value) window.open(siteAddress.value, "_blank");
+// The header hands over no site, so it opens the bench's own; a row hands over
+// its site, and opens that one.
+function openSite(site = null) {
+	const address = siteUrl(bench.value, site);
+	if (address) window.open(address, "_blank");
 }
 
 function openCodeServer() {
-	if (bench.value?.code_server_url) window.open(bench.value.code_server_url, "_blank");
+	const address = ideUrl(bench.value);
+	if (address) window.open(address, "_blank");
 }
 
 /** Lab recipes are edited on the desk form; the SPA has no editor yet. */

--- a/frontend/src/pages/LabDetail.vue
+++ b/frontend/src/pages/LabDetail.vue
@@ -109,7 +109,7 @@ import LabHeader from "@/components/lab/LabHeader.vue";
 import SitesCard from "@/components/lab/SitesCard.vue";
 import { openDeployRun } from "@/data/deployRun";
 import { userContext } from "@/data/userContext";
-import { vpnStatus } from "@/data/vpnStatus";
+import { reloadVpnStatus, vpnStatus } from "@/data/vpnStatus";
 import { ideUrl, siteUrl } from "@/utils/labActions";
 import { useSocket } from "@/socket";
 import { ErrorMessage, Tabs, createListResource, createResource, dayjsLocal } from "frappe-ui";
@@ -319,6 +319,10 @@ function endRun(liveRun, liveLog) {
 onMounted(() => {
 	socket?.on("bench_deploy_log", onDeployLog);
 	socket?.on("lab_build_log", onBuildLog);
+	// Every open button on this page is gated on the tunnel, and the tunnel is
+	// brought up outside the app — so ask again on arrival rather than trusting
+	// whatever the SPA read at boot.
+	reloadVpnStatus();
 });
 
 onUnmounted(() => {

--- a/frontend/src/utils/labActions.js
+++ b/frontend/src/utils/labActions.js
@@ -18,6 +18,7 @@ export const REBUILD = "rebuild";
 export const WAIT = "wait";
 
 export const SITE_PORT = 8000;
+export const IDE_PORT = 8080;
 
 /**
  * The primary button for a lab and the caller's deployment of it.
@@ -113,14 +114,38 @@ export function deployDialogAction({ runState, vpnConnected, siteUrl } = {}) {
 }
 
 /**
- * Where a bench's site actually answers.
+ * The host a bench answers on — the single source of every address on this page.
  *
- * The domain is a label, not a route — nothing resolves it. The site is served
- * by the container itself, reachable over the tunnel on its WireGuard address.
+ * Every open action routes through the two helpers below, so issue #130 (giving
+ * each instance a public `<instance-id>.benchpress.cloud` hostname) repoints one
+ * function rather than hunting call sites. Today a bench answers only on its
+ * WireGuard address, over the tunnel.
  */
-export function siteUrl(bench) {
-	const host = bench?.wg_ip || bench?.container_ip;
-	return host ? `http://${host}:${SITE_PORT}` : null;
+function benchHost(bench) {
+	return bench?.wg_ip || bench?.container_ip || null;
+}
+
+/**
+ * Where a site actually answers, or null when nothing serves it.
+ *
+ * With no site it is the bench's own site. With one, it is that row's address —
+ * and a row naming anything else has none: the container pins `default_site` to
+ * the bench's site and nginx serves only that, so claiming otherwise would open
+ * one site from another site's button.
+ *
+ * The domain is a label, not a route — nothing resolves it.
+ */
+export function siteUrl(bench, site = null) {
+	const host = benchHost(bench);
+	if (!host) return null;
+	if (site && site.site_name !== bench?.site_name) return null;
+	return `http://${host}:${SITE_PORT}`;
+}
+
+/** Where the IDE answers — the same host, code-server's port. */
+export function ideUrl(bench) {
+	const host = benchHost(bench);
+	return host ? `http://${host}:${IDE_PORT}/` : null;
 }
 
 /** What that address is called on screen. */
@@ -135,6 +160,6 @@ export function siteLabel(bench, site) {
 }
 
 function hostLabel(bench) {
-	const host = bench?.wg_ip || bench?.container_ip;
+	const host = benchHost(bench);
 	return host ? `${host}:${SITE_PORT}` : "";
 }

--- a/frontend/src/utils/labActions.js
+++ b/frontend/src/utils/labActions.js
@@ -142,6 +142,45 @@ export function siteUrl(bench, site = null) {
 	return `http://${host}:${SITE_PORT}`;
 }
 
+/**
+ * The Open button on one site row: what it says, and why it cannot be pressed.
+ *
+ * A stopped container and a down tunnel are different problems with different
+ * remedies, so they never collapse into one word — telling a user on the VPN to
+ * register a device is how this UI lost their trust once already. The button is
+ * never hidden, only disabled with its reason, as everywhere else on this page.
+ *
+ * @param {object} state
+ * @param {string} state.status `Bench Site.status`.
+ * @param {string|null} state.url Where this row's site answers, if anything serves it.
+ * @param {boolean} state.vpnConnected Whether this device's tunnel is up.
+ * @returns {{label: string, disabled: boolean, hint: string}}
+ */
+export function siteOpenAction({ status, url, vpnConnected } = {}) {
+	if (status !== "Active") {
+		return {
+			label: "Not running",
+			disabled: true,
+			hint: "This site's container is stopped. Deploy the lab to bring it back.",
+		};
+	}
+	if (!vpnConnected) {
+		return {
+			label: "Unreachable",
+			disabled: true,
+			hint: "Register this device on the VPN to reach this site.",
+		};
+	}
+	if (!url) {
+		return {
+			label: "Unreachable",
+			disabled: true,
+			hint: "Nothing serves this site — the container answers only on its own site.",
+		};
+	}
+	return { label: "Open", disabled: false, hint: "" };
+}
+
 /** Where the IDE answers — the same host, code-server's port. */
 export function ideUrl(bench) {
 	const host = benchHost(bench);

--- a/frontend/src/utils/labActions.js
+++ b/frontend/src/utils/labActions.js
@@ -202,3 +202,53 @@ function hostLabel(bench) {
 	const host = benchHost(bench);
 	return host ? `${host}:${SITE_PORT}` : "";
 }
+
+export const PROMPT_LOADING = "loading";
+export const PROMPT_READY = "ready";
+export const PROMPT_ERROR = "error";
+
+/**
+ * What the IDE dialog says while the password it was opened for is fetched.
+ *
+ * The IDE tab is opened by the click itself; this dialog exists so the password
+ * arrives with it instead of being hunted for behind the "Reveal secrets"
+ * toggle. It is never put in the URL — a query parameter would land in browser
+ * history, in the container's access log and in every proxy in between.
+ *
+ * @param {object} state
+ * @param {boolean} state.loading Whether `get_code_server_credentials` is in flight.
+ * @param {string|object} state.error What it failed with, if it failed.
+ * @param {string} state.password What it returned.
+ * @returns {{status: string, message: string, password: string, error: string}}
+ */
+export function codeServerPrompt({ loading, error, password } = {}) {
+	if (loading) return prompt(PROMPT_LOADING, "Fetching this lab's IDE password…");
+	if (error) {
+		return prompt(
+			PROMPT_ERROR,
+			"The IDE opened, but its password could not be read. Connection details holds it.",
+			{ error: errorText(error) }
+		);
+	}
+	if (!password) {
+		return prompt(
+			PROMPT_ERROR,
+			"This lab has no IDE password recorded. Redeploy it to set one."
+		);
+	}
+	return prompt(
+		PROMPT_READY,
+		"code-server asks for this password. Every redeploy replaces it.",
+		{
+			password,
+		}
+	);
+}
+
+function prompt(status, message, rest = {}) {
+	return { status, message, password: "", error: "", ...rest };
+}
+
+function errorText(error) {
+	return typeof error === "string" ? error : error?.message || "";
+}

--- a/frontend/src/utils/labActions.spec.js
+++ b/frontend/src/utils/labActions.spec.js
@@ -7,6 +7,7 @@ import {
 	VIEW_LOG,
 	WAIT,
 	deployDialogAction,
+	ideUrl,
 	primaryAction,
 	siteLabel,
 	siteUrl,
@@ -104,6 +105,21 @@ describe("siteUrl", () => {
 	it("has no address for a bench that never got one", () => {
 		expect(siteUrl({})).toBeNull();
 		expect(siteUrl(null)).toBeNull();
+	});
+
+	it("answers for the row it is handed, not for the bench", () => {
+		const bench = { wg_ip: "172.27.0.2", site_name: "lab-abc" };
+		expect(siteUrl(bench, { site_name: "lab-abc" })).toBe(SITE);
+		// The container serves its own site and nothing else, so any other row is
+		// unreachable — opening the bench's site from it would be the old lie.
+		expect(siteUrl(bench, { site_name: "somebody-elses" })).toBeNull();
+	});
+});
+
+describe("ideUrl", () => {
+	it("is the same host on code-server's port", () => {
+		expect(ideUrl({ wg_ip: "172.27.0.2" })).toBe("http://172.27.0.2:8080/");
+		expect(ideUrl({})).toBeNull();
 	});
 });
 

--- a/frontend/src/utils/labActions.spec.js
+++ b/frontend/src/utils/labActions.spec.js
@@ -10,6 +10,7 @@ import {
 	ideUrl,
 	primaryAction,
 	siteLabel,
+	siteOpenAction,
 	siteUrl,
 } from "./labActions";
 
@@ -113,6 +114,42 @@ describe("siteUrl", () => {
 		// The container serves its own site and nothing else, so any other row is
 		// unreachable — opening the bench's site from it would be the old lie.
 		expect(siteUrl(bench, { site_name: "somebody-elses" })).toBeNull();
+	});
+});
+
+describe("siteOpenAction", () => {
+	const active = { status: "Active", url: SITE };
+
+	it("opens only when the site is running and the tunnel is up", () => {
+		expect(siteOpenAction({ ...active, vpnConnected: true })).toMatchObject({
+			label: "Open",
+			disabled: false,
+			hint: "",
+		});
+	});
+
+	it("blames the tunnel when the site is running and the tunnel is not", () => {
+		const state = siteOpenAction({ ...active, vpnConnected: false });
+		expect(state).toMatchObject({ label: "Unreachable", disabled: true });
+		expect(state.hint).toContain("VPN");
+	});
+
+	// The two reasons send the user somewhere different — the VPN page, or Deploy —
+	// so a stopped site says so even with the tunnel up, and never says "Unreachable".
+	it("blames the container when the site is not running, tunnel or no tunnel", () => {
+		for (const status of ["Inactive", "Creating", "Error"]) {
+			for (const vpnConnected of [true, false]) {
+				const state = siteOpenAction({ status, url: SITE, vpnConnected });
+				expect(state).toMatchObject({ label: "Not running", disabled: true });
+				expect(state.hint).toContain("stopped");
+			}
+		}
+	});
+
+	it("stays disabled for a running site nothing serves", () => {
+		const state = siteOpenAction({ status: "Active", url: null, vpnConnected: true });
+		expect(state).toMatchObject({ label: "Unreachable", disabled: true });
+		expect(state.hint).toContain("Nothing serves");
 	});
 });
 

--- a/frontend/src/utils/labActions.spec.js
+++ b/frontend/src/utils/labActions.spec.js
@@ -3,9 +3,13 @@ import {
 	CONNECT_VPN,
 	DEPLOY,
 	OPEN,
+	PROMPT_ERROR,
+	PROMPT_LOADING,
+	PROMPT_READY,
 	REBUILD,
 	VIEW_LOG,
 	WAIT,
+	codeServerPrompt,
 	deployDialogAction,
 	ideUrl,
 	primaryAction,
@@ -206,5 +210,39 @@ describe("deployDialogAction", () => {
 			label: "View the failing log",
 			disabled: false,
 		});
+	});
+});
+
+describe("codeServerPrompt", () => {
+	it("says the password is on its way while the fetch is in flight", () => {
+		expect(codeServerPrompt({ loading: true })).toMatchObject({
+			status: PROMPT_LOADING,
+			password: "",
+		});
+	});
+
+	it("hands over the password the fetch returned", () => {
+		expect(codeServerPrompt({ password: "s3cret" })).toMatchObject({
+			status: PROMPT_READY,
+			password: "s3cret",
+		});
+	});
+
+	it("points at Connection details when the fetch failed", () => {
+		const prompt = codeServerPrompt({ error: new Error("Bench must be running") });
+		expect(prompt.status).toBe(PROMPT_ERROR);
+		expect(prompt.error).toBe("Bench must be running");
+		expect(prompt.password).toBe("");
+	});
+
+	it("treats a missing password as a failure, not as an empty one", () => {
+		expect(codeServerPrompt({ password: "" })).toMatchObject({
+			status: PROMPT_ERROR,
+			password: "",
+		});
+	});
+
+	it("reads a string error as its own message", () => {
+		expect(codeServerPrompt({ error: "denied" }).error).toBe("denied");
 	});
 });


### PR DESCRIPTION
Every defect in this branch is one defect wearing four hats: **the UI reported success it had not verified.** Four phases, one per hat.

| Phase | Commit | What it does |
|---|---|---|
| 1 | `c00ec4b` | The Sites tab tells the truth, and **Open** opens the site in the row you clicked |
| 2 | `cd19fa3` | A site's status follows its container; actions on a container-less instance fail cleanly |
| 3 | `83e9c78` | Every discarded exit code in the deploy path is checked; a build failure is attributed to the build |
| 4 | `d4317d3` | The IDE opens with its password in hand, and the shell story is written down and proven |

## Phase 1 — the Sites tab stops offering what it cannot deliver

- Deleted `api.create_site`, `_create_site_on_bench`, the create dialog and `Bench Site`'s `create` DocPerm. The container serves one site — `common_site_config.json` pins `default_site` and `setup-site.sh` symlinks only the first — so every extra site the create path made was unreachable.
- **This takes the user's 2026-08-17 decision (strip it), which contradicts #126 and #131.** Multi-site would need per-site serving plus Host-header or per-port routing. Close those two or re-scope them.
- One helper owns every address (`frontend/src/utils/labActions.js`: `benchHost` + `siteUrl` + `ideUrl`), so #130 repoints one function. A row naming a site the bench does not serve renders a disabled "Unreachable" rather than opening someone else's site.
- `BenchSite.compute_full_domain` is now the only writer of `full_domain`. It is a display label; `site_name` is the identity every database drop uses.

## Phase 2 — status follows the container

- `deploy_manager.stop_bench` deactivates the bench's sites, and `api.bench_action("stop")` routes through it, so there is one stop path instead of two that must agree.
- `_require_container` throws *"this instance has no container — deploy it first"* before Docker is called. (#127, start-a-stopped-instance, remains its own feature.)
- `siteOpenAction` splits the two disabled reasons — "Not running" (stopped container) vs "Unreachable" (tunnel down) — and `vpnStatus` reloads on window focus and on lab-detail mount, so connecting the tunnel while sitting on a lab page no longer needs a hard reload.
- One-time patch `retire_orphaned_creating_sites` retires stranded `Creating` rows.

## Phase 3 — a green deploy means it worked

Six holes, all verified against real deployments with forced failures, not only mocks:

1. `write_file_to_container` raises on a non-zero exec — covers `common_site_config.json`, `wg0.conf` and the code-server config.
2. `_start_code_server` checks the `chown`/`chmod` on the config.
3. …and `restart.sh`, storing `code_server_url` only after both pass. It clears the field **in the row** before the attempt, because the failure path calls `bench.reload()`.
4. The `common_site_config.json` write is verified.
5. `_ensure_assets` logs a warning with the captured output instead of raising — **on purpose**: stale bundles still serve, a killed deploy does not.
6. A build failure inside a deploy is attributed to the build. `Lab.status` cannot carry it (`_run_build` restores it so one tenant's failure does not mark the shared catalog row), so `lab_detail._deploy_failure` looks for a failed `Build Log` for that lab newer than the deploy log. The banner reads "Image build failed" and its button opens the Build log tab.

## Phase 4 — the IDE opens, the terminal works, and it is written down

- **The IDE deep link now carries its password.** `get_code_server_credentials` existed with no caller; the button calls it and shows the password in `CodeServerDialog` beside the tab it just opened. The tab is opened **first**, inside the click — a `window.open` after an awaited fetch is a popup and browsers block it. The password is never a query parameter: history, the container's access log and every proxy between would keep it.
- The address opened is still `ideUrl(bench)`, not the endpoint's `url`, so #130 keeps its single seam. The endpoint's two guards (bench `Running`, a stored address) are what a user now reads when the IDE is dead, so they have tests.
- `ARCHITECTURE.md` no longer describes a `DeployPage` Terminal component that never existed. It names the real surfaces and gains a **Shell Access** section: SSH over WireGuard or the terminal inside code-server, no web terminal, and the terminals in `docs/index.html` / `www/home.html` are marketing mockups.
- `docs/lab-access-acceptance.md` is the repeatable checklist, with headless `curl` equivalents.

### Acceptance run — lab `frappe`, bench `b3873…`, `172.27.0.5`, over a real tunnel

A throwaway VPN device and an alpine `wg-quick` client, both removed afterwards.

| # | Step | Result |
|---|---|---|
| 1 | Deploy green | **Pass** — 11/11 steps `success`, no warning lines, 31.2 s |
| 2 | Site + admin login | **Pass** — `200`, and `/api/method/login` returns `Logged In` |
| 3 | IDE opens with its password | **Pass** — dialog shows it at the click; `302` → session cookie → `Location: ./?folder=/home/administrator/frappe-bench` |
| 4 | Integrated terminal | **Pass** — `whoami` = the lab's user, `pwd` = `~/frappe-bench`, `bench --site … list-apps` and `bench version` work with no `sudo` and no PATH fix |
| 5 | SSH | **Pass (interactive)** — same user, same directory, same commands |
| 6 | Off-VPN honesty | **Not exercised live** — every device peer on this host belongs to the operator's own laptop tunnel, and staling it would disconnect their machine. The disabled states are unit-tested and phase 2 verified the focus refresh |
| 7 | Stopped-bench honesty | **Pass** — IDE button gone, both site rows `Inactive` / "Not running" with the container reason, primary action back to Deploy; redeploy restored it in ~30 s and the dialog then showed the *new* password |
| 8 | Failed deploy readable | **Pass, in phase 3** — driven live from the UI there; not repeated |

Two findings from the run that are documented rather than changed:

- **A one-shot `ssh user@host "bench …"` is not the login shell.** Debian's `.bashrc` returns before the block `linkuser.sh` appends, so a non-interactive command starts in `$HOME` and `bench` reports *"Command not being executed in bench directory"*. Scripting form is `ssh host "cd frappe-bench && bench …"`. Making a non-interactive shell `cd` would break `scp host:relative/path`.
- **code-server binds `0.0.0.0:8080` with `cert: false`**, so it answers on the shared `benchpress` bridge in cleartext with its password as the only control — fine while WireGuard is the sole ingress, a blocker the moment a public hostname points at it. Recorded on #129 as a prerequisite.

## Tests

- 530 backend tests: 1 failure, `test_signup.test_a_retirement_notice_goes_out_once_per_entry`, pre-existing on this dev site and unrelated (verified by stashing when it first appeared).
- 142 vitest, 8 files.
- `pre-commit run --all-files` clean (ruff, prettier, eslint).

## Related issues

- Closes the Sites-tab and status rows of the staging punch-list; #126 / #131 need a decision (this branch takes "strip it").
- #127 start-a-stopped-instance: only the crash is fixed here, not the capability.
- #129 / #130 public hostname: this branch leaves exactly one function to repoint, and #129 now carries the code-server exposure note.
- #133 is the no-VPN re-run of `docs/lab-access-acceptance.md` once #129 lands.
