### PR TITLE
Implemented phase three

### DIFF
--- a/benchpress/benchpress/doctype/bench_instance/bench_instance.json
+++ b/benchpress/benchpress/doctype/bench_instance/bench_instance.json
@@ -20,6 +20,7 @@
   "column_break_ssh",
   "admin_password",
   "domain",
+  "public_url",
   "container_section",
   "container_id",
   "container_image",
@@ -118,6 +119,12 @@
    "fieldname": "domain",
    "fieldtype": "Data",
    "label": "Domain"
+  },
+  {
+   "fieldname": "public_url",
+   "fieldtype": "Data",
+   "label": "Public URL",
+   "read_only": 1
   },
   {
    "collapsible": 1,
@@ -289,7 +296,7 @@
    "link_fieldname": "bench"
   }
  ],
- "modified": "2026-07-26 18:30:00.000000",
+ "modified": "2026-08-19 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Benchpress",
  "name": "Bench Instance",

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -4,8 +4,10 @@
 import json
 import secrets
 import shlex
+from pathlib import Path
 
 import frappe
+import yaml
 from frappe.utils.file_lock import LockTimeoutError
 from frappe.utils.synchronization import filelock
 
@@ -57,6 +59,48 @@ NOTHING_TO_ROLL_BACK = "Cleanup: nothing to roll back — no container was creat
 SITE_HTTP_PORT = 8000
 
 ADOPTED_MARKER = "already exists — adopting it"
+
+# Module constant, not inlined, so tests can monkeypatch it to a tmp path.
+TRAEFIK_DYNAMIC_DIR = Path("/etc/traefik/dynamic/instances")
+
+
+def _public_site_url(instance_id: str, base_domain: str | None) -> str | None:
+	if not base_domain or base_domain == "localhost":
+		return None
+	return f"https://{instance_id}.{base_domain}"
+
+
+def _write_instance_route(instance_id: str, base_domain: str, container_ip: str) -> None:
+	"""Write a Traefik file-provider route for this instance's site.
+
+	`tls: {}` (empty section, no `certResolver`) deliberately — it turns TLS on for this
+	router using Traefik's existing default cert store, which already holds the wildcard
+	SAN from the control-plane router. No new ACME issuance happens per instance.
+
+	One file per instance, named by instance ID, so a redeploy naturally overwrites it
+	with the fresh `container_ip` — no dedup logic needed.
+	"""
+	if not base_domain or base_domain == "localhost":
+		return
+	TRAEFIK_DYNAMIC_DIR.mkdir(parents=True, exist_ok=True)
+	config = {
+		"http": {
+			"routers": {
+				f"site-{instance_id}": {
+					"rule": f"Host(`{instance_id}.{base_domain}`)",
+					"entryPoints": ["websecure"],
+					"service": f"site-{instance_id}",
+					"tls": {},
+				},
+			},
+			"services": {
+				f"site-{instance_id}": {
+					"loadBalancer": {"servers": [{"url": f"http://{container_ip}:{SITE_HTTP_PORT}"}]}
+				},
+			},
+		}
+	}
+	(TRAEFIK_DYNAMIC_DIR / f"{instance_id}.yml").write_text(yaml.safe_dump(config))
 
 
 def _cleanup_failed_deploy(bench, container_id, append_log) -> None:
@@ -241,6 +285,8 @@ def _deploy_bench(bench_name: str) -> None:
 		frappe.db.commit()
 
 		settings = frappe.get_cached_doc("BenchPress Settings")
+		bench.public_url = _public_site_url(bench.name, settings.base_domain)
+		_write_instance_route(bench.name, settings.base_domain, container_ip)
 
 		_setup_container_vpn(bench, container_id, pipeline)
 

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -70,11 +70,17 @@ def _public_site_url(instance_id: str, base_domain: str | None) -> str | None:
 	return f"https://{instance_id}.{base_domain}"
 
 
-def _write_instance_route(instance_id: str, base_domain: str, container_ip: str) -> None:
-	"""Write a Traefik file-provider route for this instance's site.
+def _public_ide_url(instance_id: str, base_domain: str | None) -> str | None:
+	if not base_domain or base_domain == "localhost":
+		return None
+	return f"https://ide-{instance_id}.{base_domain}"
 
-	`tls: {}` (empty section, no `certResolver`) deliberately — it turns TLS on for this
-	router using Traefik's existing default cert store, which already holds the wildcard
+
+def _write_instance_route(instance_id: str, base_domain: str, container_ip: str) -> None:
+	"""Write Traefik file-provider routes for this instance's site and its code-server IDE.
+
+	`tls: {}` (empty section, no `certResolver`) deliberately — it turns TLS on for these
+	routers using Traefik's existing default cert store, which already holds the wildcard
 	SAN from the control-plane router. No new ACME issuance happens per instance.
 
 	One file per instance, named by instance ID, so a redeploy naturally overwrites it
@@ -92,11 +98,18 @@ def _write_instance_route(instance_id: str, base_domain: str, container_ip: str)
 					"service": f"site-{instance_id}",
 					"tls": {},
 				},
+				f"ide-{instance_id}": {
+					"rule": f"Host(`ide-{instance_id}.{base_domain}`)",
+					"entryPoints": ["websecure"],
+					"service": f"ide-{instance_id}",
+					"tls": {},
+				},
 			},
 			"services": {
 				f"site-{instance_id}": {
 					"loadBalancer": {"servers": [{"url": f"http://{container_ip}:{SITE_HTTP_PORT}"}]}
 				},
+				f"ide-{instance_id}": {"loadBalancer": {"servers": [{"url": f"http://{container_ip}:8080"}]}},
 			},
 		}
 	}
@@ -354,7 +367,7 @@ def _deploy_bench(bench_name: str) -> None:
 		pipeline.log(f"Site served on port {SITE_HTTP_PORT}")
 
 		if getattr(lab, "enable_code_server", 0):
-			_start_code_server(bench, container_id, pipeline)
+			_start_code_server(bench, container_id, pipeline, settings)
 		else:
 			pipeline.log("Code server is disabled for this lab — skipped")
 
@@ -397,7 +410,7 @@ def _deploy_bench(bench_name: str) -> None:
 		_notify_owner(bench.owner, f"Bench deploy failed: {bench.bench_name}", "Bench Instance", bench.name)
 
 
-def _start_code_server(bench, container_id: str, pipeline) -> None:
+def _start_code_server(bench, container_id: str, pipeline, settings) -> None:
 	"""Configure code-server, launch it, and only then claim it is up.
 
 	Every exec is checked. The config write decides whether code-server can authenticate at
@@ -425,7 +438,10 @@ def _start_code_server(bench, container_id: str, pipeline) -> None:
 	_checked_exec(container_id, "bash /opt/benchpress/scripts/restart.sh", "restart.sh")
 
 	bench.code_server_password = code_server_password
-	bench.code_server_url = f"http://{bench.wg_ip or bench.container_ip or '127.0.0.1'}:8080/"
+	bench.code_server_url = (
+		_public_ide_url(bench.name, settings.base_domain)
+		or f"http://{bench.wg_ip or bench.container_ip or '127.0.0.1'}:8080/"
+	)
 	pipeline.log(f"code-server ready at {bench.code_server_url}")
 
 

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -116,6 +116,17 @@ def _write_instance_route(instance_id: str, base_domain: str, container_ip: str)
 	(TRAEFIK_DYNAMIC_DIR / f"{instance_id}.yml").write_text(yaml.safe_dump(config))
 
 
+def _delete_instance_route(instance_id: str) -> None:
+	"""Remove this instance's Traefik route file, if any.
+
+	Torn-down containers free their IP back to Docker, which can hand it to the next
+	deployed instance. A route file left behind after teardown is live routing state
+	that would keep pointing the old public hostname at whatever container ends up
+	with that IP next — so this has to run at teardown, not just redeploy.
+	"""
+	(TRAEFIK_DYNAMIC_DIR / f"{instance_id}.yml").unlink(missing_ok=True)
+
+
 def _cleanup_failed_deploy(bench, container_id, append_log) -> None:
 	"""Best-effort teardown of resources created by this failed run.
 
@@ -589,6 +600,11 @@ def teardown_bench(bench) -> None:
 			remove_container(bench.container_id)
 		except Exception:
 			pass  # best-effort
+
+	try:
+		_delete_instance_route(bench.name)
+	except Exception:
+		pass  # best-effort
 
 	remove_bench_volume(bench.name)
 	_drop_site_database(bench)

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -736,15 +736,33 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		self.assertNotIn("code-server ready at", log)
 		self.assertFalse(self._bench_field(bench, "code_server_url"))
 
-	def test_a_working_step_ten_stores_the_address_and_says_ready_once(self):
+	def test_a_working_step_ten_stores_the_tunnel_address_on_localhost(self):
 		bench = self._bench()
 		self._enable_code_server()
+		self._set_base_domain("localhost")
 
 		self._run_deploy(bench)
 
 		log = self._log(bench.name)
 		self.assertEqual(log.count("code-server ready at"), 1)
 		self.assertEqual(self._bench_field(bench, "code_server_url"), "http://172.27.0.11:8080/")
+		self.assertEqual(self._bench_field(bench, "status"), "Running")
+
+	def test_a_working_step_ten_stores_the_public_ide_hostname(self):
+		from benchpress import deploy_manager
+
+		bench = self._bench()
+		self._enable_code_server()
+		self._set_base_domain("benchpress.cloud")
+
+		with patch.object(deploy_manager, "_write_instance_route", autospec=True):
+			self._run_deploy(bench)
+
+		log = self._log(bench.name)
+		self.assertEqual(log.count("code-server ready at"), 1)
+		self.assertEqual(
+			self._bench_field(bench, "code_server_url"), f"https://ide-{bench.name}.benchpress.cloud"
+		)
 		self.assertEqual(self._bench_field(bench, "status"), "Running")
 
 	# --- public_url (phase 1: public site hostname) ---
@@ -1166,6 +1184,22 @@ class TestPublicSiteUrlHelpers(unittest.TestCase):
 
 		self.assertEqual(_public_site_url("inst-1", "benchpress.cloud"), "https://inst-1.benchpress.cloud")
 
+	def test_public_ide_url_is_none_when_base_domain_unset(self):
+		from benchpress.deploy_manager import _public_ide_url
+
+		self.assertIsNone(_public_ide_url("inst-1", None))
+		self.assertIsNone(_public_ide_url("inst-1", ""))
+
+	def test_public_ide_url_is_none_for_localhost(self):
+		from benchpress.deploy_manager import _public_ide_url
+
+		self.assertIsNone(_public_ide_url("inst-1", "localhost"))
+
+	def test_public_ide_url_shape(self):
+		from benchpress.deploy_manager import _public_ide_url
+
+		self.assertEqual(_public_ide_url("inst-1", "benchpress.cloud"), "https://ide-inst-1.benchpress.cloud")
+
 	def test_write_instance_route_writes_router_and_service(self):
 		from benchpress import deploy_manager
 
@@ -1181,6 +1215,14 @@ class TestPublicSiteUrlHelpers(unittest.TestCase):
 
 			service = config["http"]["services"]["site-inst-1"]
 			self.assertEqual(service["loadBalancer"]["servers"], [{"url": "http://172.30.0.11:8000"}])
+
+			ide_router = config["http"]["routers"]["ide-inst-1"]
+			self.assertEqual(ide_router["rule"], "Host(`ide-inst-1.benchpress.cloud`)")
+			self.assertEqual(ide_router["service"], "ide-inst-1")
+			self.assertEqual(ide_router["tls"], {})
+
+			ide_service = config["http"]["services"]["ide-inst-1"]
+			self.assertEqual(ide_service["loadBalancer"]["servers"], [{"url": "http://172.30.0.11:8080"}])
 
 	def test_write_instance_route_no_ops_for_localhost(self):
 		from benchpress import deploy_manager

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -1,10 +1,14 @@
 # Copyright (c) 2026, Venkatesh and Contributors
 # See license.txt
 
+import tempfile
+import unittest
 from contextlib import nullcontext
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import frappe
+import yaml
 from frappe.tests import IntegrationTestCase
 
 from benchpress.benchpress.doctype.bench_instance import get_instance_id
@@ -743,6 +747,35 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		self.assertEqual(self._bench_field(bench, "code_server_url"), "http://172.27.0.11:8080/")
 		self.assertEqual(self._bench_field(bench, "status"), "Running")
 
+	# --- public_url (phase 1: public site hostname) ---
+
+	def _set_base_domain(self, value):
+		before = frappe.db.get_single_value("BenchPress Settings", "base_domain")
+		frappe.db.set_single_value("BenchPress Settings", "base_domain", value)
+		frappe.clear_cache(doctype="BenchPress Settings")
+		self.addCleanup(frappe.db.set_single_value, "BenchPress Settings", "base_domain", before)
+		self.addCleanup(frappe.clear_cache, doctype="BenchPress Settings")
+		frappe.db.commit()
+
+	def test_public_url_set_when_base_domain_is_configured(self):
+		from benchpress import deploy_manager
+
+		bench = self._bench()
+		self._set_base_domain("benchpress.cloud")
+
+		with patch.object(deploy_manager, "_write_instance_route", autospec=True):
+			self._run_deploy(bench)
+
+		self.assertEqual(self._bench_field(bench, "public_url"), f"https://{bench.name}.benchpress.cloud")
+
+	def test_public_url_stays_unset_with_localhost_base_domain(self):
+		bench = self._bench()
+		self._set_base_domain("localhost")
+
+		self._run_deploy(bench)
+
+		self.assertFalse(self._bench_field(bench, "public_url"))
+
 	def test_a_failed_file_write_fails_the_deploy_at_the_step_that_wrote_it(self):
 		"""Hole 4: a silently unwritten `common_site_config.json` is a site that cannot find redis."""
 		bench = self._bench()
@@ -1112,3 +1145,49 @@ class TestRecordPrimarySite(IntegrationTestCase):
 		# The name the database was actually created under must be among those dropped.
 		self.assertIn(bench.site_name, dropped)
 		self.assertIn(site.full_domain, dropped)
+
+
+class TestPublicSiteUrlHelpers(unittest.TestCase):
+	"""Pure-function tests, no container/DB — see phase-1-public-site-hostname.md."""
+
+	def test_public_site_url_is_none_when_base_domain_unset(self):
+		from benchpress.deploy_manager import _public_site_url
+
+		self.assertIsNone(_public_site_url("inst-1", None))
+		self.assertIsNone(_public_site_url("inst-1", ""))
+
+	def test_public_site_url_is_none_for_localhost(self):
+		from benchpress.deploy_manager import _public_site_url
+
+		self.assertIsNone(_public_site_url("inst-1", "localhost"))
+
+	def test_public_site_url_shape(self):
+		from benchpress.deploy_manager import _public_site_url
+
+		self.assertEqual(_public_site_url("inst-1", "benchpress.cloud"), "https://inst-1.benchpress.cloud")
+
+	def test_write_instance_route_writes_router_and_service(self):
+		from benchpress import deploy_manager
+
+		with tempfile.TemporaryDirectory() as tmp:
+			with patch.object(deploy_manager, "TRAEFIK_DYNAMIC_DIR", Path(tmp) / "instances"):
+				deploy_manager._write_instance_route("inst-1", "benchpress.cloud", "172.30.0.11")
+				config = yaml.safe_load((Path(tmp) / "instances" / "inst-1.yml").read_text())
+
+			router = config["http"]["routers"]["site-inst-1"]
+			self.assertEqual(router["rule"], "Host(`inst-1.benchpress.cloud`)")
+			self.assertEqual(router["service"], "site-inst-1")
+			self.assertEqual(router["tls"], {})
+
+			service = config["http"]["services"]["site-inst-1"]
+			self.assertEqual(service["loadBalancer"]["servers"], [{"url": "http://172.30.0.11:8000"}])
+
+	def test_write_instance_route_no_ops_for_localhost(self):
+		from benchpress import deploy_manager
+
+		with tempfile.TemporaryDirectory() as tmp:
+			target_dir = Path(tmp) / "instances"
+			with patch.object(deploy_manager, "TRAEFIK_DYNAMIC_DIR", target_dir):
+				deploy_manager._write_instance_route("inst-1", "localhost", "172.30.0.11")
+
+			self.assertFalse(target_dir.exists())

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -1164,6 +1164,37 @@ class TestRecordPrimarySite(IntegrationTestCase):
 		self.assertIn(bench.site_name, dropped)
 		self.assertIn(site.full_domain, dropped)
 
+	def test_teardown_removes_the_instance_route_file(self):
+		"""Freed container IPs get reused by Docker — a stale route file left after teardown
+		would keep pointing the old public hostname at whoever gets that IP next. See
+		phase-3-teardown-cleanup.md."""
+		from benchpress import deploy_manager
+		from benchpress.deploy_manager import teardown_bench
+
+		bench = self._bench()
+
+		with tempfile.TemporaryDirectory() as tmp:
+			with patch.object(deploy_manager, "TRAEFIK_DYNAMIC_DIR", Path(tmp) / "instances"):
+				deploy_manager._write_instance_route(bench.name, "benchpress.cloud", "172.30.0.11")
+				route_file = Path(tmp) / "instances" / f"{bench.name}.yml"
+				self.assertTrue(route_file.exists())
+
+				teardown_bench(bench)
+
+				self.assertFalse(route_file.exists())
+
+	def test_teardown_does_not_raise_when_no_route_file_exists(self):
+		"""The `base_domain = localhost` case: phase 1 never wrote a route file, so teardown
+		must no-op cleanly rather than raising on a missing path."""
+		from benchpress import deploy_manager
+		from benchpress.deploy_manager import teardown_bench
+
+		bench = self._bench()
+
+		with tempfile.TemporaryDirectory() as tmp:
+			with patch.object(deploy_manager, "TRAEFIK_DYNAMIC_DIR", Path(tmp) / "instances"):
+				teardown_bench(bench)
+
 
 class TestPublicSiteUrlHelpers(unittest.TestCase):
 	"""Pure-function tests, no container/DB — see phase-1-public-site-hostname.md."""


### PR DESCRIPTION
## Summary

Phase 1 of `specs/in-progress/public-instance-hostnames/` — the tracer-bullet slice giving a deployed instance's *site* a public hostname, `https://<instance-id>.<base_domain>`, reachable with no VPN.

- **`Bench Instance`**: new `public_url` (Data, read_only) field alongside `domain`/`code_server_url`.
- **`deploy_manager.py`**:
  - `_public_site_url(instance_id, base_domain)` — pure helper, `None` unless `base_domain` is set and isn't `"localhost"`.
  - `_write_instance_route(instance_id, base_domain, container_ip)` — writes a Traefik file-provider router+service block to `TRAEFIK_DYNAMIC_DIR` (one file per instance, `tls: {}` reusing the existing wildcard cert — no new ACME issuance). No-ops for `localhost`.
  - Both wired into `_deploy_bench` right after `settings` loads; `public_url` rides the same `bench.save()` that already persists `container_ip`/`wg_ip`.

**Not in this PR** (paired manual change in the sibling `benchpress_devops` repo, per the spec): switching Traefik's file provider to a watched directory, the `traefik-dynamic-instances` volume, and joining Traefik to the `benchpress` network.

**Explicitly deferred** to phase 2 (IDE hostname) and phase 3 (route cleanup on teardown) — not oversights.

## Test plan

- [x] `bench --site frontend migrate` — new `public_url` field applies cleanly
- [x] `bench --site frontend run-tests --module benchpress.tests.test_deploy_manager` — 51/51 pass, including new `_public_site_url`/`_write_instance_route` unit tests and the deploy-flow `public_url` assertions for both a configured `base_domain` and `"localhost"`
- [x] `bench --site frontend run-tests --app benchpress` — full suite, 563/563 pass
- [x] `uvx pre-commit@4.3.0 run --all-files` — clean
- [ ] End-to-end `curl -I https://<instance-id>.<test-domain>` from outside the VPN — needs the paired `benchpress_devops` change deployed first (spec step 3)