### PR TITLE
Implemented phase three

### DIFF
--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -7,6 +7,7 @@ from frappe.query_builder import DocType
 from frappe.query_builder.functions import Count
 
 from benchpress import image_cache, lab_detail, lab_templates, labs
+from benchpress.benchpress.doctype.bench_instance.bench_instance import DEPLOY_JOB_TIMEOUT
 from benchpress.credits import account, metering, payments
 from benchpress.credits.guard import (
 	build_charge,
@@ -192,11 +193,7 @@ def create_bench(data: str) -> dict:
 		"benchpress.deploy_manager.deploy_bench",
 		bench_name=doc.name,
 		queue="long",
-		# Covers the measured worst case with headroom: a 7-app first deploy spends
-		# most of an hour in site install + the SSH user's chown over a ~20GB bench.
-		# RQ kills the job at this limit while the real work keeps running orphaned
-		# in the container — the instance then wedges in "Deploying" forever.
-		timeout=7200,
+		timeout=DEPLOY_JOB_TIMEOUT,
 		job_id=f"deploy_bench:{doc.name}",
 		deduplicate=True,
 		enqueue_after_commit=True,

--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -65,7 +65,7 @@ def build_lab_image(lab_name: str) -> dict:
 		"benchpress.deploy_manager.build_lab",
 		lab_name=lab_name,
 		queue="long",
-		timeout=3600,
+		timeout=10800,
 	)
 	return {"name": lab_name, "status": "Building"}
 

--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -192,7 +192,11 @@ def create_bench(data: str) -> dict:
 		"benchpress.deploy_manager.deploy_bench",
 		bench_name=doc.name,
 		queue="long",
-		timeout=3600,
+		# Covers the measured worst case with headroom: a 7-app first deploy spends
+		# most of an hour in site install + the SSH user's chown over a ~20GB bench.
+		# RQ kills the job at this limit while the real work keeps running orphaned
+		# in the container — the instance then wedges in "Deploying" forever.
+		timeout=7200,
 		job_id=f"deploy_bench:{doc.name}",
 		deduplicate=True,
 		enqueue_after_commit=True,

--- a/benchpress/benchpress/doctype/bench_instance/bench_instance.py
+++ b/benchpress/benchpress/doctype/bench_instance/bench_instance.py
@@ -6,9 +6,12 @@ import re
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.utils.background_jobs import is_job_enqueued
 
 from benchpress.benchpress.doctype.bench_instance import get_instance_id
 from benchpress.credits.guard import cap_concurrent_instances, instance_runway, requires_credits
+
+DEPLOY_JOB_TIMEOUT = 7200
 
 
 class BenchInstance(Document):
@@ -16,9 +19,6 @@ class BenchInstance(Document):
 		instance_id = get_instance_id(frappe.session.user, self.lab)
 		self.bench_name = instance_id
 		if not self.site_name:
-			# The site is named by its public hostname so Frappe resolves the Host
-			# header to it directly — a `.localhost` site only answers through the
-			# default_site fallback and reads as a dev artifact on every screen.
 			base_domain = frappe.get_cached_doc("BenchPress Settings").base_domain
 			suffix = base_domain if base_domain and base_domain != "localhost" else "localhost"
 			self.site_name = f"{instance_id}.{suffix}"
@@ -48,19 +48,18 @@ class BenchInstance(Document):
 	@frappe.whitelist()
 	@requires_credits(cost=instance_runway, caps=(cap_concurrent_instances,))
 	def enqueue_deploy(self):
-		job = frappe.enqueue(
+		if is_job_enqueued(self._deploy_job_id()):
+			frappe.msgprint(_("A deploy is already in progress for this bench."))
+			return
+		frappe.enqueue(
 			"benchpress.deploy_manager.deploy_bench",
 			bench_name=self.name,
 			queue="long",
-			# Same ceiling as api.create_bench: the real worst case (7-app install +
-			# chown of a ~20GB bench) far exceeds the old 30 minutes.
-			timeout=7200,
-			job_id=f"deploy_bench:{self.name}",
+			timeout=DEPLOY_JOB_TIMEOUT,
+			job_id=self._deploy_job_id(),
 			deduplicate=True,
+			enqueue_after_commit=True,
 		)
-		if not job:
-			frappe.msgprint(_("A deploy is already in progress for this bench."))
-			return
 		frappe.msgprint(_("Deploy started. Watch the Deploy Log for progress."))
 
 	@frappe.whitelist()
@@ -73,20 +72,22 @@ class BenchInstance(Document):
 	@frappe.whitelist()
 	@requires_credits(cost=instance_runway, caps=(cap_concurrent_instances,))
 	def enqueue_redeploy(self):
-		job = frappe.enqueue(
+		if is_job_enqueued(self._deploy_job_id()):
+			frappe.msgprint(_("A deploy is already in progress for this bench."))
+			return
+		frappe.enqueue(
 			"benchpress.deploy_manager.redeploy_bench",
 			bench_name=self.name,
 			queue="long",
-			# Same ceiling as api.create_bench: the real worst case (7-app install +
-			# chown of a ~20GB bench) far exceeds the old 30 minutes.
-			timeout=7200,
-			job_id=f"deploy_bench:{self.name}",
+			timeout=DEPLOY_JOB_TIMEOUT,
+			job_id=self._deploy_job_id(),
 			deduplicate=True,
+			enqueue_after_commit=True,
 		)
-		if not job:
-			frappe.msgprint(_("A deploy is already in progress for this bench."))
-			return
 		frappe.msgprint(_("Redeploy started. Watch the Deploy Log for progress."))
+
+	def _deploy_job_id(self) -> str:
+		return f"deploy_bench:{self.name}"
 
 	@frappe.whitelist()
 	@requires_credits(cost=instance_runway, caps=(cap_concurrent_instances,))

--- a/benchpress/benchpress/doctype/bench_instance/bench_instance.py
+++ b/benchpress/benchpress/doctype/bench_instance/bench_instance.py
@@ -16,7 +16,12 @@ class BenchInstance(Document):
 		instance_id = get_instance_id(frappe.session.user, self.lab)
 		self.bench_name = instance_id
 		if not self.site_name:
-			self.site_name = f"{instance_id}.localhost"
+			# The site is named by its public hostname so Frappe resolves the Host
+			# header to it directly — a `.localhost` site only answers through the
+			# default_site fallback and reads as a dev artifact on every screen.
+			base_domain = frappe.get_cached_doc("BenchPress Settings").base_domain
+			suffix = base_domain if base_domain and base_domain != "localhost" else "localhost"
+			self.site_name = f"{instance_id}.{suffix}"
 		self.ssh_username = self._derive_username()
 
 	def autoname(self):

--- a/benchpress/benchpress/doctype/bench_instance/bench_instance.py
+++ b/benchpress/benchpress/doctype/bench_instance/bench_instance.py
@@ -52,7 +52,9 @@ class BenchInstance(Document):
 			"benchpress.deploy_manager.deploy_bench",
 			bench_name=self.name,
 			queue="long",
-			timeout=1800,
+			# Same ceiling as api.create_bench: the real worst case (7-app install +
+			# chown of a ~20GB bench) far exceeds the old 30 minutes.
+			timeout=7200,
 			job_id=f"deploy_bench:{self.name}",
 			deduplicate=True,
 		)
@@ -75,7 +77,9 @@ class BenchInstance(Document):
 			"benchpress.deploy_manager.redeploy_bench",
 			bench_name=self.name,
 			queue="long",
-			timeout=1800,
+			# Same ceiling as api.create_bench: the real worst case (7-app install +
+			# chown of a ~20GB bench) far exceeds the old 30 minutes.
+			timeout=7200,
 			job_id=f"deploy_bench:{self.name}",
 			deduplicate=True,
 		)

--- a/benchpress/benchpress/doctype/bench_instance/test_bench_instance.py
+++ b/benchpress/benchpress/doctype/bench_instance/test_bench_instance.py
@@ -70,9 +70,11 @@ class IntegrationTestBenchInstance(IntegrationTestCase):
 		expected = get_instance_id("Administrator", self.lab_name)
 		self.assertEqual(bench.bench_name, expected)
 
-	def test_before_insert_sets_site_name_with_localhost_suffix(self):
+	def test_before_insert_names_the_site_after_the_base_domain(self):
 		bench = self._insert_bench()
-		self.assertTrue(bench.site_name.endswith(".localhost"))
+		base_domain = frappe.get_cached_doc("BenchPress Settings").base_domain
+		suffix = base_domain if base_domain and base_domain != "localhost" else "localhost"
+		self.assertEqual(bench.site_name, f"{bench.bench_name}.{suffix}")
 
 	def test_before_insert_honors_a_caller_supplied_site_name(self):
 		bench = self._insert_bench(site_name="caller-chosen.localhost")

--- a/benchpress/benchpress/doctype/lab/lab.py
+++ b/benchpress/benchpress/doctype/lab/lab.py
@@ -7,6 +7,7 @@ from frappe.model.document import Document
 from frappe.utils.data import cint
 
 from benchpress.docker_manager import validate_lab_id
+from benchpress.image_cache import build_spec
 
 BASELINE_CPU_CORES = 1
 
@@ -16,6 +17,19 @@ class Lab(Document):
 		validate_lab_id(self.lab_id)
 		self.apply_instance_size()
 		self.validate_cpu_cores()
+		self.reset_status_if_spec_changed()
+
+	def reset_status_if_spec_changed(self):
+		"""A `Ready` lab's image tag is static now (`benchpress/<lab_id>:lab`, not a content
+		hash), so an edit to what actually gets built no longer changes the tag by itself —
+		nothing else would catch a Ready lab quietly pointing at a stale image.
+		"""
+		if self.status != "Ready" or self.is_new():
+			return
+		before = self.get_doc_before_save()
+		if before and build_spec(self) != build_spec(before):
+			self.status = "Draft"
+			frappe.msgprint(_("Lab spec changed — rebuild the image before deploying."))
 
 	def apply_instance_size(self):
 		"""Copy the chosen size's resources onto the two fields Docker actually reads.

--- a/benchpress/benchpress/doctype/lab/test_lab.py
+++ b/benchpress/benchpress/doctype/lab/test_lab.py
@@ -56,3 +56,32 @@ class IntegrationTestLab(IntegrationTestCase):
 
 		with self.assertRaisesRegex(frappe.ValidationError, "CPU cores must be at least 1"):
 			lab.insert()
+
+	def test_a_ready_lab_s_spec_change_resets_it_to_draft(self):
+		lab = _new_lab("spec-change-resets")
+		lab.append("apps", {"app_name": "crm", "git_url": "https://github.com/frappe/crm", "branch": "main"})
+		lab.insert()
+		lab.status = "Ready"
+		lab.image_tag = "benchpress/spec-change-resets:lab"
+		lab.save()
+		self.addCleanup(lab.delete)
+
+		lab.append(
+			"apps", {"app_name": "hrms", "git_url": "https://github.com/frappe/hrms", "branch": "version-16"}
+		)
+		lab.save()
+
+		self.assertEqual(lab.status, "Draft")
+
+	def test_a_ready_lab_saved_with_no_spec_change_stays_ready(self):
+		lab = _new_lab("spec-unchanged-stays-ready")
+		lab.insert()
+		lab.status = "Ready"
+		lab.image_tag = "benchpress/spec-unchanged-stays-ready:lab"
+		lab.save()
+		self.addCleanup(lab.delete)
+
+		lab.title = "Test Lab (renamed)"
+		lab.save()
+
+		self.assertEqual(lab.status, "Ready")

--- a/benchpress/benchpress/doctype/lab_template/lab_template.json
+++ b/benchpress/benchpress/doctype/lab_template/lab_template.json
@@ -9,6 +9,7 @@
  "field_order": [
   "key",
   "title",
+  "logo",
   "description",
   "column_break_meta",
   "frappe_version",
@@ -38,6 +39,12 @@
    "in_list_view": 1,
    "label": "Title",
    "reqd": 1
+  },
+  {
+   "description": "Shown on the template card instead of the app mark. Falls back to the primary app's icon when unset.",
+   "fieldname": "logo",
+   "fieldtype": "Attach Image",
+   "label": "Logo"
   },
   {
    "fieldname": "description",

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -35,7 +35,7 @@ from benchpress.notifications import notify_owner
 
 
 def _remove_stale_container(bench) -> None:
-	"""Remove any existing container, preserving the data volume."""
+	"""Remove any existing container for this bench."""
 	from benchpress.docker_manager import get_client
 
 	client = get_client()
@@ -85,12 +85,9 @@ def _public_ide_url(instance_id: str, base_domain: str | None) -> str | None:
 def _write_instance_route(instance_id: str, base_domain: str, container_ip: str) -> None:
 	"""Write Traefik file-provider routes for this instance's site and its code-server IDE.
 
-	The routers name their own certificate (`certResolver` + the wildcard domain set)
-	rather than `tls: {}`: the control-plane router's cert covers *its* hostname's
-	wildcard, which is not necessarily `base_domain` — with a bare `tls: {}` and no
-	matching cert in the store, Traefik silently serves its self-signed default and
-	every instance URL dies with a certificate error. Every instance writes the same
-	domain set, so Traefik issues the `*.{base_domain}` wildcard once and shares it.
+	The routers name their certificate explicitly: every instance shares one
+	`*.{base_domain}` wildcard, issued once by the resolver. A bare `tls: {}` would
+	serve Traefik's self-signed default whenever the store holds no covering cert.
 
 	One file per instance, named by instance ID, so a redeploy naturally overwrites it
 	with the fresh `container_ip` — no dedup logic needed.
@@ -99,7 +96,6 @@ def _write_instance_route(instance_id: str, base_domain: str, container_ip: str)
 		return
 
 	def tls():
-		# Fresh dict per router: a shared one would serialize as a YAML anchor/alias.
 		return {
 			"certResolver": "letsencrypt",
 			"domains": [{"main": base_domain, "sans": [f"*.{base_domain}"]}],
@@ -148,8 +144,8 @@ def _cleanup_failed_deploy(bench, container_id, append_log) -> None:
 	"""Best-effort teardown of resources created by this failed run.
 
 	Fires only when this run created a container — earlier failures leave the
-	previous deploy's container and peer untouched. Never touches the data
-	volume and never raises: the except block must still record Error state.
+	previous deploy's container and peer untouched. Never raises: the except
+	block must still record Error state.
 
 	Either way the outcome is written to the log, so the screen reporting the
 	failure can state what was rolled back instead of inferring it from silence.
@@ -201,7 +197,7 @@ def create_site_in_container(
 	container_id: str, db_server, site_name: str, admin_password: str, apps_csv: str
 ) -> tuple[int, str]:
 	"""Run setup-site.sh inside a bench container using a temporary MariaDB user."""
-	bench_dir = "/home/frappe/frappe-bench"  # fixed: the data volume binds at /home/frappe
+	bench_dir = "/home/frappe/frappe-bench"
 	db_name, temp_user, temp_password = create_mariadb_user(db_server.name, site_name)
 	try:
 		return exec_in_container(
@@ -321,7 +317,7 @@ def _deploy_bench(bench_name: str) -> None:
 
 		_setup_container_vpn(bench, container_id, pipeline)
 
-		bench_dir = "/home/frappe/frappe-bench"  # fixed: the data volume binds at /home/frappe
+		bench_dir = "/home/frappe/frappe-bench"
 		site_name = bench.site_name
 		config = {
 			**db_server.get_connection_config(),
@@ -339,10 +335,7 @@ def _deploy_bench(bench_name: str) -> None:
 		pipeline.log(f"{bench_dir}/sites/common_site_config.json written")
 
 		pipeline.step("site")
-		# The container is always fresh here, so a database that already exists can only be
-		# the leftover of an interrupted earlier run (worker killed mid `bench new-site`).
-		# `bench new-site` refuses to overwrite it; dropping it first makes deploy
-		# re-runnable instead of permanently wedged on its own debris.
+		# Drop the leftover of an interrupted run; `bench new-site` refuses to overwrite it.
 		_drop_site_database(bench)
 		apps_csv = ",".join(a.app_name for a in lab.apps if a.app_name.lower() != "frappe")
 		pipeline.log(f"Site {site_name} with {apps_csv or 'frappe'}")
@@ -355,13 +348,7 @@ def _deploy_bench(bench_name: str) -> None:
 		_record_primary_site(bench, lab, admin_password)
 
 		pipeline.step("assets")
-		# Assets ship in the image: its build already ran `bench build --production`
-		# (lab-templates/Dockerfile layer 5). The old in-container check looked for
-		# `sites/assets/<app>/dist`, a layout SPA-style apps (crm, helpdesk, lms) and
-		# asset-less apps (payments, telephony) never use — so it re-ran `bench build`
-		# live on every deploy of such labs, for 20+ minutes, inside the instance's
-		# own memory limit. Deploy never builds; rebuilding the lab image is the one
-		# way to refresh a stale bundle.
+		# Deploy never builds; rebuilding the lab image is how a stale bundle is refreshed.
 		pipeline.log("Assets ship in the image — bundled at build time")
 
 		if not bench.ssh_username:
@@ -371,11 +358,7 @@ def _deploy_bench(bench_name: str) -> None:
 		linkuser_args = build_linkuser_args(bench, lab, settings, ssh_password)
 		pipeline.step("ssh_user")
 		pipeline.log(f"linkuser.sh {bench.ssh_username}")
-		# The image bakes a copy of linkuser.sh, but the app's copy is authoritative:
-		# pushing it before the run rolls script fixes out to every already-built lab
-		# image without an image rebuild (rebuilding the largest lab costs ~1.5h).
-		# Joined with pathlib, not get_app_path(parts...): that helper scrubs each part
-		# and would turn the real "lab-templates" directory into "lab_templates".
+		# The app's copy of linkuser.sh is authoritative over the one baked into the image.
 		linkuser_script = (
 			Path(frappe.get_app_path("benchpress")) / "lab-templates" / "scripts" / "linkuser.sh"
 		)

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -339,6 +339,11 @@ def _deploy_bench(bench_name: str) -> None:
 		pipeline.log(f"{bench_dir}/sites/common_site_config.json written")
 
 		pipeline.step("site")
+		# The container is always fresh here, so a database that already exists can only be
+		# the leftover of an interrupted earlier run (worker killed mid `bench new-site`).
+		# `bench new-site` refuses to overwrite it; dropping it first makes deploy
+		# re-runnable instead of permanently wedged on its own debris.
+		_drop_site_database(bench)
 		apps_csv = ",".join(a.app_name for a in lab.apps if a.app_name.lower() != "frappe")
 		pipeline.log(f"Site {site_name} with {apps_csv or 'frappe'}")
 		exit_code, output = create_site_in_container(

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -371,6 +371,17 @@ def _deploy_bench(bench_name: str) -> None:
 		linkuser_args = build_linkuser_args(bench, lab, settings, ssh_password)
 		pipeline.step("ssh_user")
 		pipeline.log(f"linkuser.sh {bench.ssh_username}")
+		# The image bakes a copy of linkuser.sh, but the app's copy is authoritative:
+		# pushing it before the run rolls script fixes out to every already-built lab
+		# image without an image rebuild (rebuilding the largest lab costs ~1.5h).
+		# Joined with pathlib, not get_app_path(parts...): that helper scrubs each part
+		# and would turn the real "lab-templates" directory into "lab_templates".
+		linkuser_script = (
+			Path(frappe.get_app_path("benchpress")) / "lab-templates" / "scripts" / "linkuser.sh"
+		)
+		write_file_to_container(
+			container_id, linkuser_script.read_text(), "/opt/benchpress/scripts/linkuser.sh"
+		)
 		linkuser_cmd = "bash /opt/benchpress/scripts/linkuser.sh " + " ".join(f"'{a}'" for a in linkuser_args)
 		exit_code, output = exec_in_container(container_id, linkuser_cmd, user="root")
 		if output:

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -355,7 +355,14 @@ def _deploy_bench(bench_name: str) -> None:
 		_record_primary_site(bench, lab, admin_password)
 
 		pipeline.step("assets")
-		_ensure_assets(container_id, bench_dir, lab, pipeline)
+		# Assets ship in the image: its build already ran `bench build --production`
+		# (lab-templates/Dockerfile layer 5). The old in-container check looked for
+		# `sites/assets/<app>/dist`, a layout SPA-style apps (crm, helpdesk, lms) and
+		# asset-less apps (payments, telephony) never use — so it re-ran `bench build`
+		# live on every deploy of such labs, for 20+ minutes, inside the instance's
+		# own memory limit. Deploy never builds; rebuilding the lab image is the one
+		# way to refresh a stale bundle.
+		pipeline.log("Assets ship in the image — bundled at build time")
 
 		if not bench.ssh_username:
 			bench.ssh_username = bench._derive_username(bench.owner)
@@ -513,49 +520,6 @@ def _site_app_names(lab) -> list[str]:
 	"""The apps this site was created with — frappe first, then the lab's own, in order."""
 	extras = [row.app_name for row in (lab.apps or []) if row.app_name and row.app_name.lower() != "frappe"]
 	return ["frappe", *extras]
-
-
-def _ensure_assets(container_id: str, bench_dir: str, lab, pipeline) -> None:
-	"""Bundle the apps the image did not already bundle — normally none of them.
-
-	Asked of the container, not assumed from the Dockerfile: the cache key does not cover
-	the Dockerfile, so an image built before assets moved into it must still build here.
-	"""
-	missing = sorted(_asset_app_names(lab) - _bundled_apps(container_id, bench_dir))
-	if not missing:
-		pipeline.log("Assets already bundled in the image — no build needed")
-		return
-	pipeline.log(f"bench build — no bundle in the image for: {', '.join(missing)}")
-	exit_code, output = exec_in_container(container_id, "bench build", user="frappe", workdir=bench_dir)
-	if exit_code != 0:
-		# The one step in this pipeline that logs instead of raising, deliberately: a site with
-		# stale or missing bundles still loads and the user can rebuild from the IDE, so losing
-		# an otherwise-good deploy over asset bundling costs more than it saves. The captured
-		# output goes into the line so the warning is actionable. Do not "fix" this into a raise.
-		pipeline.log(
-			f"bench build failed (exit {exit_code}) — assets may be stale: {output.strip()}", "warning"
-		)
-		return
-	pipeline.log("bench build finished")
-
-
-def _asset_app_names(lab) -> set[str]:
-	"""Every app whose bundle this instance serves. Frappe is always one of them."""
-	return {"frappe"} | {row.app_name.strip().lower() for row in (lab.apps or []) if row.app_name}
-
-
-def _bundled_apps(container_id: str, bench_dir: str) -> set[str]:
-	"""Apps that already carry a bundle, in one exec.
-
-	The glob is expanded by the container's shell: app names come from a Lab row and must
-	never be interpolated into a command string.
-	"""
-	exit_code, output = exec_in_container(
-		container_id, "ls -d sites/assets/*/dist 2>/dev/null", user="frappe", workdir=bench_dir
-	)
-	if exit_code != 0:
-		return set()
-	return {path.split("/")[2] for path in output.split() if path.count("/") == 3}
 
 
 def _setup_container_vpn(bench, container_id: str, pipeline) -> None:

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import frappe
 import yaml
+from frappe import _
 from frappe.utils.file_lock import LockTimeoutError
 from frappe.utils.synchronization import filelock
 
@@ -61,7 +62,12 @@ SITE_HTTP_PORT = 8000
 ADOPTED_MARKER = "already exists — adopting it"
 
 # Module constant, not inlined, so tests can monkeypatch it to a tmp path.
-TRAEFIK_DYNAMIC_DIR = Path("/etc/traefik/dynamic/instances")
+# Flat, not a subdirectory: Traefik's file provider does not recurse, so this
+# must be the exact directory the `directory:` provider in traefik.yml.template
+# watches, and the exact host path bind-mounted read-write into queue-long /
+# read-only into traefik in docker-compose.prod.yml. dynamic.yml (the
+# control-plane router) lives in this same directory.
+TRAEFIK_DYNAMIC_DIR = Path("/etc/traefik/dynamic")
 
 
 def _public_site_url(instance_id: str, base_domain: str | None) -> str | None:
@@ -645,34 +651,17 @@ def _drop_site_database(bench) -> None:
 
 
 def _prepare_lab_image(lab, pipeline, user: str) -> None:
-	"""Adopt the shared image for this lab's spec, or build it if nobody has yet.
+	"""Use this lab's already-built image, or fail immediately — deploy never builds.
 
-	The cache is keyed by the build spec rather than by the lab, so the second user to deploy a
-	given template performs no build at all. It also closes a staleness hole in the old
-	`status == "Ready"` check: editing a Ready lab's apps changed what should be built but kept
-	pointing at the image built from the previous recipe.
-
-	A build started here writes a `Build Log`, as an explicit rebuild does; the deploy log
-	keeps the step and a pointer to it.
+	Building is the explicit admin action (`build_lab`) alone; a deploy that finds no image, or
+	finds a lab that isn't `Ready` (its spec changed since the last build — see
+	`Lab.reset_status_if_spec_changed`), throws right away instead of eating a 10-40 minute build
+	inside what the caller expects to be a fast operation.
 	"""
 	tag, hit = image_cache.resolve(lab)
-	if not hit:
-		pipeline.log(f"Building lab image for {lab.title} — output goes to the build log")
-		image_tag = _run_build(lab, user)
-		pipeline.log(f"Lab image ready: {image_tag}")
-		return
-	pipeline.log(f"Cache hit: reusing shared image {tag} — no build needed")
-	_adopt_cached_image(lab, tag)
-
-
-def _adopt_cached_image(lab, tag: str) -> None:
-	"""Point the lab at an image somebody else's build already produced."""
-	if lab.image_tag == tag and lab.status == "Ready":
-		return
-	lab.image_tag = tag
-	lab.status = "Ready"
-	lab.save(ignore_permissions=True)
-	frappe.db.commit()  # nosemgrep -- the container is created from this tag, so persist it first
+	if not hit or lab.status != "Ready" or lab.image_tag != tag:
+		frappe.throw(_("No built image for lab '{0}'. Build it first from the Lab record.").format(lab.title))
+	pipeline.log(f"Using built image {tag}")
 
 
 def _build_lab_with_logs(lab, log_fn) -> None:

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -85,15 +85,26 @@ def _public_ide_url(instance_id: str, base_domain: str | None) -> str | None:
 def _write_instance_route(instance_id: str, base_domain: str, container_ip: str) -> None:
 	"""Write Traefik file-provider routes for this instance's site and its code-server IDE.
 
-	`tls: {}` (empty section, no `certResolver`) deliberately — it turns TLS on for these
-	routers using Traefik's existing default cert store, which already holds the wildcard
-	SAN from the control-plane router. No new ACME issuance happens per instance.
+	The routers name their own certificate (`certResolver` + the wildcard domain set)
+	rather than `tls: {}`: the control-plane router's cert covers *its* hostname's
+	wildcard, which is not necessarily `base_domain` — with a bare `tls: {}` and no
+	matching cert in the store, Traefik silently serves its self-signed default and
+	every instance URL dies with a certificate error. Every instance writes the same
+	domain set, so Traefik issues the `*.{base_domain}` wildcard once and shares it.
 
 	One file per instance, named by instance ID, so a redeploy naturally overwrites it
 	with the fresh `container_ip` — no dedup logic needed.
 	"""
 	if not base_domain or base_domain == "localhost":
 		return
+
+	def tls():
+		# Fresh dict per router: a shared one would serialize as a YAML anchor/alias.
+		return {
+			"certResolver": "letsencrypt",
+			"domains": [{"main": base_domain, "sans": [f"*.{base_domain}"]}],
+		}
+
 	TRAEFIK_DYNAMIC_DIR.mkdir(parents=True, exist_ok=True)
 	config = {
 		"http": {
@@ -102,13 +113,13 @@ def _write_instance_route(instance_id: str, base_domain: str, container_ip: str)
 					"rule": f"Host(`{instance_id}.{base_domain}`)",
 					"entryPoints": ["websecure"],
 					"service": f"site-{instance_id}",
-					"tls": {},
+					"tls": tls(),
 				},
 				f"ide-{instance_id}": {
 					"rule": f"Host(`ide-{instance_id}.{base_domain}`)",
 					"entryPoints": ["websecure"],
 					"service": f"ide-{instance_id}",
-					"tls": {},
+					"tls": tls(),
 				},
 			},
 			"services": {
@@ -161,16 +172,6 @@ def _cleanup_failed_deploy(bench, container_id, append_log) -> None:
 	bench.container_id = None
 	bench.container_ip = None
 	bench.wg_ip = None
-
-
-def remove_bench_volume(bench_name: str) -> None:
-	"""Remove the bench data volume if it exists."""
-	from benchpress.docker_manager import get_client
-
-	try:
-		get_client().volumes.get(f"benchpress-{bench_name}-data").remove(force=True)
-	except Exception:
-		pass  # best-effort
 
 
 def build_linkuser_args(bench, lab, settings, ssh_password: str) -> list[str]:
@@ -612,7 +613,6 @@ def teardown_bench(bench) -> None:
 	except Exception:
 		pass  # best-effort
 
-	remove_bench_volume(bench.name)
 	_drop_site_database(bench)
 	# Marked, not deleted: a redeploy refreshes them, and the reaper leaves the instance
 	# one click from running.

--- a/benchpress/docker_manager.py
+++ b/benchpress/docker_manager.py
@@ -215,9 +215,10 @@ def create_bench_container(bench_doc, lab_doc) -> str:
 		hostname=name,
 		cap_add=["NET_ADMIN"],
 		devices=["/dev/net/tun:/dev/net/tun:rwm"],
-		volumes={
-			f"benchpress-{name}-data": {"bind": "/home/frappe", "mode": "rw"},
-		},
+		# No volume over /home/frappe: the bench lives in the image and the container's
+		# own copy-on-write layer. A named volume here forced Docker to copy the whole
+		# multi-GB bench on every create (~2-17 min per deploy) for zero persistence —
+		# teardown always removed the volume with the container anyway.
 		mem_limit=lab_doc.memory_limit or "512m",
 		nano_cpus=int((lab_doc.cpu_cores or 1) * 1e9),
 		pids_limit=pids_limit,

--- a/benchpress/docker_manager.py
+++ b/benchpress/docker_manager.py
@@ -215,10 +215,8 @@ def create_bench_container(bench_doc, lab_doc) -> str:
 		hostname=name,
 		cap_add=["NET_ADMIN"],
 		devices=["/dev/net/tun:/dev/net/tun:rwm"],
-		# No volume over /home/frappe: the bench lives in the image and the container's
-		# own copy-on-write layer. A named volume here forced Docker to copy the whole
-		# multi-GB bench on every create (~2-17 min per deploy) for zero persistence —
-		# teardown always removed the volume with the container anyway.
+		# No volume over /home/frappe — a named volume forces a full copy of the bench
+		# on every create; the container's own layer is the bench's storage.
 		mem_limit=lab_doc.memory_limit or "512m",
 		nano_cpus=int((lab_doc.cpu_cores or 1) * 1e9),
 		pids_limit=pids_limit,

--- a/benchpress/image_cache.py
+++ b/benchpress/image_cache.py
@@ -23,7 +23,7 @@ from benchpress.request_cache import clear_local_cache, local_cache
 CACHE_REPOSITORY = "benchpress"
 TAGS_ATTRIBUTE = "benchpress_cached_image_tags"
 
-BUILD_TIMEOUT = 3600
+BUILD_TIMEOUT = 10800
 SWEEP_TIMEOUT = 600
 PREWARM_JOB_ID = "benchpress_prewarm_catalog"
 SWEEP_JOB_ID = "benchpress_sweep_cached_images"

--- a/benchpress/image_cache.py
+++ b/benchpress/image_cache.py
@@ -1,28 +1,18 @@
 # Copyright (c) 2026, Venkatesh and contributors
 # For license information, please see license.txt
 
-"""One image per build spec, not one per lab.
+"""One image per lab, tagged by the lab's own identity.
 
-A Lab used to own its image — `benchpress/<lab_id>:latest`, rebuilt from scratch for every user
-who picked the same template. Ten people choosing ERPNext meant ten 10-20 minute builds
-producing byte-identical images, and ten copies of them on disk.
-
-The tag is now derived from the spec rather than from the lab: `benchpress/cache:<hash>`, where
-the hash covers everything that decides the image contents — the Frappe branch and the sorted
-`(app, git url, branch)` triples. Two labs with the same recipe therefore resolve to the same
-tag, and the second one to deploy performs no build at all.
-
-**Accepted imprecision**: a new commit on an already-cached branch does not change the hash, so
-it does not invalidate the cache. Hashing commits would need a `git ls-remote` per app per
-deploy and would defeat caching for every app whose branch moves. Refresh is the job of the
-admin build action and `prewarm_catalog`, which rebuild the same tag in place.
+A Lab's image is tagged `benchpress/<lab_id>:lab` — static, not derived from the build spec. The
+first Lab created from a catalog template gets that template's own key as its `lab_id`
+(`lab_templates.available_lab_id`), so a template's prewarmed image and the first unmodified Lab
+built from it naturally resolve to the same tag with no extra bookkeeping. A Lab that diverges
+from its template (edited apps/version) needs its own rebuild — see `Lab.validate()`'s staleness
+check, which resets `status` to `Draft` when `build_spec` no longer matches what was last built.
 
 Docker is asked for its image list **once** per request or job: `cached_tags` memoises the set on
 `frappe.local`, so resolving a queue of labs costs one round trip, not one per lab.
 """
-
-import hashlib
-import json
 
 import frappe
 from frappe.utils import cstr
@@ -30,8 +20,7 @@ from frappe.utils import cstr
 from benchpress import lab_templates
 from benchpress.request_cache import clear_local_cache, local_cache
 
-CACHE_REPOSITORY = "benchpress/cache"
-HASH_LENGTH = 12
+CACHE_REPOSITORY = "benchpress"
 TAGS_ATTRIBUTE = "benchpress_cached_image_tags"
 
 BUILD_TIMEOUT = 3600
@@ -55,15 +44,9 @@ def build_spec(lab_doc) -> dict:
 	}
 
 
-def build_spec_hash(lab_doc) -> str:
-	"""Stable identity of one build spec. Child-row order cannot change it: the apps are sorted."""
-	spec = json.dumps(build_spec(lab_doc), sort_keys=True)
-	return hashlib.sha256(spec.encode()).hexdigest()[:HASH_LENGTH]
-
-
 def cache_tag(lab_doc) -> str:
-	"""The shared image tag this spec builds into."""
-	return f"{CACHE_REPOSITORY}:{build_spec_hash(lab_doc)}"
+	"""The static image tag this lab builds into."""
+	return f"{CACHE_REPOSITORY}/{lab_doc.lab_id}:lab"
 
 
 def resolve(lab_doc) -> tuple[str, bool]:
@@ -83,11 +66,25 @@ def clear_cached_tags() -> None:
 
 
 def list_cached_tags() -> set[str]:
+	"""Every `benchpress/<lab_id>:lab` image on this host.
+
+	Each lab is its own repository now, not a shared one — `benchpress/*` is a glob against the
+	repository name, not a fixed exact match, so it still costs one Docker round trip for every
+	lab's image, not one per lab. The whole `benchpress/` namespace is no longer exclusively
+	ours the way `benchpress/cache/` was, so the `:lab` tag suffix is what actually identifies an
+	image this module built — the prefix alone would also catch something like a stray hand-tagged
+	`benchpress/crm-lab:latest`.
+	"""
 	from benchpress.docker_manager import get_client
 
-	prefix = f"{CACHE_REPOSITORY}:"
-	images = get_client().images.list(name=CACHE_REPOSITORY)
-	return {tag for image in images for tag in (image.tags or []) if tag.startswith(prefix)}
+	prefix = f"{CACHE_REPOSITORY}/"
+	images = get_client().images.list(name=f"{CACHE_REPOSITORY}/*")
+	return {
+		tag
+		for image in images
+		for tag in (image.tags or [])
+		if tag.startswith(prefix) and tag.endswith(":lab")
+	}
 
 
 def template_spec(template: dict):

--- a/benchpress/lab-templates/scripts/linkuser.sh
+++ b/benchpress/lab-templates/scripts/linkuser.sh
@@ -65,12 +65,7 @@ fi
 BASHEOF
 fi
 
-# No chown of /home/frappe: the tenant user is the image's frappe user *renamed*
-# (usermod --login keeps uid 1000), and every file in the image is already owned
-# by uid 1000 — ownership is stored numerically, so nothing needs changing. The
-# recursive chown this script used to run here walked 120k-1M+ inodes changing
-# zero of them, and was the single largest cost of every deploy (measured 514s
-# on a 6GB bench, ~30 min on a 20GB one).
+# No chown needed: the rename keeps uid 1000, which already owns every file.
 
 cat > "/.benchpress_config" << CFGEOF
 {

--- a/benchpress/lab-templates/scripts/linkuser.sh
+++ b/benchpress/lab-templates/scripts/linkuser.sh
@@ -65,7 +65,12 @@ fi
 BASHEOF
 fi
 
-chown -R "$USERNAME:$USERNAME" /home/frappe
+# No chown of /home/frappe: the tenant user is the image's frappe user *renamed*
+# (usermod --login keeps uid 1000), and every file in the image is already owned
+# by uid 1000 — ownership is stored numerically, so nothing needs changing. The
+# recursive chown this script used to run here walked 120k-1M+ inodes changing
+# zero of them, and was the single largest cost of every deploy (measured 514s
+# on a 6GB bench, ~30 min on a 20GB one).
 
 cat > "/.benchpress_config" << CFGEOF
 {

--- a/benchpress/lab_detail.py
+++ b/benchpress/lab_detail.py
@@ -51,8 +51,6 @@ def get_lab(name: str) -> dict:
 	return {
 		"name": lab.name,
 		"lab_id": lab.lab_id,
-		# The catalog logo the lab inherits from the template it was created from;
-		# None for a hand-made lab, and the screen falls back to the app mark.
 		"logo": frappe.db.get_value("Lab Template", lab.template, "logo") if lab.template else None,
 		"title": lab.title,
 		"description": lab.description,

--- a/benchpress/lab_detail.py
+++ b/benchpress/lab_detail.py
@@ -32,6 +32,7 @@ BENCH_FIELDS = [
 	"container_id",
 	"container_ip",
 	"wg_ip",
+	"public_url",
 	"domain",
 	"site_name",
 	"ssh_username",

--- a/benchpress/lab_detail.py
+++ b/benchpress/lab_detail.py
@@ -19,7 +19,7 @@ output — still only have `=== … ===` markers, so both are read.
 import frappe
 
 from benchpress.credits import config, passes
-from benchpress.deploy_pipeline import scan_log, step_label
+from benchpress.deploy_pipeline import scan_log
 
 BENCH_FIELDS = [
 	"name",
@@ -41,9 +41,6 @@ BENCH_FIELDS = [
 ]
 
 SITE_FIELDS = ["name", "site_name", "full_domain", "status"]
-
-# The step a deploy is inside when it builds the image, as `scan_log` reports it.
-IMAGE_STEP = step_label("image")
 
 
 def get_lab(name: str) -> dict:
@@ -159,45 +156,19 @@ def _failure(lab, bench: dict | None) -> dict | None:
 	if lab.status == "Error":
 		return _read_failure("Build Log", {"lab": lab.name}, "build")
 	if bench and bench.status == "Error":
-		return _deploy_failure(lab.name, bench["name"])
+		return _deploy_failure(bench["name"])
 	return None
 
 
-def _deploy_failure(lab_name: str, bench_name: str) -> dict | None:
-	"""The last deploy's failure — attributed to the image build when that is what broke.
+def _deploy_failure(bench_name: str) -> dict | None:
+	"""The last deploy's failure.
 
-	A deploy that misses the image cache builds, and `deploy_manager._run_build` puts
-	`Lab.status` back the way it found it so one tenant's failed build does not mark the
-	catalog entry every other tenant reads. That is why the `Lab.status` arm above never
-	fires here: without this, the banner would blame the deploy and show its tail, while the
-	Docker output that actually explains the failure sat in a `Build Log` nothing pointed at.
+	Never redirected to a build's log any more — deploy never builds (Phase 3: it looks up an
+	already-built image or fails immediately), so a deploy's own failure is never actually a
+	build's.
 	"""
 	log = _latest_log("Deploy Log", {"bench": bench_name})
-	if not log:
-		return None
-	if _broke_preparing_the_image(log.message):
-		build = _build_failure_since(lab_name, log.timestamp)
-		if build:
-			return build
-	return _failure_payload(log, "deploy")
-
-
-def _broke_preparing_the_image(message: str) -> bool:
-	"""Did the run die inside the step that resolves or builds the image?"""
-	return scan_log(message or "").step == IMAGE_STEP
-
-
-def _build_failure_since(lab_name: str, deploy_started) -> dict | None:
-	"""The failed build this deploy ran, if it ran one.
-
-	Bounded by the deploy's own log timestamp so an older failed build — somebody else's, or
-	one since fixed — cannot be blamed for this run. The image step can also fail without any
-	build at all (cache resolution, adopting a tag), and then there is nothing here to find.
-	"""
-	log = _latest_log(
-		"Build Log", {"lab": lab_name, "log_type": "error", "timestamp": (">=", deploy_started)}
-	)
-	return _failure_payload(log, "build") if log else None
+	return _failure_payload(log, "deploy") if log else None
 
 
 def _read_failure(doctype: str, filters: dict, source: str) -> dict | None:

--- a/benchpress/lab_detail.py
+++ b/benchpress/lab_detail.py
@@ -51,6 +51,9 @@ def get_lab(name: str) -> dict:
 	return {
 		"name": lab.name,
 		"lab_id": lab.lab_id,
+		# The catalog logo the lab inherits from the template it was created from;
+		# None for a hand-made lab, and the screen falls back to the app mark.
+		"logo": frappe.db.get_value("Lab Template", lab.template, "logo") if lab.template else None,
 		"title": lab.title,
 		"description": lab.description,
 		"frappe_version": lab.frappe_version,

--- a/benchpress/lab_templates.py
+++ b/benchpress/lab_templates.py
@@ -22,6 +22,7 @@ MAX_LAB_ID_ATTEMPTS = 50
 TEMPLATE_FIELDS = [
 	"name as key",
 	"title",
+	"logo",
 	"description",
 	"frappe_version",
 	"instance_size",

--- a/benchpress/labs.py
+++ b/benchpress/labs.py
@@ -71,11 +71,7 @@ def get_labs() -> list[dict]:
 
 
 def _template_logos(template_keys: list[str]) -> dict:
-	"""The catalog logo each lab inherits, in one query.
-
-	Joined on `Lab.template` (the template a lab was created from). A hand-made
-	lab has no template and simply falls back to its first app's mark.
-	"""
+	"""The catalog logo each lab inherits from its template, in one query."""
 	if not template_keys:
 		return {}
 	rows = frappe.get_all(

--- a/benchpress/labs.py
+++ b/benchpress/labs.py
@@ -27,6 +27,7 @@ LAB_FIELDS = [
 	"instance_size",
 	"memory_limit",
 	"cpu_cores",
+	"template",
 	"owner",
 ]
 
@@ -62,9 +63,27 @@ def get_labs() -> list[dict]:
 	lab_names = [lab.name for lab in labs]
 	app_names = _app_names_by_lab(lab_names)
 	benches = _benches_by_lab(lab_names)
+	logos = _template_logos([lab.template for lab in labs if lab.template])
 	for lab in labs:
 		_attach_row_facts(lab, app_names.get(lab.name, []), benches.get(lab.name, []))
+		lab.logo = logos.get(lab.template)
 	return labs
+
+
+def _template_logos(template_keys: list[str]) -> dict:
+	"""The catalog logo each lab inherits, in one query.
+
+	Joined on `Lab.template` (the template a lab was created from). A hand-made
+	lab has no template and simply falls back to its first app's mark.
+	"""
+	if not template_keys:
+		return {}
+	rows = frappe.get_all(
+		"Lab Template",
+		filters={"name": ("in", template_keys), "logo": ("is", "set")},
+		fields=["name", "logo"],
+	)
+	return {row.name: row.logo for row in rows}
 
 
 def _attach_row_facts(lab: dict, app_names: list[str], benches: list[dict]) -> None:
@@ -106,10 +125,14 @@ def get_lab_form_options() -> dict:
 
 
 def _app_names_by_lab(lab_names: list[str]) -> dict:
-	"""Every lab's app list, in the order the pipeline installs them."""
+	"""Every lab's app list, in the order the pipeline installs them.
+
+	`Lab App` is shared with `Lab Template.apps`, and a lab built from a template keeps
+	the template's name — without the `parenttype` filter every app shows up twice.
+	"""
 	rows = frappe.get_all(
 		"Lab App",
-		filters={"parent": ("in", lab_names)},
+		filters={"parent": ("in", lab_names), "parenttype": "Lab"},
 		fields=["parent", "app_name"],
 		order_by="idx asc",
 		parent_doctype="Lab",

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -693,7 +693,7 @@ class TestApi(IntegrationTestCase):
 			frappe.db.get_value("Bench Instance", bench.name, "site_name"), "stable.benchpress.cloud"
 		)
 
-	def test_create_bench_without_site_name_keeps_the_default(self):
+	def test_create_bench_without_site_name_defaults_to_the_public_hostname(self):
 		data = frappe.as_json({"lab": self.create_lab.name})
 		with patch("frappe.enqueue"):
 			result = api.create_bench(data)
@@ -701,7 +701,9 @@ class TestApi(IntegrationTestCase):
 			frappe.delete_doc, "Bench Instance", result["name"], force=True, ignore_permissions=True
 		)
 		site_name = frappe.db.get_value("Bench Instance", result["name"], "site_name")
-		self.assertTrue(site_name.endswith(".localhost"))
+		base_domain = frappe.get_cached_doc("BenchPress Settings").base_domain
+		suffix = base_domain if base_domain and base_domain != "localhost" else "localhost"
+		self.assertEqual(site_name, f"{result['name']}.{suffix}")
 
 	# --- Docker / manager side effects (patch module functions) --------------
 

--- a/benchpress/tests/test_credit_sweep.py
+++ b/benchpress/tests/test_credit_sweep.py
@@ -328,7 +328,7 @@ class TestCreditSweep(IntegrationTestCase):
 		self.stopped_for_days(100)
 		self.assertEqual(reaper.reap_stopped_instances(), {"reaped": [], "warned": []})
 
-	def test_reaping_removes_the_container_volume_and_database_and_keeps_the_lab(self):
+	def test_reaping_removes_the_container_and_database_and_keeps_the_lab(self):
 		self.enable_credits()
 		self.stopped_for_days(REAP_AFTER_DAYS + 1)
 		frappe.db.set_value(
@@ -347,7 +347,7 @@ class TestCreditSweep(IntegrationTestCase):
 		stop.assert_called_once()
 		remove.assert_called_once()
 		drop.assert_called_once()
-		client.return_value.volumes.get.assert_called_once()
+		client.return_value.volumes.get.assert_not_called()
 		self.assertTrue(frappe.db.exists("Lab", self.lab.name), "the recipe must survive the reap")
 		self.assertEqual(frappe.db.get_value(BENCH, self.bench.name, "status"), "Draft")
 

--- a/benchpress/tests/test_credits.py
+++ b/benchpress/tests/test_credits.py
@@ -321,21 +321,23 @@ class TestCredits(IntegrationTestCase):
 		self.assertEqual(self.balance(), settled)
 		self.assertEqual(self.burn_rate(), 0.0)
 
-	def test_a_cache_hit_build_writes_no_usage_row(self):
+	def test_a_deploy_against_a_built_image_writes_no_usage_row(self):
+		"""Deploy never builds, so the image step never charges — only an explicit build does."""
 		self.enable_credits()
+		tag = f"benchpress/{self.lab.name}:lab"
+		frappe.db.set_value("Lab", self.lab.name, {"status": "Ready", "image_tag": tag})
 		lab = frappe.get_doc("Lab", self.lab.name)
-		with patch.object(deploy_manager.image_cache, "resolve", return_value=("cached:tag", True)):
+
+		with patch.object(deploy_manager.image_cache, "resolve", return_value=(tag, True)):
 			deploy_manager._prepare_lab_image(lab, MagicMock(), frappe.session.user)
+
 		self.assertEqual(self.entry_count(), 0)
 
-	def test_a_cache_miss_build_writes_exactly_one_usage_row(self):
+	def test_a_build_writes_exactly_one_usage_row(self):
 		self.enable_credits()
 		lab = frappe.get_doc("Lab", self.lab.name)
-		with (
-			patch.object(deploy_manager.image_cache, "resolve", return_value=("fresh:tag", False)),
-			patch.object(deploy_manager, "build_lab_image", return_value="fresh:tag"),
-		):
-			deploy_manager._prepare_lab_image(lab, MagicMock(), frappe.session.user)
+		with patch.object(deploy_manager, "build_lab_image", return_value="fresh:tag"):
+			deploy_manager._build_lab_with_logs(lab, None)
 		self.addCleanup(self.purge_build_logs, lab.name)
 
 		entries = [entry for entry in self.entries() if entry.entry_type == "Usage"]

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -247,9 +247,6 @@ class TestDeployManager(IntegrationTestCase):
 	@patch("benchpress.deploy_manager.stop_container")
 	@patch("benchpress.docker_manager.get_client")
 	def test_redeploy_bench_never_touches_volumes(self, mock_client, mock_stop, mock_remove, mock_deploy):
-		# The per-bench data volume is gone (the bench lives in the container's own
-		# layer), so teardown has no volume work left — a regression here would mean
-		# the copy-on-create cost crept back in.
 		from benchpress.deploy_manager import redeploy_bench
 
 		bench = self._fresh_bench()
@@ -441,13 +438,18 @@ class TestDeployManager(IntegrationTestCase):
 			self.assertTrue(call.kwargs["deduplicate"])
 
 	@patch("frappe.msgprint")
-	@patch("frappe.enqueue", return_value=None)
-	def test_deduped_enqueue_messages_user(self, mock_enqueue, mock_msgprint):
+	@patch("frappe.enqueue")
+	@patch(
+		"benchpress.benchpress.doctype.bench_instance.bench_instance.is_job_enqueued",
+		return_value=True,
+	)
+	def test_deduped_enqueue_messages_user(self, mock_enqueued, mock_enqueue, mock_msgprint):
 		bench = self._fresh_bench()
 
 		bench.enqueue_deploy()
 		bench.enqueue_redeploy()
 
+		mock_enqueue.assert_not_called()
 		for call in mock_msgprint.call_args_list:
 			self.assertIn("already in progress", str(call.args[0]))
 
@@ -781,14 +783,9 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		self.assertEqual(self._bench_field(bench, "status"), "Error")
 
 	def test_the_assets_step_never_builds_in_the_container(self):
-		"""Deploy never builds: assets ship in the image (`bench build --production` at image
-		build time). The old in-container fallback probed for `sites/assets/<app>/dist`, a
-		layout SPA-style apps never use, and so re-ran `bench build` live on every deploy of
-		such labs — inside the instance's own memory limit, for 20+ minutes.
-		"""
+		"""Assets ship in the image; the deploy must never run `bench build` itself."""
 		bench = self._bench()
 
-		# Would fail the run if any exec still invoked `bench build`.
 		self._run_deploy(bench, exec_failures={"bench build": (1, "must never be called")})
 
 		log = self._log(bench.name)
@@ -1214,9 +1211,6 @@ class TestPublicSiteUrlHelpers(unittest.TestCase):
 				deploy_manager._write_instance_route("inst-1", "benchpress.cloud", "172.30.0.11")
 				config = yaml.safe_load((Path(tmp) / "instances" / "inst-1.yml").read_text())
 
-			# The routers must name their certificate: with a bare `tls: {}` and no
-			# cert covering `*.base_domain` in the store, Traefik serves its
-			# self-signed default and every instance URL fails TLS.
 			expected_tls = {
 				"certResolver": "letsencrypt",
 				"domains": [{"main": "benchpress.cloud", "sans": ["*.benchpress.cloud"]}],

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -230,8 +230,6 @@ class TestDeployManager(IntegrationTestCase):
 		bench.save(ignore_permissions=True)
 		frappe.db.commit()
 
-		mock_client.return_value.volumes.get.return_value = MagicMock()
-
 		status_at_deploy = {}
 
 		def capture_status(bench_name):
@@ -248,7 +246,10 @@ class TestDeployManager(IntegrationTestCase):
 	@patch("benchpress.deploy_manager.remove_container")
 	@patch("benchpress.deploy_manager.stop_container")
 	@patch("benchpress.docker_manager.get_client")
-	def test_redeploy_bench_removes_data_volume(self, mock_client, mock_stop, mock_remove, mock_deploy):
+	def test_redeploy_bench_never_touches_volumes(self, mock_client, mock_stop, mock_remove, mock_deploy):
+		# The per-bench data volume is gone (the bench lives in the container's own
+		# layer), so teardown has no volume work left — a regression here would mean
+		# the copy-on-create cost crept back in.
 		from benchpress.deploy_manager import redeploy_bench
 
 		bench = self._fresh_bench()
@@ -256,13 +257,9 @@ class TestDeployManager(IntegrationTestCase):
 		bench.save(ignore_permissions=True)
 		frappe.db.commit()
 
-		mock_vol = MagicMock()
-		mock_client.return_value.volumes.get.return_value = mock_vol
-
 		redeploy_bench(bench.name)
 
-		mock_client.return_value.volumes.get.assert_called_with(f"benchpress-{bench.bench_name}-data")
-		mock_vol.remove.assert_called_once_with(force=True)
+		mock_client.return_value.volumes.get.assert_not_called()
 
 	@patch("benchpress.deploy_manager._deploy_bench")
 	@patch("benchpress.deploy_manager.remove_container")
@@ -279,8 +276,6 @@ class TestDeployManager(IntegrationTestCase):
 		frappe.db.set_value("Bench Instance", bench.name, "database_server", self.db_server_name)
 		frappe.db.commit()
 		bench.reload()
-
-		mock_client.return_value.volumes.get.return_value = MagicMock()
 
 		redeploy_bench(bench.name)
 		mock_drop_db.assert_called_once_with(self.db_server_name, bench.site_name)
@@ -328,8 +323,8 @@ class TestDeployManager(IntegrationTestCase):
 		self.assertEqual(mock_deploy.call_count, 2)
 
 	@patch("benchpress.deploy_manager._deploy_bench")
-	@patch("benchpress.deploy_manager.remove_bench_volume")
-	def test_redeploy_skipped_when_lock_held(self, mock_volume, mock_deploy):
+	@patch("benchpress.deploy_manager.remove_container")
+	def test_redeploy_skipped_when_lock_held(self, mock_remove, mock_deploy):
 		from benchpress.deploy_manager import redeploy_bench
 
 		bench = self._fresh_bench()
@@ -338,7 +333,7 @@ class TestDeployManager(IntegrationTestCase):
 		with self._held_deploy_lock(bench.name):
 			redeploy_bench(bench.name)
 
-		mock_volume.assert_not_called()
+		mock_remove.assert_not_called()
 		mock_deploy.assert_not_called()
 
 	def _deploy_log(self, bench_name):
@@ -372,7 +367,6 @@ class TestDeployManager(IntegrationTestCase):
 			patch.object(deploy_manager, "start_container", autospec=True),
 			patch.object(deploy_manager, "wait_for_container_running", autospec=True) as mock_wait,
 			patch.object(deploy_manager, "remove_container", autospec=True) as mock_remove_container,
-			patch.object(deploy_manager, "remove_bench_volume", autospec=True) as mock_remove_volume,
 			patch.object(deploy_manager, "_notify_owner", autospec=True),
 			patch("benchpress.vpn_adapter.remove_bench_peer", autospec=True) as mock_remove_peer,
 		):
@@ -384,7 +378,6 @@ class TestDeployManager(IntegrationTestCase):
 
 		mock_remove_container.assert_called_once_with("cid-cleanup")
 		mock_remove_peer.assert_called_once()
-		mock_remove_volume.assert_not_called()
 		bench.reload()
 		self.assertEqual(bench.status, "Error")
 		self.assertIsNone(bench.container_id)
@@ -1216,10 +1209,18 @@ class TestPublicSiteUrlHelpers(unittest.TestCase):
 				deploy_manager._write_instance_route("inst-1", "benchpress.cloud", "172.30.0.11")
 				config = yaml.safe_load((Path(tmp) / "instances" / "inst-1.yml").read_text())
 
+			# The routers must name their certificate: with a bare `tls: {}` and no
+			# cert covering `*.base_domain` in the store, Traefik serves its
+			# self-signed default and every instance URL fails TLS.
+			expected_tls = {
+				"certResolver": "letsencrypt",
+				"domains": [{"main": "benchpress.cloud", "sans": ["*.benchpress.cloud"]}],
+			}
+
 			router = config["http"]["routers"]["site-inst-1"]
 			self.assertEqual(router["rule"], "Host(`inst-1.benchpress.cloud`)")
 			self.assertEqual(router["service"], "site-inst-1")
-			self.assertEqual(router["tls"], {})
+			self.assertEqual(router["tls"], expected_tls)
 
 			service = config["http"]["services"]["site-inst-1"]
 			self.assertEqual(service["loadBalancer"]["servers"], [{"url": "http://172.30.0.11:8000"}])
@@ -1227,7 +1228,7 @@ class TestPublicSiteUrlHelpers(unittest.TestCase):
 			ide_router = config["http"]["routers"]["ide-inst-1"]
 			self.assertEqual(ide_router["rule"], "Host(`ide-inst-1.benchpress.cloud`)")
 			self.assertEqual(ide_router["service"], "ide-inst-1")
-			self.assertEqual(ide_router["tls"], {})
+			self.assertEqual(ide_router["tls"], expected_tls)
 
 			ide_service = config["http"]["services"]["ide-inst-1"]
 			self.assertEqual(ide_service["loadBalancer"]["servers"], [{"url": "http://172.30.0.11:8080"}])

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -3,7 +3,7 @@
 
 import tempfile
 import unittest
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -80,17 +80,20 @@ def _fresh_bench(case, lab_name):
 	return bench
 
 
-def _cached_image():
-	"""Report a cache hit so a test that is not about the image step performs no real build.
+@contextmanager
+def _cached_image(lab_name):
+	"""Make `lab_name` deploy-ready: `Ready`, with an `image_tag` matching what resolve reports.
 
-	The image step resolves the shared cache by content hash, so a lab whose `image_tag` is a
-	fixture string now counts as a miss — and a miss shells out to Docker and builds a multi-GB
-	image. Every deploy that reaches step 2 in this file patches the resolve instead.
+	The image step now fails fast unless the lab is `Ready` *and* its stored `image_tag` matches
+	the freshly resolved tag — so this sets both together, rather than leaving a caller to pick a
+	fixture string that has to happen to match. Every deploy that reaches step 2 in this file
+	uses this instead of a real Docker socket.
 	"""
-	return patch(
-		"benchpress.deploy_manager.image_cache.resolve",
-		return_value=("benchpress/cache:cachedfixture", True),
-	)
+	tag = f"benchpress/{lab_name}:lab"
+	frappe.db.set_value("Lab", lab_name, {"status": "Ready", "image_tag": tag})
+	frappe.db.commit()
+	with patch("benchpress.deploy_manager.image_cache.resolve", return_value=(tag, True)):
+		yield tag
 
 
 def _ensure_owner(email):
@@ -353,7 +356,6 @@ class TestDeployManager(IntegrationTestCase):
 
 		bench = self._fresh_bench()
 		self._cleanup_deploy_logs(bench.name)
-		frappe.db.set_value("Lab", self.lab.name, {"status": "Ready", "image_tag": "benchpress/test:latest"})
 		frappe.db.set_value(
 			"Bench Instance",
 			bench.name,
@@ -362,7 +364,7 @@ class TestDeployManager(IntegrationTestCase):
 		frappe.db.commit()
 
 		with (
-			_cached_image(),
+			_cached_image(self.lab.name),
 			patch.object(deploy_manager, "ensure_infrastructure", autospec=True) as mock_infra,
 			patch.object(deploy_manager, "wait_for_mariadb", autospec=True),
 			patch.object(deploy_manager, "_remove_stale_container", autospec=True),
@@ -396,7 +398,6 @@ class TestDeployManager(IntegrationTestCase):
 
 		bench = self._fresh_bench()
 		self._cleanup_deploy_logs(bench.name)
-		frappe.db.set_value("Lab", self.lab.name, {"status": "Ready", "image_tag": "benchpress/test:latest"})
 		frappe.db.set_value(
 			"Bench Instance",
 			bench.name,
@@ -409,7 +410,7 @@ class TestDeployManager(IntegrationTestCase):
 		frappe.db.commit()
 
 		with (
-			_cached_image(),
+			_cached_image(self.lab.name),
 			patch.object(deploy_manager, "ensure_infrastructure", autospec=True) as mock_infra,
 			patch.object(deploy_manager, "remove_container", autospec=True) as mock_remove_container,
 			patch.object(deploy_manager, "_notify_owner", autospec=True),
@@ -507,7 +508,6 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		cls.db_server_name = frappe.db.get_value(
 			"Database Server", {"container_name": "test-db-steps"}, "name"
 		)
-		frappe.db.set_value("Lab", cls.lab.name, {"status": "Ready", "image_tag": "benchpress/test:latest"})
 		frappe.db.commit()
 
 	@classmethod
@@ -534,7 +534,8 @@ class TestDeployStepMarkers(IntegrationTestCase):
 	):
 		"""A whole deploy with every side effect mocked but the log itself.
 
-		`cache_hit=False` leaves the image step to the caller, so it has to build.
+		`cache_hit=False` leaves the lab `Draft` with no `image_tag`, so the image step fails
+		fast — deploy never builds.
 		`exec_failures` maps a fragment of a container command to the result that command
 		returns, so one exec can fail while the rest of the run succeeds. `write_error` makes
 		every `write_file_to_container` raise, the way a read-only target path would.
@@ -542,13 +543,14 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		from benchpress import deploy_manager
 
 		with (
-			_cached_image() if cache_hit else nullcontext(),
+			_cached_image(self.lab.name) if cache_hit else nullcontext(),
 			patch.object(deploy_manager, "ensure_infrastructure", autospec=True) as mock_infra,
 			patch.object(deploy_manager, "wait_for_mariadb", autospec=True),
 			patch.object(deploy_manager, "_remove_stale_container", autospec=True),
 			patch.object(deploy_manager, "create_bench_container", autospec=True) as mock_create,
 			patch.object(deploy_manager, "start_container", autospec=True),
 			patch.object(deploy_manager, "wait_for_container_running", autospec=True) as mock_wait,
+			patch.object(deploy_manager, "_write_instance_route", autospec=True),
 			patch.object(deploy_manager, "write_file_to_container", autospec=True) as mock_write,
 			patch.object(deploy_manager, "exec_in_container", autospec=True) as mock_exec,
 			patch.object(deploy_manager, "create_site_in_container", autospec=True) as mock_site,
@@ -665,37 +667,23 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		# A room would broadcast past the user scoping the leak fix relies on.
 		self.assertFalse(any(call.get("room") for call in published))
 
-	def test_a_build_inside_a_deploy_writes_the_build_log_not_the_deploy_log(self):
-		"""The image step's Docker output belongs to the Build log tab."""
+	def test_an_unbuilt_lab_fails_the_image_step_without_touching_the_build_log(self):
+		"""Deploy is a lookup now, never a build — Phase 3. The image step fails fast at step
+		2/11 and the Build Log tab (a separate action's log) is never written by a deploy.
+		"""
 		from benchpress import deploy_manager
 
 		bench = self._bench()
 		self.addCleanup(frappe.db.delete, "Build Log", {"lab": self.lab.name})
 
-		def fake_build(lab, log_fn=None, **kwargs):
-			log_fn("Compiling translations for hrms")
-			return "benchpress/steps:built"
-
-		with (
-			patch.object(deploy_manager.image_cache, "resolve", return_value=("fresh:tag", False)),
-			patch.object(deploy_manager, "build_lab_image", side_effect=fake_build),
-		):
+		with patch.object(deploy_manager, "build_lab_image", autospec=True) as mock_build:
 			self._run_deploy(bench, cache_hit=False)
 
+		mock_build.assert_not_called()
 		deploy_log = self._log(bench.name)
-		self.assertIn("output goes to the build log", deploy_log)
-		self.assertNotIn("Compiling translations for hrms", deploy_log)
-
-		build_log = frappe.get_all(
-			"Build Log",
-			filters={"lab": self.lab.name},
-			fields=["message", "log_type"],
-			order_by="creation desc",
-			limit_page_length=1,
-		)[0]
-		self.assertIn("Compiling translations for hrms", build_log.message)
-		self.assertIn("=== Build complete: benchpress/steps:built ===", build_log.message)
-		self.assertEqual(build_log.log_type, "success")
+		self.assertIn("Step 2/11", deploy_log)
+		self.assertIn("No built image", deploy_log)
+		self.assertEqual(frappe.db.count("Build Log", {"lab": self.lab.name}), 0)
 
 	# --- Phase 3: a command the run does not check is a claim it cannot make ---
 
@@ -749,14 +737,11 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		self.assertEqual(self._bench_field(bench, "status"), "Running")
 
 	def test_a_working_step_ten_stores_the_public_ide_hostname(self):
-		from benchpress import deploy_manager
-
 		bench = self._bench()
 		self._enable_code_server()
 		self._set_base_domain("benchpress.cloud")
 
-		with patch.object(deploy_manager, "_write_instance_route", autospec=True):
-			self._run_deploy(bench)
+		self._run_deploy(bench)
 
 		log = self._log(bench.name)
 		self.assertEqual(log.count("code-server ready at"), 1)
@@ -776,13 +761,10 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		frappe.db.commit()
 
 	def test_public_url_set_when_base_domain_is_configured(self):
-		from benchpress import deploy_manager
-
 		bench = self._bench()
 		self._set_base_domain("benchpress.cloud")
 
-		with patch.object(deploy_manager, "_write_instance_route", autospec=True):
-			self._run_deploy(bench)
+		self._run_deploy(bench)
 
 		self.assertEqual(self._bench_field(bench, "public_url"), f"https://{bench.name}.benchpress.cloud")
 
@@ -826,43 +808,24 @@ class TestDeployStepMarkers(IntegrationTestCase):
 
 		self.assertNotIn("failed", self._log(bench.name))
 
-	def test_a_build_failure_inside_a_deploy_is_attributed_to_the_build(self):
-		"""Hole 6: the banner must name the build and point at the log holding Docker's error."""
-		from benchpress import deploy_manager, lab_detail
+	def test_an_unbuilt_image_is_attributed_to_the_deploy_not_a_build(self):
+		"""Phase 3: deploy never builds, so its own failure is never redirected to a Build Log —
+		there isn't one to redirect to, and there never will be for this failure mode.
+		"""
+		from benchpress import lab_detail
 
 		bench = self._bench()
-		self.addCleanup(frappe.db.delete, "Build Log", {"lab": self.lab.name})
-		status_before = frappe.db.get_value("Lab", self.lab.name, "status")
+		frappe.db.set_value("Lab", self.lab.name, {"status": "Draft", "image_tag": None})
+		frappe.db.commit()
 
-		def exploding_build(lab, log_fn=None, **kwargs):
-			log_fn("Step 3/8 : RUN bench get-app --branch nope hrms")
-			raise Exception("branch 'nope' not found in upstream origin")
-
-		with (
-			patch.object(deploy_manager.image_cache, "resolve", return_value=("fresh:tag", False)),
-			patch.object(deploy_manager, "build_lab_image", side_effect=exploding_build),
-		):
-			self._run_deploy(bench, cache_hit=False)
-
-		# `_run_build` restores the lab, which is exactly why `Lab.status` cannot carry this.
-		self.assertEqual(frappe.db.get_value("Lab", self.lab.name, "status"), status_before)
+		self._run_deploy(bench, cache_hit=False)
 
 		failure = lab_detail.get_lab(self.lab.name)["failure"]
-		self.assertEqual(failure["source"], "build")
-		self.assertIn("branch 'nope' not found", failure["reason"])
-		self.assertEqual(
-			failure["log"],
-			frappe.get_all(
-				"Build Log",
-				filters={"lab": self.lab.name},
-				order_by="timestamp desc",
-				limit_page_length=1,
-				pluck="name",
-			)[0],
-		)
+		self.assertEqual(failure["source"], "deploy")
+		self.assertIn("No built image", failure["reason"])
 
 	def test_a_deploy_that_broke_after_the_image_still_blames_the_deploy(self):
-		"""The redirect is bounded to the image step, so an unrelated failure keeps its own log."""
+		"""A failure past the image step is a deploy failure, plainly — nothing to redirect."""
 		from benchpress import lab_detail
 
 		bench = self._bench()
@@ -965,17 +928,17 @@ class TestTerminalStateNotifications(IntegrationTestCase):
 		from benchpress import deploy_manager
 
 		bench = self._owned_bench()
-		frappe.db.set_value("Lab", self.lab.name, {"status": "Ready", "image_tag": "benchpress/test:latest"})
 		frappe.db.commit()
 
 		with (
-			_cached_image(),
+			_cached_image(self.lab.name),
 			patch.object(deploy_manager, "ensure_infrastructure", autospec=True) as mock_infra,
 			patch.object(deploy_manager, "wait_for_mariadb", autospec=True),
 			patch.object(deploy_manager, "_remove_stale_container", autospec=True),
 			patch.object(deploy_manager, "create_bench_container", autospec=True) as mock_create,
 			patch.object(deploy_manager, "start_container", autospec=True),
 			patch.object(deploy_manager, "wait_for_container_running", autospec=True) as mock_wait,
+			patch.object(deploy_manager, "_write_instance_route", autospec=True),
 			patch.object(deploy_manager, "_setup_container_vpn", autospec=True),
 			patch.object(deploy_manager, "write_file_to_container", autospec=True),
 			patch.object(deploy_manager, "exec_in_container", autospec=True) as mock_exec,

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -780,15 +780,20 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		self.assertIn("common_site_config.json failed", self._log(bench.name))
 		self.assertEqual(self._bench_field(bench, "status"), "Error")
 
-	def test_a_failed_asset_build_warns_and_the_deploy_still_finishes(self):
-		"""The one deliberate asymmetry: stale assets are recoverable, a killed deploy is not."""
+	def test_the_assets_step_never_builds_in_the_container(self):
+		"""Deploy never builds: assets ship in the image (`bench build --production` at image
+		build time). The old in-container fallback probed for `sites/assets/<app>/dist`, a
+		layout SPA-style apps never use, and so re-ran `bench build` live on every deploy of
+		such labs — inside the instance's own memory limit, for 20+ minutes.
+		"""
 		bench = self._bench()
 
-		self._run_deploy(bench, exec_failures={"bench build": (1, "esbuild: hrms bundle exploded")})
+		# Would fail the run if any exec still invoked `bench build`.
+		self._run_deploy(bench, exec_failures={"bench build": (1, "must never be called")})
 
 		log = self._log(bench.name)
-		self.assertIn("bench build failed (exit 1)", log)
-		self.assertIn("esbuild: hrms bundle exploded", log)
+		self.assertIn("Assets ship in the image", log)
+		self.assertNotIn("must never be called", log)
 		self.assertEqual(self._bench_field(bench, "status"), "Running")
 		self.assertIn("Step 11/11", log)
 

--- a/benchpress/tests/test_docker_manager.py
+++ b/benchpress/tests/test_docker_manager.py
@@ -232,6 +232,18 @@ class TestDockerManagerBlockIO(IntegrationTestCase):
 			docker_manager.create_bench_container(bench, lab)
 			return mock_client.return_value.containers.create.call_args.kwargs
 
+	def test_no_volume_is_mounted_over_the_bench(self):
+		# A named volume at /home/frappe made Docker copy the whole multi-GB bench
+		# into it on every create (minutes per deploy, no persistence gained — the
+		# volume died with its container). The bench lives in the container's own
+		# copy-on-write layer now; this pins the mount from coming back.
+		lab = _make_lab("no-volume")
+		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
+
+		kwargs = self._container_create_kwargs(lab)
+
+		self.assertNotIn("volumes", kwargs)
+
 	def test_lab_block_io_limits_passed_to_container(self):
 		lab = _make_lab("blockio-custom", iops_limit=500, bps_limit=2 * 1024 * 1024)
 		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)

--- a/benchpress/tests/test_docker_manager.py
+++ b/benchpress/tests/test_docker_manager.py
@@ -233,10 +233,7 @@ class TestDockerManagerBlockIO(IntegrationTestCase):
 			return mock_client.return_value.containers.create.call_args.kwargs
 
 	def test_no_volume_is_mounted_over_the_bench(self):
-		# A named volume at /home/frappe made Docker copy the whole multi-GB bench
-		# into it on every create (minutes per deploy, no persistence gained — the
-		# volume died with its container). The bench lives in the container's own
-		# copy-on-write layer now; this pins the mount from coming back.
+		"""A named volume over /home/frappe forces a full bench copy on every create."""
 		lab = _make_lab("no-volume")
 		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
 

--- a/benchpress/tests/test_image_cache.py
+++ b/benchpress/tests/test_image_cache.py
@@ -39,52 +39,58 @@ def _app(app_name="erpnext", git_url="https://github.com/frappe/erpnext", branch
 	return {"app_name": app_name, "git_url": git_url, "branch": branch}
 
 
-class TestBuildSpecHash(unittest.TestCase):
-	def test_row_order_cannot_change_the_hash(self):
+class TestBuildSpec(unittest.TestCase):
+	"""`build_spec` is no longer the tag's identity — the tag is static per lab now — but it's
+	still what `Lab.reset_status_if_spec_changed` compares to detect a Ready lab gone stale.
+	"""
+
+	def test_row_order_does_not_change_the_spec(self):
 		crm, erpnext = _app("crm", "https://github.com/frappe/crm", "main"), _app()
 		self.assertEqual(
-			image_cache.build_spec_hash(_spec(apps=[crm, erpnext])),
-			image_cache.build_spec_hash(_spec(apps=[erpnext, crm])),
+			image_cache.build_spec(_spec(apps=[crm, erpnext])),
+			image_cache.build_spec(_spec(apps=[erpnext, crm])),
 		)
 
-	def test_a_changed_branch_changes_the_hash(self):
+	def test_a_changed_branch_changes_the_spec(self):
 		moved = _app(branch="version-14")
 		self.assertNotEqual(
-			image_cache.build_spec_hash(_spec(apps=[_app()])),
-			image_cache.build_spec_hash(_spec(apps=[moved])),
+			image_cache.build_spec(_spec(apps=[_app()])),
+			image_cache.build_spec(_spec(apps=[moved])),
 		)
 
-	def test_a_changed_app_changes_the_hash(self):
+	def test_a_changed_app_changes_the_spec(self):
 		self.assertNotEqual(
-			image_cache.build_spec_hash(_spec(apps=[_app()])),
-			image_cache.build_spec_hash(_spec(apps=[_app(), _app("hrms")])),
+			image_cache.build_spec(_spec(apps=[_app()])),
+			image_cache.build_spec(_spec(apps=[_app(), _app("hrms")])),
 		)
 
-	def test_a_changed_git_url_changes_the_hash(self):
+	def test_a_changed_git_url_changes_the_spec(self):
 		fork = _app(git_url="https://github.com/someone/erpnext")
 		self.assertNotEqual(
-			image_cache.build_spec_hash(_spec(apps=[_app()])),
-			image_cache.build_spec_hash(_spec(apps=[fork])),
+			image_cache.build_spec(_spec(apps=[_app()])),
+			image_cache.build_spec(_spec(apps=[fork])),
 		)
 
-	def test_a_changed_frappe_version_changes_the_hash(self):
+	def test_a_changed_frappe_version_changes_the_spec(self):
 		self.assertNotEqual(
-			image_cache.build_spec_hash(_spec("version-15")),
-			image_cache.build_spec_hash(_spec("version-16")),
+			image_cache.build_spec(_spec("version-15")),
+			image_cache.build_spec(_spec("version-16")),
 		)
 
-	def test_app_name_case_cannot_change_the_hash(self):
-		# The build lowercases app names, so two specs that build the same image must hash alike.
+	def test_app_name_case_cannot_change_the_spec(self):
+		# The build lowercases app names, so two specs that build the same image must compare equal.
 		self.assertEqual(
-			image_cache.build_spec_hash(_spec(apps=[_app("ERPNext")])),
-			image_cache.build_spec_hash(_spec(apps=[_app("erpnext")])),
+			image_cache.build_spec(_spec(apps=[_app("ERPNext")])),
+			image_cache.build_spec(_spec(apps=[_app("erpnext")])),
 		)
 
-	def test_the_tag_is_the_shared_repository_plus_the_hash(self):
+	def test_the_tag_is_static_per_lab_id(self):
 		spec = _spec(apps=[_app()])
-		tag = image_cache.cache_tag(spec)
-		self.assertEqual(tag, f"{image_cache.CACHE_REPOSITORY}:{image_cache.build_spec_hash(spec)}")
-		self.assertEqual(len(tag.split(":")[1]), image_cache.HASH_LENGTH)
+		self.assertEqual(image_cache.cache_tag(spec), f"{image_cache.CACHE_REPOSITORY}/{spec.lab_id}:lab")
+		# Editing the spec must not change the tag — that's the whole point of a static tag;
+		# staleness is `Lab.reset_status_if_spec_changed`'s job, not the tag's.
+		changed = _spec(apps=[_app(), _app("hrms")])
+		self.assertEqual(image_cache.cache_tag(spec), image_cache.cache_tag(changed))
 
 
 def _client_with_tags(*tags):
@@ -112,7 +118,7 @@ class TestResolve(unittest.TestCase):
 	def test_resolve_reports_a_miss_for_an_unknown_spec(self):
 		with patch(
 			"benchpress.docker_manager.get_client",
-			return_value=_client_with_tags("benchpress/cache:000000000000"),
+			return_value=_client_with_tags("benchpress/some-other-lab:lab"),
 		):
 			_tag, hit = image_cache.resolve(_spec(apps=[_app()]))
 		self.assertFalse(hit)
@@ -237,41 +243,55 @@ class TestDeployReusesTheSharedImage(IntegrationTestCase):
 		)
 		return logs[0].message if logs else ""
 
-	def test_a_cache_hit_performs_no_build(self):
+	def test_a_ready_lab_with_its_image_cached_performs_no_build(self):
 		bench = self._bench()
 		tag = image_cache.cache_tag(self.lab)
-		frappe.db.set_value("Lab", self.lab.name, {"status": "Draft", "image_tag": None})
+		frappe.db.set_value("Lab", self.lab.name, {"status": "Ready", "image_tag": tag})
 		frappe.db.commit()
 
 		client = self._run_deploy(bench, cached_tags=[tag])
 
 		client.api.build.assert_not_called()
-		self.assertEqual(frappe.db.get_value("Lab", self.lab.name, "image_tag"), tag)
-		self.assertEqual(frappe.db.get_value("Lab", self.lab.name, "status"), "Ready")
+		self.assertIn(f"Using built image {tag}", self._log(bench.name))
 
-	def test_the_step_still_explains_itself_on_a_hit(self):
+	def test_the_step_explains_which_image_it_used(self):
 		bench = self._bench()
 		tag = image_cache.cache_tag(self.lab)
+		frappe.db.set_value("Lab", self.lab.name, {"status": "Ready", "image_tag": tag})
+		frappe.db.commit()
 
 		self._run_deploy(bench, cached_tags=[tag])
 
 		log = self._log(bench.name)
 		self.assertIn("Step 2/11", log)
-		self.assertIn(f"Cache hit: reusing shared image {tag}", log)
+		self.assertIn(f"Using built image {tag}", log)
 
-	def test_a_miss_builds_and_tags_by_content_hash(self):
+	def test_a_deploy_never_builds_it_fails_fast_instead(self):
+		"""The core contract this phase adds: deploy is a lookup, never a build."""
 		bench = self._bench()
-		frappe.db.set_value("Lab", self.lab.name, {"status": "Ready", "image_tag": "benchpress/stale:latest"})
+		frappe.db.set_value("Lab", self.lab.name, {"status": "Draft", "image_tag": None})
 		frappe.db.commit()
 
-		client = self._run_deploy(bench, cached_tags=["benchpress/cache:000000000000"])
+		client = self._run_deploy(bench, cached_tags=[])
 
-		client.api.build.assert_called_once()
-		self.assertEqual(client.api.build.call_args.kwargs["tag"], image_cache.cache_tag(self.lab))
-		# A Ready lab whose apps changed used to keep pointing at the previous recipe's image.
-		self.assertEqual(
-			frappe.db.get_value("Lab", self.lab.name, "image_tag"), image_cache.cache_tag(self.lab)
+		client.api.build.assert_not_called()
+		self.assertEqual(frappe.db.get_value("Bench Instance", bench.name, "status"), "Error")
+		self.assertIn("No built image", self._log(bench.name))
+
+	def test_a_stale_tag_on_a_ready_lab_also_fails_fast(self):
+		"""`status == Ready` alone isn't enough — the tag must match what's actually cached."""
+		bench = self._bench()
+		frappe.db.set_value(
+			"Lab",
+			self.lab.name,
+			{"status": "Ready", "image_tag": f"{image_cache.CACHE_REPOSITORY}/stale:lab"},
 		)
+		frappe.db.commit()
+
+		client = self._run_deploy(bench, cached_tags=[image_cache.cache_tag(self.lab)])
+
+		client.api.build.assert_not_called()
+		self.assertEqual(frappe.db.get_value("Bench Instance", bench.name, "status"), "Error")
 
 
 class TestPrewarmCatalog(IntegrationTestCase):
@@ -326,7 +346,7 @@ class TestPrewarmCatalog(IntegrationTestCase):
 		for call in enqueue.call_args_list:
 			self.assertEqual(call.kwargs["queue"], "long")
 
-	def test_a_template_build_tags_by_the_template_s_own_hash(self):
+	def test_a_template_build_tags_by_the_template_s_own_key(self):
 		from benchpress import lab_templates
 
 		client = _client_with_tags()
@@ -341,7 +361,7 @@ class TestPrewarmCatalog(IntegrationTestCase):
 class TestSweepCachedImages(IntegrationTestCase):
 	"""Cached images outlive their Labs, so an unswept cache leaks disk without bound."""
 
-	ORPHAN = "benchpress/cache:deadbeefdead"
+	ORPHAN = "benchpress/orphan-lab:lab"
 
 	@classmethod
 	def setUpClass(cls):
@@ -385,7 +405,7 @@ class TestSweepCachedImages(IntegrationTestCase):
 	def test_a_catalog_tag_is_kept_even_with_no_lab(self):
 		from benchpress import lab_templates
 
-		catalog = image_cache.cache_tag(image_cache.template_spec(lab_templates.get_template("lms")))
+		catalog = image_cache.cache_tag(image_cache.template_spec(lab_templates.get_template("erpnext")))
 		result, _client = self._sweep(catalog, self.ORPHAN)
 		self.assertEqual(result["removed"], [self.ORPHAN])
 

--- a/benchpress/tests/test_lab_templates.py
+++ b/benchpress/tests/test_lab_templates.py
@@ -118,11 +118,15 @@ class TestLabTemplates(IntegrationTestCase):
 		self.assertEqual(lab.template, "erpnext")
 
 	def test_catalog_points_a_used_template_at_the_lab_it_built(self):
-		lab = self._make_lab("hrms", "tmpl-hrms-used")
+		# Picked from the live catalog, not hardcoded: the active template set is
+		# admin-curated data (templates get deactivated), and this test only needs
+		# *some* active template that no lab has used yet.
+		unused = next(t["key"] for t in lab_templates.get_catalog() if not t["lab"])
+		lab = self._make_lab(unused, f"tmpl-{unused}-used")
 		catalog = {template["key"]: template for template in lab_templates.get_catalog()}
 
-		self.assertEqual(catalog["hrms"]["lab"]["name"], lab.name)
-		self.assertEqual(catalog["hrms"]["lab"]["status"], lab.status)
+		self.assertEqual(catalog[unused]["lab"]["name"], lab.name)
+		self.assertEqual(catalog[unused]["lab"]["status"], lab.status)
 
 	def test_catalog_reports_a_lab_only_where_one_was_built(self):
 		for template in lab_templates.get_catalog():

--- a/benchpress/tests/test_lab_templates.py
+++ b/benchpress/tests/test_lab_templates.py
@@ -118,9 +118,7 @@ class TestLabTemplates(IntegrationTestCase):
 		self.assertEqual(lab.template, "erpnext")
 
 	def test_catalog_points_a_used_template_at_the_lab_it_built(self):
-		# Picked from the live catalog, not hardcoded: the active template set is
-		# admin-curated data (templates get deactivated), and this test only needs
-		# *some* active template that no lab has used yet.
+		# Any active, unused template works; the active set is admin-curated data.
 		unused = next(t["key"] for t in lab_templates.get_catalog() if not t["lab"])
 		lab = self._make_lab(unused, f"tmpl-{unused}-used")
 		catalog = {template["key"]: template for template in lab_templates.get_catalog()}

--- a/frontend/src/components/lab/ConnectionDetails.vue
+++ b/frontend/src/components/lab/ConnectionDetails.vue
@@ -15,8 +15,8 @@
 		</template>
 
 		<p class="border-b border-outline-gray-1 px-4 py-2.5 text-2xs text-ink-gray-5">
-			Everything below is reachable only over the VPN. Passwords are regenerated on every
-			redeploy.
+			The public URL works from anywhere; everything else is reachable only over the VPN.
+			Passwords are regenerated on every redeploy.
 		</p>
 
 		<ul class="divide-y divide-outline-gray-1">
@@ -79,7 +79,7 @@
 // re-masks. Copy feedback is a tooltip on the button that was pressed, which
 // replaces the teleported page-corner alert the old screen used.
 import SectionCard from "@/components/SectionCard.vue";
-import { ideUrl } from "@/utils/labActions";
+import { ideUrl, privateSiteUrl } from "@/utils/labActions";
 import { Button, FormControl, Tooltip } from "frappe-ui";
 import { computed, ref } from "vue";
 
@@ -96,7 +96,6 @@ const props = defineProps({
 	bench: { type: Object, required: true },
 	// What `get_bench_credentials` returned; empty until it resolves.
 	credentials: { type: Object, default: () => ({}) },
-	siteUrl: { type: String, default: null },
 });
 
 const revealed = ref(false);
@@ -107,7 +106,10 @@ const address = computed(() => props.bench.wg_ip || props.bench.container_ip || 
 
 const rows = computed(() =>
 	[
-		{ key: "site", label: "Site URL", value: props.siteUrl },
+		// Both addresses, always: the public one for sharing outside the tunnel,
+		// the private one for teammates already on the VPN.
+		{ key: "public-url", label: "Public URL", value: props.bench.public_url },
+		{ key: "private-url", label: "Private URL (VPN)", value: privateSiteUrl(props.bench) },
 		{ key: "wg-ip", label: "WireGuard IP", value: props.bench.wg_ip },
 		codeServerRow(),
 		sshRow(),

--- a/frontend/src/components/lab/LabHeader.vue
+++ b/frontend/src/components/lab/LabHeader.vue
@@ -45,11 +45,12 @@
 
 		<div class="flex flex-col items-end gap-1">
 			<div class="flex items-center gap-2">
-				<!-- Off-tunnel the IDE is unreachable; the caption below covers both buttons. -->
+				<!-- A tunnel-only IDE address is unreachable off-tunnel; a public one opens
+				     from anywhere. The caption below covers both buttons. -->
 				<Button
 					v-if="showCodeServer"
 					variant="subtle"
-					:disabled="!vpnConnected"
+					:disabled="!vpnConnected && urlNeedsVpn(ideUrl(bench))"
 					data-test="open-code-server"
 					@click="emit('code-server')"
 				>
@@ -92,7 +93,7 @@
 import AppIcon from "@/components/AppIcon.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 import { rateLabel } from "@/utils/credits";
-import { OPEN, REBUILD, primaryAction } from "@/utils/labActions";
+import { OPEN, REBUILD, ideUrl, primaryAction, urlNeedsVpn } from "@/utils/labActions";
 import { cpuLabel, memoryLabel } from "@/utils/labSpecs";
 import { Button, ConfirmDialog, Dropdown } from "frappe-ui";
 import { computed, ref } from "vue";

--- a/frontend/src/components/lab/LabHeader.vue
+++ b/frontend/src/components/lab/LabHeader.vue
@@ -3,7 +3,13 @@
 		<span
 			class="grid size-10 flex-none place-items-center rounded-md border border-outline-gray-1 bg-surface-white"
 		>
-			<AppIcon :app="primaryApp" :size="24" />
+			<img
+				v-if="lab.logo"
+				:src="lab.logo"
+				:alt="lab.title"
+				class="size-full rounded-md object-cover"
+			/>
+			<AppIcon v-else :app="primaryApp" :size="24" />
 		</span>
 
 		<div class="min-w-0 flex-1">

--- a/frontend/src/pages/LabDetail.vue
+++ b/frontend/src/pages/LabDetail.vue
@@ -51,7 +51,6 @@
 								:lab="lab.data"
 								:bench="bench"
 								:credentials="credentials.data ?? {}"
-								:site-url="siteAddress"
 							/>
 						</div>
 

--- a/frontend/src/pages/LabTemplates.vue
+++ b/frontend/src/pages/LabTemplates.vue
@@ -41,7 +41,13 @@
 					<span
 						class="grid size-8 flex-none place-items-center rounded-md border border-outline-gray-1 bg-surface-white"
 					>
-						<AppIcon :app="markFor(template)" :size="20" />
+						<img
+							v-if="template.logo"
+							:src="template.logo"
+							:alt="template.title"
+							class="size-full rounded-md object-cover"
+						/>
+						<AppIcon v-else :app="markFor(template)" :size="20" />
 					</span>
 					<div class="min-w-0 flex-1">
 						<h2 class="truncate text-sm font-semibold text-ink-gray-9">

--- a/frontend/src/pages/Labs.vue
+++ b/frontend/src/pages/Labs.vue
@@ -69,7 +69,13 @@
 					<span
 						class="grid size-7 flex-none place-items-center rounded-md border border-outline-gray-1 bg-surface-white"
 					>
-						<AppIcon :app="primaryApp(row)" :size="17" />
+						<img
+							v-if="row.logo"
+							:src="row.logo"
+							:alt="row.title"
+							class="size-full rounded-md object-cover"
+						/>
+						<AppIcon v-else :app="primaryApp(row)" :size="17" />
 					</span>
 					<span class="min-w-0" :data-test="`lab-${row.name}`">
 						<span class="block truncate text-body font-medium text-ink-gray-9">
@@ -88,20 +94,33 @@
 					{{ row.frappe_version }}
 				</span>
 
-				<div v-else-if="column.key === 'apps'" class="flex min-w-0 flex-wrap gap-1">
+				<div v-else-if="column.key === 'apps'" class="flex min-w-0 items-center gap-1">
 					<span
-						v-for="app in row.app_names"
+						v-for="app in visibleApps(row)"
 						:key="app"
-						class="rounded bg-surface-gray-2 px-1.5 py-px text-2xs text-ink-gray-7"
+						class="whitespace-nowrap rounded bg-surface-gray-2 px-1.5 py-px text-2xs text-ink-gray-7"
 					>
 						{{ appLabel(app) }}
 					</span>
+					<Tooltip v-if="hiddenApps(row).length" :text="hiddenAppsText(row)">
+						<span
+							class="whitespace-nowrap rounded bg-surface-gray-2 px-1.5 py-px text-2xs text-ink-gray-5"
+						>
+							+{{ hiddenApps(row).length }}
+						</span>
+					</Tooltip>
 					<span v-if="!row.app_names.length" class="text-2xs text-ink-gray-4">
 						Bare bench
 					</span>
 				</div>
 
-				<StatusBadge v-else-if="column.key === 'status'" :status="row.status" />
+				<!-- A deployed lab's row answers "what is it doing now": the running
+				     instance's state outranks the image's Ready. Undeployed labs keep
+				     showing the image lifecycle (Draft/Building/Ready/Error). -->
+				<StatusBadge
+					v-else-if="column.key === 'status'"
+					:status="row.deployed_as?.status || row.status"
+				/>
 
 				<div v-else-if="column.key === 'deployed_as'" class="min-w-0">
 					<template v-if="row.deployed_as">
@@ -148,7 +167,7 @@ import { userContext } from "@/data/userContext";
 import { labelFor as appLabel } from "@/utils/appIcons";
 import { ALL, matches, optionsFrom } from "@/utils/filters";
 import { benchLabel } from "@/utils/labSpecs";
-import { Button, FormControl, Select, dayjsLocal } from "frappe-ui";
+import { Button, FormControl, Select, Tooltip, dayjsLocal } from "frappe-ui";
 import { computed, onMounted, ref } from "vue";
 import { useRouter } from "vue-router";
 
@@ -165,7 +184,7 @@ import SearchIcon from "~icons/lucide/search";
 const COLUMNS = [
 	{ label: "Lab", key: "lab", width: "240px" },
 	{ label: "Version", key: "frappe_version", width: "96px" },
-	{ label: "Apps", key: "apps", width: "140px" },
+	{ label: "Apps", key: "apps", width: "168px" },
 	{ label: "Status", key: "status", width: "112px" },
 	{ label: "Deployed as", key: "deployed_as", width: "190px" },
 	{ label: "Last run", key: "last_run", width: "96px" },
@@ -224,6 +243,22 @@ function clearFilters() {
 	statusFilter.value = ALL;
 	versionFilter.value = ALL;
 	ownerFilter.value = ALL;
+}
+
+// Rows are a fixed 52px, so the cell can't wrap: show two badges and fold the
+// rest into a "+N" whose tooltip lists them.
+const MAX_APP_BADGES = 2;
+
+function visibleApps(lab) {
+	return (lab.app_names ?? []).slice(0, MAX_APP_BADGES);
+}
+
+function hiddenApps(lab) {
+	return (lab.app_names ?? []).slice(MAX_APP_BADGES);
+}
+
+function hiddenAppsText(lab) {
+	return hiddenApps(lab).map(appLabel).join(", ");
 }
 
 /** The mark a lab wears — its first non-Frappe app, else the Frappe mark. */

--- a/frontend/src/utils/appIcons.js
+++ b/frontend/src/utils/appIcons.js
@@ -21,6 +21,10 @@ export const APP_LABEL = {
 	helpdesk: "Helpdesk",
 	lms: "Learning",
 	india_compliance: "India Compliance",
+	telephony: "Telephony",
+	payments: "Payments",
+	vpn_management: "VPN Management",
+	benchpress: "BenchPress",
 };
 
 const APP_ICON = {

--- a/frontend/src/utils/labActions.js
+++ b/frontend/src/utils/labActions.js
@@ -53,21 +53,21 @@ function waiting(label) {
 }
 
 function openAction({ vpnConnected, siteUrl }) {
-	if (!vpnConnected) {
-		return {
-			action: OPEN,
-			label: "Open site — VPN off",
-			disabled: true,
-			// Covers the IDE button too: both answer only on the bench's WireGuard address.
-			hint: "Register this device on the VPN to reach the site or the IDE.",
-		};
-	}
 	if (!siteUrl) {
 		return {
 			action: OPEN,
 			label: "Open site",
 			disabled: true,
 			hint: "This bench has no address yet.",
+		};
+	}
+	// A public address answers from anywhere; only the tunnel-only fallback gates on VPN.
+	if (urlNeedsVpn(siteUrl) && !vpnConnected) {
+		return {
+			action: OPEN,
+			label: "Open site — VPN off",
+			disabled: true,
+			hint: "Register this device on the VPN to reach the site or the IDE.",
 		};
 	}
 	return { action: OPEN, label: "Open site", disabled: false, hint: "" };
@@ -102,7 +102,7 @@ export function deployDialogAction({ runState, vpnConnected, siteUrl } = {}) {
 	if (runState !== "success") {
 		return { action: WAIT, label: "Deploying…", disabled: true, loading: true };
 	}
-	if (!vpnConnected) {
+	if (urlNeedsVpn(siteUrl) && !vpnConnected) {
 		return {
 			action: CONNECT_VPN,
 			label: "Connect VPN to open",
@@ -118,15 +118,37 @@ export function deployDialogAction({ runState, vpnConnected, siteUrl } = {}) {
  *
  * Every open action routes through the two helpers below, so issue #130 (giving
  * each instance a public `<instance-id>.benchpress.cloud` hostname) repoints one
- * function rather than hunting call sites. Today a bench answers only on its
- * WireGuard address, over the tunnel.
+ * function rather than hunting call sites. A bench with a `public_url` answers
+ * there from anywhere; without one it answers only on its WireGuard address,
+ * over the tunnel.
  */
 function benchHost(bench) {
 	return bench?.wg_ip || bench?.container_ip || null;
 }
 
+/** The tunnel-only address — answers only for devices on the WireGuard network. */
+export function privateSiteUrl(bench) {
+	const host = benchHost(bench);
+	return host ? `http://${host}:${SITE_PORT}` : null;
+}
+
+/**
+ * Whether an address answers only over the tunnel.
+ *
+ * Both address kinds are built by this codebase, never typed by hand: public
+ * ones are `https://` hostnames behind the reverse proxy (deploy_manager),
+ * private ones are plain-http tunnel IPs (this file). The scheme is therefore
+ * a reliable discriminator, not a heuristic.
+ */
+export function urlNeedsVpn(url) {
+	return !!url && url.startsWith("http://");
+}
+
 /**
  * Where a site actually answers, or null when nothing serves it.
+ *
+ * The public hostname wins when the bench has one — it works without the
+ * tunnel — and the WireGuard address is the fallback for VPN-only deployments.
  *
  * With no site it is the bench's own site. With one, it is that row's address —
  * and a row naming anything else has none: the container pins `default_site` to
@@ -136,10 +158,8 @@ function benchHost(bench) {
  * The domain is a label, not a route — nothing resolves it.
  */
 export function siteUrl(bench, site = null) {
-	const host = benchHost(bench);
-	if (!host) return null;
 	if (site && site.site_name !== bench?.site_name) return null;
-	return `http://${host}:${SITE_PORT}`;
+	return bench?.public_url || privateSiteUrl(bench);
 }
 
 /**
@@ -164,13 +184,6 @@ export function siteOpenAction({ status, url, vpnConnected } = {}) {
 			hint: "This site's container is stopped. Deploy the lab to bring it back.",
 		};
 	}
-	if (!vpnConnected) {
-		return {
-			label: "Unreachable",
-			disabled: true,
-			hint: "Register this device on the VPN to reach this site.",
-		};
-	}
 	if (!url) {
 		return {
 			label: "Unreachable",
@@ -178,11 +191,22 @@ export function siteOpenAction({ status, url, vpnConnected } = {}) {
 			hint: "Nothing serves this site — the container answers only on its own site.",
 		};
 	}
+	if (urlNeedsVpn(url) && !vpnConnected) {
+		return {
+			label: "Unreachable",
+			disabled: true,
+			hint: "Register this device on the VPN to reach this site.",
+		};
+	}
 	return { label: "Open", disabled: false, hint: "" };
 }
 
-/** Where the IDE answers — the same host, code-server's port. */
+/**
+ * Where the IDE answers. The deploy stores the public IDE hostname on the bench
+ * when the deployment has one; the tunnel address is the VPN-only fallback.
+ */
 export function ideUrl(bench) {
+	if (bench?.code_server_url) return bench.code_server_url;
 	const host = benchHost(bench);
 	return host ? `http://${host}:${IDE_PORT}/` : null;
 }

--- a/frontend/src/utils/labActions.spec.js
+++ b/frontend/src/utils/labActions.spec.js
@@ -16,9 +16,11 @@ import {
 	siteLabel,
 	siteOpenAction,
 	siteUrl,
+	urlNeedsVpn,
 } from "./labActions";
 
 const SITE = "http://172.27.0.2:8000";
+const PUBLIC = "https://abc123.benchpress.cloud";
 
 // The whole contextual matrix the header has to get right. It is pure logic,
 // so it is asserted here rather than clicked through four times in a browser.
@@ -46,6 +48,12 @@ const MATRIX = [
 		state: { labStatus: "Ready", benchStatus: "Running", siteUrl: SITE },
 		up: { action: OPEN, label: "Open site", disabled: false },
 		down: { action: OPEN, label: "Open site — VPN off", disabled: true },
+	},
+	{
+		name: "a bench with a public address opens with or without the tunnel",
+		state: { labStatus: "Ready", benchStatus: "Running", siteUrl: PUBLIC },
+		up: { action: OPEN, label: "Open site", disabled: false },
+		down: { action: OPEN, label: "Open site", disabled: false },
 	},
 	{
 		name: "a failed image offers a rebuild in both tunnel states",
@@ -107,6 +115,10 @@ describe("siteUrl", () => {
 		expect(siteUrl({ container_ip: "172.30.0.5" })).toBe("http://172.30.0.5:8000");
 	});
 
+	it("prefers the public hostname over the tunnel address", () => {
+		expect(siteUrl({ public_url: PUBLIC, wg_ip: "172.27.0.2" })).toBe(PUBLIC);
+	});
+
 	it("has no address for a bench that never got one", () => {
 		expect(siteUrl({})).toBeNull();
 		expect(siteUrl(null)).toBeNull();
@@ -150,6 +162,15 @@ describe("siteOpenAction", () => {
 		}
 	});
 
+	it("opens a public address with the tunnel down", () => {
+		expect(
+			siteOpenAction({ status: "Active", url: PUBLIC, vpnConnected: false })
+		).toMatchObject({
+			label: "Open",
+			disabled: false,
+		});
+	});
+
 	it("stays disabled for a running site nothing serves", () => {
 		const state = siteOpenAction({ status: "Active", url: null, vpnConnected: true });
 		expect(state).toMatchObject({ label: "Unreachable", disabled: true });
@@ -161,6 +182,20 @@ describe("ideUrl", () => {
 	it("is the same host on code-server's port", () => {
 		expect(ideUrl({ wg_ip: "172.27.0.2" })).toBe("http://172.27.0.2:8080/");
 		expect(ideUrl({})).toBeNull();
+	});
+
+	it("prefers the address the deploy stored — public when the deployment has one", () => {
+		expect(
+			ideUrl({ code_server_url: "https://ide-abc123.benchpress.cloud", wg_ip: "172.27.0.2" })
+		).toBe("https://ide-abc123.benchpress.cloud");
+	});
+});
+
+describe("urlNeedsVpn", () => {
+	it("gates tunnel IPs and passes public hostnames", () => {
+		expect(urlNeedsVpn(SITE)).toBe(true);
+		expect(urlNeedsVpn(PUBLIC)).toBe(false);
+		expect(urlNeedsVpn(null)).toBe(false);
 	});
 });
 
@@ -196,6 +231,12 @@ describe("deployDialogAction", () => {
 		expect(
 			deployDialogAction({ runState: "success", vpnConnected: false, siteUrl: SITE })
 		).toMatchObject({ action: CONNECT_VPN, label: "Connect VPN to open", disabled: false });
+	});
+
+	it("offers a public address even with the tunnel down", () => {
+		expect(
+			deployDialogAction({ runState: "success", vpnConnected: false, siteUrl: PUBLIC })
+		).toMatchObject({ action: OPEN, label: "Open site", disabled: false });
 	});
 
 	it("cannot open a deployed bench that has no address yet", () => {


### PR DESCRIPTION
Deploy pipeline speed and reliability — phases 1, 2, 3 and phase 4's timeout half of the `deploy-pipeline-speed` spec, shipped out of numbered order for the demo, plus the fixes proving them end to end.

## What this branch does

- **Phase 2 — image cache redesign** (`0e3be8e`): static per-lab tags (`benchpress/<lab_id>:lab`), deploy fails fast on a missing image instead of silently building for 30-45 min, staleness reset when a Ready lab's spec changes.
- **Phase 1 — drop the per-bench volume** (`81331d0`): container creation no longer copies the whole 4-20 GB bench into a named volume. Measured live: container step 91s → 0.4s.
- **Phase 3 — assets never build in the container** (`c54fecc`): the dist-dir probe false-positived on SPA-style apps and re-ran `bench build` live on every deploy of such labs; assets ship in the image.
- **Phase 4 (timeouts)** (`c54fecc`, `2f1f8c9`): deploy/redeploy job ceiling raised to 2h to cover the real worst case; the site step drops a half-created database first so a killed run can't wedge an instance permanently.
- **Chown removal** (`df77ccc`): linkuser.sh's recursive chown was a structural no-op (the tenant user is the renamed uid-1000 frappe user) costing 8-30 min per deploy; the deploy now pushes the app's linkuser.sh into containers so the fix reaches already-built images.
- **Instance TLS + public URLs** (`81331d0`): instance Traefik routes name their certificate (the old `tls: {}` served Traefik's self-signed default → Cloudflare 526); sites are named `<instance-id>.<base_domain>`; the SPA prefers the public URL (no VPN gate) and shows public + private URLs side by side.
- **Labs UI** (`70d7bd4`): labs wear their template's attached logo, deployed rows read Running instead of Ready, app chips deduped with a +N overflow.

## Measured result

ERPNext lab, stop → redeploy → Running: **10.7 min before → 111s (1.9 min) after.** Site creation (~100s of real `bench new-site` work) is now the entire cost.

## Verify

Redeploy any Ready lab: the Deploy Log's container step completes in under a second, the assets step does no build, and `https://<instance-id>.benchpress.cloud` (site) and `https://ide-<instance-id>.benchpress.cloud` (code-server) open without the VPN.

Note: the paired infra fix (Traefik attached to the lab docker network, lab network created before compose up) lives in the parent benchpress_devops repo, commit `b3950af`.

Remaining spec work (not in this PR): phase 5 (build/deploy queue split) and phase 4's orphan-detection half.