### PR TITLE
fix: linkuser shell quoting and dead-container reconciliation

### DIFF
--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -191,9 +191,8 @@ def build_linkuser_args(bench, lab, settings, ssh_password: str) -> list[str]:
 def linkuser_command(script_args: list[str]) -> str:
 	"""The linkuser.sh invocation, with every argument shell-quoted.
 
-	This runs as root inside the container and the arguments carry free text (the
-	lab title, the owner's email). Naive single-quote wrapping let an apostrophe
-	break the deploy — and anything worse walk into a root shell.
+	Runs as root inside the container, and the arguments carry free text
+	(the lab title, the owner's email).
 	"""
 	return "bash /opt/benchpress/scripts/linkuser.sh " + " ".join(shlex.quote(a) for a in script_args)
 

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -188,6 +188,16 @@ def build_linkuser_args(bench, lab, settings, ssh_password: str) -> list[str]:
 	]
 
 
+def linkuser_command(args: list[str]) -> str:
+	"""The linkuser.sh invocation, with every argument shell-quoted.
+
+	This runs as root inside the container and the args carry free text (the lab
+	title, the owner's email). Naive single-quote wrapping let an apostrophe break
+	the deploy — and anything worse walk into a root shell.
+	"""
+	return "bash /opt/benchpress/scripts/linkuser.sh " + " ".join(shlex.quote(a) for a in args)
+
+
 # The desk alert on a terminal deploy/build state. Shared with the enforcement sweep and the
 # reaper, which announce the same kind of thing about the same documents.
 _notify_owner = notify_owner
@@ -365,7 +375,7 @@ def _deploy_bench(bench_name: str) -> None:
 		write_file_to_container(
 			container_id, linkuser_script.read_text(), "/opt/benchpress/scripts/linkuser.sh"
 		)
-		linkuser_cmd = "bash /opt/benchpress/scripts/linkuser.sh " + " ".join(f"'{a}'" for a in linkuser_args)
+		linkuser_cmd = linkuser_command(linkuser_args)
 		exit_code, output = exec_in_container(container_id, linkuser_cmd, user="root")
 		if output:
 			pipeline.log(output.strip())

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -188,14 +188,14 @@ def build_linkuser_args(bench, lab, settings, ssh_password: str) -> list[str]:
 	]
 
 
-def linkuser_command(args: list[str]) -> str:
+def linkuser_command(script_args: list[str]) -> str:
 	"""The linkuser.sh invocation, with every argument shell-quoted.
 
-	This runs as root inside the container and the args carry free text (the lab
-	title, the owner's email). Naive single-quote wrapping let an apostrophe break
-	the deploy — and anything worse walk into a root shell.
+	This runs as root inside the container and the arguments carry free text (the
+	lab title, the owner's email). Naive single-quote wrapping let an apostrophe
+	break the deploy — and anything worse walk into a root shell.
 	"""
-	return "bash /opt/benchpress/scripts/linkuser.sh " + " ".join(shlex.quote(a) for a in args)
+	return "bash /opt/benchpress/scripts/linkuser.sh " + " ".join(shlex.quote(a) for a in script_args)
 
 
 # The desk alert on a terminal deploy/build state. Shared with the enforcement sweep and the

--- a/benchpress/docker_manager.py
+++ b/benchpress/docker_manager.py
@@ -265,8 +265,7 @@ def wait_for_container_running(container_id: str, timeout: int = 60) -> str:
 
 
 def stop_container(container_id: str) -> None:
-	"""Stop a container. One that no longer exists is already stopped, not an error —
-	the stop path must still work on a bench whose container crashed and was reaped."""
+	"""Stop a container; one that no longer exists is already stopped, not an error."""
 	client = get_client()
 	try:
 		client.containers.get(container_id).stop(timeout=30)
@@ -332,8 +331,7 @@ def _decoded(output) -> str:
 def container_is_gone(container_id: str) -> bool:
 	"""True only when Docker positively reports the container does not exist.
 
-	A daemon error is not "gone" — a caller reconciling bench status must never
-	act on a socket hiccup.
+	A daemon error is not "gone": callers stop benches on this answer.
 	"""
 	try:
 		get_client().containers.get(container_id)

--- a/benchpress/docker_manager.py
+++ b/benchpress/docker_manager.py
@@ -265,8 +265,13 @@ def wait_for_container_running(container_id: str, timeout: int = 60) -> str:
 
 
 def stop_container(container_id: str) -> None:
+	"""Stop a container. One that no longer exists is already stopped, not an error —
+	the stop path must still work on a bench whose container crashed and was reaped."""
 	client = get_client()
-	client.containers.get(container_id).stop(timeout=30)
+	try:
+		client.containers.get(container_id).stop(timeout=30)
+	except docker.errors.NotFound:
+		pass
 
 
 def restart_container(container_id: str) -> None:
@@ -322,6 +327,21 @@ def _decoded(output) -> str:
 	if isinstance(output, bytes):
 		return output.decode("utf-8", errors="replace")
 	return "" if output is None else str(output)
+
+
+def container_is_gone(container_id: str) -> bool:
+	"""True only when Docker positively reports the container does not exist.
+
+	A daemon error is not "gone" — a caller reconciling bench status must never
+	act on a socket hiccup.
+	"""
+	try:
+		get_client().containers.get(container_id)
+		return False
+	except docker.errors.NotFound:
+		return True
+	except Exception:
+		return False
 
 
 def get_container_health(container_id: str) -> str:

--- a/benchpress/stats_collector.py
+++ b/benchpress/stats_collector.py
@@ -9,12 +9,10 @@ from benchpress.docker_manager import container_is_gone, get_container_health, g
 
 
 def collect_bench_stats() -> None:
-	"""Poll Docker for every Running bench: resource usage, health, and drift.
+	"""Poll Docker for every Running bench: resource usage, health, and reconciliation.
 
-	Health is not just a badge. `status` is what the page shows and what the
-	credit sweep bills, so a container that crashed while its bench still said
-	Running would burn the owner's credits for nothing. This poll is the
-	reconciler: Docker is the truth, the doctype follows.
+	`status` drives billing, so a bench whose container died must be stopped,
+	not just marked unhealthy.
 	"""
 	running_benches = frappe.get_all(
 		"Bench Instance",
@@ -68,12 +66,10 @@ def _update_bench_health(bench: dict) -> str:
 
 
 def _stop_if_dead(bench: dict, health: str) -> None:
-	"""Route a bench whose container died through the one stop path.
+	"""Stop a bench whose container died.
 
-	Unhealthy is a container Docker can see and reports as not running — a
-	crash, an OOM kill, a `docker stop` behind our back. Unknown is acted on
-	only when the container is positively gone: an inspect error must never
-	stop anyone's bench.
+	Unknown health is acted on only when the container is positively gone —
+	an inspect error must never stop a bench.
 	"""
 	if health == "Healthy":
 		return

--- a/benchpress/stats_collector.py
+++ b/benchpress/stats_collector.py
@@ -2,17 +2,24 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.utils import now_datetime
 
-from benchpress.docker_manager import get_container_health, get_container_stats
+from benchpress.docker_manager import container_is_gone, get_container_health, get_container_stats
 
 
 def collect_bench_stats() -> None:
-	"""Poll Docker stats for all running benches and update their resource usage fields."""
+	"""Poll Docker for every Running bench: resource usage, health, and drift.
+
+	Health is not just a badge. `status` is what the page shows and what the
+	credit sweep bills, so a container that crashed while its bench still said
+	Running would burn the owner's credits for nothing. This poll is the
+	reconciler: Docker is the truth, the doctype follows.
+	"""
 	running_benches = frappe.get_all(
 		"Bench Instance",
 		filters={"status": "Running", "container_id": ["is", "set"]},
-		fields=["name", "container_id"],
+		fields=["name", "container_id", "owner"],
 	)
 
 	for bench in running_benches:
@@ -33,19 +40,53 @@ def collect_bench_stats() -> None:
 				message=frappe.get_traceback(),
 			)
 
-		_update_bench_health(bench)
+		try:
+			health = _update_bench_health(bench)
+			_stop_if_dead(bench, health)
+		except Exception:
+			frappe.log_error(
+				title=f"Health reconciliation failed for {bench['name']}",
+				message=frappe.get_traceback(),
+			)
 
 	frappe.db.commit()
 
 
-def _update_bench_health(bench: dict) -> None:
-	"""Record the container health and check timestamp for a single bench."""
+def _update_bench_health(bench: dict) -> str:
+	"""Record the container health and check timestamp; returns the health label."""
+	health = get_container_health(bench["container_id"])
 	frappe.db.set_value(
 		"Bench Instance",
 		bench["name"],
 		{
-			"container_health": get_container_health(bench["container_id"]),
+			"container_health": health,
 			"last_health_check": now_datetime(),
 		},
 		update_modified=False,
+	)
+	return health
+
+
+def _stop_if_dead(bench: dict, health: str) -> None:
+	"""Route a bench whose container died through the one stop path.
+
+	Unhealthy is a container Docker can see and reports as not running — a
+	crash, an OOM kill, a `docker stop` behind our back. Unknown is acted on
+	only when the container is positively gone: an inspect error must never
+	stop anyone's bench.
+	"""
+	if health == "Healthy":
+		return
+	if health == "Unknown" and not container_is_gone(bench["container_id"]):
+		return
+
+	from benchpress.deploy_manager import stop_bench
+	from benchpress.notifications import notify_owner
+
+	stop_bench(bench["name"])
+	notify_owner(
+		bench["owner"],
+		_("Bench {0} was stopped: its container is no longer running.").format(bench["name"]),
+		"Bench Instance",
+		bench["name"],
 	)

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -483,6 +483,21 @@ class TestDeployManager(IntegrationTestCase):
 
 		self.assertEqual(args[-1], "/bin/bash")
 
+	def test_linkuser_command_survives_hostile_arguments(self):
+		# The command runs as root in the container, and the lab title is free
+		# text. An apostrophe used to break the deploy; anything sharper walked
+		# into the shell. Every argument must round-trip exactly.
+		import shlex
+
+		from benchpress.deploy_manager import linkuser_command
+
+		args = ["tester", "o'brien@example.com", "Venki's Lab; rm -rf /", "$(id)", "`id`", ""]
+		command = linkuser_command(args)
+
+		parsed = shlex.split(command)
+		self.assertEqual(parsed[0:2], ["bash", "/opt/benchpress/scripts/linkuser.sh"])
+		self.assertEqual(parsed[2:], args)
+
 
 class TestDeployStepMarkers(IntegrationTestCase):
 	"""Phase 4: the run reports its eleven steps, in the order the code runs them."""

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -484,9 +484,6 @@ class TestDeployManager(IntegrationTestCase):
 		self.assertEqual(args[-1], "/bin/bash")
 
 	def test_linkuser_command_survives_hostile_arguments(self):
-		# The command runs as root in the container, and the lab title is free
-		# text. An apostrophe used to break the deploy; anything sharper walked
-		# into the shell. Every argument must round-trip exactly.
 		import shlex
 
 		from benchpress.deploy_manager import linkuser_command

--- a/benchpress/tests/test_stats_collector.py
+++ b/benchpress/tests/test_stats_collector.py
@@ -1,12 +1,7 @@
 # Copyright (c) 2026, Venkatesh and Contributors
 # See license.txt
 
-"""The stats poll is also the reconciler: Docker is the truth, status follows.
-
-A container that crashed while its bench still said Running burned credits
-for nothing — `container_health` was collected every minute and acted on by
-nothing. These tests pin the acting-on part.
-"""
+"""The stats poll must stop a Running bench whose container died — `status` drives billing."""
 
 import unittest
 from unittest.mock import patch
@@ -39,8 +34,6 @@ class TestStopIfDead(unittest.TestCase):
 		notify_mock.assert_not_called()
 
 	def test_unhealthy_container_stops_the_bench_and_tells_the_owner(self):
-		# Docker can see the container and reports it not running — a crash,
-		# an OOM kill, a stop behind our back. Status and billing must follow.
 		stop_mock, notify_mock, _ = self._run("Unhealthy")
 		stop_mock.assert_called_once_with(BENCH["name"])
 		notify_mock.assert_called_once()
@@ -51,15 +44,13 @@ class TestStopIfDead(unittest.TestCase):
 		stop_mock.assert_called_once_with(BENCH["name"])
 
 	def test_inspect_error_never_stops_a_bench(self):
-		# Unknown can also mean the Docker socket hiccuped. Only a positive
-		# "does not exist" may stop someone's bench.
+		# Unknown can mean a socket hiccup, not a missing container.
 		stop_mock, notify_mock, gone_mock = self._run("Unknown", gone=False)
 		gone_mock.assert_called_once_with(BENCH["container_id"])
 		stop_mock.assert_not_called()
 		notify_mock.assert_not_called()
 
 	def test_reconciliation_failure_does_not_kill_the_poll(self):
-		# One bench's failure must not starve the rest of the fleet of stats.
 		second = {"name": "bench-002", "container_id": "dec0de", "owner": "user@example.com"}
 		with (
 			patch("benchpress.stats_collector.frappe") as frappe_mock,

--- a/benchpress/tests/test_stats_collector.py
+++ b/benchpress/tests/test_stats_collector.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+"""The stats poll is also the reconciler: Docker is the truth, status follows.
+
+A container that crashed while its bench still said Running burned credits
+for nothing — `container_health` was collected every minute and acted on by
+nothing. These tests pin the acting-on part.
+"""
+
+import unittest
+from unittest.mock import patch
+
+BENCH = {"name": "bench-001", "container_id": "c0ffee", "owner": "user@example.com"}
+
+
+class TestStopIfDead(unittest.TestCase):
+	def _run(self, health, gone=False):
+		"""Run one poll over a single Running bench and report what it did."""
+		with (
+			patch("benchpress.stats_collector.frappe") as frappe_mock,
+			patch("benchpress.stats_collector.get_container_stats", side_effect=Exception("no stats")),
+			patch("benchpress.stats_collector.get_container_health", return_value=health),
+			patch("benchpress.stats_collector.container_is_gone", return_value=gone) as gone_mock,
+			patch("benchpress.deploy_manager.stop_bench") as stop_mock,
+			patch("benchpress.notifications.notify_owner") as notify_mock,
+		):
+			frappe_mock.get_all.return_value = [dict(BENCH)]
+			frappe_mock._ = lambda s: s
+
+			from benchpress.stats_collector import collect_bench_stats
+
+			collect_bench_stats()
+		return stop_mock, notify_mock, gone_mock
+
+	def test_healthy_bench_is_left_alone(self):
+		stop_mock, notify_mock, _ = self._run("Healthy")
+		stop_mock.assert_not_called()
+		notify_mock.assert_not_called()
+
+	def test_unhealthy_container_stops_the_bench_and_tells_the_owner(self):
+		# Docker can see the container and reports it not running — a crash,
+		# an OOM kill, a stop behind our back. Status and billing must follow.
+		stop_mock, notify_mock, _ = self._run("Unhealthy")
+		stop_mock.assert_called_once_with(BENCH["name"])
+		notify_mock.assert_called_once()
+		self.assertEqual(notify_mock.call_args.args[0], BENCH["owner"])
+
+	def test_vanished_container_stops_the_bench(self):
+		stop_mock, _notify, _ = self._run("Unknown", gone=True)
+		stop_mock.assert_called_once_with(BENCH["name"])
+
+	def test_inspect_error_never_stops_a_bench(self):
+		# Unknown can also mean the Docker socket hiccuped. Only a positive
+		# "does not exist" may stop someone's bench.
+		stop_mock, notify_mock, gone_mock = self._run("Unknown", gone=False)
+		gone_mock.assert_called_once_with(BENCH["container_id"])
+		stop_mock.assert_not_called()
+		notify_mock.assert_not_called()
+
+	def test_reconciliation_failure_does_not_kill_the_poll(self):
+		# One bench's failure must not starve the rest of the fleet of stats.
+		second = {"name": "bench-002", "container_id": "dec0de", "owner": "user@example.com"}
+		with (
+			patch("benchpress.stats_collector.frappe") as frappe_mock,
+			patch("benchpress.stats_collector.get_container_stats", side_effect=Exception("no stats")),
+			patch("benchpress.stats_collector.get_container_health", return_value="Unhealthy"),
+			patch("benchpress.deploy_manager.stop_bench", side_effect=[Exception("boom"), None]) as stop_mock,
+			patch("benchpress.notifications.notify_owner"),
+		):
+			frappe_mock.get_all.return_value = [dict(BENCH), second]
+			frappe_mock._ = lambda s: s
+
+			from benchpress.stats_collector import collect_bench_stats
+
+			collect_bench_stats()
+
+		self.assertEqual(stop_mock.call_count, 2)


### PR DESCRIPTION
## What this changes

Two backend fixes, one commit each.

### Shell-quote every linkuser.sh argument (`fix(deploy)`)

- The linkuser.sh command runs as root inside the bench container, and its arguments carry free text such as the lab title and the owner's email.
- Naive single-quote wrapping let an apostrophe break the deploy, and let anything sharper walk into a root shell.
- `linkuser_command()` now quotes each argument with `shlex.quote`. A test round-trips hostile arguments — an apostrophe, a command chain, `$(id)`, backticks and an empty string.

### Stop a bench whose container died (`fix(stats)`)

- `container_health` was collected every minute and acted on by nothing. A container that crashed while its bench still said Running kept the site listed as up and burned the owner's credits, since the credit sweep bills on status.
- The stats poll is now the reconciler: Docker is the truth, the doctype follows. A dead container routes the bench through the normal `stop_bench` path and the owner gets a notification.
- Two guards keep it from overreacting. Unknown health stops a bench only when Docker positively reports the container gone (`container_is_gone`), so a socket hiccup never stops anyone's bench. And `stop_container` treats an already-removed container as stopped, so the stop path works on a reaped container.

## Testing

- `bench --site frontend run-tests --module benchpress.tests.test_stats_collector` — 5 tests pass (new module).
- `bench --site frontend run-tests --module benchpress.tests.test_deploy_manager --test test_linkuser_command_survives_hostile_arguments` — passes.
- `uvx pre-commit@4.3.0` passes on every changed file.

## Note for reviewers

`deploy_manager.py` also carries an unrelated per-container Redis change in the working tree. That change is not in this PR — only the two linkuser hunks are committed here. The Redis work comes in its own PR.