### PR TITLE
Implemented phase one

### DIFF
--- a/benchpress/lab_templates.py
+++ b/benchpress/lab_templates.py
@@ -14,7 +14,7 @@ from frappe import _
 
 # Bumped whenever the template set or its fields change so an install can tell
 # which catalog a lab was created against.
-CATALOG_VERSION = 5
+CATALOG_VERSION = 6
 
 # Each template names its `Instance Size`. `memory_limit` / `cpu_cores` below must agree
 # with it: they are what the card renders, and `Lab.apply_instance_size` overwrites them.
@@ -84,13 +84,21 @@ LAB_TEMPLATES = [
 		"instance_size": "Medium",
 		"memory_limit": "2g",
 		"cpu_cores": 2,
+		# hrms requires erpnext, so erpnext must install first. The
+		# build/deploy pipeline installs apps in this listed order.
 		"apps": [
+			{
+				"app_name": "erpnext",
+				"app_label": "ERPNext",
+				"git_url": "https://github.com/frappe/erpnext",
+				"branch": "version-15",
+			},
 			{
 				"app_name": "hrms",
 				"app_label": "Frappe HR",
 				"git_url": "https://github.com/frappe/hrms",
 				"branch": "version-15",
-			}
+			},
 		],
 	},
 	{
@@ -103,13 +111,21 @@ LAB_TEMPLATES = [
 		"instance_size": "Small",
 		"memory_limit": "1g",
 		"cpu_cores": 1,
+		# lms requires payments, so payments must install first. The
+		# build/deploy pipeline installs apps in this listed order.
 		"apps": [
+			{
+				"app_name": "payments",
+				"app_label": "Payments",
+				"git_url": "https://github.com/frappe/payments",
+				"branch": "version-15",
+			},
 			{
 				"app_name": "lms",
 				"app_label": "Frappe Learning",
 				"git_url": "https://github.com/frappe/lms",
 				"branch": "main",
-			}
+			},
 		],
 	},
 	{
@@ -122,13 +138,21 @@ LAB_TEMPLATES = [
 		"instance_size": "Small",
 		"memory_limit": "1g",
 		"cpu_cores": 1,
+		# helpdesk requires telephony, so telephony must install first. The
+		# build/deploy pipeline installs apps in this listed order.
 		"apps": [
+			{
+				"app_name": "telephony",
+				"app_label": "Telephony",
+				"git_url": "https://github.com/frappe/telephony",
+				"branch": "develop",
+			},
 			{
 				"app_name": "helpdesk",
 				"app_label": "Frappe Helpdesk",
 				"git_url": "https://github.com/frappe/helpdesk",
 				"branch": "main",
-			}
+			},
 		],
 	},
 	{

--- a/benchpress/tests/test_lab_templates.py
+++ b/benchpress/tests/test_lab_templates.py
@@ -47,10 +47,16 @@ class TestLabTemplates(IntegrationTestCase):
 		self.assertEqual(lab_templates.get_template("erpnext")["key"], "erpnext")
 
 	def test_first_party_app_templates_present(self):
-		for key in ("hrms", "lms", "helpdesk"):
+		# Each first-party app template also lists the dependency that app's own
+		# hooks.py declares in `required_apps`, installed before the app itself.
+		expected = {
+			"hrms": ["erpnext", "hrms"],
+			"lms": ["payments", "lms"],
+			"helpdesk": ["telephony", "helpdesk"],
+		}
+		for key, app_names in expected.items():
 			template = lab_templates.get_template(key)
-			self.assertEqual(len(template["apps"]), 1)
-			self.assertEqual(template["apps"][0]["app_name"], key)
+			self.assertEqual([app["app_name"] for app in template["apps"]], app_names)
 
 	def test_india_compliance_template_installs_erpnext_first(self):
 		template = lab_templates.get_template("india-compliance")


### PR DESCRIPTION
Fixes #144.

`hrms`/`lms`/`helpdesk` templates each listed only their headline app, but that app's own `hooks.py` declares a `required_apps` dependency the template never installed:

- `hrms` → `erpnext` (`required_apps = ["frappe/erpnext"]`)
- `lms` → `payments` (`required_apps = ["frappe/payments"]`)
- `helpdesk` → `telephony` (`required_apps = ["telephony"]`)

Since the build derives `INSTALL_APPS` straight from a template's `apps` list, the image never contained the dependency, and `bench new-site --install-app <app>` died with `ModuleNotFoundError` partway through site setup. Reproduced live on staging (Bench Instance `e3a527ce5e07a16cc9473647c60ba40f`, Error Log `9m9dv2p9f4`).

This is a scope-down from #128 (the full app-dependency resolver, deferred past the conference deadline) — it only hand-patches these three known-broken lists.

## Changes

- `benchpress/lab_templates.py` — each of `hrms`/`lms`/`helpdesk` now lists its dependency before itself, matching the install-order convention already used by `india-compliance` (`erpnext` before `india_compliance`). Branches verified against the actual upstream repos: `erpnext`→`version-15`, `payments`→`version-15` (real branch on that repo), `telephony`→`develop` (the *only* branch that repo has — no `version-15`/`main`/`master`). `CATALOG_VERSION` bumped 5 → 6 per the file's own convention.
- `benchpress/tests/test_lab_templates.py` — `test_first_party_app_templates_present` updated to assert the two-app, dependency-first order for each template.

No manual cache-clear needed: `image_cache.py`'s tag is a hash of `frappe_version` + the sorted `(app, git_url, branch)` triples, so adding an app automatically changes the tag — a new spec can never resolve to the old broken image.

Spec: `specs/in-progress/template-app-dependency-patch/` (single tracer-bullet phase — the three edits are mechanically identical and requested together as one issue, so splitting into separate phases would be padding).

## Test plan

- [x] `bench --site frontend run-tests --app benchpress --module benchpress.tests.test_lab_templates` — 14/14 pass
- [x] `uvx pre-commit@4.3.0 run --files benchpress/lab_templates.py benchpress/tests/test_lab_templates.py` — clean
- [ ] **Not done in this PR — staging operational step still required before #144's acceptance criteria are met:** deploy this to staging, delete/recreate the already-`Error` `hrms`/`lms` labs (and a fresh `helpdesk` lab) from the fixed templates, redeploy, and confirm each site actually opens (not just `Bench Instance.status == Running`) with no `ModuleNotFoundError` in the deploy log.