### PR TITLE
Implemented phase two

### DIFF
--- a/benchpress/lab_templates.py
+++ b/benchpress/lab_templates.py
@@ -229,6 +229,157 @@ SEED_TEMPLATES = [
 			}
 		],
 	},
+	{
+		"key": "frappe-16",
+		"title": "Frappe Framework",
+		"description": "Bare Frappe bench with no extra apps — the lightest starting point.",
+		"frappe_version": "version-16",
+		"instance_size": "Small",
+		"memory_limit": "1g",
+		"cpu_cores": 1,
+		"eta_minutes": 3,
+		"most_used": 0,
+		"is_active": 1,
+		"sort_order": 9,
+		"apps": [],
+	},
+	{
+		"key": "crm-16",
+		"title": "Frappe CRM",
+		"description": "Lightweight sales CRM on Frappe — leads, deals and contacts.",
+		"frappe_version": "version-16",
+		"instance_size": "Small",
+		"memory_limit": "1g",
+		"cpu_cores": 1,
+		"eta_minutes": 4,
+		"most_used": 0,
+		"is_active": 1,
+		"sort_order": 10,
+		"apps": [
+			{
+				"app_name": "crm",
+				"app_label": "Frappe CRM",
+				"git_url": "https://github.com/frappe/crm",
+				"branch": "main",
+			}
+		],
+	},
+	{
+		"key": "hrms-16",
+		"title": "Frappe HR",
+		"description": "HR & payroll suite — employees, leaves, attendance and payroll.",
+		"frappe_version": "version-16",
+		"instance_size": "Medium",
+		"memory_limit": "2g",
+		"cpu_cores": 2,
+		"eta_minutes": 5,
+		"most_used": 0,
+		"is_active": 1,
+		"sort_order": 11,
+		# hrms requires erpnext, so erpnext must install first. The
+		# build/deploy pipeline installs apps in this listed order.
+		"apps": [
+			{
+				"app_name": "erpnext",
+				"app_label": "ERPNext",
+				"git_url": "https://github.com/frappe/erpnext",
+				"branch": "version-16",
+			},
+			{
+				"app_name": "hrms",
+				"app_label": "Frappe HR",
+				"git_url": "https://github.com/frappe/hrms",
+				"branch": "version-16",
+			},
+		],
+	},
+	{
+		"key": "lms-16",
+		"title": "Frappe Learning",
+		"description": "Learning management system — courses, quizzes and batches.",
+		"frappe_version": "version-16",
+		"instance_size": "Small",
+		"memory_limit": "1g",
+		"cpu_cores": 1,
+		"eta_minutes": 4,
+		"most_used": 0,
+		"is_active": 1,
+		"sort_order": 12,
+		# lms requires payments, so payments must install first. The
+		# build/deploy pipeline installs apps in this listed order.
+		"apps": [
+			{
+				"app_name": "payments",
+				"app_label": "Payments",
+				"git_url": "https://github.com/frappe/payments",
+				"branch": "version-16",
+			},
+			{
+				"app_name": "lms",
+				"app_label": "Frappe Learning",
+				"git_url": "https://github.com/frappe/lms",
+				"branch": "main",
+			},
+		],
+	},
+	{
+		"key": "helpdesk-16",
+		"title": "Frappe Helpdesk",
+		"description": "Customer support desk — tickets, SLAs and a knowledge base.",
+		"frappe_version": "version-16",
+		"instance_size": "Small",
+		"memory_limit": "1g",
+		"cpu_cores": 1,
+		"eta_minutes": 4,
+		"most_used": 0,
+		"is_active": 1,
+		"sort_order": 13,
+		# helpdesk requires telephony, so telephony must install first. The
+		# build/deploy pipeline installs apps in this listed order.
+		"apps": [
+			{
+				"app_name": "telephony",
+				"app_label": "Telephony",
+				"git_url": "https://github.com/frappe/telephony",
+				"branch": "develop",
+			},
+			{
+				"app_name": "helpdesk",
+				"app_label": "Frappe Helpdesk",
+				"git_url": "https://github.com/frappe/helpdesk",
+				"branch": "main",
+			},
+		],
+	},
+	{
+		"key": "india-compliance-16",
+		"title": "ERPNext + India Compliance",
+		"description": "ERPNext with GST, e-invoicing and TDS for Indian businesses.",
+		"frappe_version": "version-16",
+		"instance_size": "Medium",
+		"memory_limit": "2g",
+		"cpu_cores": 2,
+		"eta_minutes": 7,
+		"most_used": 0,
+		"is_active": 1,
+		"sort_order": 14,
+		# india_compliance extends ERPNext, so ERPNext must install first. The
+		# build/deploy pipeline installs apps in this listed order.
+		"apps": [
+			{
+				"app_name": "erpnext",
+				"app_label": "ERPNext",
+				"git_url": "https://github.com/frappe/erpnext",
+				"branch": "version-16",
+			},
+			{
+				"app_name": "india_compliance",
+				"app_label": "India Compliance",
+				"git_url": "https://github.com/resilient-tech/india-compliance",
+				"branch": "version-16",
+			},
+		],
+	},
 ]
 
 

--- a/benchpress/lab_templates.py
+++ b/benchpress/lab_templates.py
@@ -208,6 +208,27 @@ SEED_TEMPLATES = [
 			},
 		],
 	},
+	{
+		"key": "erpnext-16",
+		"title": "ERPNext",
+		"description": "Full ERP suite: accounting, inventory, manufacturing and more.",
+		"frappe_version": "version-16",
+		"instance_size": "Medium",
+		"memory_limit": "2g",
+		"cpu_cores": 2,
+		"eta_minutes": 6,
+		"most_used": 0,
+		"is_active": 1,
+		"sort_order": 8,
+		"apps": [
+			{
+				"app_name": "erpnext",
+				"app_label": "ERPNext",
+				"git_url": "https://github.com/frappe/erpnext",
+				"branch": "version-16",
+			}
+		],
+	},
 ]
 
 

--- a/benchpress/patches.txt
+++ b/benchpress/patches.txt
@@ -17,3 +17,4 @@ benchpress.patches.stamp_template_on_labs
 benchpress.patches.index_tenant_reads
 benchpress.patches.retire_orphaned_creating_sites
 benchpress.patches.seed_lab_templates
+benchpress.patches.seed_v16_lab_templates

--- a/benchpress/patches.txt
+++ b/benchpress/patches.txt
@@ -18,3 +18,4 @@ benchpress.patches.index_tenant_reads
 benchpress.patches.retire_orphaned_creating_sites
 benchpress.patches.seed_lab_templates
 benchpress.patches.seed_v16_lab_templates
+benchpress.patches.seed_remaining_v16_lab_templates

--- a/benchpress/patches/seed_remaining_v16_lab_templates.py
+++ b/benchpress/patches/seed_remaining_v16_lab_templates.py
@@ -1,0 +1,5 @@
+from benchpress.lab_templates import seed_lab_templates
+
+
+def execute():
+	seed_lab_templates()

--- a/benchpress/patches/seed_v16_lab_templates.py
+++ b/benchpress/patches/seed_v16_lab_templates.py
@@ -1,0 +1,5 @@
+from benchpress.lab_templates import seed_lab_templates
+
+
+def execute():
+	seed_lab_templates()

--- a/benchpress/tests/test_doctype_scoping.py
+++ b/benchpress/tests/test_doctype_scoping.py
@@ -34,6 +34,7 @@ TENANT_SCOPED = {
 # Shared catalogues. Every app user may read every row, and no user can create one.
 GLOBAL_BY_DESIGN = {
 	"Lab": "admin-authored recipes; BenchPress User has no create",
+	"Lab Template": "the ready-made catalog; BenchPress User has no create",
 	"Credit Pack": "the price list",
 	"Instance Size": "the size list",
 	"Always On Pass": "read through owner-scoped endpoints; rows name their own bench",

--- a/benchpress/tests/test_lab_templates.py
+++ b/benchpress/tests/test_lab_templates.py
@@ -74,6 +74,11 @@ class TestLabTemplates(IntegrationTestCase):
 		# india_compliance extends ERPNext; order matters at install time.
 		self.assertEqual(app_names, ["erpnext", "india_compliance"])
 
+	def test_v16_erpnext_template_present(self):
+		template = lab_templates.get_template("erpnext-16")
+		self.assertEqual(template["frappe_version"], "version-16")
+		self.assertEqual(template["apps"][0]["branch"], "version-16")
+
 	def test_get_template_unknown_throws(self):
 		with self.assertRaises(frappe.ValidationError):
 			lab_templates.get_template("does-not-exist")

--- a/benchpress/tests/test_lab_templates.py
+++ b/benchpress/tests/test_lab_templates.py
@@ -63,21 +63,34 @@ class TestLabTemplates(IntegrationTestCase):
 			"hrms": ["erpnext", "hrms"],
 			"lms": ["payments", "lms"],
 			"helpdesk": ["telephony", "helpdesk"],
+			"hrms-16": ["erpnext", "hrms"],
+			"lms-16": ["payments", "lms"],
+			"helpdesk-16": ["telephony", "helpdesk"],
 		}
 		for key, app_names in expected.items():
 			template = lab_templates.get_template(key)
 			self.assertEqual([app["app_name"] for app in template["apps"]], app_names)
 
 	def test_india_compliance_template_installs_erpnext_first(self):
-		template = lab_templates.get_template("india-compliance")
-		app_names = [app["app_name"] for app in template["apps"]]
-		# india_compliance extends ERPNext; order matters at install time.
-		self.assertEqual(app_names, ["erpnext", "india_compliance"])
+		for key in ("india-compliance", "india-compliance-16"):
+			template = lab_templates.get_template(key)
+			app_names = [app["app_name"] for app in template["apps"]]
+			# india_compliance extends ERPNext; order matters at install time.
+			self.assertEqual(app_names, ["erpnext", "india_compliance"])
 
-	def test_v16_erpnext_template_present(self):
-		template = lab_templates.get_template("erpnext-16")
-		self.assertEqual(template["frappe_version"], "version-16")
-		self.assertEqual(template["apps"][0]["branch"], "version-16")
+	def test_v16_templates_present(self):
+		v16_keys = [
+			"erpnext-16",
+			"frappe-16",
+			"crm-16",
+			"hrms-16",
+			"lms-16",
+			"helpdesk-16",
+			"india-compliance-16",
+		]
+		for key in v16_keys:
+			template = lab_templates.get_template(key)
+			self.assertEqual(template["frappe_version"], "version-16", key)
 
 	def test_get_template_unknown_throws(self):
 		with self.assertRaises(frappe.ValidationError):

--- a/frontend/src/pages/LabTemplates.vue
+++ b/frontend/src/pages/LabTemplates.vue
@@ -8,7 +8,21 @@
 			</p>
 		</div>
 
-		<p v-if="templates.loading && !rows.length" class="text-body text-ink-gray-5">
+		<div v-if="allTemplates.length" class="mb-3 flex flex-wrap items-center gap-2">
+			<FormControl
+				class="w-[240px]"
+				type="text"
+				placeholder="Search templates"
+				v-model="search"
+				data-test="templates-search"
+			>
+				<template #prefix><SearchIcon class="size-3.5 text-ink-gray-4" /></template>
+			</FormControl>
+			<Select v-model="appsFilter" :options="appOptions" data-test="filter-apps" />
+			<Select v-model="versionFilter" :options="versionOptions" data-test="filter-version" />
+		</div>
+
+		<p v-if="templates.loading && !allTemplates.length" class="text-body text-ink-gray-5">
 			Loading templates…
 		</p>
 
@@ -94,6 +108,16 @@
 			</article>
 		</div>
 
+		<SectionCard v-else-if="allTemplates.length" :padded="false">
+			<EmptyState message="No templates match these filters.">
+				<template #action>
+					<Button variant="subtle" data-test="clear-filters" @click="clearFilters">
+						Clear filters
+					</Button>
+				</template>
+			</EmptyState>
+		</SectionCard>
+
 		<SectionCard v-else :padded="false">
 			<EmptyState
 				message="The template catalog is empty — create a lab from scratch instead."
@@ -115,10 +139,22 @@ import EmptyState from "@/components/EmptyState.vue";
 import SectionCard from "@/components/SectionCard.vue";
 import { openDeployRun } from "@/data/deployRun";
 import { labsResource } from "@/data/labs";
+import { labelFor as appLabel } from "@/utils/appIcons";
+import { ALL, matches, optionsFrom } from "@/utils/filters";
 import { cpuLabel, etaLabel, memoryLabel } from "@/utils/labSpecs";
-import { Badge, Button, ErrorMessage, createResource, toast } from "frappe-ui";
+import {
+	Badge,
+	Button,
+	ErrorMessage,
+	FormControl,
+	Select,
+	createResource,
+	toast,
+} from "frappe-ui";
 import { computed, ref } from "vue";
 import { useRouter } from "vue-router";
+
+import SearchIcon from "~icons/lucide/search";
 
 // The catalog is `benchpress/lab_templates.py` — every entry, its apps, its
 // resources, its estimate and the "Most used" flag come from there. Nothing
@@ -135,7 +171,47 @@ const LAB_STATES = {
 
 const templates = createResource({ url: "benchpress.api.get_lab_templates", auto: true });
 
-const rows = computed(() => templates.data ?? []);
+const allTemplates = computed(() => templates.data ?? []);
+
+const search = ref("");
+const appsFilter = ref(ALL);
+const versionFilter = ref(ALL);
+
+const appOptions = computed(() =>
+	optionsFrom("Apps", allTemplates.value.flatMap(appsOf), appLabel)
+);
+const versionOptions = computed(() =>
+	optionsFrom(
+		"Version",
+		allTemplates.value.map((template) => template.frappe_version)
+	)
+);
+
+const rows = computed(() =>
+	allTemplates.value.filter(
+		(template) =>
+			matches(template.frappe_version, versionFilter.value) &&
+			matchesApps(template) &&
+			matchesSearch(template)
+	)
+);
+
+function matchesApps(template) {
+	return appsFilter.value === ALL || appsOf(template).includes(appsFilter.value);
+}
+
+function matchesSearch(template) {
+	const query = search.value.trim().toLowerCase();
+	if (!query) return true;
+	const haystack = [template.key, template.title, template.description, ...appsOf(template)];
+	return haystack.some((value) => (value || "").toLowerCase().includes(query));
+}
+
+function clearFilters() {
+	search.value = "";
+	appsFilter.value = ALL;
+	versionFilter.value = ALL;
+}
 
 const createAction = createResource({ url: "benchpress.api.create_lab_from_template" });
 const deployAction = createResource({ url: "benchpress.api.create_bench" });

--- a/frontend/src/pages/Labs.vue
+++ b/frontend/src/pages/Labs.vue
@@ -146,6 +146,7 @@ import OnboardingPanel from "@/components/overview/OnboardingPanel.vue";
 import { labsResource } from "@/data/labs";
 import { userContext } from "@/data/userContext";
 import { labelFor as appLabel } from "@/utils/appIcons";
+import { ALL, matches, optionsFrom } from "@/utils/filters";
 import { benchLabel } from "@/utils/labSpecs";
 import { Button, FormControl, Select, dayjsLocal } from "frappe-ui";
 import { computed, onMounted, ref } from "vue";
@@ -169,8 +170,6 @@ const COLUMNS = [
 	{ label: "Deployed as", key: "deployed_as", width: "190px" },
 	{ label: "Last run", key: "last_run", width: "96px" },
 ];
-
-const ALL = "__all__";
 
 const router = useRouter();
 const search = ref("");
@@ -203,15 +202,6 @@ const ownerOptions = computed(() =>
 	)
 );
 
-/** "All" plus each value actually present, so no filter offers an empty result. */
-function optionsFrom(label, values) {
-	const present = [...new Set(values.filter(Boolean))].sort();
-	return [
-		{ label: `${label}: all`, value: ALL },
-		...present.map((value) => ({ label: value, value })),
-	];
-}
-
 const rows = computed(() =>
 	labs.value.filter(
 		(lab) =>
@@ -221,10 +211,6 @@ const rows = computed(() =>
 			matchesSearch(lab)
 	)
 );
-
-function matches(value, filter) {
-	return filter === ALL || value === filter;
-}
 
 function matchesSearch(lab) {
 	const query = search.value.trim().toLowerCase();

--- a/frontend/src/utils/filters.js
+++ b/frontend/src/utils/filters.js
@@ -1,0 +1,15 @@
+/** Sentinel filter value meaning "no filter applied". */
+export const ALL = "__all__";
+
+/** "All" plus each value actually present, so no filter offers an empty result. */
+export function optionsFrom(label, values, labelFor = (value) => value) {
+	const present = [...new Set(values.filter(Boolean))].sort();
+	return [
+		{ label: `${label}: all`, value: ALL },
+		...present.map((value) => ({ label: labelFor(value), value })),
+	];
+}
+
+export function matches(value, filter) {
+	return filter === ALL || value === filter;
+}

--- a/frontend/src/utils/filters.spec.js
+++ b/frontend/src/utils/filters.spec.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { ALL, matches, optionsFrom } from "./filters";
+
+describe("optionsFrom", () => {
+	it("leads with an all option and sorts the rest", () => {
+		const options = optionsFrom("Version", ["version-16", "version-15", "version-16"]);
+		expect(options).toEqual([
+			{ label: "Version: all", value: ALL },
+			{ label: "version-15", value: "version-15" },
+			{ label: "version-16", value: "version-16" },
+		]);
+	});
+
+	it("drops blank values", () => {
+		const options = optionsFrom("Owner", ["", null, undefined, "admin@example.com"]);
+		expect(options).toEqual([
+			{ label: "Owner: all", value: ALL },
+			{ label: "admin@example.com", value: "admin@example.com" },
+		]);
+	});
+
+	it("labels each option through the given labelFor, keyed on the raw value", () => {
+		const options = optionsFrom("Apps", ["erpnext", "hrms"], (value) => value.toUpperCase());
+		expect(options).toEqual([
+			{ label: "Apps: all", value: ALL },
+			{ label: "ERPNEXT", value: "erpnext" },
+			{ label: "HRMS", value: "hrms" },
+		]);
+	});
+});
+
+describe("matches", () => {
+	it("accepts anything when the filter is ALL", () => {
+		expect(matches("Running", ALL)).toBe(true);
+		expect(matches(undefined, ALL)).toBe(true);
+	});
+
+	it("otherwise requires an exact match", () => {
+		expect(matches("Running", "Running")).toBe(true);
+		expect(matches("Running", "Stopped")).toBe(false);
+	});
+});


### PR DESCRIPTION
Phase 1 of [catalog-v16-templates](specs/in-progress/catalog-v16-templates/README.md): the `erpnext-16` tracer bullet.

Adds one new `Lab Template` seed entry (`erpnext-16`, `frappe_version: version-16`, single-app ERPNext on the `version-16` branch) and a new idempotent `[post_model_sync]` patch (`seed_v16_lab_templates`) to backfill it onto sites that already ran the old `seed_lab_templates` patch — appending to `SEED_TEMPLATES` alone does nothing on those sites.

Proves the seed-data shape, the new backfill patch, and the deploy pipeline all work for a v16 catalog key before repeating the pattern for the other 6 templates in phase 2.

## Verify
1. `bench --site frontend migrate` — `seed_v16_lab_templates` runs cleanly; `frappe.db.exists("Lab Template", "erpnext-16")` → `True`.
2. `bench --site frontend run-tests --module benchpress.tests.test_lab_templates` — full module green (15/15), including the new `test_v16_erpnext_template_present`.
3. Deployed `erpnext-16` end to end via `create_lab_from_template` + `create_bench`: `Bench Instance` reached `Running`, and the site (Frappe 16.31.0, `installed_apps: [frappe, erpnext]`) returned HTTP 200 on its login page.