### PR TITLE
Implemented phase three

### DIFF
--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -156,6 +156,10 @@ def create_bench(data: str) -> dict:
 	instance_id = get_instance_id(frappe.session.user, lab_name)
 	if frappe.db.exists("Bench Instance", instance_id):
 		doc = frappe.get_doc("Bench Instance", instance_id)
+		site_name = resolve_site_name(requested_site_name, exclude_bench=doc.name)
+		if site_name and site_name != doc.site_name:
+			_assert_site_name_changeable(doc)
+			doc.site_name = site_name
 		doc.status = "Deploying"
 		doc.save()
 	else:
@@ -195,6 +199,25 @@ def create_bench(data: str) -> dict:
 	)
 
 	return {"name": doc.name, "status": "Deploying"}
+
+
+def _assert_site_name_changeable(doc) -> None:
+	"""Refuse to rename a bench whose current name might still own a live database.
+
+	`Draft` is the only status that guarantees no live site exists under `doc.site_name`:
+	either nothing was ever deployed, or `teardown_bench` ran and actually dropped the
+	database before resetting status. `stop_bench` marks the instance `Stopped` and
+	deactivates its `Bench Site` rows WITHOUT dropping the database (only `teardown_bench`
+	does that) — so `Stopped` must still block a rename, or the old database would be
+	silently orphaned. The caller stops/deletes the instance first to rename it.
+	"""
+	if doc.status != "Draft":
+		frappe.throw(
+			_(
+				"'{0}' is already deployed as '{1}'. Stop or delete this instance before choosing "
+				"a different site name."
+			).format(doc.name, doc.site_name)
+		)
 
 
 @frappe.whitelist()

--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -142,6 +142,7 @@ def _counts_by_bench(doctype: str, column: str, bench_names: list[str]) -> dict[
 def create_bench(data: str) -> dict:
 	require_app_user()
 	from benchpress.benchpress.doctype.bench_instance import get_instance_id
+	from benchpress.docker_manager import resolve_site_name
 
 	data = frappe.parse_json(data)
 
@@ -150,6 +151,7 @@ def create_bench(data: str) -> dict:
 		frappe.throw(_("Lab is required to create a bench."))
 
 	lab = frappe.get_cached_doc("Lab", lab_name)
+	requested_site_name = data.get("site_name") or data.get("site")
 
 	instance_id = get_instance_id(frappe.session.user, lab_name)
 	if frappe.db.exists("Bench Instance", instance_id):
@@ -164,6 +166,7 @@ def create_bench(data: str) -> dict:
 				"lab": lab_name,
 				"frappe_version": lab.frappe_version,
 				"domain": data.get("domain"),
+				"site_name": resolve_site_name(requested_site_name),
 				"status": "Draft",
 			}
 		)

--- a/benchpress/benchpress/doctype/bench_instance/bench_instance.py
+++ b/benchpress/benchpress/doctype/bench_instance/bench_instance.py
@@ -15,7 +15,8 @@ class BenchInstance(Document):
 	def before_insert(self):
 		instance_id = get_instance_id(frappe.session.user, self.lab)
 		self.bench_name = instance_id
-		self.site_name = f"{instance_id}.localhost"
+		if not self.site_name:
+			self.site_name = f"{instance_id}.localhost"
 		self.ssh_username = self._derive_username()
 
 	def autoname(self):

--- a/benchpress/benchpress/doctype/bench_instance/test_bench_instance.py
+++ b/benchpress/benchpress/doctype/bench_instance/test_bench_instance.py
@@ -43,7 +43,7 @@ class IntegrationTestBenchInstance(IntegrationTestCase):
 		frappe.db.commit()
 		super().tearDownClass()
 
-	def _insert_bench(self):
+	def _insert_bench(self, **extra):
 		frappe.set_user("Administrator")
 		existing = get_instance_id("Administrator", self.lab_name)
 		if frappe.db.exists("Bench Instance", existing):
@@ -53,6 +53,7 @@ class IntegrationTestBenchInstance(IntegrationTestCase):
 			{
 				"doctype": "Bench Instance",
 				"lab": self.lab_name,
+				**extra,
 			}
 		).insert(ignore_permissions=True)
 		frappe.db.commit()
@@ -74,26 +75,7 @@ class IntegrationTestBenchInstance(IntegrationTestCase):
 		self.assertTrue(bench.site_name.endswith(".localhost"))
 
 	def test_before_insert_honors_a_caller_supplied_site_name(self):
-		frappe.set_user("Administrator")
-		existing = get_instance_id("Administrator", self.lab_name)
-		if frappe.db.exists("Bench Instance", existing):
-			frappe.delete_doc("Bench Instance", existing, force=True, ignore_permissions=True)
-			frappe.db.commit()
-		bench = frappe.get_doc(
-			{
-				"doctype": "Bench Instance",
-				"lab": self.lab_name,
-				"site_name": "caller-chosen.localhost",
-			}
-		).insert(ignore_permissions=True)
-		frappe.db.commit()
-		self.addCleanup(
-			lambda n=bench.name: frappe.delete_doc("Bench Instance", n, force=True, ignore_permissions=True)
-			if frappe.db.exists("Bench Instance", n)
-			else None
-		)
-		self.addCleanup(frappe.db.commit)
-
+		bench = self._insert_bench(site_name="caller-chosen.localhost")
 		self.assertEqual(bench.site_name, "caller-chosen.localhost")
 		self.assertEqual(bench.bench_name, get_instance_id("Administrator", self.lab_name))
 

--- a/benchpress/benchpress/doctype/bench_instance/test_bench_instance.py
+++ b/benchpress/benchpress/doctype/bench_instance/test_bench_instance.py
@@ -73,6 +73,30 @@ class IntegrationTestBenchInstance(IntegrationTestCase):
 		bench = self._insert_bench()
 		self.assertTrue(bench.site_name.endswith(".localhost"))
 
+	def test_before_insert_honors_a_caller_supplied_site_name(self):
+		frappe.set_user("Administrator")
+		existing = get_instance_id("Administrator", self.lab_name)
+		if frappe.db.exists("Bench Instance", existing):
+			frappe.delete_doc("Bench Instance", existing, force=True, ignore_permissions=True)
+			frappe.db.commit()
+		bench = frappe.get_doc(
+			{
+				"doctype": "Bench Instance",
+				"lab": self.lab_name,
+				"site_name": "caller-chosen.localhost",
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+		self.addCleanup(
+			lambda n=bench.name: frappe.delete_doc("Bench Instance", n, force=True, ignore_permissions=True)
+			if frappe.db.exists("Bench Instance", n)
+			else None
+		)
+		self.addCleanup(frappe.db.commit)
+
+		self.assertEqual(bench.site_name, "caller-chosen.localhost")
+		self.assertEqual(bench.bench_name, get_instance_id("Administrator", self.lab_name))
+
 	def test_before_insert_derives_ssh_username_from_email(self):
 		bench = self._insert_bench()
 		self.assertEqual(bench.ssh_username, "administrator")

--- a/benchpress/docker_manager.py
+++ b/benchpress/docker_manager.py
@@ -35,13 +35,16 @@ SITE_LABEL_MAX_LENGTH = 63
 SITE_LABEL_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
 
 
-def resolve_site_name(raw_site_name: str | None) -> str | None:
-	"""Normalize a caller-chosen site name into `<label>.<base_domain>`.
+def resolve_site_name(raw_site_name: str | None, *, exclude_bench: str | None = None) -> str | None:
+	"""Normalize a caller-chosen site name and refuse anything unsafe or already taken.
 
 	Returns `None` when `raw_site_name` is empty, so the caller falls back to its own
 	default. A bare label is required — dots are rejected rather than treated as an
 	already-qualified domain, so the resolved name is always exactly
-	`<label>.<base_domain>`, never an arbitrary suffix a caller supplied.
+	`<label>.<base_domain>`, never an arbitrary suffix a caller supplied. The resolved
+	name becomes a MariaDB db/user name and an on-disk site folder, both unique
+	server-wide, so the collision check is global — `exclude_bench` exists only so a
+	redeploy can recheck its own name without colliding with itself.
 	"""
 	if not raw_site_name or not raw_site_name.strip():
 		return None
@@ -61,7 +64,17 @@ def resolve_site_name(raw_site_name: str | None) -> str | None:
 			).format(raw_site_name, SITE_LABEL_MAX_LENGTH)
 		)
 	base_domain = frappe.db.get_single_value("BenchPress Settings", "base_domain") or "localhost"
-	return f"{candidate}.{base_domain}"
+	resolved = f"{candidate}.{base_domain}"
+	_assert_site_name_available(resolved, exclude_bench)
+	return resolved
+
+
+def _assert_site_name_available(site_name: str, exclude_bench: str | None) -> None:
+	filters = {"site_name": site_name, "status": ("!=", "Inactive")}
+	if exclude_bench:
+		filters["bench"] = ("!=", exclude_bench)
+	if frappe.db.exists("Bench Site", filters):
+		frappe.throw(_("Site name '{0}' is already in use. Choose a different name.").format(site_name))
 
 
 def _get_host_block_devices() -> list[str]:

--- a/benchpress/docker_manager.py
+++ b/benchpress/docker_manager.py
@@ -31,6 +31,39 @@ def validate_lab_id(lab_id: str) -> None:
 		)
 
 
+SITE_LABEL_MAX_LENGTH = 63
+SITE_LABEL_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+
+
+def resolve_site_name(raw_site_name: str | None) -> str | None:
+	"""Normalize a caller-chosen site name into `<label>.<base_domain>`.
+
+	Returns `None` when `raw_site_name` is empty, so the caller falls back to its own
+	default. A bare label is required — dots are rejected rather than treated as an
+	already-qualified domain, so the resolved name is always exactly
+	`<label>.<base_domain>`, never an arbitrary suffix a caller supplied.
+	"""
+	if not raw_site_name or not raw_site_name.strip():
+		return None
+	candidate = raw_site_name.strip().lower()
+	if "." in candidate:
+		frappe.throw(
+			_(
+				"Site name '{0}' must be a single label without dots — the domain is added automatically."
+			).format(raw_site_name)
+		)
+	if not SITE_LABEL_RE.match(candidate) or len(candidate) > SITE_LABEL_MAX_LENGTH:
+		frappe.throw(
+			_(
+				"Site name '{0}' is not valid: use lowercase letters, numbers and single '-' "
+				"separators, starting and ending with a letter or number (max {1} characters), "
+				"e.g. 'acme' or 'acme-labs'."
+			).format(raw_site_name, SITE_LABEL_MAX_LENGTH)
+		)
+	base_domain = frappe.db.get_single_value("BenchPress Settings", "base_domain") or "localhost"
+	return f"{candidate}.{base_domain}"
+
+
 def _get_host_block_devices() -> list[str]:
 	try:
 		result = subprocess.run(

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -602,6 +602,31 @@ class TestApi(IntegrationTestCase):
 			frappe.db.get_value("Bench Instance", result["name"], "site_name"), "acme.benchpress.cloud"
 		)
 
+	def test_create_bench_rejects_a_duplicate_site_name(self):
+		self._set_base_domain("benchpress.cloud")
+		other_lab = _ensure_lab("api-timing-dup-site-lab")
+		other_bench = _ensure_bench(other_lab)
+		self.addCleanup(
+			frappe.delete_doc, "Bench Instance", other_bench.name, force=True, ignore_permissions=True
+		)
+		self.addCleanup(frappe.delete_doc, "Lab", other_lab.name, force=True, ignore_permissions=True)
+		site = frappe.get_doc(
+			{
+				"doctype": "Bench Site",
+				"bench": other_bench.name,
+				"site_name": "acme.benchpress.cloud",
+				"status": "Active",
+			}
+		).insert(ignore_permissions=True)
+		self.addCleanup(frappe.delete_doc, "Bench Site", site.name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+		data = frappe.as_json({"lab": self.create_lab.name, "site_name": "acme"})
+		with self.assertRaises(frappe.ValidationError):
+			api.create_bench(data)
+		instance_id = get_instance_id(frappe.session.user, self.create_lab.name)
+		self.assertFalse(frappe.db.exists("Bench Instance", instance_id))
+
 	def test_create_bench_without_site_name_keeps_the_default(self):
 		data = frappe.as_json({"lab": self.create_lab.name})
 		with patch("frappe.enqueue"):

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -627,6 +627,72 @@ class TestApi(IntegrationTestCase):
 		instance_id = get_instance_id(frappe.session.user, self.create_lab.name)
 		self.assertFalse(frappe.db.exists("Bench Instance", instance_id))
 
+	def test_create_bench_refuses_to_rename_a_deployed_instance(self):
+		self._set_base_domain("benchpress.cloud")
+		lab = _ensure_lab("api-timing-rename-running-lab", apps=[_lab_app()])
+		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
+		bench = _ensure_bench(lab, status="Running", site_name="original.benchpress.cloud")
+		self.addCleanup(frappe.delete_doc, "Bench Instance", bench.name, force=True, ignore_permissions=True)
+
+		data = frappe.as_json({"lab": lab.name, "site_name": "renamed"})
+		with self.assertRaises(frappe.ValidationError):
+			api.create_bench(data)
+		self.assertEqual(
+			frappe.db.get_value("Bench Instance", bench.name, "site_name"), "original.benchpress.cloud"
+		)
+
+	def test_create_bench_refuses_to_rename_a_stopped_instance(self):
+		"""`stop_bench` never drops the database, so a `Stopped` instance's site is still live."""
+		self._set_base_domain("benchpress.cloud")
+		lab = _ensure_lab("api-timing-rename-stopped-lab", apps=[_lab_app()])
+		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
+		bench = _ensure_bench(lab, status="Stopped", site_name="original.benchpress.cloud")
+		self.addCleanup(frappe.delete_doc, "Bench Instance", bench.name, force=True, ignore_permissions=True)
+
+		data = frappe.as_json({"lab": lab.name, "site_name": "renamed"})
+		with self.assertRaises(frappe.ValidationError):
+			api.create_bench(data)
+		self.assertEqual(
+			frappe.db.get_value("Bench Instance", bench.name, "site_name"), "original.benchpress.cloud"
+		)
+
+	def test_create_bench_allows_a_new_site_name_after_teardown(self):
+		self._set_base_domain("benchpress.cloud")
+		lab = _ensure_lab("api-timing-rename-draft-lab", apps=[_lab_app()])
+		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
+		bench = _ensure_bench(lab, status="Draft", site_name="old.benchpress.cloud")
+		self.addCleanup(frappe.delete_doc, "Bench Instance", bench.name, force=True, ignore_permissions=True)
+
+		data = frappe.as_json({"lab": lab.name, "site_name": "fresh"})
+		with patch("frappe.enqueue"):
+			result = api.create_bench(data)
+		self.assertEqual(result["status"], "Deploying")
+		self.assertEqual(
+			frappe.db.get_value("Bench Instance", bench.name, "site_name"), "fresh.benchpress.cloud"
+		)
+
+	def test_create_bench_redeploy_with_the_same_site_name_is_a_no_op(self):
+		self._set_base_domain("benchpress.cloud")
+		lab = _ensure_lab("api-timing-rename-noop-lab", apps=[_lab_app()])
+		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
+		bench = _ensure_bench(lab, status="Running", site_name="stable.benchpress.cloud")
+		self.addCleanup(frappe.delete_doc, "Bench Instance", bench.name, force=True, ignore_permissions=True)
+
+		data = frappe.as_json({"lab": lab.name, "site_name": "stable"})
+		with patch("frappe.enqueue"):
+			result = api.create_bench(data)
+		self.assertEqual(result["status"], "Deploying")
+		self.assertEqual(
+			frappe.db.get_value("Bench Instance", bench.name, "site_name"), "stable.benchpress.cloud"
+		)
+
+		data_without_site_name = frappe.as_json({"lab": lab.name})
+		with patch("frappe.enqueue"):
+			api.create_bench(data_without_site_name)
+		self.assertEqual(
+			frappe.db.get_value("Bench Instance", bench.name, "site_name"), "stable.benchpress.cloud"
+		)
+
 	def test_create_bench_without_site_name_keeps_the_default(self):
 		data = frappe.as_json({"lab": self.create_lab.name})
 		with patch("frappe.enqueue"):

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -585,6 +585,33 @@ class TestApi(IntegrationTestCase):
 		self.assertTrue(frappe.db.exists("Bench Instance", result["name"]))
 		self.assert_within_budget("create_bench", elapsed_ms)
 
+	def _set_base_domain(self, value):
+		before = frappe.db.get_single_value("BenchPress Settings", "base_domain")
+		frappe.db.set_single_value("BenchPress Settings", "base_domain", value)
+		self.addCleanup(frappe.db.set_single_value, "BenchPress Settings", "base_domain", before)
+
+	def test_create_bench_honors_an_explicit_site_name(self):
+		self._set_base_domain("benchpress.cloud")
+		data = frappe.as_json({"lab": self.create_lab.name, "site_name": "acme"})
+		with patch("frappe.enqueue"):
+			result = api.create_bench(data)
+		self.addCleanup(
+			frappe.delete_doc, "Bench Instance", result["name"], force=True, ignore_permissions=True
+		)
+		self.assertEqual(
+			frappe.db.get_value("Bench Instance", result["name"], "site_name"), "acme.benchpress.cloud"
+		)
+
+	def test_create_bench_without_site_name_keeps_the_default(self):
+		data = frappe.as_json({"lab": self.create_lab.name})
+		with patch("frappe.enqueue"):
+			result = api.create_bench(data)
+		self.addCleanup(
+			frappe.delete_doc, "Bench Instance", result["name"], force=True, ignore_permissions=True
+		)
+		site_name = frappe.db.get_value("Bench Instance", result["name"], "site_name")
+		self.assertTrue(site_name.endswith(".localhost"))
+
 	# --- Docker / manager side effects (patch module functions) --------------
 
 	def test_bench_action_start_stop_restart_and_timing(self):

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -1079,6 +1079,20 @@ class TestRecordPrimarySite(IntegrationTestCase):
 		self.assertEqual(site.status, "Active")
 		self.assertEqual([row.app_name for row in site.apps_installed], ["frappe"])
 
+	def test_a_caller_chosen_site_name_carries_through_to_the_bench_site_row(self):
+		"""Closes the loop on issue #125: the row must carry the chosen name, not just a hash."""
+		from benchpress.deploy_manager import _record_primary_site
+
+		bench = self._bench()
+		bench.site_name = "acme.benchpress.cloud"
+		bench.save(ignore_permissions=True)
+
+		_record_primary_site(bench, self.lab, "secret-one")
+
+		site = frappe.get_doc("Bench Site", {"bench": bench.name})
+		self.assertEqual(site.site_name, "acme.benchpress.cloud")
+		self.assertEqual(frappe.db.get_value("Bench Instance", bench.name, "site_name"), site.site_name)
+
 	def test_the_controller_alone_owns_full_domain(self):
 		"""Two writers meant the label could name a site that does not exist.
 

--- a/benchpress/tests/test_docker_manager.py
+++ b/benchpress/tests/test_docker_manager.py
@@ -117,6 +117,33 @@ class TestWaitForContainerRunning(unittest.TestCase):
 		self.assertEqual(sleep.call_count, 30)
 
 
+class TestResolveSiteName(unittest.TestCase):
+	def test_returns_none_for_empty_input(self):
+		self.assertIsNone(docker_manager.resolve_site_name(None))
+		self.assertIsNone(docker_manager.resolve_site_name(""))
+		self.assertIsNone(docker_manager.resolve_site_name("   "))
+
+	@patch("benchpress.docker_manager.frappe.db.get_single_value", return_value="benchpress.cloud")
+	def test_lowercases_and_appends_base_domain(self, get_single_value):
+		self.assertEqual(docker_manager.resolve_site_name("Acme"), "acme.benchpress.cloud")
+
+	@patch("benchpress.docker_manager.frappe.db.get_single_value", return_value=None)
+	def test_falls_back_to_localhost_when_base_domain_unset(self, get_single_value):
+		self.assertEqual(docker_manager.resolve_site_name("acme"), "acme.localhost")
+
+	def test_rejects_a_dotted_label(self):
+		with self.assertRaises(frappe.ValidationError):
+			docker_manager.resolve_site_name("acme.example.com")
+
+	def test_rejects_invalid_characters(self):
+		with self.assertRaises(frappe.ValidationError):
+			docker_manager.resolve_site_name("Acme_1")
+
+	def test_rejects_a_label_over_max_length(self):
+		with self.assertRaises(frappe.ValidationError):
+			docker_manager.resolve_site_name("a" * 64)
+
+
 def _make_lab(lab_id, **extra):
 	if frappe.db.exists("Lab", lab_id):
 		frappe.delete_doc("Lab", lab_id, force=True, ignore_permissions=True)

--- a/benchpress/tests/test_docker_manager.py
+++ b/benchpress/tests/test_docker_manager.py
@@ -144,6 +144,58 @@ class TestResolveSiteName(unittest.TestCase):
 			docker_manager.resolve_site_name("a" * 64)
 
 
+class TestResolveSiteNameCollisions(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.lab = _make_lab("site-collision-lab")
+		cls.other_bench = frappe.get_doc(
+			{"doctype": "Bench Instance", "lab": cls.lab.name, "frappe_version": cls.lab.frappe_version}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.delete_doc("Bench Instance", cls.other_bench.name, force=True, ignore_permissions=True)
+		frappe.delete_doc("Lab", cls.lab.name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def _make_site(self, site_name, status, bench=None):
+		site = frappe.get_doc(
+			{
+				"doctype": "Bench Site",
+				"bench": bench or self.other_bench.name,
+				"site_name": site_name,
+				"status": status,
+			}
+		).insert(ignore_permissions=True)
+		self.addCleanup(frappe.delete_doc, "Bench Site", site.name, force=True, ignore_permissions=True)
+		self.addCleanup(frappe.db.commit)
+		frappe.db.commit()
+		return site
+
+	@patch("benchpress.docker_manager.frappe.db.get_single_value", return_value="benchpress.cloud")
+	def test_resolve_site_name_throws_on_a_live_collision(self, get_single_value):
+		self._make_site("acme.benchpress.cloud", "Active")
+		with self.assertRaises(frappe.ValidationError):
+			docker_manager.resolve_site_name("acme")
+
+	@patch("benchpress.docker_manager.frappe.db.get_single_value", return_value="benchpress.cloud")
+	def test_resolve_site_name_ignores_an_inactive_collision(self, get_single_value):
+		self._make_site("acme.benchpress.cloud", "Inactive")
+		self.assertEqual(docker_manager.resolve_site_name("acme"), "acme.benchpress.cloud")
+
+	@patch("benchpress.docker_manager.frappe.db.get_single_value", return_value="benchpress.cloud")
+	def test_resolve_site_name_excludes_its_own_bench_from_the_collision_check(self, get_single_value):
+		self._make_site("acme.benchpress.cloud", "Active", bench=self.other_bench.name)
+		self.assertEqual(
+			docker_manager.resolve_site_name("acme", exclude_bench=self.other_bench.name),
+			"acme.benchpress.cloud",
+		)
+
+
 def _make_lab(lab_id, **extra):
 	if frappe.db.exists("Lab", lab_id):
 		frappe.delete_doc("Lab", lab_id, force=True, ignore_permissions=True)


### PR DESCRIPTION
## Summary

Phase 1 of `specs/in-progress/caller-chosen-site-name/`: the thinnest end-to-end slice for a caller-chosen site name at deploy time.

- `create_bench({lab, site_name: "acme"})` on a **new** instance now deploys `acme.<base_domain>` instead of the hash-derived default.
- New `resolve_site_name` in `benchpress/docker_manager.py`: normalizes/validates a caller-supplied label (lowercases, rejects dots, enforces DNS-label shape, max 63 chars) and suffixes it with `BenchPress Settings.base_domain` (falls back to `localhost`).
- `Bench Instance.before_insert` no longer clobbers an already-set `site_name`; `bench_name` is untouched.
- `create_bench`'s insert branch resolves `data.site_name`/`data.site` through the new validator before building the doc. The existing-instance (redeploy) branch is untouched — that's phase 3.

Not in scope for this phase (see README): rejecting a name already in use elsewhere (phase 2), and guarding a redeploy from silently renaming a live instance (phase 3).

## Test plan

- [x] `bench --site frontend run-tests --app benchpress` — full suite green (109 tests incl. new ones)
- [x] New unit tests in `benchpress/tests/test_docker_manager.py::TestResolveSiteName` (None/empty → None, lowercasing, base_domain suffix, localhost fallback, dotted/invalid/over-length rejection)
- [x] New test in `test_bench_instance.py::test_before_insert_honors_a_caller_supplied_site_name` (site_name survives, bench_name still hash-derived); existing `test_before_insert_sets_site_name_with_localhost_suffix` still passes unmodified
- [x] New tests in `test_api.py`: `test_create_bench_honors_an_explicit_site_name`, `test_create_bench_without_site_name_keeps_the_default`
- [x] `uvx pre-commit@4.3.0 run --all-files` on changed files — clean
- [ ] Manual: `create_bench({lab, site_name: "acme"})` against a real lab, then `bench --site acme.<base_domain> list-apps` inside the resulting container