### PR TITLE
Implemented phase three

### DIFF
--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -97,6 +97,7 @@ def get_benches() -> list[dict]:
 			"status",
 			"container_id",
 			"container_ip",
+			"runtime",
 			"wg_ip",
 			"cpu_usage",
 			"memory_usage",

--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -525,3 +525,12 @@ def run_diagnostics() -> list[dict]:
 	from benchpress.diagnostics import run_diagnostics as _run_diagnostics
 
 	return _run_diagnostics()
+
+
+@frappe.whitelist()
+def preflight_runtime(runtime: str) -> dict:
+	"""Prove a runtime works, which `run_diagnostics` cannot: this one creates a container."""
+	require_admin()
+	from benchpress.docker_manager import preflight_runtime as _preflight_runtime
+
+	return _preflight_runtime(runtime)

--- a/benchpress/benchpress/doctype/bench_instance/bench_instance.json
+++ b/benchpress/benchpress/doctype/bench_instance/bench_instance.json
@@ -24,6 +24,7 @@
   "container_section",
   "container_id",
   "container_image",
+  "runtime",
   "column_break_container",
   "container_ip",
   "started_at",
@@ -143,6 +144,14 @@
    "fieldtype": "Data",
    "label": "Container Image",
    "read_only": 1
+  },
+  {
+   "default": "runc",
+   "description": "Container runtime. sysbox user-namespaces the container so container root is unprivileged on the host.",
+   "fieldname": "runtime",
+   "fieldtype": "Select",
+   "label": "Runtime",
+   "options": "runc\nsysbox"
   },
   {
    "fieldname": "column_break_container",
@@ -296,7 +305,7 @@
    "link_fieldname": "bench"
   }
  ],
- "modified": "2026-08-19 00:00:00.000000",
+ "modified": "2026-08-24 18:00:00.000000",
  "modified_by": "Administrator",
  "module": "Benchpress",
  "name": "Bench Instance",

--- a/benchpress/benchpress/doctype/bench_instance/bench_instance.json
+++ b/benchpress/benchpress/doctype/bench_instance/bench_instance.json
@@ -146,12 +146,12 @@
    "read_only": 1
   },
   {
-   "default": "runc",
    "description": "Container runtime. sysbox user-namespaces the container so container root is unprivileged on the host.",
    "fieldname": "runtime",
    "fieldtype": "Select",
    "label": "Runtime",
-   "options": "runc\nsysbox"
+   "options": "\nrunc\nsysbox",
+   "permlevel": 1
   },
   {
    "fieldname": "column_break_container",
@@ -305,7 +305,7 @@
    "link_fieldname": "bench"
   }
  ],
- "modified": "2026-08-24 18:00:00.000000",
+ "modified": "2026-08-24 19:30:00.000000",
  "modified_by": "Administrator",
  "module": "Benchpress",
  "name": "Bench Instance",
@@ -342,6 +342,23 @@
    "report": 1,
    "role": "BenchPress User",
    "write": 1
+  },
+  {
+   "permlevel": 1,
+   "read": 1,
+   "role": "System Manager",
+   "write": 1
+  },
+  {
+   "permlevel": 1,
+   "read": 1,
+   "role": "BenchPress Admin",
+   "write": 1
+  },
+  {
+   "permlevel": 1,
+   "read": 1,
+   "role": "BenchPress User"
   }
  ],
  "row_format": "Dynamic",

--- a/benchpress/benchpress/doctype/bench_instance/bench_instance.py
+++ b/benchpress/benchpress/doctype/bench_instance/bench_instance.py
@@ -10,6 +10,7 @@ from frappe.utils.background_jobs import is_job_enqueued
 
 from benchpress.benchpress.doctype.bench_instance import get_instance_id
 from benchpress.credits.guard import cap_concurrent_instances, instance_runway, requires_credits
+from benchpress.permissions import is_admin
 
 DEPLOY_JOB_TIMEOUT = 7200
 
@@ -23,6 +24,40 @@ class BenchInstance(Document):
 			suffix = base_domain if base_domain and base_domain != "localhost" else "localhost"
 			self.site_name = f"{instance_id}.{suffix}"
 		self.ssh_username = self._derive_username()
+
+	def validate(self):
+		if self.is_new():
+			# Not in `before_insert`: `runtime` is permlevel 1, and Frappe resets a permlevel field
+			# to its new-doc value in between the two, discarding whatever was chosen there. That
+			# value is the Select's empty first option, which is why it carries one.
+			if not self.runtime:
+				self.runtime = self._default_runtime()
+			return
+		if not self.has_value_changed("runtime"):
+			return
+		if not is_admin():
+			frappe.throw(_("Only an administrator can change a bench's runtime."), frappe.PermissionError)
+		if self.status != "Draft":
+			frappe.throw(
+				_(
+					"'{0}' is already deployed. A container's runtime is fixed when it is created — "
+					"delete this instance and deploy again to change it."
+				).format(self.name)
+			)
+
+	def validate_higher_perm_levels(self):
+		"""Refuse a runtime the caller may not set, where Frappe would silently drop it.
+
+		The base method resets a permlevel field the caller cannot write back to its stored value
+		and says nothing, so a tenant lowering their own isolation would read as success.
+		"""
+		requested = self.runtime
+		super().validate_higher_perm_levels()
+		if not self.is_new() and self.runtime != requested:
+			frappe.throw(_("Only an administrator can change a bench's runtime."), frappe.PermissionError)
+
+	def _default_runtime(self) -> str:
+		return frappe.get_cached_doc("BenchPress Settings").default_bench_runtime or "runc"
 
 	def autoname(self):
 		self.name = self.bench_name

--- a/benchpress/benchpress/doctype/bench_instance/test_bench_instance.py
+++ b/benchpress/benchpress/doctype/bench_instance/test_bench_instance.py
@@ -2,6 +2,7 @@
 # See license.txt
 
 import hashlib
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import frappe
@@ -124,18 +125,34 @@ class IntegrationTestBenchInstance(IntegrationTestCase):
 			result = bench._derive_username()
 		self.assertLessEqual(len(result), 32)
 
+	@contextmanager
+	def _default_runtime(self, value):
+		"""Set the Settings default for one test, without saving the whole Single.
+
+		`change_settings` saves the document, which validates every mandatory field.
+		`base_domain` is unset on a fresh CI site, so the save raises MandatoryError —
+		a ValidationError, which any test asserting ValidationError swallows as a pass.
+		"""
+		field = "default_bench_runtime"
+		previous = frappe.db.get_single_value("BenchPress Settings", field)
+		frappe.db.set_single_value("BenchPress Settings", field, value)
+		try:
+			yield
+		finally:
+			frappe.db.set_single_value("BenchPress Settings", field, previous)
+
 	def test_a_new_bench_takes_the_runtime_from_settings(self):
-		with self.change_settings("BenchPress Settings", default_bench_runtime="sysbox"):
+		with self._default_runtime("sysbox"):
 			bench = self._insert_bench()
 		self.assertEqual(bench.runtime, "sysbox")
 
 	def test_a_new_bench_falls_back_to_runc_when_settings_names_nothing(self):
-		with self.change_settings("BenchPress Settings", default_bench_runtime=""):
+		with self._default_runtime(""):
 			bench = self._insert_bench()
 		self.assertEqual(bench.runtime, "runc")
 
 	def test_an_admin_can_change_the_runtime_of_a_draft_bench(self):
-		with self.change_settings("BenchPress Settings", default_bench_runtime="sysbox"):
+		with self._default_runtime("sysbox"):
 			bench = self._insert_bench()
 		bench.runtime = "runc"
 		bench.save(ignore_permissions=True)
@@ -143,7 +160,7 @@ class IntegrationTestBenchInstance(IntegrationTestCase):
 
 	def test_a_non_admin_cannot_change_the_runtime(self):
 		"""The controller's own guard, reached with permlevel bypassed — it may not rely on it."""
-		with self.change_settings("BenchPress Settings", default_bench_runtime="sysbox"):
+		with self._default_runtime("sysbox"):
 			bench = self._insert_bench()
 		frappe.set_user(self.tenant)
 		bench.runtime = "runc"
@@ -151,14 +168,18 @@ class IntegrationTestBenchInstance(IntegrationTestCase):
 			bench.save(ignore_permissions=True)
 
 	def test_changing_the_runtime_of_a_running_bench_is_refused(self):
-		self.assertRaises(frappe.ValidationError, self._change_runtime_at_status, "Running")
+		# Matched on the message, not the class: MandatoryError is a ValidationError too,
+		# and a bare assertRaises here passed for months on the wrong exception.
+		with self.assertRaisesRegex(frappe.ValidationError, "already deployed"):
+			self._change_runtime_at_status("Running")
 
 	def test_changing_the_runtime_of_a_stopped_bench_is_refused(self):
 		"""A stopped bench still owns a container built under the old runtime."""
-		self.assertRaises(frappe.ValidationError, self._change_runtime_at_status, "Stopped")
+		with self.assertRaisesRegex(frappe.ValidationError, "already deployed"):
+			self._change_runtime_at_status("Stopped")
 
 	def _change_runtime_at_status(self, status):
-		with self.change_settings("BenchPress Settings", default_bench_runtime="sysbox"):
+		with self._default_runtime("sysbox"):
 			bench = self._insert_bench()
 		bench.status = status
 		bench.save(ignore_permissions=True)

--- a/benchpress/benchpress/doctype/bench_instance/test_bench_instance.py
+++ b/benchpress/benchpress/doctype/bench_instance/test_bench_instance.py
@@ -13,6 +13,20 @@ EXTRA_TEST_RECORD_DEPENDENCIES = []
 IGNORE_TEST_RECORD_DEPENDENCIES = []
 
 
+def _make_tenant(email="bench-instance-tenant@example.com"):
+	if not frappe.db.exists("User", email):
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": "BenchInstance Tenant",
+				"send_welcome_email": 0,
+				"roles": [{"role": "BenchPress User"}],
+			}
+		).insert(ignore_permissions=True)
+	return email
+
+
 def _make_lab(lab_id="test-lab-bench-instance"):
 	if frappe.db.exists("Lab", lab_id):
 		return frappe.get_doc("Lab", lab_id)
@@ -33,6 +47,7 @@ class IntegrationTestBenchInstance(IntegrationTestCase):
 		frappe.set_user("Administrator")
 		cls.lab = _make_lab()
 		cls.lab_name = cls.lab.name
+		cls.tenant = _make_tenant()
 
 	@classmethod
 	def tearDownClass(cls):
@@ -40,8 +55,13 @@ class IntegrationTestBenchInstance(IntegrationTestCase):
 		for name in frappe.get_all("Bench Instance", filters={"lab": cls.lab_name}, pluck="name"):
 			frappe.delete_doc("Bench Instance", name, force=True, ignore_permissions=True)
 		cls.lab.delete(ignore_permissions=True)
+		if frappe.db.exists("User", cls.tenant):
+			frappe.delete_doc("User", cls.tenant, force=True, ignore_permissions=True)
 		frappe.db.commit()
 		super().tearDownClass()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
 
 	def _insert_bench(self, **extra):
 		frappe.set_user("Administrator")
@@ -103,6 +123,47 @@ class IntegrationTestBenchInstance(IntegrationTestCase):
 		with patch.object(frappe, "session", MagicMock(user=long_email)):
 			result = bench._derive_username()
 		self.assertLessEqual(len(result), 32)
+
+	def test_a_new_bench_takes_the_runtime_from_settings(self):
+		with self.change_settings("BenchPress Settings", default_bench_runtime="sysbox"):
+			bench = self._insert_bench()
+		self.assertEqual(bench.runtime, "sysbox")
+
+	def test_a_new_bench_falls_back_to_runc_when_settings_names_nothing(self):
+		with self.change_settings("BenchPress Settings", default_bench_runtime=""):
+			bench = self._insert_bench()
+		self.assertEqual(bench.runtime, "runc")
+
+	def test_an_admin_can_change_the_runtime_of_a_draft_bench(self):
+		with self.change_settings("BenchPress Settings", default_bench_runtime="sysbox"):
+			bench = self._insert_bench()
+		bench.runtime = "runc"
+		bench.save(ignore_permissions=True)
+		self.assertEqual(frappe.db.get_value("Bench Instance", bench.name, "runtime"), "runc")
+
+	def test_a_non_admin_cannot_change_the_runtime(self):
+		"""The controller's own guard, reached with permlevel bypassed — it may not rely on it."""
+		with self.change_settings("BenchPress Settings", default_bench_runtime="sysbox"):
+			bench = self._insert_bench()
+		frappe.set_user(self.tenant)
+		bench.runtime = "runc"
+		with self.assertRaises(frappe.PermissionError):
+			bench.save(ignore_permissions=True)
+
+	def test_changing_the_runtime_of_a_running_bench_is_refused(self):
+		self.assertRaises(frappe.ValidationError, self._change_runtime_at_status, "Running")
+
+	def test_changing_the_runtime_of_a_stopped_bench_is_refused(self):
+		"""A stopped bench still owns a container built under the old runtime."""
+		self.assertRaises(frappe.ValidationError, self._change_runtime_at_status, "Stopped")
+
+	def _change_runtime_at_status(self, status):
+		with self.change_settings("BenchPress Settings", default_bench_runtime="sysbox"):
+			bench = self._insert_bench()
+		bench.status = status
+		bench.save(ignore_permissions=True)
+		bench.runtime = "runc"
+		bench.save(ignore_permissions=True)
 
 	def test_enqueue_start_throws_when_no_container_id(self):
 		bench = self._insert_bench()

--- a/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
+++ b/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
@@ -9,6 +9,7 @@
   "docker_section",
   "docker_socket",
   "default_image",
+  "default_bench_runtime",
   "column_break_docker",
   "base_domain",
   "traefik_network",
@@ -37,6 +38,14 @@
    "fieldname": "default_image",
    "fieldtype": "Data",
    "label": "Default Image"
+  },
+  {
+   "default": "sysbox",
+   "description": "Runtime new benches are created with. sysbox user-namespaces the container so container root is unprivileged on the host; runc does not.",
+   "fieldname": "default_bench_runtime",
+   "fieldtype": "Select",
+   "label": "Default Bench Runtime",
+   "options": "runc\nsysbox"
   },
   {
    "fieldname": "column_break_docker",
@@ -101,7 +110,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-08-17 08:13:00.000000",
+ "modified": "2026-08-24 19:00:00.000000",
  "modified_by": "Administrator",
  "module": "Benchpress",
  "name": "BenchPress Settings",

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -20,9 +20,12 @@ from benchpress.credits import metering
 from benchpress.deploy_pipeline import DeployLogWriter, DeployPipeline
 from benchpress.docker_manager import (
 	build_lab_image,
+	container_runtime,
 	create_bench_container,
 	exec_in_container,
+	host_runtimes,
 	remove_container,
+	resolve_runtime,
 	start_container,
 	stop_container,
 	wait_for_container_running,
@@ -35,6 +38,22 @@ from benchpress.mariadb_manager import (
 	wait_for_mariadb,
 )
 from benchpress.notifications import notify_owner
+
+
+def _assert_runtime_registered(bench) -> None:
+	"""Refuse a bench whose runtime the daemon does not have. No fallback to runc.
+
+	A bench that cannot be isolated must not silently run unisolated, so this
+	fails the deploy and leaves the choice to an admin.
+	"""
+	runtime = resolve_runtime(bench)
+	registered = host_runtimes()["names"]
+	if runtime and runtime not in registered:
+		frappe.throw(
+			_("Bench runtime '{0}' is not registered with the Docker daemon (it has: {1}).").format(
+				runtime, ", ".join(sorted(registered))
+			)
+		)
 
 
 def _remove_stale_container(bench) -> None:
@@ -571,6 +590,10 @@ def _deploy_bench(bench_name: str) -> None:
 		bench.save(ignore_permissions=True)
 		frappe.db.commit()
 
+		# Ahead of the image step on purpose: the build is where the minutes go,
+		# and a bench the host cannot isolate has no business paying for one.
+		_assert_runtime_registered(bench)
+
 		# One step whichever way it goes: the run either builds the image or
 		# adopts a cached one, and the detail line says which.
 		pipeline.step("image")
@@ -580,6 +603,9 @@ def _deploy_bench(bench_name: str) -> None:
 		pipeline.step("container")
 		container_id = create_bench_container(bench, lab)
 		created_container_id = container_id
+		# Read back rather than assumed: the stored log answers what a bench was
+		# isolated by long after the run.
+		pipeline.log(f"container runtime {container_runtime(container_id)}")
 		bench.container_id = container_id
 		bench.container_image = lab.image_tag
 		bench.save(ignore_permissions=True)

--- a/benchpress/diagnostics.py
+++ b/benchpress/diagnostics.py
@@ -11,7 +11,7 @@ each check catches its own exceptions and reports them as a fail row.
 import docker
 import frappe
 
-from benchpress.docker_manager import get_client
+from benchpress.docker_manager import CONTAINER_RUNTIMES, get_client, host_runtimes
 from benchpress.mariadb_manager import check_mariadb_health
 from benchpress.vpn_adapter import DEFAULT_INTERFACE
 
@@ -43,6 +43,7 @@ def run_diagnostics() -> list[dict]:
 		_check_docker_network(),
 		_check_mariadb(),
 		_check_redis(),
+		_check_container_runtimes(),
 		check_vpn_server(),
 	]
 
@@ -109,6 +110,22 @@ def _check_redis() -> dict:
 		)
 	except Exception as e:
 		return check_row("redis", False, f"Could not check Redis: {e}")
+
+
+def _check_container_runtimes() -> dict:
+	"""Registered, not working — proving one runs takes `preflight_runtime`."""
+	required = sorted(name for name in CONTAINER_RUNTIMES.values() if name)
+	try:
+		missing = [name for name in required if name not in host_runtimes()["names"]]
+		if missing:
+			return check_row(
+				"container_runtimes",
+				False,
+				f"Docker has no {', '.join(missing)} — benches on that runtime cannot deploy",
+			)
+		return check_row("container_runtimes", True, f"Docker has {', '.join(required)} registered")
+	except Exception as e:
+		return check_row("container_runtimes", False, f"Could not read Docker runtimes: {e}")
 
 
 def check_vpn_server() -> dict:

--- a/benchpress/docker_manager.py
+++ b/benchpress/docker_manager.py
@@ -17,6 +17,23 @@ DEFAULT_PIDS_LIMIT = 500
 DEFAULT_IOPS = 1000
 DEFAULT_BPS = 40 * 1024 * 1024
 
+# Field value -> the runtime name registered with the Docker daemon. None means
+# "pass no runtime", which leaves the daemon's own default-runtime in charge.
+CONTAINER_RUNTIMES = {"runc": None, "sysbox": "sysbox-runc"}
+
+
+def resolve_runtime(bench_doc) -> str | None:
+	"""The daemon runtime name for a bench, or None to use the daemon default."""
+	name = getattr(bench_doc, "runtime", None) or "runc"
+	if name not in CONTAINER_RUNTIMES:
+		frappe.throw(
+			_("Unknown container runtime '{0}'. Allowed: {1}.").format(
+				name, ", ".join(sorted(CONTAINER_RUNTIMES))
+			)
+		)
+	return CONTAINER_RUNTIMES[name]
+
+
 LAB_ID_MAX_LENGTH = 64
 LAB_ID_RE = re.compile(r"^[a-z0-9]+([._-][a-z0-9]+)*$")
 
@@ -193,6 +210,9 @@ def create_bench_container(bench_doc, lab_doc) -> str:
 	iops = int(getattr(lab_doc, "iops_limit", None) or DEFAULT_IOPS)
 	bps = int(getattr(lab_doc, "bps_limit", None) or DEFAULT_BPS)
 
+	runtime = resolve_runtime(bench_doc)
+	runtime_kwargs = {"runtime": runtime} if runtime else {}
+
 	devices = _get_host_block_devices()
 	device_read_iops = [{"Path": dev, "Rate": iops} for dev in devices]
 	device_write_iops = [{"Path": dev, "Rate": iops} for dev in devices]
@@ -205,8 +225,9 @@ def create_bench_container(bench_doc, lab_doc) -> str:
 	# benchpress-mariadb mariadb -u root` reads EVERY tenant's database, defeating
 	# the per-site DB isolation (Press-style scoped grants in mariadb_manager).
 	# WireGuard (entry.sh `wg-quick up wg0`) needs only NET_ADMIN + /dev/net/tun,
-	# NOT full privilege. For defense-in-depth (container-root != host-root), enable
-	# Docker daemon userns-remap on the host (see docs/wireguard-setup.md).
+	# NOT full privilege. Defense-in-depth (container-root != host-root) comes from
+	# the sysbox runtime, which user-namespaces the container, not from daemon-wide
+	# userns-remap.
 	container = client.containers.create(
 		image=lab_doc.image_tag,
 		name=name,
@@ -225,6 +246,7 @@ def create_bench_container(bench_doc, lab_doc) -> str:
 		device_read_bps=device_read_bps or None,
 		device_write_bps=device_write_bps or None,
 		network="benchpress",
+		**runtime_kwargs,
 	)
 
 	return container.id

--- a/benchpress/docker_manager.py
+++ b/benchpress/docker_manager.py
@@ -12,6 +12,7 @@ import frappe
 from frappe import _
 
 from benchpress.image_cache import cache_tag, clear_cached_tags
+from benchpress.request_cache import local_cache
 
 DEFAULT_PIDS_LIMIT = 500
 DEFAULT_IOPS = 1000
@@ -21,10 +22,17 @@ DEFAULT_BPS = 40 * 1024 * 1024
 # "pass no runtime", which leaves the daemon's own default-runtime in charge.
 CONTAINER_RUNTIMES = {"runc": None, "sysbox": "sysbox-runc"}
 
+HOST_RUNTIMES_ATTRIBUTE = "benchpress_host_runtimes"
+PREFLIGHT_IMAGE = "alpine"
+
 
 def resolve_runtime(bench_doc) -> str | None:
 	"""The daemon runtime name for a bench, or None to use the daemon default."""
-	name = getattr(bench_doc, "runtime", None) or "runc"
+	return daemon_runtime(getattr(bench_doc, "runtime", None) or "runc")
+
+
+def daemon_runtime(name: str) -> str | None:
+	"""The runtime an allow-listed field value names, or None for the daemon default."""
 	if name not in CONTAINER_RUNTIMES:
 		frappe.throw(
 			_("Unknown container runtime '{0}'. Allowed: {1}.").format(
@@ -119,6 +127,32 @@ def _get_host_block_devices() -> list[str]:
 def get_client() -> docker.DockerClient:
 	settings = frappe.get_cached_doc("BenchPress Settings")
 	return docker.DockerClient(base_url=settings.docker_socket, timeout=600)
+
+
+def host_runtimes() -> dict:
+	"""The daemon's registered runtime names and its default, memoised per job."""
+	return local_cache(HOST_RUNTIMES_ATTRIBUTE, _read_host_runtimes)
+
+
+def _read_host_runtimes() -> dict:
+	info = get_client().info()
+	return {"names": set(info.get("Runtimes") or {}), "default": info.get("DefaultRuntime") or ""}
+
+
+def preflight_runtime(name: str) -> dict:
+	"""Prove a runtime works by running a throwaway container: {"ok": bool, "detail": str}.
+
+	The only check that answers "does it work" rather than "is it registered" — a
+	broken runtime stays listed in `docker info` with its unit active. Reports
+	instead of raising because a diagnostics screen is what reads it.
+	"""
+	runtime = daemon_runtime(name)
+	runtime_kwargs = {"runtime": runtime} if runtime else {}
+	try:
+		get_client().containers.run(PREFLIGHT_IMAGE, "echo ok", remove=True, **runtime_kwargs)
+	except Exception as e:
+		return {"ok": False, "detail": str(e)}
+	return {"ok": True, "detail": f"{runtime or host_runtimes()['default']} ran a container"}
 
 
 def get_lab_template_dir() -> str:
@@ -250,6 +284,11 @@ def create_bench_container(bench_doc, lab_doc) -> str:
 	)
 
 	return container.id
+
+
+def container_runtime(container_id: str) -> str:
+	"""The runtime the daemon actually created this container under."""
+	return get_client().containers.get(container_id).attrs["HostConfig"]["Runtime"]
 
 
 def get_container_ip(container_id: str) -> str:

--- a/benchpress/lab_detail.py
+++ b/benchpress/lab_detail.py
@@ -31,6 +31,7 @@ BENCH_FIELDS = [
 	"memory_usage",
 	"container_id",
 	"container_ip",
+	"runtime",
 	"wg_ip",
 	"public_url",
 	"domain",

--- a/benchpress/overview.py
+++ b/benchpress/overview.py
@@ -32,6 +32,7 @@ INFRASTRUCTURE_LABELS = {
 	"docker_network": "Docker network",
 	"mariadb": "MariaDB",
 	"redis": "Redis",
+	"container_runtimes": "Container runtimes",
 	"vpn_server": "WireGuard",
 }
 
@@ -265,7 +266,7 @@ def _bench_labels(bench_names: list[str]) -> dict:
 
 
 def _infrastructure(admin: bool) -> list[dict] | None:
-	"""The five real diagnostics checks — admins only, never a placeholder."""
+	"""The six real diagnostics checks — admins only, never a placeholder."""
 	if not admin:
 		return None
 	from benchpress.diagnostics import display_row, run_diagnostics

--- a/benchpress/patches.txt
+++ b/benchpress/patches.txt
@@ -19,3 +19,4 @@ benchpress.patches.retire_orphaned_creating_sites
 benchpress.patches.seed_lab_templates
 benchpress.patches.seed_v16_lab_templates
 benchpress.patches.seed_remaining_v16_lab_templates
+benchpress.patches.backfill_bench_runtime

--- a/benchpress/patches/backfill_bench_runtime.py
+++ b/benchpress/patches/backfill_bench_runtime.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""Name the runtime every existing bench already runs, then make sysbox the default for new ones.
+
+The stamp has to land before the seed. A container's runtime is fixed when it is created, so a
+row filled in by the new default would claim an isolation its container was never built with,
+and every reader downstream would believe it. Rows that already name a runtime are left alone:
+a bench deployed on sysbox is telling the truth and must not be relabelled either way.
+"""
+
+import frappe
+
+SETTINGS = "BenchPress Settings"
+FIELD = "default_bench_runtime"
+
+
+def execute():
+	for name in frappe.get_all("Bench Instance", filters={"runtime": ("in", ["", None])}, pluck="name"):
+		frappe.db.set_value("Bench Instance", name, "runtime", "runc", update_modified=False)
+
+	if FIELD not in frappe.db.get_singles_dict(SETTINGS):
+		frappe.db.set_single_value(SETTINGS, FIELD, "sysbox")

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -46,13 +46,14 @@ BUDGETS_MS = {
 	"get_deploy_history": 600,
 }
 
-# The five rows benchpress.diagnostics always returns; the real checks talk to
+# The six rows benchpress.diagnostics always returns; the real checks talk to
 # Docker and MariaDB, so the Overview timing test never runs them.
 DIAGNOSTICS_ROWS = [
 	{"check": "docker_socket", "status": "pass", "hint": "Docker daemon reachable"},
 	{"check": "docker_network", "status": "pass", "hint": "benchpress network exists"},
 	{"check": "mariadb", "status": "pass", "hint": "MariaDB responding"},
 	{"check": "redis", "status": "fail", "hint": "benchpress-redis container not found"},
+	{"check": "container_runtimes", "status": "pass", "hint": "Docker has sysbox-runc registered"},
 	{"check": "vpn_server", "status": "pass", "hint": "WireGuard server 'wg0' configured"},
 ]
 

--- a/benchpress/tests/test_api_authorization.py
+++ b/benchpress/tests/test_api_authorization.py
@@ -168,6 +168,7 @@ class TestApiAuthorization(IntegrationTestCase):
 		self.assert_denied(lambda: api.build_lab_image(self.lab.name))
 		self.assert_denied(lambda: api.prewarm_catalog())
 		self.assert_denied(lambda: api.run_diagnostics())
+		self.assert_denied(lambda: api.preflight_runtime("sysbox"))
 
 	def test_guest_denied_from_overview_endpoints(self):
 		frappe.set_user("Guest")
@@ -228,6 +229,18 @@ class TestApiAuthorization(IntegrationTestCase):
 	def test_non_admin_denied_from_run_diagnostics(self):
 		frappe.set_user(self.user_a)
 		self.assert_denied(lambda: api.run_diagnostics())
+
+	def test_non_admin_denied_from_preflight_runtime(self):
+		"""It creates a container on the host — the guard is the only thing stopping a tenant."""
+		frappe.set_user(self.user_a)
+		self.assert_denied(lambda: api.preflight_runtime("sysbox"))
+
+	def test_an_admin_reaches_preflight_runtime(self):
+		"""The positive control: the guard must not be refusing everyone."""
+		frappe.set_user("Administrator")
+		with patch("benchpress.docker_manager.get_client") as mock_client:
+			self.assertTrue(api.preflight_runtime("sysbox")["ok"])
+		self.assertEqual(mock_client.return_value.containers.run.call_args.kwargs["runtime"], "sysbox-runc")
 
 	def test_owner_denied_from_deleting_own_bench(self):
 		# user_a passes require_bench_access on its own bench, but delete is admin-only.

--- a/benchpress/tests/test_api_authorization.py
+++ b/benchpress/tests/test_api_authorization.py
@@ -16,6 +16,7 @@ import pkgutil
 from unittest.mock import MagicMock, patch
 
 import frappe
+import frappe.client
 from frappe.tests import IntegrationTestCase
 
 import benchpress
@@ -95,6 +96,7 @@ def _ensure_owned_bench(owner, lab):
 				"lab": lab.name,
 				"frappe_version": lab.frappe_version,
 				"status": "Running",
+				"runtime": "sysbox",
 				"container_id": "authz-container",
 				"code_server_url": "http://localhost:8443",
 				"code_server_password": "cs-secret",
@@ -233,6 +235,22 @@ class TestApiAuthorization(IntegrationTestCase):
 		self.assert_denied(lambda: api.bench_action(self.bench.name, "delete"))
 
 	# --- Cross-user isolation (user_b against user_a's bench) -----------------
+
+	def test_owner_denied_from_lowering_their_own_benchs_runtime(self):
+		"""`if_owner` write is granted on Bench Instance, so only permlevel stands between a
+		tenant and their own isolation."""
+		frappe.set_user(self.user_a)
+		self.assert_denied(
+			lambda: frappe.client.set_value("Bench Instance", self.bench.name, "runtime", "runc")
+		)
+		frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value("Bench Instance", self.bench.name, "runtime"), "sysbox")
+
+	def test_owner_can_still_see_their_benchs_runtime(self):
+		"""The positive control: read at permlevel 1 is granted on purpose."""
+		frappe.set_user(self.user_a)
+		mine = [b for b in api.get_benches() if b["name"] == self.bench.name]
+		self.assertEqual([b["runtime"] for b in mine], ["sysbox"])
 
 	def test_cross_user_denied_from_get_deploy_logs(self):
 		frappe.set_user(self.user_b)

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -397,6 +397,8 @@ class TestDeployManager(IntegrationTestCase):
 			patch.object(deploy_manager, "wait_for_mariadb", autospec=True),
 			patch.object(deploy_manager, "_ensure_wildcard_anchor", autospec=True),
 			patch.object(deploy_manager, "_remove_stale_container", autospec=True),
+			patch.object(deploy_manager, "host_runtimes", autospec=True) as mock_runtimes,
+			patch.object(deploy_manager, "container_runtime", autospec=True) as mock_runtime_of,
 			patch.object(deploy_manager, "create_bench_container", autospec=True) as mock_create,
 			patch.object(deploy_manager, "start_container", autospec=True),
 			patch.object(deploy_manager, "wait_for_container_running", autospec=True) as mock_wait,
@@ -405,6 +407,8 @@ class TestDeployManager(IntegrationTestCase):
 			patch("benchpress.vpn_adapter.remove_bench_peer", autospec=True) as mock_remove_peer,
 		):
 			mock_infra.return_value = self.db_server_name
+			mock_runtimes.return_value = {"names": {"runc", "sysbox-runc"}, "default": "runc"}
+			mock_runtime_of.return_value = "sysbox-runc"
 			mock_create.return_value = "cid-cleanup"
 			mock_wait.side_effect = Exception("container did not report running")
 
@@ -581,6 +585,7 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		exec_failures=None,
 		write_error=None,
 		cert_error=None,
+		registered_runtimes=("runc", "sysbox-runc"),
 	):
 		"""A whole deploy with every side effect mocked but the log itself.
 
@@ -591,6 +596,8 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		every `write_file_to_container` raise, the way a read-only target path would.
 		`cert_error` is what the certificate check reports; only the socket is mocked, so the
 		line the log carries is still written by the real `_log_certificate_state`.
+		`registered_runtimes` is what the daemon claims to have, so a test can starve the
+		pre-build gate without depending on what this host happens to run.
 		"""
 		from benchpress import deploy_manager
 
@@ -608,6 +615,8 @@ class TestDeployStepMarkers(IntegrationTestCase):
 			patch.object(deploy_manager, "ensure_infrastructure", autospec=True) as mock_infra,
 			patch.object(deploy_manager, "wait_for_mariadb", autospec=True),
 			patch.object(deploy_manager, "_remove_stale_container", autospec=True),
+			patch.object(deploy_manager, "host_runtimes", autospec=True) as mock_runtimes,
+			patch.object(deploy_manager, "container_runtime", autospec=True) as mock_runtime_of,
 			patch.object(deploy_manager, "create_bench_container", autospec=True) as mock_create,
 			patch.object(deploy_manager, "start_container", autospec=True),
 			patch.object(deploy_manager, "wait_for_container_running", autospec=True) as mock_wait,
@@ -627,6 +636,8 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		):
 			self.cert_check = mock_cert
 			mock_infra.return_value = self.db_server_name
+			mock_runtimes.return_value = {"names": set(registered_runtimes), "default": "runc"}
+			mock_runtime_of.return_value = "sysbox-runc"
 			mock_create.return_value = "cid-steps"
 			mock_wait.return_value = "172.30.0.11"
 			mock_exec.side_effect = _exec_results(exec_failures)
@@ -712,6 +723,41 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		log = self._log(bench.name)
 		self.assertIn("Step 10/11", log)
 		self.assertIn("Code server is disabled for this lab", log)
+
+	def test_an_unregistered_runtime_fails_before_the_image_step(self):
+		"""The image build is where the minutes go; a doomed deploy must not pay for one."""
+		bench = self._bench()
+		frappe.db.set_value("Bench Instance", bench.name, "runtime", "sysbox")
+		frappe.db.commit()
+
+		self._run_deploy(bench, registered_runtimes=("runc",))
+
+		log = self._log(bench.name)
+		keys = [step["step_key"] for step in self._emitted_steps(bench.name)]
+		self.assertEqual(keys, ["infrastructure"])
+		self.assertNotIn("Step 2/11", log)
+		self.assertIn("sysbox-runc", log)
+		self.assertIn("runc", log)
+		self.assertEqual(frappe.db.get_value("Bench Instance", bench.name, "status"), "Error")
+
+	def test_a_registered_runtime_passes_the_gate(self):
+		"""The negative control: a gate that only ever sees failing input is not a gate."""
+		bench = self._bench()
+		frappe.db.set_value("Bench Instance", bench.name, "runtime", "sysbox")
+		frappe.db.commit()
+
+		self._run_deploy(bench)
+
+		keys = [step["step_key"] for step in self._emitted_steps(bench.name)]
+		self.assertEqual(keys[-1], "complete")
+
+	def test_the_log_records_the_runtime_the_container_actually_ran_under(self):
+		"""Read back off the container, so a bench's isolation is answerable from the log."""
+		bench = self._bench()
+
+		self._run_deploy(bench)
+
+		self.assertIn("container runtime sysbox-runc", self._log(bench.name))
 
 	def _deploy_messages(self, publish):
 		"""Only our own events: a deploy also saves docs, and every save publishes."""
@@ -1067,6 +1113,8 @@ class TestTerminalStateNotifications(IntegrationTestCase):
 			patch.object(deploy_manager, "ensure_infrastructure", autospec=True) as mock_infra,
 			patch.object(deploy_manager, "wait_for_mariadb", autospec=True),
 			patch.object(deploy_manager, "_remove_stale_container", autospec=True),
+			patch.object(deploy_manager, "host_runtimes", autospec=True) as mock_runtimes,
+			patch.object(deploy_manager, "container_runtime", autospec=True) as mock_runtime_of,
 			patch.object(deploy_manager, "create_bench_container", autospec=True) as mock_create,
 			patch.object(deploy_manager, "start_container", autospec=True),
 			patch.object(deploy_manager, "wait_for_container_running", autospec=True) as mock_wait,
@@ -1079,6 +1127,8 @@ class TestTerminalStateNotifications(IntegrationTestCase):
 			patch.object(deploy_manager, "create_site_in_container", autospec=True) as mock_site,
 		):
 			mock_infra.return_value = self.db_server_name
+			mock_runtimes.return_value = {"names": {"runc", "sysbox-runc"}, "default": "runc"}
+			mock_runtime_of.return_value = "sysbox-runc"
 			mock_create.return_value = "cid-notify"
 			mock_wait.return_value = "172.30.0.9"
 			mock_exec.return_value = (0, "")

--- a/benchpress/tests/test_diagnostics.py
+++ b/benchpress/tests/test_diagnostics.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Venkatesh and Contributors
 # See license.txt
 
-"""run_diagnostics contract: five rows, fixed order, never raises, never mutates."""
+"""run_diagnostics contract: six rows, fixed order, never raises, never mutates."""
 
 import unittest
 from unittest.mock import MagicMock, patch
@@ -11,7 +11,8 @@ import frappe
 
 from benchpress.diagnostics import run_diagnostics
 
-CHECK_ORDER = ["docker_socket", "docker_network", "mariadb", "redis", "vpn_server"]
+CHECK_ORDER = ["docker_socket", "docker_network", "mariadb", "redis", "container_runtimes", "vpn_server"]
+HOST_RUNTIMES = {"names": {"runc", "sysbox-runc"}, "default": "runc"}
 DB_ROW = frappe._dict(name="db-server-1", status="Running", container_name="benchpress-mariadb")
 
 
@@ -26,6 +27,7 @@ class TestDiagnostics(unittest.TestCase):
 		self,
 		client=None,
 		client_error=None,
+		runtimes=None,
 		mariadb_healthy=True,
 		db_rows=None,
 		installed_apps=None,
@@ -38,6 +40,13 @@ class TestDiagnostics(unittest.TestCase):
 		client = client or _healthy_client()
 		with (
 			patch("benchpress.diagnostics.get_client", side_effect=client_error, return_value=client),
+			# A separate patch, because the runtime check reads `docker info` through
+			# its own memoised helper rather than through this client.
+			patch(
+				"benchpress.diagnostics.host_runtimes",
+				side_effect=client_error,
+				return_value=HOST_RUNTIMES if runtimes is None else runtimes,
+			),
 			patch("benchpress.diagnostics.check_mariadb_health", return_value=mariadb_healthy),
 			patch("benchpress.diagnostics.frappe") as frappe_mock,
 		):
@@ -62,7 +71,7 @@ class TestDiagnostics(unittest.TestCase):
 	def test_docker_down_marks_docker_checks_failed_without_raising(self):
 		# completing without an exception IS the core assertion
 		by_check, rows = self._run(client_error=Exception("socket unreachable"))
-		self.assertEqual(len(rows), 5)
+		self.assertEqual(len(rows), 6)
 		for check in ("docker_socket", "docker_network", "redis"):
 			self.assertEqual(by_check[check]["status"], "fail")
 
@@ -93,6 +102,12 @@ class TestDiagnostics(unittest.TestCase):
 		by_check, _rows = self._run(client=client)
 		self.assertEqual(by_check["redis"]["status"], "fail")
 
+	def test_unregistered_runtime_fails_and_names_it(self):
+		"""The cheap check: registered or not. Whether it works takes preflight_runtime."""
+		by_check, _rows = self._run(runtimes={"names": {"runc"}, "default": "runc"})
+		self.assertEqual(by_check["container_runtimes"]["status"], "fail")
+		self.assertIn("sysbox-runc", by_check["container_runtimes"]["hint"])
+
 	def test_vpn_missing_app_fails(self):
 		by_check, _rows = self._run(installed_apps=["frappe", "benchpress"])
 		self.assertEqual(by_check["vpn_server"]["status"], "fail")
@@ -104,9 +119,13 @@ class TestDiagnostics(unittest.TestCase):
 		client.networks.get.side_effect = docker.errors.NotFound("no network")
 		client.containers.get.side_effect = docker.errors.NotFound("gone")
 		_by_check, rows = self._run(
-			client=client, mariadb_healthy=False, db_rows=[], installed_apps=["frappe"]
+			client=client,
+			runtimes={"names": set(), "default": "runc"},
+			mariadb_healthy=False,
+			db_rows=[],
+			installed_apps=["frappe"],
 		)
-		self.assertEqual([row["status"] for row in rows], ["fail"] * 5)
+		self.assertEqual([row["status"] for row in rows], ["fail"] * 6)
 		client.networks.create.assert_not_called()
 		client.containers.create.assert_not_called()
 		client.containers.run.assert_not_called()

--- a/benchpress/tests/test_docker_manager.py
+++ b/benchpress/tests/test_docker_manager.py
@@ -14,9 +14,14 @@ from benchpress.docker_manager import (
 	DEFAULT_BPS,
 	DEFAULT_IOPS,
 	DEFAULT_PIDS_LIMIT,
+	HOST_RUNTIMES_ATTRIBUTE,
+	container_runtime,
 	get_container_health,
+	host_runtimes,
+	preflight_runtime,
 	wait_for_container_running,
 )
+from benchpress.request_cache import clear_local_cache
 
 
 def _client_returning(status):
@@ -302,3 +307,94 @@ class TestDockerManagerBlockIO(IntegrationTestCase):
 
 		with self.assertRaises(frappe.ValidationError):
 			self._container_create_kwargs(lab, runtime="gvisor")
+
+
+class TestHostRuntimes(unittest.TestCase):
+	def setUp(self):
+		self.addCleanup(clear_local_cache, HOST_RUNTIMES_ATTRIBUTE)
+		clear_local_cache(HOST_RUNTIMES_ATTRIBUTE)
+
+	@staticmethod
+	def _client(**info):
+		client = MagicMock()
+		client.info.return_value = {
+			"Runtimes": {"runc": {}, "sysbox-runc": {}},
+			"DefaultRuntime": "runc",
+			**info,
+		}
+		return client
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_reports_the_names_and_the_default(self, get_client):
+		get_client.return_value = self._client()
+
+		self.assertEqual(host_runtimes(), {"names": {"runc", "sysbox-runc"}, "default": "runc"})
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_asked_twice_costs_one_round_trip(self, get_client):
+		"""The deploy gate reads this per bench; a job must not pay `docker info` each time."""
+		client = self._client()
+		get_client.return_value = client
+
+		host_runtimes()
+		host_runtimes()
+
+		client.info.assert_called_once()
+
+
+class TestPreflightRuntime(unittest.TestCase):
+	@patch("benchpress.docker_manager.get_client")
+	def test_a_working_runtime_reports_ok(self, get_client):
+		client = MagicMock()
+		get_client.return_value = client
+
+		result = preflight_runtime("sysbox")
+
+		self.assertTrue(result["ok"])
+		self.assertEqual(client.containers.run.call_args.kwargs["runtime"], "sysbox-runc")
+		self.assertTrue(client.containers.run.call_args.kwargs["remove"])
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_a_registered_but_broken_runtime_reports_dockers_own_message(self, get_client):
+		"""The trap this exists for: `docker info` lists it, and it still cannot start."""
+		client = MagicMock()
+		client.containers.run.side_effect = docker.errors.APIError("failed to create shim task")
+		get_client.return_value = client
+
+		result = preflight_runtime("sysbox")
+
+		self.assertFalse(result["ok"])
+		self.assertIn("failed to create shim task", result["detail"])
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_runc_runs_under_the_daemon_default(self, get_client):
+		client = MagicMock()
+		client.info.return_value = {"Runtimes": {"runc": {}}, "DefaultRuntime": "runc"}
+		get_client.return_value = client
+		self.addCleanup(clear_local_cache, HOST_RUNTIMES_ATTRIBUTE)
+		clear_local_cache(HOST_RUNTIMES_ATTRIBUTE)
+
+		result = preflight_runtime("runc")
+
+		self.assertTrue(result["ok"])
+		self.assertNotIn("runtime", client.containers.run.call_args.kwargs)
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_a_runtime_outside_the_allow_list_never_reaches_docker(self, get_client):
+		client = MagicMock()
+		get_client.return_value = client
+
+		with self.assertRaises(frappe.ValidationError):
+			preflight_runtime("gvisor")
+
+		client.containers.run.assert_not_called()
+
+
+class TestContainerRuntime(unittest.TestCase):
+	@patch("benchpress.docker_manager.get_client")
+	def test_reads_the_runtime_the_daemon_recorded(self, get_client):
+		client = MagicMock()
+		client.containers.get.return_value.attrs = {"HostConfig": {"Runtime": "sysbox-runc"}}
+		get_client.return_value = client
+
+		self.assertEqual(container_runtime("cid"), "sysbox-runc")

--- a/benchpress/tests/test_docker_manager.py
+++ b/benchpress/tests/test_docker_manager.py
@@ -219,10 +219,10 @@ class TestDockerManagerBlockIO(IntegrationTestCase):
 		super().setUpClass()
 		frappe.set_user("Administrator")
 
-	def _container_create_kwargs(self, lab):
+	def _container_create_kwargs(self, lab, runtime="runc"):
 		"""Run create_bench_container with Docker mocked and return the
 		kwargs passed to client.containers.create."""
-		bench = types.SimpleNamespace(bench_name="blockio-test-bench")
+		bench = types.SimpleNamespace(bench_name="blockio-test-bench", runtime=runtime)
 		with (
 			patch("benchpress.docker_manager.get_client") as mock_client,
 			patch("benchpress.docker_manager.ensure_network"),
@@ -278,3 +278,27 @@ class TestDockerManagerBlockIO(IntegrationTestCase):
 		kwargs = self._container_create_kwargs(lab)
 
 		self.assertEqual(kwargs["pids_limit"], DEFAULT_PIDS_LIMIT)
+
+	def test_runc_passes_no_runtime_kwarg(self):
+		"""A runc bench must produce the call it produced before runtimes existed."""
+		lab = _make_lab("runtime-runc")
+		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
+
+		kwargs = self._container_create_kwargs(lab, runtime="runc")
+
+		self.assertNotIn("runtime", kwargs)
+
+	def test_sysbox_passes_the_registered_runtime_name(self):
+		lab = _make_lab("runtime-sysbox")
+		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
+
+		kwargs = self._container_create_kwargs(lab, runtime="sysbox")
+
+		self.assertEqual(kwargs["runtime"], "sysbox-runc")
+
+	def test_unknown_runtime_is_refused_before_docker(self):
+		lab = _make_lab("runtime-unknown")
+		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
+
+		with self.assertRaises(frappe.ValidationError):
+			self._container_create_kwargs(lab, runtime="gvisor")

--- a/benchpress/tests/test_image_cache.py
+++ b/benchpress/tests/test_image_cache.py
@@ -21,6 +21,8 @@ import frappe
 from frappe.tests import IntegrationTestCase
 
 from benchpress import image_cache
+from benchpress.docker_manager import HOST_RUNTIMES_ATTRIBUTE
+from benchpress.request_cache import clear_local_cache
 
 BUILD_STREAM = [{"stream": "Successfully built abc123"}]
 
@@ -97,6 +99,10 @@ def _client_with_tags(*tags):
 	client = MagicMock()
 	client.images.list.return_value = [MagicMock(tags=list(tags))]
 	client.api.build.return_value = iter(BUILD_STREAM)
+	# This mock stands in for the whole daemon, and a deploy asks it twice more: for its
+	# runtimes before the image step, and for the runtime the new container got.
+	client.info.return_value = {"Runtimes": {"runc": {}, "sysbox-runc": {}}, "DefaultRuntime": "runc"}
+	client.containers.get.return_value.attrs = {"HostConfig": {"Runtime": "sysbox-runc"}}
 	return client
 
 
@@ -197,6 +203,8 @@ class TestDeployReusesTheSharedImage(IntegrationTestCase):
 		frappe.set_user("Administrator")
 		image_cache.clear_cached_tags()
 		self.addCleanup(image_cache.clear_cached_tags)
+		clear_local_cache(HOST_RUNTIMES_ATTRIBUTE)
+		self.addCleanup(clear_local_cache, HOST_RUNTIMES_ATTRIBUTE)
 
 	def _bench(self):
 		from benchpress.tests.test_deploy_manager import _fresh_bench

--- a/benchpress/tests/test_patches.py
+++ b/benchpress/tests/test_patches.py
@@ -4,6 +4,9 @@
 import frappe
 from frappe.tests import IntegrationTestCase
 
+from benchpress.patches.backfill_bench_runtime import FIELD as RUNTIME_FIELD
+from benchpress.patches.backfill_bench_runtime import SETTINGS
+from benchpress.patches.backfill_bench_runtime import execute as backfill_bench_runtime
 from benchpress.patches.retire_orphaned_creating_sites import execute as retire_creating_sites
 
 
@@ -64,3 +67,76 @@ class TestRetireOrphanedCreatingSites(IntegrationTestCase):
 
 		statuses = [frappe.db.get_value("Bench Site", site.name, "status") for site in untouched]
 		self.assertEqual(statuses, ["Active", "Error"])
+
+
+class TestBackfillBenchRuntime(IntegrationTestCase):
+	"""A container's runtime is fixed when it is created; the field must never claim otherwise."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.lab = frappe.get_doc(
+			{
+				"doctype": "Lab",
+				"lab_id": "test-lab-backfill-runtime",
+				"title": "Test Lab (Backfill Runtime)",
+				"frappe_version": "version-15",
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		for name in frappe.get_all("Bench Instance", filters={"lab": cls.lab.name}, pluck="name"):
+			frappe.delete_doc("Bench Instance", name, force=True, ignore_permissions=True)
+		frappe.delete_doc("Lab", cls.lab.name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self.previous = frappe.db.get_single_value(SETTINGS, RUNTIME_FIELD)
+		self.addCleanup(self._restore_settings)
+		frappe.db.delete("Singles", {"doctype": SETTINGS, "field": RUNTIME_FIELD})
+		frappe.clear_document_cache(SETTINGS, SETTINGS)
+
+	def _restore_settings(self):
+		frappe.db.set_single_value(SETTINGS, RUNTIME_FIELD, self.previous)
+		frappe.clear_document_cache(SETTINGS, SETTINGS)
+
+	def _bench(self, runtime):
+		bench = frappe.get_doc({"doctype": "Bench Instance", "lab": self.lab.name}).insert(
+			ignore_permissions=True
+		)
+		frappe.db.set_value("Bench Instance", bench.name, "runtime", runtime, update_modified=False)
+		self.addCleanup(frappe.delete_doc, "Bench Instance", bench.name, force=True, ignore_permissions=True)
+		return bench.name
+
+	def test_a_bench_that_predates_the_field_is_stamped_runc(self):
+		predates = self._bench("")
+
+		backfill_bench_runtime()
+
+		self.assertEqual(frappe.db.get_value("Bench Instance", predates, "runtime"), "runc")
+
+	def test_a_bench_already_running_sysbox_is_left_alone(self):
+		"""Stamping it `runc` would be the same lie in the other direction."""
+		deployed = self._bench("sysbox")
+
+		backfill_bench_runtime()
+
+		self.assertEqual(frappe.db.get_value("Bench Instance", deployed, "runtime"), "sysbox")
+
+	def test_sysbox_becomes_the_default_for_new_benches(self):
+		backfill_bench_runtime()
+
+		self.assertEqual(frappe.db.get_single_value(SETTINGS, RUNTIME_FIELD), "sysbox")
+
+	def test_an_operator_who_has_already_chosen_keeps_that_choice(self):
+		frappe.db.set_single_value(SETTINGS, RUNTIME_FIELD, "runc")
+
+		backfill_bench_runtime()
+
+		self.assertEqual(frappe.db.get_single_value(SETTINGS, RUNTIME_FIELD), "runc")

--- a/frontend/src/components/lab/ConnectionDetails.vue
+++ b/frontend/src/components/lab/ConnectionDetails.vue
@@ -111,6 +111,7 @@ const rows = computed(() =>
 		{ key: "public-url", label: "Public URL", value: props.bench.public_url },
 		{ key: "private-url", label: "Private URL (VPN)", value: privateSiteUrl(props.bench) },
 		{ key: "wg-ip", label: "WireGuard IP", value: props.bench.wg_ip },
+		{ key: "runtime", label: "Runtime", value: props.bench.runtime },
 		codeServerRow(),
 		sshRow(),
 		{

--- a/frontend/src/components/overview/InfrastructureCard.vue
+++ b/frontend/src/components/overview/InfrastructureCard.vue
@@ -8,7 +8,7 @@
 import CheckList from "@/components/CheckList.vue";
 import SectionCard from "@/components/SectionCard.vue";
 
-// The five real checks from benchpress.diagnostics — never a placeholder list.
+// The six real checks from benchpress.diagnostics — never a placeholder list.
 defineProps({
 	checks: { type: Array, default: () => [] },
 });

--- a/frontend/src/data/benches.js
+++ b/frontend/src/data/benches.js
@@ -21,6 +21,7 @@ export const benchesResource = createListResource({
 		"site_name",
 		"status",
 		"container_ip",
+		"runtime",
 		"wg_ip",
 		"cpu_usage",
 		"memory_usage",

--- a/frontend/src/pages/BenchInstances.vue
+++ b/frontend/src/pages/BenchInstances.vue
@@ -56,6 +56,15 @@
 					:status="row.container_health"
 				/>
 
+				<!-- Read-only everywhere: only an admin can change a runtime, and
+				     only while the bench is still Draft. -->
+				<span
+					v-else-if="column.key === 'runtime'"
+					class="block truncate font-mono text-2xs text-ink-gray-6"
+				>
+					{{ row.runtime || "—" }}
+				</span>
+
 				<UsageBar v-else-if="column.key === 'usage'" :usage="usageOf(row)" />
 
 				<!-- `truncate` only earns its ellipsis on a block: an inline span
@@ -114,6 +123,7 @@ const COLUMNS = [
 	{ label: "Bench", key: "bench", width: "240px" },
 	{ label: "Status", key: "status", width: "110px" },
 	{ label: "Health", key: "container_health", width: "104px" },
+	{ label: "Runtime", key: "runtime", width: "96px" },
 	{ label: "CPU / memory", key: "usage", width: "150px" },
 	{ label: "Site", key: "site", width: "170px" },
 	{ label: "Owner", key: "owner", width: "100px" },


### PR DESCRIPTION
Phase 1 of the `sysbox-default-runtime` spec: a bench names the runtime it runs on, and `sysbox` is available as a choice.

## What this adds

- `CONTAINER_RUNTIMES` in `docker_manager.py` — an allow-list mapping a field value to a runtime name the daemon has registered. `None` means "pass no runtime", which leaves the daemon's `default-runtime`.
- `resolve_runtime(bench_doc)` — throws on anything outside the allow-list, so a stored string never reaches `containers.create` unchecked.
- `runtime` Select on Bench Instance (`runc` / `sysbox`), default `runc`.
- The `runtime=` kwarg is passed **only** when the resolved value is not `None`, so a bench on `runc` produces the same `containers.create` call it produced before this branch.

The host half is in `benchpress_devops` on the branch of the same name: `scripts/enable-sysbox.sh` and a `PRODUCTION.md` §5.17 findings entry.

## How to verify

Deployed a real bench (`crm` lab) with `runtime = sysbox` on staging:

```
docker inspect --format '{{.HostConfig.Runtime}}' <c>   -> sysbox-runc
docker exec <c> cat /proc/self/uid_map                  -> 0 231072 65536
docker exec <c> id                                      -> uid=0(root)
```

`uid_map` is the check that matters — `HostConfig.Runtime` records what was asked for. The identity map `0 0 4294967295` (what every bench read before this change) would mean Sysbox did nothing. Container root is now host UID 231072, unprivileged.

WireGuard still works under the user namespace — `wg show` lists the peer with a live handshake, `wg0` holds its `172.27.0.8/32`. The site serves: `HTTP 200`, `/api/method/ping` returns `pong`. Deploy ran all 11 steps in 46.0s; the container-create step cost 0.4s.

The three pre-existing benches still run on `runc` and still read the identity `uid_map` — unchanged. `docker info` still reports `Default Runtime: runc`.

Backend tests: the three new runtime cases pass. Frontend: 154 pass. `uvx pre-commit@4.3.0 run --all-files`: 12 hooks pass.

## Deliberately not in this phase

Sysbox is not the default, the field is not admin-only, existing rows carry no backfilled value, and a bench asking for a runtime the host lacks still fails late with Docker's own error. Phases 2 and 3.