### PR TITLE
Implemented phase three

### DIFF
--- a/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.py
+++ b/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.py
@@ -1,9 +1,31 @@
 # Copyright (c) 2026, Venkatesh and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 
 class BenchPressSettings(Document):
-	pass
+	def on_update(self):
+		"""Re-anchor the wildcard when the bench zone changes.
+
+		Enqueued, not called: this controller runs in `backend`, which does not mount the
+		Traefik route directory. A direct write would land in that container's own
+		filesystem and Traefik would never see it — silently, with every check green.
+		`queue-long` is the only worker that consumes `long` and the only one with the mount.
+
+		The guard keeps an unrelated settings save — a toggle, a timeout — from queueing a
+		directory sweep.
+		"""
+		if not self.has_value_changed("base_domain"):
+			return
+
+		frappe.enqueue(
+			"benchpress.deploy_manager.reconcile_instance_routes",
+			queue="long",
+			job_id="reconcile_instance_routes",
+			deduplicate=True,
+			# The job re-reads `base_domain` from the database, so it must not start before
+			# the new value is committed. Same mistake `6e25962` fixed for deploys.
+			enqueue_after_commit=True,
+		)

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -222,9 +222,11 @@ def _delete_instance_route(instance_id: str) -> None:
 def reconcile_instance_routes() -> dict:
 	"""Make the Traefik route directory agree with the database.
 
-	Docker and the doctype are the truth; the directory follows. Returns counts rather
-	than a bare success: a reaper that reports "issued" instead of "converged" is how a
-	directory drifts for weeks without anyone noticing.
+	The Bench Instance table is the truth and the directory follows it. Containers are not
+	inspected — an orphaned container is a real problem, but it is todo item 8's, and a
+	pass that quietly took on two jobs would be harder to trust with either. Returns counts
+	rather than a bare success: a reaper that reports "issued" instead of "converged" is how
+	a directory drifts for weeks without anyone noticing.
 
 	Deleting is the load-bearing half. A torn-down container frees its IP back to
 	Docker, which hands it to the next bench, so a route file left behind keeps pointing

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -4,6 +4,8 @@
 import json
 import secrets
 import shlex
+import socket
+import ssl
 from pathlib import Path
 
 import frappe
@@ -73,6 +75,11 @@ TRAEFIK_DYNAMIC_DIR = Path("/etc/traefik/dynamic")
 # certificate resolver. Fixed name so it is idempotently overwritten and can never
 # collide with an instance file, which is always a 32-character hex id.
 WILDCARD_ANCHOR_FILE = "wildcard-anchor.yml"
+
+# Traefik's compose service name. queue-long and traefik both sit on frappe_network, so
+# this resolves; it is the same TLS endpoint the internet reaches, which is the point —
+# checking anything else would prove something else.
+TRAEFIK_HOST = "traefik"
 
 
 def _public_site_url(instance_id: str, base_domain: str | None) -> str | None:
@@ -200,6 +207,58 @@ def _delete_instance_route(instance_id: str) -> None:
 	with that IP next — so this has to run at teardown, not just redeploy.
 	"""
 	(TRAEFIK_DYNAMIC_DIR / f"{instance_id}.yml").unlink(missing_ok=True)
+
+
+def _log_certificate_state(instance_id: str, base_domain: str | None, pipeline) -> None:
+	"""State in the deploy log which certificate this bench's URL will be served on.
+
+	The instance routers name no resolver, so they serve whatever the store already holds.
+	That reliance is otherwise invisible: if the store were ever wrong the first evidence
+	would be a user meeting Cloudflare's 526, which names neither TLS nor a certificate.
+
+	Only the site hostname is checked. The IDE hostname is one label under the same
+	`base_domain` and so is covered by the same wildcard — a second handshake would only
+	re-prove the first one.
+	"""
+	if not base_domain or base_domain == "localhost":
+		return
+
+	hostname = f"{instance_id}.{base_domain}"
+	error = _certificate_error(hostname)
+	if error:
+		pipeline.log(f"WARNING: {error} — the public URL will fail in a browser")
+		return
+
+	pipeline.log(f"TLS ready for {hostname} on the *.{base_domain} wildcard")
+
+
+def _certificate_error(hostname: str, timeout: int = 5) -> str | None:
+	"""Return why `hostname`'s certificate is unusable, or None when it is fine.
+
+	Verifies the way a browser does — full chain and hostname match — against the same TLS
+	endpoint the internet reaches. The store is matched by SNI independently of routing, so
+	this does not race Traefik's file watcher and needs no Traefik API, which this
+	deployment deliberately does not expose.
+
+	Reports rather than raises. A certificate problem must not fail a deploy whose container
+	is up and whose site exists; the owner can still work over the VPN, and the log is where
+	an operator looks.
+	"""
+	context = ssl.create_default_context()
+	try:
+		with socket.create_connection((TRAEFIK_HOST, 443), timeout=timeout) as raw:
+			with context.wrap_socket(raw, server_hostname=hostname):
+				return None
+	except ssl.SSLCertVerificationError as exc:
+		# `verify_message` is set by the C module on a real handshake failure but is absent
+		# on an exception built any other way, and a bare attribute read there would raise
+		# out of the handler — the one thing this function must never do.
+		return f"certificate does not cover {hostname} ({getattr(exc, 'verify_message', None) or exc})"
+	except OSError as exc:
+		# Timeout, refused connection and DNS failure all mean "could not check", not
+		# "certificate is bad". A dev checkout has no Traefik at all, so this is its
+		# normal path — the two causes call for different actions and must stay apart.
+		return f"could not reach Traefik to check {hostname} ({exc})"
 
 
 def _cleanup_failed_deploy(bench, container_id, append_log) -> None:
@@ -391,6 +450,7 @@ def _deploy_bench(bench_name: str) -> None:
 
 		bench.public_url = _public_site_url(bench.name, settings.base_domain)
 		_write_instance_route(bench.name, settings.base_domain, container_ip)
+		_log_certificate_state(bench.name, settings.base_domain, pipeline)
 
 		_setup_container_vpn(bench, container_id, pipeline)
 

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -69,6 +69,11 @@ ADOPTED_MARKER = "already exists — adopting it"
 # control-plane router) lives in this same directory.
 TRAEFIK_DYNAMIC_DIR = Path("/etc/traefik/dynamic")
 
+# One file, one router, one identity set — the only place in this app that names a
+# certificate resolver. Fixed name so it is idempotently overwritten and can never
+# collide with an instance file, which is always a 32-character hex id.
+WILDCARD_ANCHOR_FILE = "wildcard-anchor.yml"
+
 
 def _public_site_url(instance_id: str, base_domain: str | None) -> str | None:
 	if not base_domain or base_domain == "localhost":
@@ -82,24 +87,81 @@ def _public_ide_url(instance_id: str, base_domain: str | None) -> str | None:
 	return f"https://ide-{instance_id}.{base_domain}"
 
 
+def _wildcard_anchor_config(base_domain: str) -> dict:
+	"""The router whose only job is to hold `*.{base_domain}` in Traefik's store.
+
+	`domains` is a fixed list, so the resolver is asked for exactly one identity set no
+	matter what arrives. That is the whole safety property: a router that names a
+	resolver and *omits* `domains` makes Traefik issue per-SNI on demand, which is how a
+	stranger pointing DNS at this host burns the weekly certificate budget.
+
+	The router is inert by construction. Traefik's default priority is the rule length
+	and every instance rule is 40+ characters, so `priority: 1` can never win a tie (0 is
+	ignored, so 1 is the floor). The backend is a dead address on purpose:
+	`*.{base_domain}` is wildcard-resolved, so `tls-anchor.{base_domain}` does answer, and
+	pointing it at the control plane would publish an unadvertised way in. A 502 is the
+	honest reply for a name that exists only to own a certificate. The service is still
+	*defined*, because Traefik drops a router naming an undefined service — and a dropped
+	router would take the certificate request with it.
+	"""
+	return {
+		"http": {
+			"routers": {
+				"benchpress-wildcard-anchor": {
+					"rule": f"Host(`tls-anchor.{base_domain}`)",
+					"entryPoints": ["websecure"],
+					"priority": 1,
+					"service": "benchpress-wildcard-anchor",
+					"tls": {
+						"certResolver": "letsencrypt",
+						"domains": [{"main": base_domain, "sans": [f"*.{base_domain}"]}],
+					},
+				}
+			},
+			"services": {
+				"benchpress-wildcard-anchor": {"loadBalancer": {"servers": [{"url": "http://127.0.0.1:1"}]}}
+			},
+		}
+	}
+
+
+def _ensure_wildcard_anchor(base_domain: str | None) -> bool:
+	"""Put the bench-zone wildcard in Traefik's certificate store, once.
+
+	Returns True when the file was written. Rewrites only on a real change: Traefik
+	reloads on mtime, and a deploy has no business making it reload to say nothing.
+
+	Never deleted at teardown — it has to outlive every bench, because it is what keeps
+	the certificate renewing.
+	"""
+	if not base_domain or base_domain == "localhost":
+		return False
+
+	wanted = yaml.safe_dump(_wildcard_anchor_config(base_domain))
+	path = TRAEFIK_DYNAMIC_DIR / WILDCARD_ANCHOR_FILE
+	if path.exists() and path.read_text() == wanted:
+		return False
+
+	TRAEFIK_DYNAMIC_DIR.mkdir(parents=True, exist_ok=True)
+	path.write_text(wanted)
+	return True
+
+
 def _write_instance_route(instance_id: str, base_domain: str, container_ip: str) -> None:
 	"""Write Traefik file-provider routes for this instance's site and its code-server IDE.
 
-	The routers name their certificate explicitly: every instance shares one
-	`*.{base_domain}` wildcard, issued once by the resolver. A bare `tls: {}` would
-	serve Traefik's self-signed default whenever the store holds no covering cert.
+	`tls: {}` turns TLS on and names no resolver, so these routers serve whatever
+	certificate the store already holds for the requested SNI. Deliberate, and the point
+	of the whole design: Let's Encrypt allows five certificates per identifier set per
+	seven days, so a router that asked for one would cap bench churn at five a week.
+	`_ensure_wildcard_anchor` is what puts `*.{base_domain}` in the store, and it is the
+	only place in this app that names a resolver.
 
 	One file per instance, named by instance ID, so a redeploy naturally overwrites it
 	with the fresh `container_ip` — no dedup logic needed.
 	"""
 	if not base_domain or base_domain == "localhost":
 		return
-
-	def tls():
-		return {
-			"certResolver": "letsencrypt",
-			"domains": [{"main": base_domain, "sans": [f"*.{base_domain}"]}],
-		}
 
 	TRAEFIK_DYNAMIC_DIR.mkdir(parents=True, exist_ok=True)
 	config = {
@@ -109,13 +171,13 @@ def _write_instance_route(instance_id: str, base_domain: str, container_ip: str)
 					"rule": f"Host(`{instance_id}.{base_domain}`)",
 					"entryPoints": ["websecure"],
 					"service": f"site-{instance_id}",
-					"tls": tls(),
+					"tls": {},
 				},
 				f"ide-{instance_id}": {
 					"rule": f"Host(`ide-{instance_id}.{base_domain}`)",
 					"entryPoints": ["websecure"],
 					"service": f"ide-{instance_id}",
-					"tls": tls(),
+					"tls": {},
 				},
 			},
 			"services": {
@@ -294,6 +356,13 @@ def _deploy_bench(bench_name: str) -> None:
 		wait_for_mariadb(db_server_name, timeout=60)
 		pipeline.log(f"MariaDB reachable at {db_server.container_name}:{db_server.port or 3306}")
 
+		# First step of the deploy, so this runs minutes ahead of the image build —
+		# headroom a fresh install needs, because DNS-01 has to finish issuing before
+		# the bench route goes live.
+		settings = frappe.get_cached_doc("BenchPress Settings")
+		if _ensure_wildcard_anchor(settings.base_domain):
+			pipeline.log(f"Traefik wildcard anchor written for *.{settings.base_domain}")
+
 		bench.database_server = db_server_name
 		bench.save(ignore_permissions=True)
 		frappe.db.commit()
@@ -320,7 +389,6 @@ def _deploy_bench(bench_name: str) -> None:
 		bench.save(ignore_permissions=True)
 		frappe.db.commit()
 
-		settings = frappe.get_cached_doc("BenchPress Settings")
 		bench.public_url = _public_site_url(bench.name, settings.base_domain)
 		_write_instance_route(bench.name, settings.base_domain, container_ip)
 

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -76,6 +76,16 @@ TRAEFIK_DYNAMIC_DIR = Path("/etc/traefik/dynamic")
 # collide with an instance file, which is always a 32-character hex id.
 WILDCARD_ANCHOR_FILE = "wildcard-anchor.yml"
 
+# The parent repo renders the control plane's own router into this same flat directory.
+# It is not this app's to write and not this app's to remove.
+CONTROL_PLANE_ROUTE_FILE = "dynamic.yml"
+
+# The two files `reconcile_instance_routes` must never delete, named one by one rather
+# than matched by shape. Deleting `dynamic.yml` takes the control plane off the internet;
+# deleting the anchor takes every bench's certificate with it. A filename pattern is a
+# guess about what future files will look like — a set is a decision about these two.
+PROTECTED_ROUTE_FILES = frozenset({CONTROL_PLANE_ROUTE_FILE, WILDCARD_ANCHOR_FILE})
+
 # Traefik's compose service name. queue-long and traefik both sit on frappe_network, so
 # this resolves; it is the same TLS endpoint the internet reaches, which is the point —
 # checking anything else would prove something else.
@@ -207,6 +217,67 @@ def _delete_instance_route(instance_id: str) -> None:
 	with that IP next — so this has to run at teardown, not just redeploy.
 	"""
 	(TRAEFIK_DYNAMIC_DIR / f"{instance_id}.yml").unlink(missing_ok=True)
+
+
+def reconcile_instance_routes() -> dict:
+	"""Make the Traefik route directory agree with the database.
+
+	Docker and the doctype are the truth; the directory follows. Returns counts rather
+	than a bare success: a reaper that reports "issued" instead of "converged" is how a
+	directory drifts for weeks without anyone noticing.
+
+	Deleting is the load-bearing half. A torn-down container frees its IP back to
+	Docker, which hands it to the next bench, so a route file left behind keeps pointing
+	an old public hostname at whatever container inherits that address — a live
+	cross-owner misroute, not merely a dead link.
+
+	Must run on `queue-long`: it is the only container that mounts the route directory
+	read-write. That is also what keeps this from racing a deploy — both are `long` jobs
+	on a single worker, so a bench part-way through `_deploy_bench` is never read here
+	between its container IP being known and its status reaching `Running`.
+
+	Run it by hand with:
+	    bench --site frontend execute benchpress.deploy_manager.reconcile_instance_routes
+	"""
+	base_domain = frappe.get_cached_doc("BenchPress Settings").base_domain
+	anchored = _ensure_wildcard_anchor(base_domain)
+	if not base_domain or base_domain == "localhost":
+		# A dev checkout has no route directory and must stay byte-for-byte unaffected —
+		# skipped silently, exactly as the writers skip it.
+		return {"anchored": anchored, "written": 0, "deleted": 0, "kept": 0}
+
+	routable = _routable_instance_ips()
+	for instance_id, container_ip in routable.items():
+		_write_instance_route(instance_id, base_domain, container_ip)
+
+	deleted = kept = 0
+	for path in sorted(TRAEFIK_DYNAMIC_DIR.glob("*.yml")):
+		if path.name in PROTECTED_ROUTE_FILES:
+			kept += 1
+			continue
+		if path.stem in routable:
+			continue
+		_delete_instance_route(path.stem)
+		deleted += 1
+
+	return {"anchored": anchored, "written": len(routable), "deleted": deleted, "kept": kept}
+
+
+def _routable_instance_ips() -> dict[str, str]:
+	"""Every bench that should own a route file, mapped to the address it should point at.
+
+	`Running` and nothing else. A `Stopped`, `Draft` or `Error` bench has no container
+	answering, and its recorded `container_ip` is a freed address Docker is free to hand
+	to somebody else's bench — which is the misroute, not a dead link. A row with no IP
+	at all is dropped for the same reason a route to nowhere is worse than no route.
+	"""
+	instance = frappe.qb.DocType("Bench Instance")
+	rows = (
+		frappe.qb.from_(instance)
+		.select(instance.name, instance.container_ip)
+		.where(instance.status == "Running")
+	).run(as_dict=True)
+	return {row.name: row.container_ip for row in rows if row.container_ip}
 
 
 def _log_certificate_state(instance_id: str, base_domain: str | None, pipeline) -> None:

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -1387,7 +1387,7 @@ class TestPublicSiteUrlHelpers(unittest.TestCase):
 class TestWildcardAnchor(unittest.TestCase):
 	"""`_ensure_wildcard_anchor` — the one place in this app that names a resolver.
 
-	See specs/in-progress/wildcard-cert-routing/phase-1-resolver-free-routers.md.
+	See specs/completed/wildcard-cert-routing/phase-1-resolver-free-routers.md.
 	"""
 
 	@contextmanager
@@ -1473,7 +1473,7 @@ class TestCertificateVerification(unittest.TestCase):
 	unit under test is the reporting, and a test that needed a running Traefik would fail
 	for reasons that have nothing to do with the code.
 
-	See specs/in-progress/wildcard-cert-routing/phase-2-certificate-verification.md.
+	See specs/completed/wildcard-cert-routing/phase-2-certificate-verification.md.
 	"""
 
 	def _pipeline(self):
@@ -1602,7 +1602,7 @@ class TestCertificateVerification(unittest.TestCase):
 class TestReconcileInstanceRoutes(IntegrationTestCase):
 	"""`reconcile_instance_routes` — the route directory converges on the database.
 
-	See specs/in-progress/wildcard-cert-routing/phase-3-route-convergence.md.
+	See specs/completed/wildcard-cert-routing/phase-3-route-convergence.md.
 	"""
 
 	@classmethod

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -359,6 +359,7 @@ class TestDeployManager(IntegrationTestCase):
 			_cached_image(self.lab.name),
 			patch.object(deploy_manager, "ensure_infrastructure", autospec=True) as mock_infra,
 			patch.object(deploy_manager, "wait_for_mariadb", autospec=True),
+			patch.object(deploy_manager, "_ensure_wildcard_anchor", autospec=True),
 			patch.object(deploy_manager, "_remove_stale_container", autospec=True),
 			patch.object(deploy_manager, "create_bench_container", autospec=True) as mock_create,
 			patch.object(deploy_manager, "start_container", autospec=True),
@@ -549,15 +550,22 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		"""
 		from benchpress import deploy_manager
 
+		# Traefik's route directory is mounted into queue-long, not into the container the
+		# tests run in, so it is redirected rather than mocked — the real anchor and route
+		# writers run, and `self.route_dir` is what they wrote.
+		route_dir = tempfile.TemporaryDirectory()
+		self.addCleanup(route_dir.cleanup)
+		self.route_dir = Path(route_dir.name) / "dynamic"
+
 		with (
 			_cached_image(self.lab.name) if cache_hit else nullcontext(),
+			patch.object(deploy_manager, "TRAEFIK_DYNAMIC_DIR", self.route_dir),
 			patch.object(deploy_manager, "ensure_infrastructure", autospec=True) as mock_infra,
 			patch.object(deploy_manager, "wait_for_mariadb", autospec=True),
 			patch.object(deploy_manager, "_remove_stale_container", autospec=True),
 			patch.object(deploy_manager, "create_bench_container", autospec=True) as mock_create,
 			patch.object(deploy_manager, "start_container", autospec=True),
 			patch.object(deploy_manager, "wait_for_container_running", autospec=True) as mock_wait,
-			patch.object(deploy_manager, "_write_instance_route", autospec=True),
 			patch.object(deploy_manager, "write_file_to_container", autospec=True) as mock_write,
 			patch.object(deploy_manager, "exec_in_container", autospec=True) as mock_exec,
 			patch.object(deploy_manager, "create_site_in_container", autospec=True) as mock_site,
@@ -783,6 +791,31 @@ class TestDeployStepMarkers(IntegrationTestCase):
 
 		self.assertFalse(self._bench_field(bench, "public_url"))
 
+	def test_a_localhost_deploy_writes_no_traefik_config_at_all(self):
+		"""A dev checkout has no Traefik: the deploy completes and the route directory is
+		never even created — skipped silently, not attempted and failed."""
+		bench = self._bench()
+		self._set_base_domain("localhost")
+
+		self._run_deploy(bench)
+
+		self.assertIn("Step 11/11", self._log(bench.name))
+		self.assertFalse(self.route_dir.exists())
+
+	def test_a_public_deploy_writes_the_anchor_beside_the_instance_route(self):
+		"""The two halves ship together: without the anchor the instance routers name no
+		resolver and nothing has asked for the wildcard, which is the 526 that reverted
+		this shape once already."""
+		bench = self._bench()
+		self._set_base_domain("benchpress.cloud")
+
+		self._run_deploy(bench)
+
+		written = sorted(p.name for p in self.route_dir.iterdir())
+		self.assertEqual(written, sorted(["wildcard-anchor.yml", f"{bench.name}.yml"]))
+		self.assertIn("Traefik wildcard anchor written for *.benchpress.cloud", self._log(bench.name))
+		self.assertNotIn("certResolver", (self.route_dir / f"{bench.name}.yml").read_text())
+
 	def test_a_failed_file_write_fails_the_deploy_at_the_step_that_wrote_it(self):
 		"""Hole 4: a silently unwritten `common_site_config.json` is a site that cannot find redis."""
 		bench = self._bench()
@@ -946,6 +979,7 @@ class TestTerminalStateNotifications(IntegrationTestCase):
 			patch.object(deploy_manager, "start_container", autospec=True),
 			patch.object(deploy_manager, "wait_for_container_running", autospec=True) as mock_wait,
 			patch.object(deploy_manager, "_write_instance_route", autospec=True),
+			patch.object(deploy_manager, "_ensure_wildcard_anchor", autospec=True),
 			patch.object(deploy_manager, "_setup_container_vpn", autospec=True),
 			patch.object(deploy_manager, "write_file_to_container", autospec=True),
 			patch.object(deploy_manager, "exec_in_container", autospec=True) as mock_exec,
@@ -1167,6 +1201,25 @@ class TestRecordPrimarySite(IntegrationTestCase):
 
 				self.assertFalse(route_file.exists())
 
+	def test_teardown_keeps_the_wildcard_anchor(self):
+		"""The anchor outlives every bench — it is what keeps the certificate renewing,
+		so a reaper that tidies it away would silently stop renewal."""
+		from benchpress import deploy_manager
+		from benchpress.deploy_manager import teardown_bench
+
+		bench = self._bench()
+
+		with tempfile.TemporaryDirectory() as tmp:
+			with patch.object(deploy_manager, "TRAEFIK_DYNAMIC_DIR", Path(tmp) / "instances"):
+				deploy_manager._ensure_wildcard_anchor("benchpress.cloud")
+				deploy_manager._write_instance_route(bench.name, "benchpress.cloud", "172.30.0.11")
+				anchor = Path(tmp) / "instances" / "wildcard-anchor.yml"
+
+				teardown_bench(bench)
+
+				self.assertFalse((Path(tmp) / "instances" / f"{bench.name}.yml").exists())
+				self.assertTrue(anchor.exists())
+
 	def test_teardown_does_not_raise_when_no_route_file_exists(self):
 		"""The `base_domain = localhost` case: phase 1 never wrote a route file, so teardown
 		must no-op cleanly rather than raising on a missing path."""
@@ -1223,10 +1276,9 @@ class TestPublicSiteUrlHelpers(unittest.TestCase):
 				deploy_manager._write_instance_route("inst-1", "benchpress.cloud", "172.30.0.11")
 				config = yaml.safe_load((Path(tmp) / "instances" / "inst-1.yml").read_text())
 
-			expected_tls = {
-				"certResolver": "letsencrypt",
-				"domains": [{"main": "benchpress.cloud", "sans": ["*.benchpress.cloud"]}],
-			}
+			# TLS on, no resolver — the certificate comes from the store, put there by
+			# `wildcard-anchor.yml`. See test_instance_route_names_no_certificate_resolver.
+			expected_tls = {}
 
 			router = config["http"]["routers"]["site-inst-1"]
 			self.assertEqual(router["rule"], "Host(`inst-1.benchpress.cloud`)")
@@ -1253,3 +1305,105 @@ class TestPublicSiteUrlHelpers(unittest.TestCase):
 				deploy_manager._write_instance_route("inst-1", "localhost", "172.30.0.11")
 
 			self.assertFalse(target_dir.exists())
+
+	def test_instance_route_names_no_certificate_resolver(self):
+		"""A resolver here would cost an ACME call per bench spawn.
+
+		Let's Encrypt allows five certificates per identifier set per seven days, so a
+		per-bench resolver caps the platform at about five benches a week. The wildcard is
+		held by `wildcard-anchor.yml` instead. Asserted against the rendered text because
+		the regression is a resolver at *any* depth, not one known key.
+		"""
+		from benchpress import deploy_manager
+
+		with tempfile.TemporaryDirectory() as tmp:
+			with patch.object(deploy_manager, "TRAEFIK_DYNAMIC_DIR", Path(tmp) / "instances"):
+				deploy_manager._write_instance_route("inst-1", "benchpress.cloud", "172.30.0.11")
+				written_text = (Path(tmp) / "instances" / "inst-1.yml").read_text()
+
+		self.assertNotIn("certResolver", written_text)
+		# Two separate `{}` literals, so PyYAML emits the mapping twice rather than an
+		# anchor/alias pair that Traefik would have to resolve.
+		self.assertEqual(written_text.count("tls: {}"), 2)
+
+
+class TestWildcardAnchor(unittest.TestCase):
+	"""`_ensure_wildcard_anchor` — the one place in this app that names a resolver.
+
+	See specs/in-progress/wildcard-cert-routing/phase-1-resolver-free-routers.md.
+	"""
+
+	@contextmanager
+	def _anchor_dir(self):
+		from benchpress import deploy_manager
+
+		with tempfile.TemporaryDirectory() as tmp:
+			target_dir = Path(tmp) / "instances"
+			with patch.object(deploy_manager, "TRAEFIK_DYNAMIC_DIR", target_dir):
+				yield deploy_manager, target_dir
+
+	def test_anchor_names_one_identity_set(self):
+		"""`domains` is fixed, so the resolver is asked for exactly one identity set no
+		matter which SNI arrives — a resolver without it issues per-SNI on demand."""
+		with self._anchor_dir() as (deploy_manager, target_dir):
+			self.assertTrue(deploy_manager._ensure_wildcard_anchor("benchpress.cloud"))
+
+			files = sorted(p.name for p in target_dir.iterdir())
+			self.assertEqual(files, ["wildcard-anchor.yml"])
+
+			config = yaml.safe_load((target_dir / "wildcard-anchor.yml").read_text())
+			router = config["http"]["routers"]["benchpress-wildcard-anchor"]
+			self.assertEqual(router["tls"]["certResolver"], "letsencrypt")
+			self.assertEqual(
+				router["tls"]["domains"],
+				[{"main": "benchpress.cloud", "sans": ["*.benchpress.cloud"]}],
+			)
+			# 0 is ignored by Traefik, so 1 is the floor — and every instance rule is
+			# 40+ characters, so the anchor can never win a tie on rule length.
+			self.assertEqual(router["priority"], 1)
+			self.assertEqual(router["service"], "benchpress-wildcard-anchor")
+			self.assertIn("benchpress-wildcard-anchor", config["http"]["services"])
+
+	def test_anchor_is_not_rewritten_when_unchanged(self):
+		"""Traefik reloads on mtime, so a deploy that changes nothing must not touch it."""
+		with self._anchor_dir() as (deploy_manager, target_dir):
+			deploy_manager._ensure_wildcard_anchor("benchpress.cloud")
+			anchor = target_dir / "wildcard-anchor.yml"
+			mtime = anchor.stat().st_mtime_ns
+
+			self.assertFalse(deploy_manager._ensure_wildcard_anchor("benchpress.cloud"))
+
+			self.assertEqual(anchor.stat().st_mtime_ns, mtime)
+
+	def test_anchor_is_rewritten_in_place_for_a_new_domain(self):
+		"""A changed `base_domain` replaces the anchor rather than adding a second one —
+		two anchors would be two identity sets against the weekly budget."""
+		with self._anchor_dir() as (deploy_manager, target_dir):
+			deploy_manager._ensure_wildcard_anchor("benchpress.cloud")
+
+			self.assertTrue(deploy_manager._ensure_wildcard_anchor("example.com"))
+
+			files = sorted(p.name for p in target_dir.iterdir())
+			self.assertEqual(files, ["wildcard-anchor.yml"])
+			config = yaml.safe_load((target_dir / "wildcard-anchor.yml").read_text())
+			router = config["http"]["routers"]["benchpress-wildcard-anchor"]
+			self.assertEqual(router["rule"], "Host(`tls-anchor.example.com`)")
+			self.assertEqual(
+				router["tls"]["domains"],
+				[{"main": "example.com", "sans": ["*.example.com"]}],
+			)
+
+	def test_anchor_no_ops_without_a_public_domain(self):
+		"""A dev checkout is byte-for-byte unaffected: skipped silently, not attempted
+		and failed. Matches `_write_instance_route`'s existing behaviour."""
+		for base_domain in (None, "", "localhost"):
+			with (
+				self.subTest(base_domain=base_domain),
+				self._anchor_dir() as (
+					deploy_manager,
+					target_dir,
+				),
+			):
+				self.assertFalse(deploy_manager._ensure_wildcard_anchor(base_domain))
+
+				self.assertFalse(target_dir.exists())

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026, Venkatesh and Contributors
 # See license.txt
 
+import ssl
 import tempfile
 import unittest
 from contextlib import contextmanager, nullcontext
@@ -538,7 +539,13 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		return bench
 
 	def _run_deploy(
-		self, bench, site_result=(0, "site created"), cache_hit=True, exec_failures=None, write_error=None
+		self,
+		bench,
+		site_result=(0, "site created"),
+		cache_hit=True,
+		exec_failures=None,
+		write_error=None,
+		cert_error=None,
 	):
 		"""A whole deploy with every side effect mocked but the log itself.
 
@@ -547,6 +554,8 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		`exec_failures` maps a fragment of a container command to the result that command
 		returns, so one exec can fail while the rest of the run succeeds. `write_error` makes
 		every `write_file_to_container` raise, the way a read-only target path would.
+		`cert_error` is what the certificate check reports; only the socket is mocked, so the
+		line the log carries is still written by the real `_log_certificate_state`.
 		"""
 		from benchpress import deploy_manager
 
@@ -566,6 +575,11 @@ class TestDeployStepMarkers(IntegrationTestCase):
 			patch.object(deploy_manager, "create_bench_container", autospec=True) as mock_create,
 			patch.object(deploy_manager, "start_container", autospec=True),
 			patch.object(deploy_manager, "wait_for_container_running", autospec=True) as mock_wait,
+			# Only the socket is mocked, not the reporting around it: a unit test must not
+			# depend on a running Traefik, but the log line must still be the real one.
+			patch.object(
+				deploy_manager, "_certificate_error", autospec=True, return_value=cert_error
+			) as mock_cert,
 			patch.object(deploy_manager, "write_file_to_container", autospec=True) as mock_write,
 			patch.object(deploy_manager, "exec_in_container", autospec=True) as mock_exec,
 			patch.object(deploy_manager, "create_site_in_container", autospec=True) as mock_site,
@@ -575,6 +589,7 @@ class TestDeployStepMarkers(IntegrationTestCase):
 			patch("benchpress.vpn_adapter.configure_container", autospec=True),
 			patch("benchpress.vpn_adapter.create_container_peer", autospec=True) as mock_peer,
 		):
+			self.cert_check = mock_cert
 			mock_infra.return_value = self.db_server_name
 			mock_create.return_value = "cid-steps"
 			mock_wait.return_value = "172.30.0.11"
@@ -816,6 +831,47 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		self.assertIn("Traefik wildcard anchor written for *.benchpress.cloud", self._log(bench.name))
 		self.assertNotIn("certResolver", (self.route_dir / f"{bench.name}.yml").read_text())
 
+	def test_a_public_deploy_states_which_certificate_serves_the_url(self):
+		"""Phase 2: the routers name no resolver, so the deploy has to say the store held a
+		certificate — otherwise the first evidence it did not is a user meeting a 526."""
+		bench = self._bench()
+		self._set_base_domain("benchpress.cloud")
+
+		self._run_deploy(bench)
+
+		self.cert_check.assert_called_once_with(f"{bench.name}.benchpress.cloud")
+		self.assertIn(
+			f"TLS ready for {bench.name}.benchpress.cloud on the *.benchpress.cloud wildcard",
+			self._log(bench.name),
+		)
+
+	def test_a_bad_certificate_warns_without_failing_the_deploy(self):
+		"""Non-fatal by design. The container is up and the site exists, so the owner can still
+		work over the VPN — turning a cosmetic problem into a failed deploy would cost more
+		than it reports."""
+		bench = self._bench()
+		self._set_base_domain("benchpress.cloud")
+
+		self._run_deploy(bench, cert_error=f"certificate does not cover {bench.name}.benchpress.cloud")
+
+		log = self._log(bench.name)
+		self.assertIn(f"WARNING: certificate does not cover {bench.name}.benchpress.cloud", log)
+		self.assertIn("the public URL will fail in a browser", log)
+		# The deploy still finished: eleven steps, and the bench is usable.
+		self.assertIn("Step 11/11", log)
+		self.assertEqual(self._bench_field(bench, "status"), "Running")
+
+	def test_a_localhost_deploy_opens_no_socket_and_logs_no_certificate_line(self):
+		"""A dev checkout has no Traefik, so checking would time out to say nothing. Matches
+		the anchor and route writers: skipped silently, not attempted and failed."""
+		bench = self._bench()
+		self._set_base_domain("localhost")
+
+		self._run_deploy(bench)
+
+		self.cert_check.assert_not_called()
+		self.assertNotIn("TLS ready", self._log(bench.name))
+
 	def test_a_failed_file_write_fails_the_deploy_at_the_step_that_wrote_it(self):
 		"""Hole 4: a silently unwritten `common_site_config.json` is a site that cannot find redis."""
 		bench = self._bench()
@@ -980,6 +1036,7 @@ class TestTerminalStateNotifications(IntegrationTestCase):
 			patch.object(deploy_manager, "wait_for_container_running", autospec=True) as mock_wait,
 			patch.object(deploy_manager, "_write_instance_route", autospec=True),
 			patch.object(deploy_manager, "_ensure_wildcard_anchor", autospec=True),
+			patch.object(deploy_manager, "_certificate_error", autospec=True, return_value=None),
 			patch.object(deploy_manager, "_setup_container_vpn", autospec=True),
 			patch.object(deploy_manager, "write_file_to_container", autospec=True),
 			patch.object(deploy_manager, "exec_in_container", autospec=True) as mock_exec,
@@ -1407,3 +1464,136 @@ class TestWildcardAnchor(unittest.TestCase):
 				self.assertFalse(deploy_manager._ensure_wildcard_anchor(base_domain))
 
 				self.assertFalse(target_dir.exists())
+
+
+class TestCertificateVerification(unittest.TestCase):
+	"""`_log_certificate_state` / `_certificate_error` — phase 2.
+
+	The check reports, it never acts and never raises. No test here opens a socket: the
+	unit under test is the reporting, and a test that needed a running Traefik would fail
+	for reasons that have nothing to do with the code.
+
+	See specs/in-progress/wildcard-cert-routing/phase-2-certificate-verification.md.
+	"""
+
+	def _pipeline(self):
+		pipeline = MagicMock()
+		pipeline.logged = []
+		pipeline.log.side_effect = lambda line, *args, **kwargs: pipeline.logged.append(line)
+		return pipeline
+
+	def test_a_healthy_certificate_is_stated_by_name(self):
+		"""Naming the wildcard is the point: it says the bench is served by the anchor's
+		certificate rather than by one of its own."""
+		from benchpress import deploy_manager
+
+		pipeline = self._pipeline()
+		with patch.object(deploy_manager, "_certificate_error", autospec=True, return_value=None):
+			deploy_manager._log_certificate_state("inst-1", "benchpress.cloud", pipeline)
+
+		self.assertEqual(
+			pipeline.logged,
+			["TLS ready for inst-1.benchpress.cloud on the *.benchpress.cloud wildcard"],
+		)
+
+	def test_a_certificate_problem_warns_and_does_not_raise(self):
+		"""The whole contract. A check that raised would turn a cosmetic problem into a
+		failed deploy, for a bench whose container is up and whose site exists."""
+		from benchpress import deploy_manager
+
+		pipeline = self._pipeline()
+		with patch.object(
+			deploy_manager,
+			"_certificate_error",
+			autospec=True,
+			return_value="certificate does not cover inst-1.benchpress.cloud (hostname mismatch)",
+		):
+			deploy_manager._log_certificate_state("inst-1", "benchpress.cloud", pipeline)
+
+		self.assertEqual(len(pipeline.logged), 1)
+		self.assertIn("WARNING: certificate does not cover inst-1.benchpress.cloud", pipeline.logged[0])
+		self.assertIn("the public URL will fail in a browser", pipeline.logged[0])
+
+	def test_only_the_site_hostname_is_checked(self):
+		"""The IDE hostname is one label under the same `base_domain`, so the same wildcard
+		covers it — a second handshake would only re-prove the first."""
+		from benchpress import deploy_manager
+
+		with patch.object(
+			deploy_manager, "_certificate_error", autospec=True, return_value=None
+		) as mock_check:
+			deploy_manager._log_certificate_state("inst-1", "benchpress.cloud", self._pipeline())
+
+		mock_check.assert_called_once_with("inst-1.benchpress.cloud")
+
+	def test_no_check_and_no_line_without_a_public_domain(self):
+		"""A dev checkout is byte-for-byte unaffected — no socket, no log line. Matches
+		`_write_instance_route` and `_ensure_wildcard_anchor`."""
+		from benchpress import deploy_manager
+
+		for base_domain in (None, "", "localhost"):
+			with self.subTest(base_domain=base_domain):
+				pipeline = self._pipeline()
+				with patch.object(deploy_manager, "_certificate_error", autospec=True) as mock_check:
+					deploy_manager._log_certificate_state("inst-1", base_domain, pipeline)
+
+				mock_check.assert_not_called()
+				self.assertEqual(pipeline.logged, [])
+
+	def test_an_unreachable_traefik_is_not_reported_as_a_bad_certificate(self):
+		"""The two causes call for different actions, so they must stay apart in a log
+		someone reads at 2am: one means fix the certificate, the other means Traefik is
+		down — or that there is no Traefik, which is the dev-checkout case."""
+		from benchpress import deploy_manager
+
+		with patch.object(
+			deploy_manager.socket, "create_connection", autospec=True, side_effect=OSError("refused")
+		):
+			error = deploy_manager._certificate_error("inst-1.benchpress.cloud")
+
+		self.assertIn("could not reach Traefik to check inst-1.benchpress.cloud", error)
+		self.assertNotIn("does not cover", error)
+
+	def test_a_hostname_the_certificate_misses_is_named(self):
+		"""The 526 this feature exists to prevent, caught at deploy time and named."""
+		from benchpress import deploy_manager
+
+		failure = ssl.SSLCertVerificationError("hostname mismatch")
+		failure.verify_message = "Hostname mismatch, certificate is not valid for 'nope.example.com'"
+
+		with patch.object(deploy_manager.socket, "create_connection", autospec=True, side_effect=failure):
+			error = deploy_manager._certificate_error("nope.example.com")
+
+		self.assertIn("certificate does not cover nope.example.com", error)
+		self.assertIn("Hostname mismatch", error)
+
+	def test_a_verification_error_without_a_verify_message_still_reports(self):
+		"""`verify_message` is set by the C module on a real handshake failure and is absent
+		otherwise, so reading it bare would raise out of the handler — reporting the
+		exception itself keeps the failure a warning."""
+		from benchpress import deploy_manager
+
+		with patch.object(
+			deploy_manager.socket,
+			"create_connection",
+			autospec=True,
+			side_effect=ssl.SSLCertVerificationError("no verify_message here"),
+		):
+			error = deploy_manager._certificate_error("nope.example.com")
+
+		self.assertIn("certificate does not cover nope.example.com", error)
+		self.assertIn("no verify_message here", error)
+
+	def test_a_usable_certificate_reports_nothing(self):
+		"""None is the healthy answer — the caller logs the success line off the absence.
+
+		The context is mocked alongside the socket because a real `SSLContext` handed a mock
+		socket fails on the mock, not on the certificate.
+		"""
+		from benchpress import deploy_manager
+
+		with (
+			patch.object(deploy_manager.socket, "create_connection", autospec=True),
+			patch.object(deploy_manager.ssl, "create_default_context", autospec=True),
+		):
+			self.assertIsNone(deploy_manager._certificate_error("inst-1.benchpress.cloud"))

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -1597,3 +1597,223 @@ class TestCertificateVerification(unittest.TestCase):
 			patch.object(deploy_manager.ssl, "create_default_context", autospec=True),
 		):
 			self.assertIsNone(deploy_manager._certificate_error("inst-1.benchpress.cloud"))
+
+
+class TestReconcileInstanceRoutes(IntegrationTestCase):
+	"""`reconcile_instance_routes` — the route directory converges on the database.
+
+	See specs/in-progress/wildcard-cert-routing/phase-3-route-convergence.md.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.lab = _make_lab("test-lab-reconcile-routes")
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		for name in frappe.get_all("Bench Instance", filters={"lab": cls.lab.name}, pluck="name"):
+			frappe.delete_doc("Bench Instance", name, force=True, ignore_permissions=True)
+		cls.lab.delete(ignore_permissions=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	@contextmanager
+	def _route_dir(self, base_domain="benchpress.cloud"):
+		"""A tmp route directory, with `base_domain` supplied rather than read from live settings.
+
+		The settings doc is patched, never saved: saving it on a real host would re-anchor the
+		certificate for whatever value a test happened to pick.
+		"""
+		from benchpress import deploy_manager
+
+		with tempfile.TemporaryDirectory() as tmp:
+			target_dir = Path(tmp) / "dynamic"
+			target_dir.mkdir()
+			with (
+				patch.object(deploy_manager, "TRAEFIK_DYNAMIC_DIR", target_dir),
+				patch("frappe.get_cached_doc", return_value=frappe._dict(base_domain=base_domain)),
+			):
+				yield deploy_manager, target_dir
+
+	def _bench(self, status, container_ip):
+		bench = _fresh_bench(self, self.lab.name)
+		bench.status = status
+		bench.container_ip = container_ip
+		bench.save(ignore_permissions=True)
+		frappe.db.commit()
+		return bench
+
+	def _seed(self, target_dir, name, body="stale\n"):
+		path = target_dir / name
+		path.write_text(body)
+		return path
+
+	def _instance_files(self, target_dir):
+		from benchpress.deploy_manager import PROTECTED_ROUTE_FILES
+
+		return sorted(p.name for p in target_dir.glob("*.yml") if p.name not in PROTECTED_ROUTE_FILES)
+
+	def test_a_route_file_naming_no_bench_instance_is_deleted(self):
+		"""The orphan case: a hostname with no document behind it still resolves and still
+		routes, so it keeps serving whichever container inherited that IP."""
+		with self._route_dir() as (deploy_manager, target_dir):
+			orphan = self._seed(target_dir, "091131f54bcdfc7bc37cbc45763547fa.yml")
+
+			result = deploy_manager.reconcile_instance_routes()
+
+			self.assertFalse(orphan.exists())
+			self.assertGreaterEqual(result["deleted"], 1)
+
+	def test_a_bench_that_is_not_running_loses_its_route_file(self):
+		"""A stopped bench's recorded IP is an address Docker has already handed back, so the
+		file is not a dead link — it is the next bench's hostname collision."""
+		for status in ("Stopped", "Draft", "Error"):
+			with self.subTest(status=status):
+				bench = self._bench(status, "172.30.0.11")
+				with self._route_dir() as (deploy_manager, target_dir):
+					route_file = self._seed(target_dir, f"{bench.name}.yml")
+
+					deploy_manager.reconcile_instance_routes()
+
+					self.assertFalse(route_file.exists())
+
+	def test_a_running_bench_route_is_rewritten_with_its_current_ip(self):
+		"""Convergence, not merely reaping: a file that survives must also be right. Seeded with
+		the wrong backend so passing means it was rewritten, not left alone."""
+		bench = self._bench("Running", "172.30.0.12")
+
+		with self._route_dir() as (deploy_manager, target_dir):
+			self._seed(target_dir, f"{bench.name}.yml", "http://172.30.0.99:8000\n")
+
+			result = deploy_manager.reconcile_instance_routes()
+
+			config = yaml.safe_load((target_dir / f"{bench.name}.yml").read_text())
+			backends = [
+				server["url"]
+				for service in config["http"]["services"].values()
+				for server in service["loadBalancer"]["servers"]
+			]
+			self.assertIn("http://172.30.0.12:8000", backends)
+			self.assertNotIn("http://172.30.0.99:8000", str(backends))
+			self.assertGreaterEqual(result["written"], 1)
+
+	def test_the_control_plane_router_and_the_anchor_survive_a_full_sweep(self):
+		"""The guard that stops this pass taking the platform off the internet. `dynamic.yml` is
+		the control plane's own router and the anchor is every bench's certificate; a run that
+		deletes every instance file must still leave both."""
+		with self._route_dir() as (deploy_manager, target_dir):
+			control_plane = self._seed(target_dir, "dynamic.yml", "control plane\n")
+			deploy_manager._ensure_wildcard_anchor("benchpress.cloud")
+			anchor = target_dir / "wildcard-anchor.yml"
+			anchor_text = anchor.read_text()
+			self._seed(target_dir, "16b283bccf6560ab1aa5f078d492d005.yml")
+			self._seed(target_dir, "5dc12efd9c154796adae757adec1b2f3.yml")
+
+			result = deploy_manager.reconcile_instance_routes()
+
+			self.assertEqual(control_plane.read_text(), "control plane\n")
+			self.assertEqual(anchor.read_text(), anchor_text)
+			self.assertEqual(result["kept"], 2)
+
+	def test_a_run_always_leaves_the_certificate_anchored(self):
+		"""The anchor is what holds the wildcard the resolver-free bench routers serve, so the
+		pass writes it first rather than waiting for the next deploy."""
+		with self._route_dir() as (deploy_manager, target_dir):
+			result = deploy_manager.reconcile_instance_routes()
+
+			self.assertTrue(result["anchored"])
+			config = yaml.safe_load((target_dir / "wildcard-anchor.yml").read_text())
+			router = config["http"]["routers"]["benchpress-wildcard-anchor"]
+			self.assertEqual(router["rule"], "Host(`tls-anchor.benchpress.cloud`)")
+
+	def test_the_returned_counts_match_what_happened_on_disk(self):
+		"""A reaper that reports what it attempted rather than what converged is how a directory
+		drifts for weeks without anyone noticing."""
+		bench = self._bench("Running", "172.30.0.13")
+
+		with self._route_dir() as (deploy_manager, target_dir):
+			self._seed(target_dir, "dynamic.yml", "control plane\n")
+			self._seed(target_dir, f"{bench.name}.yml")
+			self._seed(target_dir, "091131f54bcdfc7bc37cbc45763547fa.yml")
+			self._seed(target_dir, "5dc12efd9c154796adae757adec1b2f3.yml")
+
+			result = deploy_manager.reconcile_instance_routes()
+
+			self.assertEqual(result["deleted"], 2)
+			self.assertEqual(result["kept"], 2)
+			self.assertEqual(result["written"], len(self._instance_files(target_dir)))
+			self.assertIn(f"{bench.name}.yml", self._instance_files(target_dir))
+
+	def test_a_second_run_deletes_nothing(self):
+		"""Idempotence is the read side agreeing with the write side. A pass that keeps finding
+		things to delete is one that disagrees with the files it just wrote."""
+		self._bench("Running", "172.30.0.14")
+
+		with self._route_dir() as (deploy_manager, target_dir):
+			self._seed(target_dir, "091131f54bcdfc7bc37cbc45763547fa.yml")
+			deploy_manager.reconcile_instance_routes()
+
+			result = deploy_manager.reconcile_instance_routes()
+
+			self.assertEqual(result["deleted"], 0)
+			self.assertFalse(result["anchored"])
+
+	def test_reconcile_writes_nothing_at_all_without_a_public_domain(self):
+		"""A dev checkout must be byte-for-byte unaffected — and must not reap either, since a
+		directory it never writes is not a directory it understands."""
+		for base_domain in (None, "", "localhost"):
+			with (
+				self.subTest(base_domain=base_domain),
+				self._route_dir(base_domain) as (
+					deploy_manager,
+					target_dir,
+				),
+			):
+				survivor = self._seed(target_dir, "091131f54bcdfc7bc37cbc45763547fa.yml")
+
+				result = deploy_manager.reconcile_instance_routes()
+
+				self.assertTrue(survivor.exists())
+				self.assertEqual(result, {"anchored": False, "written": 0, "deleted": 0, "kept": 0})
+
+
+class TestSettingsReAnchor(IntegrationTestCase):
+	"""`BenchPress Settings.on_update` hands the sweep to the worker that can do it.
+
+	`on_update` is called directly on an unsaved document. Saving the real Single would write
+	a domain to a live host, and the whole point of the controller is that it does not do the
+	work itself — what needs asserting is which queue it hands it to.
+	"""
+
+	def _settings(self, previous_domain):
+		settings = frappe.get_doc("BenchPress Settings")
+		settings._doc_before_save = frappe._dict(base_domain=previous_domain)
+		return settings
+
+	def test_a_changed_base_domain_enqueues_the_sweep_on_the_long_queue(self):
+		"""`queue-long` is the only worker that mounts the route directory. A sweep on any other
+		queue writes into that container's own filesystem, and Traefik never sees it."""
+		settings = self._settings("some-other-zone.example")
+
+		with patch("frappe.enqueue") as enqueue:
+			settings.on_update()
+
+		enqueue.assert_called_once()
+		args, kwargs = enqueue.call_args
+		self.assertEqual(args[0], "benchpress.deploy_manager.reconcile_instance_routes")
+		self.assertEqual(kwargs["queue"], "long")
+		# The job re-reads `base_domain`, so it must not start before the new value is committed.
+		self.assertTrue(kwargs["enqueue_after_commit"])
+
+	def test_an_unrelated_settings_save_enqueues_nothing(self):
+		"""A toggle or a timeout is not a reason to sweep the route directory."""
+		settings = self._settings(frappe.get_cached_doc("BenchPress Settings").base_domain)
+
+		with patch("frappe.enqueue") as enqueue:
+			settings.on_update()
+
+		enqueue.assert_not_called()

--- a/benchpress/tests/test_image_cache.py
+++ b/benchpress/tests/test_image_cache.py
@@ -224,6 +224,11 @@ class TestDeployReusesTheSharedImage(IntegrationTestCase):
 			patch.object(deploy_manager, "exec_in_container", autospec=True) as mock_exec,
 			patch.object(deploy_manager, "create_site_in_container", autospec=True) as mock_site,
 			patch.object(deploy_manager, "_notify_owner", autospec=True),
+			# Traefik's route directory is mounted into queue-long, not into the container
+			# these tests run in, so both writers have to be mocked for the deploy to reach
+			# its end — as the docstring above says it does.
+			patch.object(deploy_manager, "_ensure_wildcard_anchor", autospec=True),
+			patch.object(deploy_manager, "_write_instance_route", autospec=True),
 		):
 			mock_infra.return_value = self.db_server_name
 			mock_create.return_value = "cid-image-cache"

--- a/benchpress/tests/test_image_cache.py
+++ b/benchpress/tests/test_image_cache.py
@@ -229,6 +229,9 @@ class TestDeployReusesTheSharedImage(IntegrationTestCase):
 			# its end — as the docstring above says it does.
 			patch.object(deploy_manager, "_ensure_wildcard_anchor", autospec=True),
 			patch.object(deploy_manager, "_write_instance_route", autospec=True),
+			# The certificate check opens a real TLS socket to Traefik; a unit test must
+			# not depend on one running.
+			patch.object(deploy_manager, "_certificate_error", autospec=True, return_value=None),
 		):
 			mock_infra.return_value = self.db_server_name
 			mock_create.return_value = "cid-image-cache"


### PR DESCRIPTION
Phase 1 of the `wildcard-cert-routing` spec.

## What this changes

Every bench route file named a certificate resolver, so a bench spawn asked Let's Encrypt for a certificate. Let's Encrypt allows five certificates per identifier set per seven days, so the design had a ceiling of about five benches a week hidden inside it. Nothing issued today only because Traefik de-duplicated the identical request against its store — lose `acme.json`, change `base_domain`, or vary the domain set, and the ceiling becomes real.

Bench routers now carry `tls: {}`: TLS on, no resolver, serving whatever the store already holds for the requested SNI. A single anchor router in `wildcard-anchor.yml` owns `*.<base_domain>` and is the only place in this app that names a resolver. It does not multiply with bench count, so bench churn costs zero ACME calls at any rate.

The two halves ship together on purpose. Bench routers without the anchor is the 526 that reverted this exact shape in PR #150 — `PUBLIC_HOSTNAME` and `BenchPress Settings.base_domain` are different zones, so dropping the resolver alone leaves nothing asking for the bench wildcard.

Details:

- The anchor is written in the `infrastructure` step, minutes ahead of the image build, so a fresh install has room for DNS-01 to finish.
- It rewrites only on a real change, because Traefik reloads on mtime.
- It is never deleted at teardown — it is what keeps the certificate renewing.
- Its `domains` list is fixed, so the resolver is asked for one identity set no matter which SNI arrives. A resolver without `domains` issues per-SNI on demand, which is how a stranger pointing DNS at the host burns the weekly budget.
- The anchor is inert: `priority: 1` (0 is ignored by Traefik) and a deliberately dead backend, so it answers 502.
- No new pipeline step. Still 11.
- `base_domain` unset or `localhost` writes nothing and creates no directory.

## Verified on the live host

A `client-frappe-16` bench deployed after the change, 11/11 steps in 175s:

- Its route file contains `tls: {}` twice and zero `certResolver`; `wildcard-anchor.yml` sits beside it and is the only file in the watched directory naming a resolver.
- `openssl s_client -servername` at the origin returns the Let's Encrypt `benchpress.cloud` / `*.benchpress.cloud` wildcard for both the site and IDE hostnames — not `TRAEFIK DEFAULT CERT`.
- Site answers `{"message":"pong"}` and 200, IDE answers 302, both without `curl -k`.
- `acme.json` holds exactly the two identity sets it held before, byte-identical: the deploy issued nothing.
- Traefik's log shows no ACME, obtain, renew or 429 line for the whole window.
- `tls-anchor.benchpress.cloud` returns 502 on the wildcard, as designed.
- `staging.benchpress.cloud` and the two pre-existing benches keep serving on trusted certificates throughout.

Traefik was never restarted. Every file here is dynamic config in a watched host-bind directory.

## Tests

`run-tests --app benchpress`: 556 tests, and the 13 failures are the same set that fails on a clean `version-16` (credit-ledger, TTL and demo-data timing — none routing-related). `uvx pre-commit@4.3.0 run --all-files` is green.

The spec expected the full-pipeline harnesses to need no change. They did: they never patched the new anchor call, and `/etc/traefik` cannot be created inside the container the tests run in, so every pipeline test failed at step 1. Rather than mock the writers, the harnesses now point `TRAEFIK_DYNAMIC_DIR` at a temporary directory, so they exercise this code instead of skipping it. That also turned the `localhost` case into a real proof that a dev checkout writes nothing at all.

## Known gaps, deferred by the spec

- The deploy log says nothing about the certificate it relies on — phase 2.
- The legacy route files on disk keep their `certResolver` until their bench is next deployed, and the cross-owner misroute the spec documents is untouched — phase 3.
- `BenchPress Settings.on_update` does nothing, so on a fresh install the anchor first appears at the first deploy — phase 3.