### PR TITLE
Implemented phase three

### DIFF
--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -24,11 +24,10 @@ from benchpress.credits import account, config, lease, metering, payments
 from benchpress.credits.guard import (
 	build_charge,
 	cap_builds_per_day,
-	cap_concurrent_instances,
 	cap_devices,
 	payload_lease_cost,
 	require_balance,
-	requires_credits,
+	requires_admission,
 )
 from benchpress.permissions import (
 	get_bench_owner_filter,
@@ -83,7 +82,7 @@ def create_lab_from_template(template: str, lab_id: str | None = None, title: st
 
 
 @frappe.whitelist()
-@requires_credits(cost=build_charge, caps=(cap_builds_per_day,))
+@requires_admission(cost=build_charge, caps=(cap_builds_per_day,))
 def build_lab_image(lab_name: str) -> dict:
 	require_admin()
 	frappe.enqueue(
@@ -164,7 +163,7 @@ def _counts_by_bench(doctype: str, column: str, bench_names: list[str]) -> dict[
 
 
 @frappe.whitelist()
-@requires_credits(cost=payload_lease_cost, caps=(cap_concurrent_instances,))
+@requires_admission(cost=payload_lease_cost)
 def create_bench(data: str) -> dict:
 	require_app_user()
 	from benchpress.benchpress.doctype.bench_instance import get_instance_id
@@ -380,7 +379,7 @@ def get_deploy_history() -> dict:
 
 
 @frappe.whitelist()
-@requires_credits(caps=(cap_devices,))
+@requires_admission(caps=(cap_devices,))
 def add_device(device_name: str, device_type: str, public_key: str | None = None) -> dict:
 	require_app_user()
 	from benchpress.vpn_adapter import register_device

--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -179,40 +179,20 @@ def create_bench(data: str) -> dict:
 	lab = frappe.get_cached_doc("Lab", lab_name)
 	requested_site_name = data.get("site_name") or data.get("site")
 
+	site_name = resolve_site_name(requested_site_name)
 	instance_id = get_instance_id(frappe.session.user, lab_name)
 	if frappe.db.exists("Bench Instance", instance_id):
-		doc = frappe.get_doc("Bench Instance", instance_id)
-		site_name = resolve_site_name(requested_site_name, exclude_bench=doc.name)
-		if site_name and site_name != doc.site_name:
-			_assert_site_name_changeable(doc)
-			doc.site_name = site_name
-		doc.status = "Deploying"
-		doc.save()
+		doc = _redeploy_instance(instance_id, site_name)
 	else:
-		doc = frappe.get_doc(
-			{
-				"doctype": "Bench Instance",
-				"bench_name": data.get("bench_name"),
-				"lab": lab_name,
-				"frappe_version": lab.frappe_version,
-				"domain": data.get("domain"),
-				"site_name": resolve_site_name(requested_site_name),
-				"status": "Draft",
-			}
-		)
+		try:
+			doc = _new_instance(lab, data, site_name)
+		except frappe.DuplicateEntryError:
+			# A call for the same (user, lab) that arrived first already named this bench.
+			# `get_instance_id` is deterministic, so the branch was always meant to be idempotent.
+			frappe.clear_last_message()
+			doc = _redeploy_instance(instance_id, site_name)
 
-		for app in lab.apps:
-			doc.append(
-				"apps",
-				{
-					"app_name": app.app_name,
-					"app_label": app.app_label,
-					"git_url": app.git_url,
-					"branch": app.branch,
-				},
-			)
-
-		doc.insert()
+	_claim_site_name(doc)
 
 	frappe.enqueue(
 		"benchpress.deploy_manager.deploy_bench",
@@ -225,6 +205,77 @@ def create_bench(data: str) -> dict:
 	)
 
 	return {"name": doc.name, "status": "Deploying"}
+
+
+def _redeploy_instance(instance_id: str, site_name: str | None):
+	doc = frappe.get_doc("Bench Instance", instance_id)
+	if site_name and site_name != doc.site_name:
+		_assert_site_name_changeable(doc)
+		doc.site_name = site_name
+	doc.status = "Deploying"
+	doc.save()
+	return doc
+
+
+def _new_instance(lab, data: dict, site_name: str | None):
+	doc = frappe.get_doc(
+		{
+			"doctype": "Bench Instance",
+			"bench_name": data.get("bench_name"),
+			"lab": lab.name,
+			"frappe_version": lab.frappe_version,
+			"domain": data.get("domain"),
+			"site_name": site_name,
+			"status": "Draft",
+		}
+	)
+	for app in lab.apps:
+		doc.append(
+			"apps",
+			{
+				"app_name": app.app_name,
+				"app_label": app.app_label,
+				"git_url": app.git_url,
+				"branch": app.branch,
+			},
+		)
+	return doc.insert()
+
+
+def _claim_site_name(bench) -> None:
+	"""Claim the site name by insert. The primary key is the check, and nothing else is.
+
+	The name is held for exactly as long as the row: `teardown_bench` keeps it so a redeploy
+	still owns its own name, and only `_delete_bench` frees it - which is when the database
+	behind it actually stops existing.
+	"""
+	try:
+		site = frappe.get_doc(
+			{
+				"doctype": "Bench Site",
+				"site_name": bench.site_name,
+				"bench": bench.name,
+				"status": "Creating",
+			}
+		).insert(ignore_permissions=True)
+	except frappe.DuplicateEntryError:
+		_refuse_taken_site_name(bench)
+		return
+	# After the insert, which stamps the session user over any owner handed to it. `Bench Site`
+	# is read `if_owner`, so an admin deploying somebody else's instance would otherwise take the
+	# row over and empty that tenant's Sites tab.
+	frappe.db.set_value("Bench Site", site.name, "owner", bench.owner, update_modified=False)
+
+
+def _refuse_taken_site_name(bench) -> None:
+	# First, and on both paths: the framework msgprints "Bench Site X already exists" before it
+	# raises, so a redeploy would carry that internal sentence on an otherwise successful reply.
+	frappe.clear_last_message()
+	# A locking read, because this session is REPEATABLE READ: a plain one answers from a
+	# snapshot taken before the winner committed, and would refuse this caller their own name.
+	if frappe.db.get_value("Bench Site", bench.site_name, "bench", for_update=True) == bench.name:
+		return
+	frappe.throw(_("Site name '{0}' is already in use. Choose a different name.").format(bench.site_name))
 
 
 def _assert_site_name_changeable(doc) -> None:

--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -25,6 +25,7 @@ from benchpress.credits.guard import (
 	build_charge,
 	cap_builds_per_day,
 	cap_devices,
+	instance_lease_cost,
 	payload_lease_cost,
 	require_balance,
 	requires_admission,
@@ -247,9 +248,6 @@ def _assert_site_name_changeable(doc) -> None:
 
 @frappe.whitelist()
 def bench_action(bench_name: str, action: str) -> dict:
-	from benchpress.deploy_manager import enqueue_route_sync
-	from benchpress.docker_manager import restart_container, start_container
-
 	require_bench_access(bench_name)
 	if action == "delete" and not is_admin():
 		frappe.throw(_("Only admins can delete bench instances."), frappe.PermissionError)
@@ -263,6 +261,19 @@ def bench_action(bench_name: str, action: str) -> dict:
 
 	if action not in ("start", "restart"):
 		frappe.throw(_("Invalid action: {0}").format(action))
+
+	return _start_bench(bench, action)
+
+
+@requires_admission(cost=instance_lease_cost)
+def _start_bench(bench, action: str) -> dict:
+	"""Bring a deployed container back up, behind the same gate every other start carries.
+
+	This is the start path the SPA uses, so it is where the cap and the hold have to be. Stopping
+	and deleting stay outside the gate: stopping is what a refused caller is being told to do.
+	"""
+	from benchpress.deploy_manager import enqueue_route_sync
+	from benchpress.docker_manager import restart_container, start_container
 
 	_require_container(bench)
 	if action == "start":

--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -378,11 +378,9 @@ def _delete_bench(bench) -> dict:
 	from benchpress.vpn_adapter import remove_bench_peer
 
 	teardown_bench(bench)
+	# Before the instance: it reads the `Bench Site` rows, which `BenchInstance.on_trash` removes.
 	_drop_bench_site_databases(bench)
 	remove_bench_peer(bench)
-	# Before the instance: `force=True` skips the link check, so these would orphan.
-	for site in frappe.get_all("Bench Site", filters={"bench": bench.name}, pluck="name"):
-		frappe.delete_doc("Bench Site", site, force=True, ignore_permissions=True)
 	frappe.delete_doc("Bench Instance", bench.name, force=True)
 	frappe.db.commit()
 	return {"status": "deleted"}

--- a/benchpress/benchpress/doctype/bench_admission/bench_admission.json
+++ b/benchpress/benchpress/doctype/bench_admission/bench_admission.json
@@ -10,7 +10,8 @@
   "bench",
   "account",
   "column_break_claim",
-  "claimed_at"
+  "claimed_at",
+  "held_credits"
  ],
  "fields": [
   {
@@ -42,12 +43,22 @@
    "in_list_view": 1,
    "label": "Claimed At",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "description": "Credits this claim reserved for the start that took it, given back when that start's lease is charged. A hold is not a charge: it moves no balance and writes no ledger row.",
+   "fieldname": "held_credits",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Held Credits",
+   "precision": "6",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 0,
  "links": [],
- "modified": "2026-08-25 00:00:00.000000",
+ "modified": "2026-08-25 13:00:00.000000",
  "modified_by": "Administrator",
  "module": "Benchpress",
  "name": "Bench Admission",

--- a/benchpress/benchpress/doctype/bench_admission/bench_admission.json
+++ b/benchpress/benchpress/doctype/bench_admission/bench_admission.json
@@ -1,0 +1,89 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "field:bench",
+ "creation": "2026-08-25 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 0,
+ "engine": "InnoDB",
+ "field_order": [
+  "bench",
+  "account",
+  "column_break_claim",
+  "claimed_at"
+ ],
+ "fields": [
+  {
+   "description": "The Bench Instance name this slot is held for. Data rather than a Link: the claim is taken before the instance row exists, which is what closes the window between admission and Running.",
+   "fieldname": "bench",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Bench",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "account",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Account",
+   "options": "Credit Account",
+   "read_only": 1,
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "column_break_claim",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "claimed_at",
+   "fieldtype": "Datetime",
+   "in_list_view": 1,
+   "label": "Claimed At",
+   "read_only": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-08-25 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Benchpress",
+ "name": "Bench Admission",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "BenchPress Admin",
+   "share": 1
+  },
+  {
+   "if_owner": 1,
+   "read": 1,
+   "role": "BenchPress User"
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 0
+}

--- a/benchpress/benchpress/doctype/bench_admission/bench_admission.py
+++ b/benchpress/benchpress/doctype/bench_admission/bench_admission.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""One row per bench that currently holds a concurrency slot. Its existence is the slot.
+
+Nothing writes this by hand. `benchpress.credits.admission` inserts it under the caller's
+`Credit Account` row lock and deletes it on every path a bench leaves `Deploying` or `Running`;
+`benchpress.credits.admission_repair` heals whatever a killed worker left behind.
+"""
+
+from frappe.model.document import Document
+
+
+class BenchAdmission(Document):
+	pass

--- a/benchpress/benchpress/doctype/bench_instance/bench_instance.py
+++ b/benchpress/benchpress/doctype/bench_instance/bench_instance.py
@@ -9,7 +9,7 @@ from frappe.model.document import Document
 from frappe.utils.background_jobs import is_job_enqueued
 
 from benchpress.benchpress.doctype.bench_instance import get_instance_id
-from benchpress.credits.guard import cap_concurrent_instances, instance_lease_cost, requires_credits
+from benchpress.credits.guard import instance_lease_cost, requires_admission
 from benchpress.permissions import is_admin
 
 DEPLOY_JOB_TIMEOUT = 7200
@@ -57,6 +57,15 @@ class BenchInstance(Document):
 
 		lease.refresh_into(self)
 
+	def on_trash(self):
+		"""Give the concurrency slot back. `api._delete_bench` deletes with `force=True`, which
+		skips the link check, and `Bench Admission.bench` is `Data` - so nothing else would ever
+		notice the orphan.
+		"""
+		from benchpress.credits import admission
+
+		admission.release(self.name)
+
 	def validate_higher_perm_levels(self):
 		"""Refuse a runtime the caller may not set, where Frappe would silently drop it.
 
@@ -93,7 +102,7 @@ class BenchInstance(Document):
 		return username
 
 	@frappe.whitelist()
-	@requires_credits(cost=instance_lease_cost, caps=(cap_concurrent_instances,))
+	@requires_admission(cost=instance_lease_cost)
 	def enqueue_deploy(self):
 		if is_job_enqueued(self._deploy_job_id()):
 			frappe.msgprint(_("A deploy is already in progress for this bench."))
@@ -117,7 +126,7 @@ class BenchInstance(Document):
 		frappe.msgprint(_("Bench stopped."))
 
 	@frappe.whitelist()
-	@requires_credits(cost=instance_lease_cost, caps=(cap_concurrent_instances,))
+	@requires_admission(cost=instance_lease_cost)
 	def enqueue_redeploy(self):
 		if is_job_enqueued(self._deploy_job_id()):
 			frappe.msgprint(_("A deploy is already in progress for this bench."))
@@ -137,7 +146,7 @@ class BenchInstance(Document):
 		return f"deploy_bench:{self.name}"
 
 	@frappe.whitelist()
-	@requires_credits(cost=instance_lease_cost, caps=(cap_concurrent_instances,))
+	@requires_admission(cost=instance_lease_cost)
 	def enqueue_start(self):
 		from benchpress.credits import metering
 		from benchpress.deploy_manager import enqueue_route_sync

--- a/benchpress/benchpress/doctype/bench_instance/bench_instance.py
+++ b/benchpress/benchpress/doctype/bench_instance/bench_instance.py
@@ -58,13 +58,20 @@ class BenchInstance(Document):
 		lease.refresh_into(self)
 
 	def on_trash(self):
-		"""Give the concurrency slot back. `api._delete_bench` deletes with `force=True`, which
-		skips the link check, and `Bench Admission.bench` is `Data` - so nothing else would ever
-		notice the orphan.
+		"""Give the concurrency slot and the site name back.
+
+		`api._delete_bench` deletes with `force=True`, which skips the link check, and
+		`Bench Admission.bench` is `Data` - so nothing else would ever notice either orphan.
+
+		The site name goes here rather than at the call site because a `Bench Site` row whose
+		instance is gone can no longer drop its own database: only `api._delete_bench` does that,
+		and it needs the instance. It runs the drop before this, while the rows are still here.
 		"""
 		from benchpress.credits import admission
 
 		admission.release(self.name)
+		for site in frappe.get_all("Bench Site", filters={"bench": self.name}, pluck="name"):
+			frappe.delete_doc("Bench Site", site, force=True, ignore_permissions=True)
 
 	def validate_higher_perm_levels(self):
 		"""Refuse a runtime the caller may not set, where Frappe would silently drop it.

--- a/benchpress/benchpress/doctype/bench_site/bench_site.json
+++ b/benchpress/benchpress/doctype/bench_site/bench_site.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "field:site_name",
  "creation": "2026-03-17 22:40:36.165423",
  "doctype": "DocType",
  "editable_grid": 1,

--- a/benchpress/benchpress/doctype/credit_account/credit_account.json
+++ b/benchpress/benchpress/doctype/credit_account/credit_account.json
@@ -16,7 +16,8 @@
   "lifetime_spent",
   "state_section",
   "is_suspended",
-  "low_balance_warned"
+  "low_balance_warned",
+  "active_instances"
  ],
  "fields": [
   {
@@ -82,6 +83,15 @@
    "fieldname": "low_balance_warned",
    "fieldtype": "Check",
    "label": "Low Balance Warned",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "description": "Bench Admission rows this account holds: one per instance deploying or running. Denormalised so admission decides from the row it already locked; benchpress.credits.admission_repair heals it.",
+   "fieldname": "active_instances",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Active Instances",
    "read_only": 1
   }
  ],

--- a/benchpress/benchpress/doctype/credit_account/credit_account.json
+++ b/benchpress/benchpress/doctype/credit_account/credit_account.json
@@ -17,7 +17,8 @@
   "state_section",
   "is_suspended",
   "low_balance_warned",
-  "active_instances"
+  "active_instances",
+  "reserved_credits"
  ],
  "fields": [
   {
@@ -93,6 +94,16 @@
    "in_list_view": 1,
    "label": "Active Instances",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "description": "Credits held by the Bench Admission rows this account owns and not yet charged. Denormalised so admission decides the hold from the row it already locked; benchpress.credits.admission_repair heals it.",
+   "fieldname": "reserved_credits",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Reserved Credits",
+   "precision": "6",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
@@ -103,7 +114,7 @@
    "link_fieldname": "account"
   }
  ],
- "modified": "2026-08-17 09:30:00.000000",
+ "modified": "2026-08-25 13:00:00.000000",
  "modified_by": "Administrator",
  "module": "Benchpress",
  "name": "Credit Account",

--- a/benchpress/benchpress/doctype/credit_account/credit_account.py
+++ b/benchpress/benchpress/doctype/credit_account/credit_account.py
@@ -11,12 +11,19 @@ which is why an operator's only ways in are the two document actions below.
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.utils import cint
 
 from benchpress.credits import account, payments
 from benchpress.permissions import require_admin
 
 
 class CreditAccount(Document):
+	def validate(self):
+		# The tripwire for a lost decrement: a slot released twice would otherwise leave a
+		# negative count that reads as free capacity forever.
+		if cint(self.active_instances) < 0:
+			frappe.throw(_("Active instances cannot be negative."))
+
 	@frappe.whitelist()
 	def post_adjustment(self, credits: float, reason: str):
 		"""Move this balance by hand, in either direction, with the reason on the row.

--- a/benchpress/benchpress/doctype/credit_account/credit_account.py
+++ b/benchpress/benchpress/doctype/credit_account/credit_account.py
@@ -11,7 +11,7 @@ which is why an operator's only ways in are the two document actions below.
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import cint
+from frappe.utils import cint, flt
 
 from benchpress.credits import account, payments
 from benchpress.permissions import require_admin
@@ -20,9 +20,12 @@ from benchpress.permissions import require_admin
 class CreditAccount(Document):
 	def validate(self):
 		# The tripwire for a lost decrement: a slot released twice would otherwise leave a
-		# negative count that reads as free capacity forever.
+		# negative count that reads as free capacity forever, and a hold returned twice would
+		# leave a balance that spends more than it holds.
 		if cint(self.active_instances) < 0:
 			frappe.throw(_("Active instances cannot be negative."))
+		if flt(self.reserved_credits) < 0:
+			frappe.throw(_("Reserved credits cannot be negative."))
 
 	@frappe.whitelist()
 	def post_adjustment(self, credits: float, reason: str):

--- a/benchpress/benchpress/doctype/credit_settings/credit_settings.json
+++ b/benchpress/benchpress/doctype/credit_settings/credit_settings.json
@@ -22,6 +22,7 @@
   "caps_section",
   "max_concurrent_free",
   "max_concurrent_paid",
+  "max_concurrent_uncredited",
   "column_break_caps",
   "max_devices",
   "max_builds_per_day",
@@ -93,6 +94,13 @@
    "fieldname": "max_concurrent_paid",
    "fieldtype": "Int",
    "label": "Max Concurrent (Paid)"
+  },
+  {
+   "default": "0",
+   "description": "Concurrent instances per user while credits are switched off. 0 = unlimited, which is what an install that has never opted in keeps.",
+   "fieldname": "max_concurrent_uncredited",
+   "fieldtype": "Int",
+   "label": "Max Concurrent (Credits Off)"
   },
   {
    "fieldname": "column_break_caps",

--- a/benchpress/credits/account.py
+++ b/benchpress/credits/account.py
@@ -39,6 +39,8 @@ STATEMENT_FIELDS = ["name", "entry_type", "credits", "balance_after", "descripti
 DEFAULT_PAGE_LENGTH = 20
 MAX_PAGE_LENGTH = 100
 
+SIGNUP_REFERENCE = "User"
+
 USAGE = "Usage"
 GRANT = "Grant"
 PURCHASE = "Purchase"
@@ -124,23 +126,30 @@ def charge(user: str, credits, description: str, reference=None, request_id: str
 	"""
 	if not config.credits_enabled():
 		return
-	account = _locked(user)
+	account = locked(user)
 	account.balance = flt(flt(account.balance) - flt(credits), PRECISION)
 	account.lifetime_spent = flt(flt(account.lifetime_spent) + flt(credits), PRECISION)
-	_save(account)
+	save_account(account)
 	_write_entry(account, USAGE, -flt(credits), description, reference, request_id)
 
 
-def grant(user: str, credits, description: str) -> None:
-	"""Credit an account without a payment — the signup grant, or an operator's goodwill."""
+def grant(user: str, credits, description: str, reference=None) -> None:
+	"""Credit an account without a payment: the signup grant, or an operator's goodwill.
+
+	`reference` is what makes a grant postable exactly once. `_post_signup_grant` passes the
+	user, so the ledger itself remembers that the joining credits have landed.
+	"""
 	if not config.credits_enabled() or not flt(credits):
 		return
-	account = _locked(user)
+	_apply_grant(locked(user), credits, description, reference)
+
+
+def _apply_grant(account, credits, description: str, reference) -> None:
 	account.balance = flt(flt(account.balance) + flt(credits), PRECISION)
 	# The balance just rose, so the next depletion deserves its own warning.
 	account.low_balance_warned = 0
-	_save(account)
-	_write_entry(account, GRANT, flt(credits), description)
+	save_account(account)
+	_write_entry(account, GRANT, flt(credits), description, reference)
 
 
 def purchase(user: str, credits, description: str, reference) -> bool:
@@ -148,7 +157,7 @@ def purchase(user: str, credits, description: str, reference) -> bool:
 
 	Webhooks retry, `on_update` fires on every save of an order, and an operator pressing *Sync
 	Status* is a third delivery of the same payment — so the reference, not the caller, decides
-	whether money has already been applied. The check runs *after* `_locked`, under the same row
+	whether money has already been applied. The check runs *after* `locked`, under the same row
 	lock that applies it: two deliveries racing each other serialise there instead of both reading
 	an empty ledger and both crediting.
 
@@ -157,14 +166,14 @@ def purchase(user: str, credits, description: str, reference) -> bool:
 	"""
 	if not config.credits_enabled():
 		return False
-	account = _locked(user)
+	account = locked(user)
 	if reference_posted(reference):
 		return False
 	amount = flt(credits)
 	account.balance = flt(flt(account.balance) + amount, PRECISION)
 	account.lifetime_purchased = flt(flt(account.lifetime_purchased) + amount, PRECISION)
 	account.low_balance_warned = 0
-	_save(account)
+	save_account(account)
 	_write_entry(account, PURCHASE, amount, description, reference)
 	return True
 
@@ -180,10 +189,10 @@ def refund(user: str, credits, description: str, reference=None) -> None:
 	if not config.credits_enabled():
 		return
 	amount = abs(flt(credits))
-	account = _locked(user)
+	account = locked(user)
 	account.balance = flt(flt(account.balance) - amount, PRECISION)
 	account.lifetime_purchased = max(flt(flt(account.lifetime_purchased) - amount, PRECISION), 0.0)
-	_save(account)
+	save_account(account)
 	_write_entry(account, REFUND, -amount, description, reference)
 
 
@@ -197,10 +206,10 @@ def adjust(user: str, credits, reason: str) -> None:
 		frappe.throw(_("Credits are switched off on this site."))
 	if not cstr(reason).strip():
 		frappe.throw(_("An adjustment needs a reason."))
-	account = _locked(user)
+	account = locked(user)
 	account.balance = flt(flt(account.balance) + flt(credits), PRECISION)
 	account.low_balance_warned = 0
-	_save(account)
+	save_account(account)
 	_write_entry(account, ADJUSTMENT, flt(credits), reason)
 
 
@@ -253,14 +262,34 @@ def reference_posted(reference) -> bool:
 
 
 def ensure_account(user: str) -> str:
-	"""The account name for a user — the email itself — created on first use.
+	"""The account name for a user, the email itself, created on first use.
 
 	The signup grant is posted here rather than on user creation so it lands however the user
-	arrived: waitlist invite, Desk, or a phase-7 social login.
+	arrived: waitlist invite, Desk, or a social login. It is posted on every call rather than
+	only on the create, because admission opens accounts on a site with credits switched off and
+	those rows would otherwise never be granted when an operator flips the switch.
 	"""
-	if frappe.db.exists(ACCOUNT, user):
-		return user
-	return _create_account(user)
+	if not frappe.db.exists(ACCOUNT, user):
+		_create_account(user)
+	_post_signup_grant(user)
+	return user
+
+
+def _post_signup_grant(user: str) -> None:
+	"""Post the joining credits once ever, keyed by the user in the ledger.
+
+	An account opened before this reference existed carries its grant as an unreferenced row, so
+	any ledger row at all counts as onboarded: without that, flipping the switch would grant a
+	second time to everybody who was already trading.
+	"""
+	if not config.credits_enabled() or reference_posted((SIGNUP_REFERENCE, user)):
+		return
+	credits = flt(config.settings().signup_grant_credits)
+	if not credits or frappe.db.exists(LEDGER, {"account": user}):
+		return
+	# Not through `grant`: that would re-enter `ensure_account`, which is what called this.
+	account = frappe.get_doc(ACCOUNT, user, for_update=True)
+	_apply_grant(account, credits, "Signup grant", (SIGNUP_REFERENCE, user))
 
 
 def _create_account(user: str) -> str:
@@ -269,12 +298,11 @@ def _create_account(user: str) -> str:
 	try:
 		account.insert(ignore_permissions=True)
 	except frappe.DuplicateEntryError:
-		return user  # two parallel first deploys; the other one won
-	grant(user, config.settings().signup_grant_credits, "Signup grant")
-	return account.name
+		frappe.clear_last_message()  # two parallel first deploys; the other one won
+	return user
 
 
-def _locked(user: str):
+def locked(user: str):
 	"""The account row, locked and loaded in one `SELECT ... FOR UPDATE`.
 
 	A second worker touching the same account waits here instead of reading a balance that is
@@ -286,7 +314,7 @@ def _locked(user: str):
 	return frappe.get_doc(ACCOUNT, ensure_account(user), for_update=True)
 
 
-def _save(account) -> None:
+def save_account(account) -> None:
 	account.save(ignore_permissions=True)
 
 

--- a/benchpress/credits/account.py
+++ b/benchpress/credits/account.py
@@ -31,7 +31,7 @@ LEDGER = "Credit Ledger Entry"
 # credits, and rounding that to two places at every debit would leak the difference.
 PRECISION = 6
 
-BALANCE_FIELDS = ["balance", "is_suspended"]
+BALANCE_FIELDS = ["balance", "is_suspended", "reserved_credits"]
 # The hot path reads only what it must; the meter also needs the denominator, so it asks for one
 # field more in the same single read rather than making the guard carry it.
 SUMMARY_FIELDS = [*BALANCE_FIELDS, "lifetime_spent"]
@@ -60,6 +60,23 @@ def available(account) -> float:
 	return flt(flt(account.balance), PRECISION)
 
 
+def spendable(account) -> float:
+	"""What a new commitment may take: the balance less what admission is already holding.
+
+	Never what the sweep asks — that is `available`, and a hold must not read as running out.
+	It deliberately does not settle anything: an admission is a question, and a question that
+	wrote a ledger row would put a Usage line in the statement for merely asking.
+	"""
+	return flt(available(account) - flt(account.reserved_credits), PRECISION)
+
+
+def shortfall_message(needed, available) -> str:
+	"""Refuse by name: what this costs, what is left, the gap, and the way out of it."""
+	return _("Not enough credits: this needs {0} and {1} are available — {2} short. Top up at {3}.").format(
+		flt(needed, 2), flt(available, 2), flt(needed - available, 2), config.TOP_UP_ROUTE
+	)
+
+
 def allocated(account) -> float:
 	"""Every credit ever put into this account: what is left, plus what has gone.
 
@@ -84,11 +101,12 @@ def summary(user: str) -> dict:
 		return {"enabled": False}
 	row = frappe.db.get_value(ACCOUNT, user, SUMMARY_FIELDS, as_dict=True)
 	if not row:
-		return {"enabled": True, "balance": 0.0, "allocated": 0.0, "is_suspended": False}
+		return {"enabled": True, "balance": 0.0, "allocated": 0.0, "reserved": 0.0, "is_suspended": False}
 	return {
 		"enabled": True,
 		"balance": available(row),
 		"allocated": allocated(row),
+		"reserved": flt(row.reserved_credits, PRECISION),
 		"is_suspended": bool(row.is_suspended),
 	}
 

--- a/benchpress/credits/admission.py
+++ b/benchpress/credits/admission.py
@@ -1,16 +1,22 @@
 # Copyright (c) 2026, Venkatesh and contributors
 # For license information, please see license.txt
 
-"""Admission: the concurrency decision, taken as a write that can fail.
+"""Admission: the concurrency and credit decision, taken as a write that can fail.
 
-Counting running instances and comparing cannot refuse anything. Two requests that arrive
-together read the same count, and `api.create_bench` writes its row as `Draft` for the two
-minutes a deploy takes, so an in-flight deploy is invisible to whatever is counting deploys.
+Counting running instances and comparing cannot refuse anything, and neither can reading a
+balance. Two requests that arrive together read the same count and the same figure, and
+`api.create_bench` writes its row as `Draft` for the two minutes a deploy takes, so an in-flight
+deploy is invisible to whatever is counting deploys.
 
-So a slot is a row. `Bench Admission` autonames on the bench, which puts the claim on a primary
-key, and both the read and the write happen under `SELECT ... FOR UPDATE` on the caller's
-`Credit Account` - the one row every contender for that caller has to take. The loser waits
-there and then reads the count the winner wrote.
+So a slot is a row, and the credits it will spend are held on that row. `Bench Admission`
+autonames on the bench, which puts the claim on a primary key, and every read and write happens
+under `SELECT ... FOR UPDATE` on the caller's `Credit Account` - the one row every contender for
+that caller has to take. The loser waits there and then reads what the winner wrote.
+
+A hold is **not** a charge. It moves no balance, writes no `Credit Ledger Entry` and appears in
+no statement; the row and its `held_credits` are the whole record that a hold exists. The charge
+is `metering.on_bench_running`, which ends the hold in the same locked transaction that debits
+the lease.
 
 The lock order is fixed everywhere in this app: `Bench Instance`, then `Credit Account`, then
 `Bench Admission`. Nothing here locks an instance, so admission cannot close that cycle. There
@@ -20,26 +26,36 @@ count would walk the `status` index and next-key-lock other tenants' rows.
 
 import frappe
 from frappe import _
-from frappe.utils import cint, now_datetime
+from frappe.utils import cint, flt, now_datetime
 
 from benchpress.credits import account, config
 
 ADMISSION = "Bench Admission"
 
 
-def claim(user: str, bench_name: str | None, limit: int) -> bool:
-	"""Take a slot for `bench_name`, or refuse by name. True when this call took it.
+def claim(user: str, bench_name: str | None, limit: int, cost: float = 0.0) -> bool:
+	"""Take a slot and hold `cost` for `bench_name`, or refuse by name. True when this call took it.
 
 	Returns False without refusing when the bench already holds a slot, which is what makes a
 	redeploy, a restart and a retry free: the cap forbids new instances, not touching existing
-	ones. Raises `frappe.ValidationError` when the caller is at `limit`; `0` means unlimited.
+	ones. Such a call is still priced, because the start it asks for will still be charged.
+
+	Raises `frappe.ValidationError` when the caller is at `limit` (`0` means unlimited), when the
+	account is suspended, or when the cost is more than the account can still commit.
 	"""
 	if not bench_name:
 		return False
 	acct = account.locked(user)
+	# A hold is money, and a site with credits off has none. Normalised here rather than at the
+	# call site so no caller can reserve credits that do not exist.
+	hold = flt(cost) if config.credits_enabled() else 0.0
 	# Also a locking read: this session is REPEATABLE READ, where a plain read after the lock
 	# still answers from the snapshot the request opened.
-	if frappe.db.get_value(ADMISSION, bench_name, "name", for_update=True):
+	claimed = frappe.db.get_value(
+		ADMISSION, bench_name, ["name", "held_credits"], as_dict=True, for_update=True
+	)
+	if claimed:
+		_require_affordable(acct, hold - flt(claimed.held_credits))
 		return False
 	if limit and cint(acct.active_instances) >= limit:
 		frappe.throw(
@@ -47,33 +63,77 @@ def claim(user: str, bench_name: str | None, limit: int) -> bool:
 				"You have {0} instances running, the most your plan allows. Stop one, or buy credits at {1} to raise the limit."
 			).format(limit, config.TOP_UP_ROUTE)
 		)
-	if not _insert(acct.name, bench_name):
+	_require_affordable(acct, hold)
+	if not _insert(acct.name, bench_name, hold):
 		return False
 	acct.active_instances = cint(acct.active_instances) + 1
+	acct.reserved_credits = flt(flt(acct.reserved_credits) + hold, account.PRECISION)
 	account.save_account(acct)
 	return True
 
 
 def release(bench_name: str | None) -> None:
-	"""Give a slot back. Idempotent: a bench holding none releases nothing and says nothing."""
+	"""Give a slot and its hold back. Idempotent: a bench holding none releases nothing and says nothing."""
 	if not bench_name:
 		return
 	user = frappe.db.get_value(ADMISSION, bench_name, "account")
 	if not user:
 		return
 	acct = account.locked(user)
-	if not frappe.db.get_value(ADMISSION, bench_name, "name", for_update=True):
+	held = frappe.db.get_value(ADMISSION, bench_name, "held_credits", as_dict=True, for_update=True)
+	if not held:
 		return
 	frappe.delete_doc(ADMISSION, bench_name, force=True, ignore_permissions=True)
 	acct.active_instances = _decremented(acct)
+	acct.reserved_credits = _unreserved(acct, held.held_credits)
 	account.save_account(acct)
 
 
-def _insert(account_name: str, bench_name: str) -> bool:
+def release_hold(bench_name: str | None) -> float:
+	"""End the reservation a start made, keeping the slot. Returns what came back.
+
+	Called beside the charge the hold was taken for, so the two land under one lock: the credits
+	stop being reserved at the moment they are spent. Free on a bench holding nothing, which is
+	every renewal and every start already inside a window somebody paid for.
+	"""
+	if not bench_name:
+		return 0.0
+	user = frappe.db.get_value(ADMISSION, bench_name, "account")
+	if not user:
+		return 0.0
+	acct = account.locked(user)
+	row = frappe.db.get_value(ADMISSION, bench_name, "held_credits", as_dict=True, for_update=True)
+	held = flt(row.held_credits) if row else 0.0
+	if not held:
+		return 0.0
+	# A billing flag, not a user edit — the same discipline `lease._write` keeps.
+	frappe.db.set_value(ADMISSION, bench_name, "held_credits", 0.0, update_modified=False)
+	acct.reserved_credits = _unreserved(acct, held)
+	account.save_account(acct)
+	return held
+
+
+def _require_affordable(acct, cost: float) -> None:
+	"""Refuse a caller who cannot commit `cost` on top of what they have already reserved.
+
+	`cost` is what this call adds, so a bench that already holds part of it is judged on the
+	difference. Nothing to decide on a site with credits off: there is no money there.
+	"""
+	if not config.credits_enabled():
+		return
+	if acct.is_suspended:
+		frappe.throw(_("This account is suspended, so nothing new can be started."))
+	spendable = account.spendable(acct)
+	if flt(cost) > spendable:
+		frappe.throw(account.shortfall_message(flt(cost), spendable))
+
+
+def _insert(account_name: str, bench_name: str, cost: float) -> bool:
 	row = frappe.new_doc(ADMISSION)
 	row.bench = bench_name
 	row.account = account_name
 	row.claimed_at = now_datetime()
+	row.held_credits = cost
 	try:
 		row.insert(ignore_permissions=True)
 	except frappe.DuplicateEntryError:
@@ -91,4 +151,12 @@ def _decremented(acct) -> int:
 		# reconciler heals the counter from the rows within one tick.
 		frappe.logger("benchpress").warning(f"admission: {acct.name} released a slot it did not hold")
 		return 0
+	return remaining
+
+
+def _unreserved(acct, held) -> float:
+	remaining = flt(flt(acct.reserved_credits) - flt(held), account.PRECISION)
+	if remaining < 0:
+		frappe.logger("benchpress").warning(f"admission: {acct.name} returned a hold it did not have")
+		return 0.0
 	return remaining

--- a/benchpress/credits/admission.py
+++ b/benchpress/credits/admission.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""Admission: the concurrency decision, taken as a write that can fail.
+
+Counting running instances and comparing cannot refuse anything. Two requests that arrive
+together read the same count, and `api.create_bench` writes its row as `Draft` for the two
+minutes a deploy takes, so an in-flight deploy is invisible to whatever is counting deploys.
+
+So a slot is a row. `Bench Admission` autonames on the bench, which puts the claim on a primary
+key, and both the read and the write happen under `SELECT ... FOR UPDATE` on the caller's
+`Credit Account` - the one row every contender for that caller has to take. The loser waits
+there and then reads the count the winner wrote.
+
+The lock order is fixed everywhere in this app: `Bench Instance`, then `Credit Account`, then
+`Bench Admission`. Nothing here locks an instance, so admission cannot close that cycle. There
+is deliberately no locking count over `tabBench Instance`: it has no index on `owner`, so the
+count would walk the `status` index and next-key-lock other tenants' rows.
+"""
+
+import frappe
+from frappe import _
+from frappe.utils import cint, now_datetime
+
+from benchpress.credits import account, config
+
+ADMISSION = "Bench Admission"
+
+
+def claim(user: str, bench_name: str | None, limit: int) -> bool:
+	"""Take a slot for `bench_name`, or refuse by name. True when this call took it.
+
+	Returns False without refusing when the bench already holds a slot, which is what makes a
+	redeploy, a restart and a retry free: the cap forbids new instances, not touching existing
+	ones. Raises `frappe.ValidationError` when the caller is at `limit`; `0` means unlimited.
+	"""
+	if not bench_name:
+		return False
+	acct = account.locked(user)
+	# Also a locking read: this session is REPEATABLE READ, where a plain read after the lock
+	# still answers from the snapshot the request opened.
+	if frappe.db.get_value(ADMISSION, bench_name, "name", for_update=True):
+		return False
+	if limit and cint(acct.active_instances) >= limit:
+		frappe.throw(
+			_(
+				"You have {0} instances running, the most your plan allows. Stop one, or buy credits at {1} to raise the limit."
+			).format(limit, config.TOP_UP_ROUTE)
+		)
+	if not _insert(acct.name, bench_name):
+		return False
+	acct.active_instances = cint(acct.active_instances) + 1
+	account.save_account(acct)
+	return True
+
+
+def release(bench_name: str | None) -> None:
+	"""Give a slot back. Idempotent: a bench holding none releases nothing and says nothing."""
+	if not bench_name:
+		return
+	user = frappe.db.get_value(ADMISSION, bench_name, "account")
+	if not user:
+		return
+	acct = account.locked(user)
+	if not frappe.db.get_value(ADMISSION, bench_name, "name", for_update=True):
+		return
+	frappe.delete_doc(ADMISSION, bench_name, force=True, ignore_permissions=True)
+	acct.active_instances = _decremented(acct)
+	account.save_account(acct)
+
+
+
+def _insert(account_name: str, bench_name: str) -> bool:
+	row = frappe.new_doc(ADMISSION)
+	row.bench = bench_name
+	row.account = account_name
+	row.claimed_at = now_datetime()
+	try:
+		row.insert(ignore_permissions=True)
+	except frappe.DuplicateEntryError:
+		# Unreachable under the account lock. It is what keeps this correct if a later change
+		# drops the lock, and the message would otherwise reach the user as a second sentence.
+		frappe.clear_last_message()
+		return False
+	return True
+
+
+def _decremented(acct) -> int:
+	remaining = cint(acct.active_instances) - 1
+	if remaining < 0:
+		# Never throw on a release path: this is reached from teardown and from stop, and the
+		# reconciler heals the counter from the rows within one tick.
+		frappe.logger("benchpress").warning(f"admission: {acct.name} released a slot it did not hold")
+		return 0
+	return remaining

--- a/benchpress/credits/admission.py
+++ b/benchpress/credits/admission.py
@@ -69,7 +69,6 @@ def release(bench_name: str | None) -> None:
 	account.save_account(acct)
 
 
-
 def _insert(account_name: str, bench_name: str) -> bool:
 	row = frappe.new_doc(ADMISSION)
 	row.bench = bench_name

--- a/benchpress/credits/admission_repair.py
+++ b/benchpress/credits/admission_repair.py
@@ -36,6 +36,11 @@ HOLDING_STATUSES = ("Deploying", "Running")
 # whose bench is still `Deploying` belongs to a job that no longer exists.
 STALE_DEPLOY_HOURS = 3
 
+# A claim is taken in the request; the bench only leaves `Draft` when a worker picks the deploy
+# up. Releasing on status alone would take the slot back from a deploy that is merely queued,
+# which is exactly what happens whenever `queue-long` is behind.
+CLAIM_GRACE_MINUTES = 15
+
 
 def reconcile_admissions() -> dict:
 	"""Expire stranded claims, adopt orphaned instances, then heal the counters."""
@@ -55,22 +60,24 @@ def _release_stranded() -> list[str]:
 	if not claims:
 		return []
 	statuses = _bench_statuses([claim.bench for claim in claims])
-	cutoff = add_to_date(now_datetime(), hours=-STALE_DEPLOY_HOURS)
+	now = now_datetime()
+	settled = add_to_date(now, minutes=-CLAIM_GRACE_MINUTES)
+	abandoned = add_to_date(now, hours=-STALE_DEPLOY_HOURS)
 	released = []
 	for claim in claims:
 		status = statuses.get(claim.bench)
-		if status in HOLDING_STATUSES and not _deploy_abandoned(status, claim.claimed_at, cutoff):
-			continue
-		if status == "Deploying":
+		if status == "Deploying" and _older_than(claim.claimed_at, abandoned):
 			# A bench nobody is deploying is not deploying.
 			frappe.db.set_value(BENCH, claim.bench, "status", "Error")
+		elif status in HOLDING_STATUSES or not _older_than(claim.claimed_at, settled):
+			continue
 		admission.release(claim.bench)
 		released.append(claim.bench)
 	return released
 
 
-def _deploy_abandoned(status: str, claimed_at, cutoff) -> bool:
-	return status == "Deploying" and bool(claimed_at) and claimed_at < cutoff
+def _older_than(claimed_at, cutoff) -> bool:
+	return bool(claimed_at) and claimed_at < cutoff
 
 
 def _adopt_orphans() -> list[str]:

--- a/benchpress/credits/admission_repair.py
+++ b/benchpress/credits/admission_repair.py
@@ -1,16 +1,17 @@
 # Copyright (c) 2026, Venkatesh and contributors
 # For license information, please see license.txt
 
-"""The repair pass for admission, because a slot is denormalised twice over.
+"""The repair pass for admission, because what a claim holds is denormalised twice over.
 
 Named for admission and not for reconciliation: `credits.reconcile` was the burn-rate meter's
 repair pass, `test_meter_gone` asserts that name never comes back, and this repairs a count of
 rows rather than a rate.
 
-`Bench Admission` rows are the truth, `Credit Account.active_instances` is a count of them, and
-both are written by workers that can be killed between the two. A worker killed mid-deploy leaks
-a slot forever, and a caller with a cap of two is then locked out until somebody notices - so
-this runs on the `*/5` cron beside the balance sweep, not on the daily list.
+`Bench Admission` rows are the truth. `Credit Account.active_instances` counts them and
+`reserved_credits` sums their holds, and every one of the three is written by a worker that can
+be killed between them. A worker killed mid-deploy leaks a slot and the credits it reserved
+forever, and a caller with a cap of two is then locked out until somebody notices - so this runs
+on the `*/5` cron beside the balance sweep, not on the daily list.
 
 It is pure database work: three grouped reads, no Docker call anywhere, which is why it is safe
 on `queue-short` for exactly the reason `sweep.enforce_limits` is.
@@ -21,10 +22,10 @@ the counter follows the rows, so it cannot be driven negative by a release that 
 
 import frappe
 from frappe.query_builder import DocType
-from frappe.query_builder.functions import Count
-from frappe.utils import add_to_date, cint, now_datetime
+from frappe.query_builder.functions import Count, Sum
+from frappe.utils import add_to_date, cint, flt, now_datetime
 
-from benchpress.credits import admission
+from benchpress.credits import account, admission
 
 ACCOUNT = "Credit Account"
 ADMISSION = "Bench Admission"
@@ -35,6 +36,10 @@ HOLDING_STATUSES = ("Deploying", "Running")
 # `DEPLOY_JOB_TIMEOUT` is 7200 seconds, and this is that plus a margin. A claim older than this
 # whose bench is still `Deploying` belongs to a job that no longer exists.
 STALE_DEPLOY_HOURS = 3
+
+# Both aggregates are floats at precision 6, so they are compared with a tolerance rather than
+# for equality. Anything larger than this is drift, not arithmetic.
+TOLERANCE = 1e-6
 
 # A claim is taken in the request; the bench only leaves `Draft` when a worker picks the deploy
 # up. Releasing on status alone would take the slot back from a deploy that is merely queued,
@@ -99,14 +104,21 @@ def _adopt_orphans() -> list[str]:
 
 
 def _heal_counters() -> list[str]:
-	"""Set every `active_instances` to the number of rows that account actually holds."""
+	"""Set every account's slot count and hold to what its own rows add up to."""
 	held = _claims_by_account()
 	healed = []
-	for row in frappe.get_all(ACCOUNT, fields=["name", "active_instances"]):
-		expected = held.get(row.name, 0)
-		if cint(row.active_instances) == expected:
+	for row in frappe.get_all(ACCOUNT, fields=["name", "active_instances", "reserved_credits"]):
+		totals = held.get(row.name) or {"slots": 0, "credits": 0.0}
+		slots_agree = cint(row.active_instances) == totals["slots"]
+		credits_agree = abs(flt(row.reserved_credits) - totals["credits"]) <= TOLERANCE
+		if slots_agree and credits_agree:
 			continue
-		frappe.db.set_value(ACCOUNT, row.name, "active_instances", expected, update_modified=False)
+		frappe.db.set_value(
+			ACCOUNT,
+			row.name,
+			{"active_instances": totals["slots"], "reserved_credits": totals["credits"]},
+			update_modified=False,
+		)
 		healed.append(row.name)
 	return healed
 
@@ -116,12 +128,12 @@ def _bench_statuses(bench_names: list[str]) -> dict[str, str]:
 	return {row.name: row.status for row in rows}
 
 
-def _claims_by_account() -> dict[str, int]:
+def _claims_by_account() -> dict[str, dict]:
 	table = DocType(ADMISSION)
 	rows = (
 		frappe.qb.from_(table)
-		.select(table.account, Count("*").as_("total"))
+		.select(table.account, Count("*").as_("slots"), Sum(table.held_credits).as_("credits"))
 		.groupby(table.account)
 		.run(as_dict=True)
 	)
-	return {row.account: row.total for row in rows}
+	return {row.account: {"slots": row.slots, "credits": flt(row.credits, account.PRECISION)} for row in rows}

--- a/benchpress/credits/admission_repair.py
+++ b/benchpress/credits/admission_repair.py
@@ -13,10 +13,10 @@ be killed between them. A worker killed mid-deploy leaks a slot and the credits 
 forever, and a caller with a cap of two is then locked out until somebody notices - so this runs
 on the `*/5` cron beside the balance sweep, not on the daily list.
 
-It is pure database work: three grouped reads, no Docker call anywhere, which is why it is safe
+It is pure database work: a handful of grouped reads, no Docker call anywhere, which is why it is safe
 on `queue-short` for exactly the reason `sweep.enforce_limits` is.
 
-Three rules, in order. Expiring first and healing last is what makes a double release harmless:
+Four rules, in order. Expiring first and healing last is what makes a double release harmless:
 the counter follows the rows, so it cannot be driven negative by a release that ran twice.
 """
 
@@ -30,6 +30,7 @@ from benchpress.credits import account, admission
 ACCOUNT = "Credit Account"
 ADMISSION = "Bench Admission"
 BENCH = "Bench Instance"
+SITE = "Bench Site"
 
 HOLDING_STATUSES = ("Deploying", "Running")
 
@@ -48,15 +49,35 @@ CLAIM_GRACE_MINUTES = 15
 
 
 def reconcile_admissions() -> dict:
-	"""Expire stranded claims, adopt orphaned instances, then heal the counters."""
+	"""Expire stranded claims, retire stranded sites, adopt orphaned instances, heal the counters."""
 	released = _release_stranded()
+	retired = _retire_stranded_sites()
 	adopted = _adopt_orphans()
 	healed = _heal_counters()
-	if released or adopted or healed:
+	if released or retired or adopted or healed:
 		frappe.logger("benchpress").warning(
-			f"admission drift: released {len(released)}, adopted {len(adopted)}, healed {len(healed)}"
+			f"admission drift: released {len(released)}, retired {len(retired)}, "
+			f"adopted {len(adopted)}, healed {len(healed)}"
 		)
-	return {"released": released, "adopted": adopted, "healed": healed}
+	return {"released": released, "retired": retired, "adopted": adopted, "healed": healed}
+
+
+def _retire_stranded_sites() -> list[str]:
+	"""Deactivate every site name claimed for a deploy that never arrived.
+
+	`api.create_bench` claims the name as `Creating` and a worker sets it `Active`, so a claim
+	still `Creating` after the deploy window belongs to a job that no longer exists. Deactivated
+	and never deleted: an `Inactive` row can still own a live database, and the bench that
+	claimed the name keeps it - a redeploy reactivates the same row.
+
+	`patches.retire_orphaned_creating_sites` did this once for a removed endpoint; a claim in
+	the request makes `Creating` a state a dead worker can reach again, so it is a standing rule.
+	"""
+	cutoff = add_to_date(now_datetime(), hours=-STALE_DEPLOY_HOURS)
+	stranded = frappe.get_all(SITE, filters={"status": "Creating", "modified": ("<", cutoff)}, pluck="name")
+	for name in stranded:
+		frappe.db.set_value(SITE, name, "status", "Inactive", update_modified=False)
+	return stranded
 
 
 def _release_stranded() -> list[str]:

--- a/benchpress/credits/admission_repair.py
+++ b/benchpress/credits/admission_repair.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""The repair pass for admission, because a slot is denormalised twice over.
+
+Named for admission and not for reconciliation: `credits.reconcile` was the burn-rate meter's
+repair pass, `test_meter_gone` asserts that name never comes back, and this repairs a count of
+rows rather than a rate.
+
+`Bench Admission` rows are the truth, `Credit Account.active_instances` is a count of them, and
+both are written by workers that can be killed between the two. A worker killed mid-deploy leaks
+a slot forever, and a caller with a cap of two is then locked out until somebody notices - so
+this runs on the `*/5` cron beside the balance sweep, not on the daily list.
+
+It is pure database work: three grouped reads, no Docker call anywhere, which is why it is safe
+on `queue-short` for exactly the reason `sweep.enforce_limits` is.
+
+Three rules, in order. Expiring first and healing last is what makes a double release harmless:
+the counter follows the rows, so it cannot be driven negative by a release that ran twice.
+"""
+
+import frappe
+from frappe.query_builder import DocType
+from frappe.query_builder.functions import Count
+from frappe.utils import add_to_date, cint, now_datetime
+
+from benchpress.credits import admission
+
+ACCOUNT = "Credit Account"
+ADMISSION = "Bench Admission"
+BENCH = "Bench Instance"
+
+HOLDING_STATUSES = ("Deploying", "Running")
+
+# `DEPLOY_JOB_TIMEOUT` is 7200 seconds, and this is that plus a margin. A claim older than this
+# whose bench is still `Deploying` belongs to a job that no longer exists.
+STALE_DEPLOY_HOURS = 3
+
+
+def reconcile_admissions() -> dict:
+	"""Expire stranded claims, adopt orphaned instances, then heal the counters."""
+	released = _release_stranded()
+	adopted = _adopt_orphans()
+	healed = _heal_counters()
+	if released or adopted or healed:
+		frappe.logger("benchpress").warning(
+			f"admission drift: released {len(released)}, adopted {len(adopted)}, healed {len(healed)}"
+		)
+	return {"released": released, "adopted": adopted, "healed": healed}
+
+
+def _release_stranded() -> list[str]:
+	"""Drop every claim whose bench is no longer deploying or running, or has stopped trying."""
+	claims = frappe.get_all(ADMISSION, fields=["bench", "claimed_at"])
+	if not claims:
+		return []
+	statuses = _bench_statuses([claim.bench for claim in claims])
+	cutoff = add_to_date(now_datetime(), hours=-STALE_DEPLOY_HOURS)
+	released = []
+	for claim in claims:
+		status = statuses.get(claim.bench)
+		if status in HOLDING_STATUSES and not _deploy_abandoned(status, claim.claimed_at, cutoff):
+			continue
+		if status == "Deploying":
+			# A bench nobody is deploying is not deploying.
+			frappe.db.set_value(BENCH, claim.bench, "status", "Error")
+		admission.release(claim.bench)
+		released.append(claim.bench)
+	return released
+
+
+def _deploy_abandoned(status: str, claimed_at, cutoff) -> bool:
+	return status == "Deploying" and bool(claimed_at) and claimed_at < cutoff
+
+
+def _adopt_orphans() -> list[str]:
+	"""Claim a slot for every live instance that holds none, so the counts start honest.
+
+	The twin of the stranded rule, and what makes the feature safe to switch on with instances
+	already running: those benches predate the first claim and would otherwise be free.
+	"""
+	held = set(frappe.get_all(ADMISSION, pluck="bench"))
+	live = frappe.get_all(BENCH, filters={"status": ("in", HOLDING_STATUSES)}, fields=["name", "owner"])
+	adopted = []
+	for bench in live:
+		if bench.name in held:
+			continue
+		# No limit: adoption records what is already running, and must never refuse it.
+		if admission.claim(bench.owner, bench.name, 0):
+			adopted.append(bench.name)
+	return adopted
+
+
+def _heal_counters() -> list[str]:
+	"""Set every `active_instances` to the number of rows that account actually holds."""
+	held = _claims_by_account()
+	healed = []
+	for row in frappe.get_all(ACCOUNT, fields=["name", "active_instances"]):
+		expected = held.get(row.name, 0)
+		if cint(row.active_instances) == expected:
+			continue
+		frappe.db.set_value(ACCOUNT, row.name, "active_instances", expected, update_modified=False)
+		healed.append(row.name)
+	return healed
+
+
+def _bench_statuses(bench_names: list[str]) -> dict[str, str]:
+	rows = frappe.get_all(BENCH, filters={"name": ("in", bench_names)}, fields=["name", "status"])
+	return {row.name: row.status for row in rows}
+
+
+def _claims_by_account() -> dict[str, int]:
+	table = DocType(ADMISSION)
+	rows = (
+		frappe.qb.from_(table)
+		.select(table.account, Count("*").as_("total"))
+		.groupby(table.account)
+		.run(as_dict=True)
+	)
+	return {row.account: row.total for row in rows}

--- a/benchpress/credits/drill.py
+++ b/benchpress/credits/drill.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""Setup and teardown for `scripts/admission_drill.py`, the concurrency drill.
+
+Nothing here is whitelisted, and nothing here may become whitelisted: cleanup deletes with
+`force=True` and has no business being reachable over HTTP. The harness reaches it through
+`bench --site frontend execute benchpress.credits.drill.<fn>`.
+
+The drill fires one caller at **N distinct labs**. `get_instance_id` is `md5(email + lab)`, so
+N calls naming one lab all name the same bench - a same-lab drill would hold at the cap because
+there was only ever one thing to admit, and would report a pass against a gate that does
+nothing. Distinct labs are the whole point.
+"""
+
+import frappe
+from frappe.utils import cint
+
+from benchpress.credits import account, config
+
+ACCOUNT = "Credit Account"
+ADMISSION = "Bench Admission"
+BENCH = "Bench Instance"
+LEDGER = "Credit Ledger Entry"
+
+DRILL_USER = "admission-drill@example.com"
+DRILL_ROLE = "BenchPress User"
+LAB_PREFIX = "drill-"
+DRILL_BALANCE = 100000.0
+
+
+def setup(workers: int = 12, cap: int = 1) -> dict:
+	"""Open the drill account, mint its labs and its token, and set the cap. Idempotent.
+
+	Returns everything the harness needs, including `cap_field` and `cap_before` so it can put
+	the site's own cap back: which field the limit comes from depends on whether credits are on,
+	and the drill must not assume.
+	"""
+	workers = cint(workers)
+	user = _ensure_user()
+	labs = [_ensure_lab(index) for index in range(workers)]
+	_fund(user)
+	cap_field, cap_before = _set_cap(cap)
+	frappe.db.commit()
+	return {
+		"user": user,
+		"api_key": frappe.db.get_value("User", user, "api_key"),
+		"api_secret": frappe.utils.password.get_decrypted_password("User", user, "api_secret"),
+		"labs": labs,
+		"base_domain": frappe.db.get_single_value("BenchPress Settings", "base_domain"),
+		"credits_enabled": bool(config.credits_enabled()),
+		"cap_field": cap_field,
+		"cap_before": cap_before,
+		"cap": cint(cap),
+	}
+
+
+def restore(cap_field: str, cap_before) -> dict:
+	"""Put the site's own concurrency cap back."""
+	frappe.db.set_single_value("Credit Settings", cap_field, cint(cap_before))
+	frappe.clear_cache(doctype="Credit Settings")
+	frappe.db.commit()
+	return {cap_field: cint(cap_before)}
+
+
+def report() -> dict:
+	"""What the drill asserts on: the counter, and the rows the counter is meant to count."""
+	return {
+		"user": DRILL_USER,
+		"active_instances": cint(frappe.db.get_value(ACCOUNT, DRILL_USER, "active_instances")),
+		"admission_rows": frappe.db.count(ADMISSION, {"account": DRILL_USER}),
+		"benches": frappe.db.count(BENCH, {"owner": DRILL_USER}),
+	}
+
+
+def cleanup() -> dict:
+	"""Remove everything the drill made, filtered by the drill user and the `drill-` labs.
+
+	Never by status and never by owner alone: this runs on a host serving real tenants, and a
+	filter that reads "everything this user owns" is one typo away from being everything.
+	"""
+	labs = frappe.get_all("Lab", filters={"lab_id": ("like", f"{LAB_PREFIX}%")}, pluck="name")
+	benches = (
+		frappe.get_all(BENCH, filters={"owner": DRILL_USER, "lab": ("in", labs)}, fields=["name"])
+		if labs
+		else []
+	)
+	for bench in benches:
+		_delete_bench(bench.name)
+	frappe.db.delete(ADMISSION, {"account": DRILL_USER})
+	for lab in labs:
+		frappe.delete_doc("Lab", lab, force=True, ignore_permissions=True)
+	frappe.db.delete(LEDGER, {"account": DRILL_USER})
+	frappe.db.delete(ACCOUNT, {"user": DRILL_USER})
+	frappe.db.commit()
+	return {
+		"benches": len(benches),
+		"labs": len(labs),
+		"active_instances": cint(frappe.db.get_value(ACCOUNT, DRILL_USER, "active_instances")),
+		"admission_rows": frappe.db.count(ADMISSION, {"account": DRILL_USER}),
+	}
+
+
+def _delete_bench(bench_name: str) -> None:
+	from benchpress.deploy_manager import teardown_bench
+
+	bench = frappe.get_doc(BENCH, bench_name)
+	if bench.container_id:
+		try:
+			teardown_bench(bench)
+		except Exception:
+			# Best-effort, and named rather than swallowed: a drill container the harness cannot
+			# reach is an operator's problem, not a silent leak.
+			frappe.logger("benchpress").warning(f"drill: could not tear down {bench_name}")
+	for site in frappe.get_all("Bench Site", filters={"bench": bench_name}, pluck="name"):
+		frappe.delete_doc("Bench Site", site, force=True, ignore_permissions=True)
+	frappe.delete_doc(BENCH, bench_name, force=True, ignore_permissions=True)
+
+
+def _ensure_user() -> str:
+	if not frappe.db.exists("User", DRILL_USER):
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": DRILL_USER,
+				"first_name": "Admission",
+				"last_name": "Drill",
+				"send_welcome_email": 0,
+				"roles": [{"role": DRILL_ROLE}],
+			}
+		).insert(ignore_permissions=True)
+	user = frappe.get_doc("User", DRILL_USER)
+	if DRILL_ROLE not in {row.role for row in user.roles}:
+		user.append("roles", {"role": DRILL_ROLE})
+	user.api_key = user.api_key or frappe.generate_hash(length=15)
+	user.api_secret = frappe.generate_hash(length=15)
+	user.save(ignore_permissions=True)
+	return user.name
+
+
+def _ensure_lab(index: int) -> str:
+	lab_id = f"{LAB_PREFIX}{index}"
+	if frappe.db.exists("Lab", lab_id):
+		return lab_id
+	return (
+		frappe.get_doc(
+			{
+				"doctype": "Lab",
+				"lab_id": lab_id,
+				"title": f"Admission drill {index}",
+				"frappe_version": "version-15",
+				# A tag that exists nowhere: with deploys disabled nothing reads it, and with
+				# them enabled a pull failure is a far cheaper mistake than a real build.
+				"image_tag": "benchpress/admission-drill:latest",
+				"instance_size": config.default_size().name if config.default_size() else None,
+			}
+		)
+		.insert(ignore_permissions=True)
+		.name
+	)
+
+
+def _fund(user: str) -> None:
+	"""Enough credits that nothing is refused for the wrong reason. Set, not granted.
+
+	The drill measures the concurrency claim. A shortfall refusal would fail it for a reason
+	that has nothing to do with what is being measured, and a real grant would leave money on a
+	live site's ledger.
+	"""
+	account.ensure_account(user)
+	frappe.db.set_value(ACCOUNT, user, "balance", DRILL_BALANCE, update_modified=False)
+
+
+def _set_cap(cap: int) -> tuple[str, int]:
+	field = "max_concurrent_free" if config.credits_enabled() else "max_concurrent_uncredited"
+	before = cint(frappe.db.get_single_value("Credit Settings", field))
+	frappe.db.set_single_value("Credit Settings", field, cint(cap))
+	frappe.clear_cache(doctype="Credit Settings")
+	return field, before

--- a/benchpress/credits/drill.py
+++ b/benchpress/credits/drill.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Venkatesh and contributors
 # For license information, please see license.txt
 
-"""Setup and teardown for `scripts/admission_drill.py`, the concurrency drill.
+"""Setup and teardown for `scripts/admission_drill.py`, the admission drill.
 
 Nothing here is whitelisted, and nothing here may become whitelisted: cleanup deletes with
 `force=True` and has no business being reachable over HTTP. The harness reaches it through
@@ -11,10 +11,14 @@ The drill fires one caller at **N distinct labs**. `get_instance_id` is `md5(ema
 N calls naming one lab all name the same bench - a same-lab drill would hold at the cap because
 there was only ever one thing to admit, and would report a pass against a gate that does
 nothing. Distinct labs are the whole point.
+
+There are two modes. `cap` moves the concurrency limit and funds the account past anything it
+could be refused for; `credits` lifts the limit and funds it with exactly three leases. Each one
+has to be able to fail for its own reason and no other.
 """
 
 import frappe
-from frappe.utils import cint
+from frappe.utils import cint, flt
 
 from benchpress.credits import account, config
 
@@ -26,20 +30,35 @@ LEDGER = "Credit Ledger Entry"
 DRILL_USER = "admission-drill@example.com"
 DRILL_ROLE = "BenchPress User"
 LAB_PREFIX = "drill-"
-DRILL_BALANCE = 100000.0
+
+# Every drill lab prices its own lease, so what a drill admission costs does not depend on which
+# plan the site happens to default to. `credits` mode divides a balance by this and expects the
+# quotient.
+LEASE_PRICE = 1.0
+
+# `cap` mode measures the concurrency claim, so its account is funded past anything it could be
+# refused for. `credits` mode measures the hold, so its account affords exactly three of them.
+CAP_MODE_BALANCE = 100000.0
+CREDIT_MODE_BALANCE = 3.0
 
 
-def setup(workers: int = 12, cap: int = 1) -> dict:
+def setup(workers: int = 12, cap: int = 1, mode: str = "cap") -> dict:
 	"""Open the drill account, mint its labs and its token, and set the cap. Idempotent.
 
 	Returns everything the harness needs, including `cap_field` and `cap_before` so it can put
 	the site's own cap back: which field the limit comes from depends on whether credits are on,
 	and the drill must not assume.
+
+	`credits` mode lifts the cap to unlimited, because a run that measures the hold must not be
+	able to pass by refusing on the count instead.
 	"""
 	workers = cint(workers)
+	credits_mode = mode == "credits"
 	user = _ensure_user()
 	labs = [_ensure_lab(index) for index in range(workers)]
-	_fund(user)
+	balance = CREDIT_MODE_BALANCE if credits_mode else CAP_MODE_BALANCE
+	_fund(user, balance)
+	cap = 0 if credits_mode else cint(cap)
 	cap_field, cap_before = _set_cap(cap)
 	frappe.db.commit()
 	return {
@@ -51,7 +70,10 @@ def setup(workers: int = 12, cap: int = 1) -> dict:
 		"credits_enabled": bool(config.credits_enabled()),
 		"cap_field": cap_field,
 		"cap_before": cap_before,
-		"cap": cint(cap),
+		"cap": cap,
+		"mode": mode,
+		"balance": balance,
+		"lease_price": LEASE_PRICE,
 	}
 
 
@@ -75,12 +97,23 @@ def restore(cap_field: str, cap_before) -> dict:
 
 def report() -> dict:
 	"""What the drill asserts on: the counter, and the rows the counter is meant to count."""
+	row = frappe.db.get_value(
+		ACCOUNT, DRILL_USER, ["active_instances", "reserved_credits", "balance"], as_dict=True
+	)
 	return {
 		"user": DRILL_USER,
-		"active_instances": cint(frappe.db.get_value(ACCOUNT, DRILL_USER, "active_instances")),
+		"active_instances": cint(row.active_instances) if row else 0,
+		"reserved_credits": flt(row.reserved_credits) if row else 0.0,
+		"balance": flt(row.balance) if row else 0.0,
 		"admission_rows": frappe.db.count(ADMISSION, {"account": DRILL_USER}),
+		"held_credits": flt(_held_total()),
 		"benches": frappe.db.count(BENCH, {"owner": DRILL_USER}),
 	}
+
+
+def _held_total() -> float:
+	rows = frappe.get_all(ADMISSION, filters={"account": DRILL_USER}, pluck="held_credits")
+	return sum(flt(held) for held in rows)
 
 
 def stage_real_lab(image_tag: str, size: str = "Small") -> str:
@@ -205,8 +238,11 @@ def _api_secret(user: str) -> str | None:
 
 
 def _ensure_lab(index: int) -> str:
+	"""One drill lab, priced at `LEASE_PRICE`. Re-priced on every run, because a lab outlives one."""
 	lab_id = f"{LAB_PREFIX}{index}"
 	if frappe.db.exists("Lab", lab_id):
+		frappe.db.set_value("Lab", lab_id, "deploy_credits", LEASE_PRICE, update_modified=False)
+		frappe.clear_document_cache("Lab", lab_id)
 		return lab_id
 	return (
 		frappe.get_doc(
@@ -219,6 +255,7 @@ def _ensure_lab(index: int) -> str:
 				# them enabled a pull failure is a far cheaper mistake than a real build.
 				"image_tag": "benchpress/admission-drill:latest",
 				"instance_size": config.default_size().name if config.default_size() else None,
+				"deploy_credits": LEASE_PRICE,
 			}
 		)
 		.insert(ignore_permissions=True)
@@ -226,15 +263,22 @@ def _ensure_lab(index: int) -> str:
 	)
 
 
-def _fund(user: str) -> None:
-	"""Enough credits that nothing is refused for the wrong reason. Set, not granted.
+def _fund(user: str, balance: float) -> None:
+	"""Set the drill account to exactly `balance`, holding nothing. Set, not granted.
 
-	The drill measures the concurrency claim. A shortfall refusal would fail it for a reason
-	that has nothing to do with what is being measured, and a real grant would leave money on a
-	live site's ledger.
+	Set rather than granted because a real grant would leave money on a live site's ledger, and
+	exactly rather than at least because `credits` mode divides this figure by the lease price
+	and expects the quotient. The claims and the aggregates go with it: a previous run that was
+	not cleaned up would otherwise start this one with credits already reserved.
 	"""
 	account.ensure_account(user)
-	frappe.db.set_value(ACCOUNT, user, "balance", DRILL_BALANCE, update_modified=False)
+	frappe.db.delete(ADMISSION, {"account": user})
+	frappe.db.set_value(
+		ACCOUNT,
+		user,
+		{"balance": flt(balance), "active_instances": 0, "reserved_credits": 0.0},
+		update_modified=False,
+	)
 
 
 def _set_cap(cap: int) -> tuple[str, int]:

--- a/benchpress/credits/drill.py
+++ b/benchpress/credits/drill.py
@@ -70,7 +70,7 @@ def setup(workers: int = 12, cap: int = 1, mode: str = "cap") -> dict:
 	cap = 0 if mode in UNCAPPED_MODES else cint(cap)
 	cap_field, cap_before = _set_cap(cap)
 	base_domain = frappe.db.get_single_value("BenchPress Settings", "base_domain")
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep -- the drill's workers are separate processes and cannot see uncommitted fixtures
 	return {
 		"user": user,
 		"api_key": frappe.db.get_value("User", user, "api_key"),
@@ -95,7 +95,7 @@ def ensure_drill_user() -> str:
 	Separate from `setup` so a caller can get the token without minting labs or moving the cap.
 	"""
 	user = _ensure_user()
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep -- the token has to exist for a process that is not this one
 	return f"{frappe.db.get_value('User', user, 'api_key')}:{_api_secret(user)}"
 
 
@@ -103,7 +103,7 @@ def restore(cap_field: str, cap_before) -> dict:
 	"""Put the site's own concurrency cap back."""
 	frappe.db.set_single_value("Credit Settings", cap_field, cint(cap_before))
 	frappe.clear_cache(doctype="Credit Settings")
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep -- the cap must go back even if the caller dies mid-request
 	return {cap_field: cint(cap_before)}
 
 
@@ -153,7 +153,7 @@ def stage_real_lab(image_tag: str, size: str = "Small") -> str:
 				"enable_code_server": 0,
 			}
 		).insert(ignore_permissions=True)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep -- the workers deploy against this lab from their own processes
 	return lab_id
 
 
@@ -194,7 +194,7 @@ def cleanup() -> dict:
 		frappe.delete_doc("Lab", lab, force=True, ignore_permissions=True)
 	frappe.db.delete(LEDGER, {"account": DRILL_USER})
 	frappe.db.delete(ACCOUNT, {"user": DRILL_USER})
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep -- cleanup on a host serving real tenants must be durable
 	return {
 		"benches": len(benches),
 		"labs": len(labs),

--- a/benchpress/credits/drill.py
+++ b/benchpress/credits/drill.py
@@ -45,7 +45,7 @@ def setup(workers: int = 12, cap: int = 1) -> dict:
 	return {
 		"user": user,
 		"api_key": frappe.db.get_value("User", user, "api_key"),
-		"api_secret": frappe.utils.password.get_decrypted_password("User", user, "api_secret"),
+		"api_secret": _api_secret(user),
 		"labs": labs,
 		"base_domain": frappe.db.get_single_value("BenchPress Settings", "base_domain"),
 		"credits_enabled": bool(config.credits_enabled()),
@@ -53,6 +53,16 @@ def setup(workers: int = 12, cap: int = 1) -> dict:
 		"cap_before": cap_before,
 		"cap": cint(cap),
 	}
+
+
+def ensure_drill_user() -> str:
+	"""Open the drill user and its API keys on their own, and return the token as `key:secret`.
+
+	Separate from `setup` so a caller can get the token without minting labs or moving the cap.
+	"""
+	user = _ensure_user()
+	frappe.db.commit()
+	return f"{frappe.db.get_value('User', user, 'api_key')}:{_api_secret(user)}"
 
 
 def restore(cap_field: str, cap_before) -> dict:
@@ -183,9 +193,15 @@ def _ensure_user() -> str:
 	if DRILL_ROLE not in {row.role for row in user.roles}:
 		user.append("roles", {"role": DRILL_ROLE})
 	user.api_key = user.api_key or frappe.generate_hash(length=15)
-	user.api_secret = frappe.generate_hash(length=15)
+	if not _api_secret(user.name):
+		user.api_secret = frappe.generate_hash(length=15)
 	user.save(ignore_permissions=True)
 	return user.name
+
+
+def _api_secret(user: str) -> str | None:
+	# Absent rather than an exception: the row exists before its key does.
+	return frappe.utils.password.get_decrypted_password("User", user, "api_secret", raise_exception=False)
 
 
 def _ensure_lab(index: int) -> str:

--- a/benchpress/credits/drill.py
+++ b/benchpress/credits/drill.py
@@ -73,6 +73,51 @@ def report() -> dict:
 	}
 
 
+def stage_real_lab(image_tag: str, size: str = "Small") -> str:
+	"""A drill lab whose image already exists, for the runs that need a container to appear.
+
+	It carries the `drill-` prefix like every other drill lab, so `cleanup` tears down whatever
+	it deployed rather than leaving a container behind.
+	"""
+	lab_id = f"{LAB_PREFIX}real"
+	if not frappe.db.exists("Lab", lab_id):
+		frappe.get_doc(
+			{
+				"doctype": "Lab",
+				"lab_id": lab_id,
+				"title": "Admission drill (real image)",
+				"frappe_version": "version-15",
+				"image_tag": image_tag,
+				"instance_size": size,
+				"enable_code_server": 0,
+			}
+		).insert(ignore_permissions=True)
+	frappe.db.commit()
+	return lab_id
+
+
+def purge_deploy_jobs() -> dict:
+	"""Cancel the deploy jobs the drill's own requests queued. Call before any worker restarts.
+
+	`enqueue_after_commit=True` pushes to Redis when the request commits, so stopping the worker
+	delays a deploy rather than preventing it. Restarting one at the end of a run would deploy
+	every bench the drill just admitted, on a host with 18 GB free.
+	"""
+	from frappe.utils.background_jobs import get_job
+
+	cancelled = []
+	for bench in _drill_benches():
+		job = get_job(f"deploy_bench:{bench}")
+		if not job:
+			continue
+		try:
+			job.cancel()
+		except Exception:
+			continue  # already running or already gone; either way it is not ours to stop
+		cancelled.append(bench)
+	return {"cancelled": len(cancelled)}
+
+
 def cleanup() -> dict:
 	"""Remove everything the drill made, filtered by the drill user and the `drill-` labs.
 
@@ -80,13 +125,9 @@ def cleanup() -> dict:
 	filter that reads "everything this user owns" is one typo away from being everything.
 	"""
 	labs = frappe.get_all("Lab", filters={"lab_id": ("like", f"{LAB_PREFIX}%")}, pluck="name")
-	benches = (
-		frappe.get_all(BENCH, filters={"owner": DRILL_USER, "lab": ("in", labs)}, fields=["name"])
-		if labs
-		else []
-	)
+	benches = _drill_benches()
 	for bench in benches:
-		_delete_bench(bench.name)
+		_delete_bench(bench)
 	frappe.db.delete(ADMISSION, {"account": DRILL_USER})
 	for lab in labs:
 		frappe.delete_doc("Lab", lab, force=True, ignore_permissions=True)
@@ -101,13 +142,22 @@ def cleanup() -> dict:
 	}
 
 
+def _drill_benches() -> list[str]:
+	labs = frappe.get_all("Lab", filters={"lab_id": ("like", f"{LAB_PREFIX}%")}, pluck="name")
+	if not labs:
+		return []
+	return frappe.get_all(BENCH, filters={"owner": DRILL_USER, "lab": ("in", labs)}, pluck="name")
+
+
 def _delete_bench(bench_name: str) -> None:
 	from benchpress.deploy_manager import teardown_bench
+	from benchpress.vpn_adapter import remove_bench_peer
 
 	bench = frappe.get_doc(BENCH, bench_name)
 	if bench.container_id:
 		try:
 			teardown_bench(bench)
+			remove_bench_peer(bench)
 		except Exception:
 			# Best-effort, and named rather than swallowed: a drill container the harness cannot
 			# reach is an operator's problem, not a silent leak.

--- a/benchpress/credits/drill.py
+++ b/benchpress/credits/drill.py
@@ -12,9 +12,10 @@ N calls naming one lab all name the same bench - a same-lab drill would hold at 
 there was only ever one thing to admit, and would report a pass against a gate that does
 nothing. Distinct labs are the whole point.
 
-There are two modes. `cap` moves the concurrency limit and funds the account past anything it
-could be refused for; `credits` lifts the limit and funds it with exactly three leases. Each one
-has to be able to fail for its own reason and no other.
+There are three modes. `cap` moves the concurrency limit and funds the account past anything it
+could be refused for; `credits` lifts the limit and funds it with exactly three leases;
+`site-name` lifts the limit, funds it the same way as `cap`, and points every request at one
+site name. Each one has to be able to fail for its own reason and no other.
 """
 
 import frappe
@@ -26,10 +27,19 @@ ACCOUNT = "Credit Account"
 ADMISSION = "Bench Admission"
 BENCH = "Bench Instance"
 LEDGER = "Credit Ledger Entry"
+SITE = "Bench Site"
 
 DRILL_USER = "admission-drill@example.com"
 DRILL_ROLE = "BenchPress User"
 LAB_PREFIX = "drill-"
+
+# The one name `site-name` mode makes every request ask for. A bare label, because
+# `docker_manager.resolve_site_name` adds the domain and rejects anything carrying its own.
+SITE_LABEL = "drill-site"
+
+# A mode that measures anything other than the count has to lift the count, or it would pass by
+# refusing on the cap instead of on what it came to measure.
+UNCAPPED_MODES = ("credits", "site-name")
 
 # Every drill lab prices its own lease, so what a drill admission costs does not depend on which
 # plan the site happens to default to. `credits` mode divides a balance by this and expects the
@@ -49,24 +59,26 @@ def setup(workers: int = 12, cap: int = 1, mode: str = "cap") -> dict:
 	the site's own cap back: which field the limit comes from depends on whether credits are on,
 	and the drill must not assume.
 
-	`credits` mode lifts the cap to unlimited, because a run that measures the hold must not be
-	able to pass by refusing on the count instead.
+	`credits` and `site-name` modes lift the cap to unlimited, because a run that measures
+	anything else must not be able to pass by refusing on the count instead.
 	"""
 	workers = cint(workers)
-	credits_mode = mode == "credits"
 	user = _ensure_user()
 	labs = [_ensure_lab(index) for index in range(workers)]
-	balance = CREDIT_MODE_BALANCE if credits_mode else CAP_MODE_BALANCE
+	balance = CREDIT_MODE_BALANCE if mode == "credits" else CAP_MODE_BALANCE
 	_fund(user, balance)
-	cap = 0 if credits_mode else cint(cap)
+	cap = 0 if mode in UNCAPPED_MODES else cint(cap)
 	cap_field, cap_before = _set_cap(cap)
+	base_domain = frappe.db.get_single_value("BenchPress Settings", "base_domain")
 	frappe.db.commit()
 	return {
 		"user": user,
 		"api_key": frappe.db.get_value("User", user, "api_key"),
 		"api_secret": _api_secret(user),
 		"labs": labs,
-		"base_domain": frappe.db.get_single_value("BenchPress Settings", "base_domain"),
+		"base_domain": base_domain,
+		"site_label": SITE_LABEL if mode == "site-name" else None,
+		"site_name": f"{SITE_LABEL}.{base_domain}" if mode == "site-name" else None,
 		"credits_enabled": bool(config.credits_enabled()),
 		"cap_field": cap_field,
 		"cap_before": cap_before,
@@ -95,13 +107,19 @@ def restore(cap_field: str, cap_before) -> dict:
 	return {cap_field: cint(cap_before)}
 
 
-def report() -> dict:
-	"""What the drill asserts on: the counter, and the rows the counter is meant to count."""
+def report(site_name: str | None = None) -> dict:
+	"""What the drill asserts on: the counter, and the rows the counter is meant to count.
+
+	`site_name` is the contended name in `site-name` mode, and the two counts it adds are how
+	many rows and how many instances believe they own it. Both must read 1.
+	"""
 	row = frappe.db.get_value(
 		ACCOUNT, DRILL_USER, ["active_instances", "reserved_credits", "balance"], as_dict=True
 	)
 	return {
 		"user": DRILL_USER,
+		"named_sites": frappe.db.count(SITE, {"site_name": site_name}) if site_name else 0,
+		"named_benches": frappe.db.count(BENCH, {"site_name": site_name}) if site_name else 0,
 		"active_instances": cint(row.active_instances) if row else 0,
 		"reserved_credits": flt(row.reserved_credits) if row else 0.0,
 		"balance": flt(row.balance) if row else 0.0,
@@ -205,8 +223,8 @@ def _delete_bench(bench_name: str) -> None:
 			# Best-effort, and named rather than swallowed: a drill container the harness cannot
 			# reach is an operator's problem, not a silent leak.
 			frappe.logger("benchpress").warning(f"drill: could not tear down {bench_name}")
-	for site in frappe.get_all("Bench Site", filters={"bench": bench_name}, pluck="name"):
-		frappe.delete_doc("Bench Site", site, force=True, ignore_permissions=True)
+	for site in frappe.get_all(SITE, filters={"bench": bench_name}, pluck="name"):
+		frappe.delete_doc(SITE, site, force=True, ignore_permissions=True)
 	frappe.delete_doc(BENCH, bench_name, force=True, ignore_permissions=True)
 
 

--- a/benchpress/credits/guard.py
+++ b/benchpress/credits/guard.py
@@ -3,9 +3,12 @@
 
 """The gate: one decorator that can refuse an action before any work is queued.
 
-Phases 1-4 measured; this is where the economics start to say no. Everything refusable goes
-through `requires_credits`, so there is exactly one place that decides what "cannot afford" and
-"too many" mean, and exactly one shape of refusal.
+Everything refusable goes through `requires_admission`, so there is exactly one place that
+decides what "cannot afford" and "too many" mean, and exactly one shape of refusal.
+
+The concurrency cap is not here. It is not a count and a comparison any more but a claim, taken
+by `benchpress.credits.admission` against a row it inserts; what survives here is the number
+that claim is judged against.
 
 Two rules the refusals obey:
 
@@ -15,10 +18,9 @@ Two rules the refusals obey:
 - **`0` means unlimited.** Every cap reads its `Credit Settings` field and returns early on zero,
   so an operator disables a cap by clearing it rather than by editing code.
 
-Ordering inside the gate is deliberate: the caps run first because they are plain indexed counts,
-and the balance check last because it opens the account (posting the signup grant) as a side
-effect. A caller who is both at their cap and short of credits is told about the cap, fixes it,
-and then learns about the shortfall — two sentences, both actionable.
+Ordering inside the gate is deliberate: the claim and the caps run before the balance check, so
+a caller who is both at their cap and short of credits is told about the cap, fixes it, and then
+learns about the shortfall — two sentences, both actionable.
 
 Costs are **checks, not debits**. Nothing here writes to a balance; `metering` still owns every
 charge. What a start must prove is the price of one lease, which is the number the size picker
@@ -33,7 +35,7 @@ from frappe import _
 from frappe.utils import cint, flt, today
 
 from benchpress.benchpress.doctype.bench_instance import get_instance_id
-from benchpress.credits import account, config, lease
+from benchpress.credits import account, admission, config, lease
 from benchpress.permissions import has_app_permission
 
 ACCOUNT = "Credit Account"
@@ -44,12 +46,12 @@ SITE = "Bench Site"
 TOP_UP_ROUTE = config.TOP_UP_ROUTE
 
 
-def requires_credits(cost=None, caps=()):
+def requires_admission(cost=None, caps=()):
 	"""Refuse what the caller cannot pay for, or already has too many of.
 
 	`cost` and each entry in `caps` are called with the wrapped call's arguments by name, so they
-	read `data=` or `self=` rather than indexing a tuple. With the switch off the wrapper is a
-	pass-through and costs not one query.
+	read `data=` or `self=` rather than indexing a tuple. With the switch off only the slot claim
+	runs, and on a call about no instance that is nothing at all.
 
 	A caller without an app role is passed straight through to the endpoint's own guard. The gate
 	must never be the first thing a Guest meets: it would answer a permission question with an
@@ -60,7 +62,7 @@ def requires_credits(cost=None, caps=()):
 	def decorator(method):
 		@functools.wraps(method)
 		def wrapper(*args, **kwargs):
-			if config.credits_enabled() and has_app_permission():
+			if has_app_permission():
 				_enforce(method, cost, caps, args, kwargs)
 			return method(*args, **kwargs)
 
@@ -70,7 +72,16 @@ def requires_credits(cost=None, caps=()):
 
 
 def _enforce(method, cost, caps, args, kwargs) -> None:
+	"""Claim the slot first, then price the call.
+
+	The claim runs whatever the switch says, because concurrency is capacity rather than
+	economics and `0` is already the operator's way of turning it off. Everything below the
+	switch is money, and money does not exist on a site with credits off.
+	"""
 	arguments = _arguments_by_name(method, args, kwargs)
+	admission.claim(frappe.session.user, _subject_instance(**arguments), concurrency_limit())
+	if not config.credits_enabled():
+		return
 	for cap in caps:
 		cap(**arguments)
 	if cost:
@@ -112,24 +123,6 @@ def build_charge(**call) -> float:
 
 
 # --- The caps: one indexed count each, never a fetch-and-len -----------------
-
-
-def cap_concurrent_instances(**call) -> None:
-	"""The caller's running instances, not counting the one this call is about.
-
-	Redeploying one of N running instances still leaves N running, so counting the subject would
-	let the cap forbid the very people holding it from touching what they already have.
-	"""
-	limit = _concurrency_limit()
-	if not limit:
-		return
-	running = frappe.db.count(BENCH, _other_running_instances(**call))
-	if running >= limit:
-		frappe.throw(
-			_(
-				"You have {0} instances running, the most your plan allows. Stop one, or buy credits at {1} to raise the limit."
-			).format(limit, TOP_UP_ROUTE)
-		)
 
 
 def cap_sites_per_instance(**call) -> None:
@@ -183,29 +176,31 @@ def cap_builds_per_day(**call) -> None:
 		)
 
 
-def _other_running_instances(**call) -> dict:
-	subject = _subject_instance(**call)
-	filters = {"owner": frappe.session.user, "status": "Running"}
-	if subject:
-		filters["name"] = ("!=", subject)
-	return filters
-
-
 def _subject_instance(**call) -> str | None:
-	"""The instance this call is about — the document itself, or the one its payload names."""
+	"""The instance this call is about — the document itself, or the one its payload names.
+
+	`None` for a call that is about no instance at all, such as a device or an image build, and
+	`admission.claim` treats that as nothing to claim.
+	"""
 	bench = call.get("self")
 	if bench is not None:
 		return bench.name
-	lab_name = frappe.parse_json(call.get("data")).get("lab")
+	data = call.get("data")
+	lab_name = frappe.parse_json(data).get("lab") if data else None
 	return get_instance_id(frappe.session.user, lab_name) if lab_name else None
 
 
-def _concurrency_limit() -> int:
-	"""The paid ceiling once anything has been bought, the free one until then.
+def concurrency_limit() -> int:
+	"""How many instances this caller may hold at once. `0` means unlimited.
 
 	"Has paid" is the existence of a Purchase row, not a `lifetime_purchased` balance: a refund
 	clears the float, and somebody who bought and was refunded has still plainly paid.
+
+	With credits off there are no plans to read, so the cap is its own setting. It defaults to
+	`0`, which is what keeps an install that has never opted in behaving as it did.
 	"""
+	if not config.credits_enabled():
+		return cint(config.settings().max_concurrent_uncredited)
 	settings = config.settings()
 	paid = frappe.db.exists(LEDGER, {"account": frappe.session.user, "entry_type": account.PURCHASE})
 	return cint(settings.max_concurrent_paid if paid else settings.max_concurrent_free)

--- a/benchpress/credits/guard.py
+++ b/benchpress/credits/guard.py
@@ -6,9 +6,10 @@
 Everything refusable goes through `requires_admission`, so there is exactly one place that
 decides what "cannot afford" and "too many" mean, and exactly one shape of refusal.
 
-The concurrency cap is not here. It is not a count and a comparison any more but a claim, taken
-by `benchpress.credits.admission` against a row it inserts; what survives here is the number
-that claim is judged against.
+The concurrency cap is not here, and neither is the balance an instance is judged against. Both
+are a claim now rather than a count and a comparison, taken by `benchpress.credits.admission`
+against a row it inserts under one lock; what survives here is the numbers that claim is judged
+against and the functions that price a call.
 
 Two rules the refusals obey:
 
@@ -18,13 +19,14 @@ Two rules the refusals obey:
 - **`0` means unlimited.** Every cap reads its `Credit Settings` field and returns early on zero,
   so an operator disables a cap by clearing it rather than by editing code.
 
-Ordering inside the gate is deliberate: the claim and the caps run before the balance check, so
-a caller who is both at their cap and short of credits is told about the cap, fixes it, and then
-learns about the shortfall — two sentences, both actionable.
+Ordering inside the claim is deliberate: the cap is decided before the credits, so a caller who
+is both at their cap and short is told about the cap, fixes it, and then learns about the
+shortfall — two sentences, both actionable.
 
-Costs are **checks, not debits**. Nothing here writes to a balance; `metering` still owns every
-charge. What a start must prove is the price of one lease, which is the number the size picker
-quoted and the number the deploy is about to spend.
+Costs are **holds, not debits**. Nothing here writes to a balance; `metering` still owns every
+charge. What a start must prove is the price of one lease — the number the size picker quoted
+and the number the deploy is about to spend — and admission reserves it until that deploy
+spends it.
 """
 
 import functools
@@ -42,8 +44,6 @@ ACCOUNT = "Credit Account"
 BENCH = "Bench Instance"
 LEDGER = "Credit Ledger Entry"
 SITE = "Bench Site"
-
-TOP_UP_ROUTE = config.TOP_UP_ROUTE
 
 
 def requires_admission(cost=None, caps=()):
@@ -72,20 +72,27 @@ def requires_admission(cost=None, caps=()):
 
 
 def _enforce(method, cost, caps, args, kwargs) -> None:
-	"""Claim the slot first, then price the call.
+	"""Claim the slot and the credits together, then the caps that are about something else.
 
 	The claim runs whatever the switch says, because concurrency is capacity rather than
-	economics and `0` is already the operator's way of turning it off. Everything below the
-	switch is money, and money does not exist on a site with credits off.
+	economics and `0` is already the operator's way of turning it off. The hold inside it is
+	money, and money does not exist on a site with credits off — which is also why the price is
+	not even computed there.
+
+	The cap and the hold are one decision under one lock, so a caller at neither limit cannot be
+	admitted twice by two requests that read the same figures.
 	"""
 	arguments = _arguments_by_name(method, args, kwargs)
-	admission.claim(frappe.session.user, _subject_instance(**arguments), concurrency_limit())
+	subject = _subject_instance(**arguments)
+	needed = flt(cost(**arguments)) if cost and config.credits_enabled() else 0.0
+	admission.claim(frappe.session.user, subject, concurrency_limit(), needed)
 	if not config.credits_enabled():
 		return
 	for cap in caps:
 		cap(**arguments)
-	if cost:
-		_require_balance(cost(**arguments))
+	if needed and not subject:
+		# A custom image build holds no slot, so nothing held its price either: it stays a check.
+		require_balance(frappe.session.user, needed)
 
 
 def _arguments_by_name(method, args, kwargs) -> dict:
@@ -99,8 +106,8 @@ def _arguments_by_name(method, args, kwargs) -> dict:
 
 
 def instance_lease_cost(**call) -> float:
-	"""One lease on this instance's lab. `self` is the `Bench Instance` the method was called on."""
-	return lab_lease_cost(call["self"].lab)
+	"""One lease on this instance's lab, for a call that was handed the document itself."""
+	return lab_lease_cost(_called_on(call).lab)
 
 
 def payload_lease_cost(**call) -> float:
@@ -182,12 +189,17 @@ def _subject_instance(**call) -> str | None:
 	`None` for a call that is about no instance at all, such as a device or an image build, and
 	`admission.claim` treats that as nothing to claim.
 	"""
-	bench = call.get("self")
+	bench = _called_on(call)
 	if bench is not None:
 		return bench.name
 	data = call.get("data")
 	lab_name = frappe.parse_json(data).get("lab") if data else None
 	return get_instance_id(frappe.session.user, lab_name) if lab_name else None
+
+
+def _called_on(call):
+	"""The `Bench Instance` document this call carries, whether as a method's `self` or an argument."""
+	return call.get("self") or call.get("bench")
 
 
 def concurrency_limit() -> int:
@@ -222,19 +234,19 @@ def _site_limit(bench_name) -> int:
 def require_balance(user: str, needed) -> None:
 	"""Refuse by name, naming the shortfall and the route out of it.
 
+	What a caller may spend is `spendable` rather than `available`: credits an admitted deploy is
+	already holding are committed, and a renewal that spent them would overdraw the account the
+	moment that deploy reaches `Running`.
+
 	Takes the user rather than reading the session: a renewal is charged to the bench's owner,
 	who is not always whoever pressed the button.
 	"""
 	row = _account_row(user)
 	if row.is_suspended:
 		frappe.throw(_("This account is suspended, so nothing new can be started."))
-	available = account.available(row)
-	if flt(needed) > available:
-		frappe.throw(_shortfall_message(flt(needed), available))
-
-
-def _require_balance(needed) -> None:
-	require_balance(frappe.session.user, needed)
+	spendable = account.spendable(row)
+	if flt(needed) > spendable:
+		frappe.throw(account.shortfall_message(flt(needed), spendable))
 
 
 def _account_row(user: str):
@@ -249,9 +261,3 @@ def _account_row(user: str):
 	"""
 	name = account.ensure_account(user)
 	return frappe.db.get_value(ACCOUNT, name, account.BALANCE_FIELDS, as_dict=True, for_update=True)
-
-
-def _shortfall_message(needed, available) -> str:
-	return _("Not enough credits: this needs {0} and {1} are available — {2} short. Top up at {3}.").format(
-		flt(needed, 2), flt(available, 2), flt(needed - available, 2), TOP_UP_ROUTE
-	)

--- a/benchpress/credits/metering.py
+++ b/benchpress/credits/metering.py
@@ -21,7 +21,7 @@ billing events. `Active` means "this instance is inside a window somebody paid f
 
 import frappe
 
-from benchpress.credits import account, config, lease
+from benchpress.credits import account, admission, config, lease
 from benchpress.labs import bench_label
 
 
@@ -40,6 +40,9 @@ def on_bench_running(bench) -> None:
 	if not plan:
 		return
 	charge_lease(bench, lab, plan)
+	# Beside the charge, under the lock it just took: the credits admission reserved for this
+	# start have become the window it reserved them for, so they stop being held.
+	admission.release_hold(bench.name)
 	lease.arm(bench, lab, plan)
 
 

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -800,7 +800,7 @@ def _checked_exec(container_id: str, command: str, what: str) -> None:
 
 
 def _record_primary_site(bench, lab, admin_password: str) -> None:
-	"""Record the deploy's site as a `Bench Site`, which is what every site list reads.
+	"""Activate the `Bench Site` this deploy was admitted against, which every site list reads.
 
 	Idempotent: a deploy re-runs, so an existing row is refreshed rather than duplicated.
 
@@ -808,10 +808,7 @@ def _record_primary_site(bench, lab, admin_password: str) -> None:
 	`BenchPress User` read `if_owner`, so an admin redeploying somebody else's instance would
 	take the row over and empty that tenant's Sites tab.
 	"""
-	existing = frappe.db.get_value("Bench Site", {"bench": bench.name, "site_name": bench.site_name})
-	site = frappe.get_doc("Bench Site", existing) if existing else frappe.new_doc("Bench Site")
-	site.bench = bench.name
-	site.site_name = bench.site_name
+	site = _claimed_site(bench)
 	site.status = "Active"
 	site.admin_password = admin_password
 	site.owner = bench.owner
@@ -821,6 +818,24 @@ def _record_primary_site(bench, lab, admin_password: str) -> None:
 	site.save(ignore_permissions=True)
 	# No commit: the next log line commits, and committing here outlives a test rollback
 	# that discards the parent instance.
+
+
+def _claimed_site(bench):
+	"""The row `api.create_bench` claimed for this name, claiming it here if nothing did.
+
+	Raises when the name belongs to another bench. This is the last line of defence rather than
+	the constraint - the primary key is that - and a deploy that would write over somebody
+	else's site must fail loudly instead.
+	"""
+	if not frappe.db.exists("Bench Site", bench.site_name):
+		# A Desk deploy never went through `create_bench`, so nothing claimed the name for it.
+		from benchpress.api import _claim_site_name
+
+		_claim_site_name(bench)
+	site = frappe.get_doc("Bench Site", bench.site_name)
+	if site.bench != bench.name:
+		raise Exception(f"Site {bench.site_name} belongs to {site.bench}")
+	return site
 
 
 def _site_app_names(lab) -> list[str]:

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -16,7 +16,7 @@ from frappe.utils.file_lock import LockTimeoutError
 from frappe.utils.synchronization import filelock
 
 from benchpress import image_cache
-from benchpress.credits import lease, metering
+from benchpress.credits import admission, lease, metering
 from benchpress.deploy_pipeline import DeployLogWriter, DeployPipeline
 from benchpress.docker_manager import (
 	build_lab_image,
@@ -733,6 +733,9 @@ def _deploy_bench(bench_name: str) -> None:
 		# Settle whatever did run and charge nothing further: a failed deploy is free, and a
 		# failed *re*deploy of an instance that was already burning must not keep burning.
 		metering.on_bench_stopped(bench)
+		# Beside the settle, not behind it: `on_bench_stopped` is free on a bench that never
+		# held a lease, which is every deploy that fails before Running.
+		admission.release(bench.name)
 		frappe.db.commit()
 		append_log(f"=== Deploy failed: {e!s} ===", "error")
 		frappe.db.set_value("Deploy Log", deploy_log_name, "log_type", "error")
@@ -857,11 +860,13 @@ def redeploy_bench(bench_name: str) -> None:
 
 
 def _redeploy_bench(bench_name: str) -> None:
-	teardown_bench(frappe.get_doc("Bench Instance", bench_name))
+	# The slot is held across the whole redeploy: releasing between the two halves would hand it
+	# to somebody else and leave this caller one over their limit when their own deploy lands.
+	teardown_bench(frappe.get_doc("Bench Instance", bench_name), release_admission=False)
 	_deploy_bench(bench_name)
 
 
-def teardown_bench(bench) -> None:
+def teardown_bench(bench, *, release_admission: bool = True) -> None:
 	"""Return an instance to `Draft`: container, volume and site database all gone.
 
 	The one teardown path in the app. A redeploy runs it before building the instance again, and
@@ -870,6 +875,9 @@ def teardown_bench(bench) -> None:
 
 	Every removal is best-effort. A volume that was already gone, or a database that never
 	existed, must not leave the instance stuck describing resources it no longer has.
+
+	`release_admission=False` keeps the concurrency slot, and only `_redeploy_bench` passes it:
+	a redeploy is this plus a deploy, and the caller must not lose their own slot in between.
 	"""
 	if bench.container_id:
 		try:
@@ -896,6 +904,9 @@ def teardown_bench(bench) -> None:
 	# this the burning flag would survive the teardown and the fresh container — which
 	# `_deploy_bench` bills through the same idempotence guard — would run unmetered.
 	metering.on_bench_stopped(bench)
+
+	if release_admission:
+		admission.release(bench.name)
 
 	bench.container_id = None
 	bench.container_image = None
@@ -1065,6 +1076,9 @@ def stop_bench(bench_name: str, from_claim: bool = False) -> None:
 	lease.record_stopped(bench, expired)
 	bench.status = "Stopped"
 	metering.on_bench_stopped(bench)
+	# Stopped is free, so it must stop holding a slot too: a caller at their cap who stops
+	# everything they own would otherwise never start anything again.
+	admission.release(bench.name)
 	bench.save(ignore_permissions=True)
 	_deactivate_bench_sites(bench)
 	if expired:

--- a/benchpress/docker_manager.py
+++ b/benchpress/docker_manager.py
@@ -62,16 +62,15 @@ SITE_LABEL_MAX_LENGTH = 63
 SITE_LABEL_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
 
 
-def resolve_site_name(raw_site_name: str | None, *, exclude_bench: str | None = None) -> str | None:
-	"""Normalize a caller-chosen site name and refuse anything unsafe or already taken.
+def resolve_site_name(raw_site_name: str | None) -> str | None:
+	"""Normalize a caller-chosen site name and refuse anything unsafe.
 
 	Returns `None` when `raw_site_name` is empty, so the caller falls back to its own
 	default. A bare label is required — dots are rejected rather than treated as an
 	already-qualified domain, so the resolved name is always exactly
-	`<label>.<base_domain>`, never an arbitrary suffix a caller supplied. The resolved
-	name becomes a MariaDB db/user name and an on-disk site folder, both unique
-	server-wide, so the collision check is global — `exclude_bench` exists only so a
-	redeploy can recheck its own name without colliding with itself.
+	`<label>.<base_domain>`, never an arbitrary suffix a caller supplied. Whether the name
+	is free is not decided here: `api._claim_site_name` claims it against the `Bench Site`
+	primary key, which is the only answer that cannot go stale between here and the deploy.
 	"""
 	if not raw_site_name or not raw_site_name.strip():
 		return None
@@ -91,17 +90,7 @@ def resolve_site_name(raw_site_name: str | None, *, exclude_bench: str | None = 
 			).format(raw_site_name, SITE_LABEL_MAX_LENGTH)
 		)
 	base_domain = frappe.db.get_single_value("BenchPress Settings", "base_domain") or "localhost"
-	resolved = f"{candidate}.{base_domain}"
-	_assert_site_name_available(resolved, exclude_bench)
-	return resolved
-
-
-def _assert_site_name_available(site_name: str, exclude_bench: str | None) -> None:
-	filters = {"site_name": site_name, "status": ("!=", "Inactive")}
-	if exclude_bench:
-		filters["bench"] = ("!=", exclude_bench)
-	if frappe.db.exists("Bench Site", filters):
-		frappe.throw(_("Site name '{0}' is already in use. Choose a different name.").format(site_name))
+	return f"{candidate}.{base_domain}"
 
 
 def _get_host_block_devices() -> list[str]:

--- a/benchpress/hooks.py
+++ b/benchpress/hooks.py
@@ -239,6 +239,9 @@ scheduler_events = {
 			# Both use the same conditional claim, so running together cannot double-stop a
 			# bench. It makes no Docker calls, so it is safe on either worker.
 			"benchpress.credits.drain.sweep_expired_leases",
+			# Not the daily list: a slot leaked by a killed worker is a lockout for a caller at
+			# their cap, and it costs three grouped reads and no Docker call to find.
+			"benchpress.credits.admission_repair.reconcile_admissions",
 		],
 		"0 2 * * *": [
 			"benchpress.mariadb_manager.scheduled_backup",

--- a/benchpress/patches.txt
+++ b/benchpress/patches.txt
@@ -24,3 +24,4 @@ benchpress.patches.backfill_bench_runtime
 benchpress.patches.seed_lease_plans
 benchpress.patches.index_ledger_request_id
 benchpress.patches.drop_burn_fields
+benchpress.patches.name_bench_sites_by_site_name

--- a/benchpress/patches/name_bench_sites_by_site_name.py
+++ b/benchpress/patches/name_bench_sites_by_site_name.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""Move `Bench Site` onto its site name as a primary key, which is the constraint that was missing.
+
+`site_name` keys a MariaDB database through `"_" + sha1(site_name)[:16]`, and
+`mariadb_manager` creates it with `CREATE OR REPLACE DATABASE`. Nothing stopped two rows from
+carrying one name, so two benches could share one database and the second could drop the
+first tenant's data. `autoname: field:site_name` closes that, and existing rows have to be
+moved onto their names before the constraint can hold.
+
+A duplicate loser is suffixed and deactivated, never deleted. An `Inactive` row can still own a
+live database - `stop_bench` deactivates without dropping - and `api._drop_bench_site_databases`
+reads `site_name` to find what to drop, so a row deleted here is a database nothing will ever
+clean up. The suffixed loser is the record that the collision happened.
+"""
+
+import frappe
+from frappe.model.rename_doc import rename_doc
+
+SITE = "Bench Site"
+
+# Furthest from gone first: a row describing a live site outranks one describing a stopped or
+# broken site, and among equals the newest describes the deployment that actually happened.
+STATUS_RANK = {"Active": 3, "Creating": 2, "Inactive": 1, "Error": 0}
+
+
+def execute():
+	rows = frappe.get_all(
+		SITE, fields=["name", "site_name", "status", "bench", "creation"], order_by="creation asc"
+	)
+	suffixed = _suffix_duplicates(rows)
+	renamed = _rename_onto_site_names(rows)
+	if suffixed or renamed:
+		frappe.logger("benchpress").info(
+			f"bench site keys: renamed {renamed or 'nothing'}; deduped {suffixed or 'nothing'}"
+		)
+
+
+def _suffix_duplicates(rows: list) -> list[str]:
+	"""Leave one row per site name, and move every other one aside under a name of its own."""
+	by_site_name = {}
+	for row in rows:
+		by_site_name.setdefault(row.site_name, []).append(row)
+	suffixed = []
+	for site_name, contenders in by_site_name.items():
+		if len(contenders) < 2:
+			continue
+		for loser in sorted(contenders, key=_survival_rank, reverse=True)[1:]:
+			loser.site_name = f"{site_name}#dup-{loser.name}"
+			loser.status = "Inactive"
+			frappe.db.set_value(
+				SITE,
+				loser.name,
+				{"site_name": loser.site_name, "status": "Inactive"},
+				update_modified=False,
+			)
+			suffixed.append(f"{site_name} -> {loser.site_name}")
+	return suffixed
+
+
+def _survival_rank(row) -> tuple:
+	return (
+		bool(row.bench and frappe.db.exists("Bench Instance", row.bench)),
+		STATUS_RANK.get(row.status, 0),
+		row.creation,
+	)
+
+
+def _rename_onto_site_names(rows: list) -> list[str]:
+	"""Rename every row onto its site name, stepping a blocker aside when one already holds it."""
+	pending = [row for row in rows if row.name != row.site_name]
+	renamed = []
+	while pending:
+		movable = [row for row in pending if not frappe.db.exists(SITE, row.site_name)]
+		if not movable:
+			# Two rows already carry each other's site name; one steps aside so the other can move.
+			_rename(pending[0], f"{pending[0].name}-{frappe.generate_hash(length=6)}")
+			continue
+		for row in movable:
+			was = row.name
+			_rename(row, row.site_name)
+			renamed.append(f"{was} -> {row.name}")
+			pending.remove(row)
+	return renamed
+
+
+def _rename(row, new_name: str) -> None:
+	# The model function rather than `frappe.rename_doc`, which does not forward `validate`.
+	# Nothing here needs the checks it skips: this runs as Administrator, and the caller has
+	# already found the target name free.
+	rename_doc(SITE, row.name, new_name, force=True, validate=False, show_alert=False, rebuild_search=False)
+	row.name = new_name

--- a/benchpress/tests/test_admission.py
+++ b/benchpress/tests/test_admission.py
@@ -191,8 +191,10 @@ class TestAdmission(IntegrationTestCase):
 
 		bench = self.running_bench(self.benches[0])
 		admission.claim(USER, bench.name, 1)
-		with patch("benchpress.deploy_manager.stop_container"), patch("frappe.enqueue"), patch(
-			"frappe.db.commit"
+		with (
+			patch("benchpress.deploy_manager.stop_container"),
+			patch("frappe.enqueue"),
+			patch("frappe.db.commit"),
 		):
 			stop_bench(bench.name)
 		self.assertEqual(self.counter(), 0)
@@ -252,9 +254,16 @@ class TestAdmission(IntegrationTestCase):
 	def test_the_reconciler_releases_a_claim_whose_bench_is_not_live(self):
 		admission.claim(USER, self.benches[0].name, 0)
 		frappe.db.set_value(BENCH, self.benches[0].name, "status", "Stopped", update_modified=False)
+		self.backdate(self.benches[0].name, minutes=admission_repair.CLAIM_GRACE_MINUTES + 1)
 		admission_repair.reconcile_admissions()
 		self.assertEqual(self.rows(), [])
 		self.assertEqual(self.counter(), 0)
+
+	def test_the_reconciler_leaves_a_claim_whose_deploy_is_only_queued(self):
+		"""A bench is `Draft` until a worker picks its deploy up, which is not the same as idle."""
+		admission.claim(USER, self.benches[0].name, 0)
+		admission_repair.reconcile_admissions()
+		self.assertEqual(self.rows(), [self.benches[0].name])
 
 	def test_the_reconciler_keeps_a_claim_whose_bench_is_still_deploying(self):
 		admission.claim(USER, self.benches[0].name, 0)
@@ -266,13 +275,7 @@ class TestAdmission(IntegrationTestCase):
 		"""A worker killed mid-deploy leaves a claim no `except` block will ever reach."""
 		admission.claim(USER, self.benches[0].name, 0)
 		frappe.db.set_value(BENCH, self.benches[0].name, "status", "Deploying", update_modified=False)
-		frappe.db.set_value(
-			ADMISSION,
-			self.benches[0].name,
-			"claimed_at",
-			add_to_date(now_datetime(), hours=-(admission_repair.STALE_DEPLOY_HOURS + 1)),
-			update_modified=False,
-		)
+		self.backdate(self.benches[0].name, hours=admission_repair.STALE_DEPLOY_HOURS + 1)
 		admission_repair.reconcile_admissions()
 		self.assertEqual(frappe.db.get_value(BENCH, self.benches[0].name, "status"), "Error")
 		self.assertEqual(self.rows(), [])
@@ -292,19 +295,33 @@ class TestAdmission(IntegrationTestCase):
 
 	# --- Helpers --------------------------------------------------------------
 
+	def backdate(self, bench_name: str, **age) -> None:
+		frappe.db.set_value(
+			ADMISSION,
+			bench_name,
+			"claimed_at",
+			add_to_date(now_datetime(), **{unit: -value for unit, value in age.items()}),
+			update_modified=False,
+		)
+
 	def teardown(self, bench, **kwargs) -> None:
 		from benchpress.deploy_manager import teardown_bench
 
-		with patch("benchpress.deploy_manager.stop_container"), patch(
-			"benchpress.deploy_manager.remove_container"
-		), patch("benchpress.deploy_manager._drop_site_database"), patch(
-			"benchpress.deploy_manager._delete_instance_route"
-		), patch("frappe.db.commit"):
+		with (
+			patch("benchpress.deploy_manager.stop_container"),
+			patch("benchpress.deploy_manager.remove_container"),
+			patch("benchpress.deploy_manager._drop_site_database"),
+			patch("benchpress.deploy_manager._delete_instance_route"),
+			patch("frappe.db.commit"),
+		):
 			teardown_bench(frappe.get_doc(BENCH, bench.name), **kwargs)
 
 	def running_bench(self, bench):
 		frappe.db.set_value(
-			BENCH, bench.name, {"status": "Running", "container_id": "admission-container"}, update_modified=False
+			BENCH,
+			bench.name,
+			{"status": "Running", "container_id": "admission-container"},
+			update_modified=False,
 		)
 		return frappe.get_doc(BENCH, bench.name)
 

--- a/benchpress/tests/test_admission.py
+++ b/benchpress/tests/test_admission.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Venkatesh and Contributors
 # See license.txt
 
-"""Admission: what a claim writes, what it refuses, and what gives it back.
+"""Admission: what a claim writes and holds, what it refuses, and what gives both back.
 
 The unit tests here prove the logic. They cannot prove the property, because the suite never
 commits and a second connection would see nothing and then block on the first one's lock until
@@ -16,10 +16,11 @@ from unittest.mock import patch
 
 import frappe
 from frappe.tests import IntegrationTestCase
-from frappe.utils import add_to_date, now_datetime
+from frappe.utils import add_to_date, flt, now_datetime
 
+from benchpress import api
 from benchpress.benchpress.doctype.bench_instance import get_instance_id
-from benchpress.credits import admission, admission_repair, config
+from benchpress.credits import admission, admission_repair, config, metering
 from benchpress.credits.seed import seed_defaults
 
 ACCOUNT = "Credit Account"
@@ -33,7 +34,31 @@ USER = "admission-user@example.com"
 OTHER = "admission-other@example.com"
 LABS = ("admission-lab-a", "admission-lab-b", "admission-lab-c")
 
+# Every drill lab prices its own lease, so the hold is a number this module chose rather than
+# whatever plan the site happens to default to.
+LEASE_COST = 4.0
+ADMISSION_PLAN = "Admission 30 Minutes"
+
 TUNED_SETTINGS = ("max_concurrent_free", "max_concurrent_paid", "max_concurrent_uncredited")
+
+
+def _ensure_plan() -> str:
+	if frappe.db.exists("Lease Plan", ADMISSION_PLAN):
+		return ADMISSION_PLAN
+	return (
+		frappe.get_doc(
+			{
+				"doctype": "Lease Plan",
+				"plan_label": ADMISSION_PLAN,
+				"minutes": 30,
+				"credits": LEASE_COST,
+				"is_active": 1,
+				"sort_order": 30,
+			}
+		)
+		.insert(ignore_permissions=True)
+		.name
+	)
 
 
 def _ensure_user(email: str) -> str:
@@ -50,7 +75,7 @@ def _ensure_user(email: str) -> str:
 	return email
 
 
-def _ensure_lab(lab_id: str):
+def _ensure_lab(lab_id: str, plan: str):
 	if frappe.db.exists("Lab", lab_id):
 		return frappe.get_doc("Lab", lab_id)
 	return frappe.get_doc(
@@ -61,6 +86,8 @@ def _ensure_lab(lab_id: str):
 			"frappe_version": "version-15",
 			"image_tag": "benchpress/test:latest",
 			"instance_size": "Small",
+			"default_lease_plan": plan,
+			"deploy_credits": LEASE_COST,
 		}
 	).insert(ignore_permissions=True)
 
@@ -95,7 +122,8 @@ class TestAdmission(IntegrationTestCase):
 		}
 		cls.user = _ensure_user(USER)
 		cls.other = _ensure_user(OTHER)
-		cls.labs = [_ensure_lab(lab_id) for lab_id in LABS]
+		cls.plan = _ensure_plan()
+		cls.labs = [_ensure_lab(lab_id, cls.plan) for lab_id in LABS]
 
 	def setUp(self):
 		frappe.set_user("Administrator")
@@ -219,6 +247,149 @@ class TestAdmission(IntegrationTestCase):
 		self.assertEqual(self.counter(), 0)
 		self.assertEqual(self.rows(), [])
 
+	# --- The hold -------------------------------------------------------------
+
+	def test_a_claim_holds_the_credits_its_start_will_spend(self):
+		self.enable_credits()
+		self.set_balance(10)
+		self.assertTrue(admission.claim(USER, self.benches[0].name, 0, cost=LEASE_COST))
+		self.assertEqual(self.reserved(), LEASE_COST)
+		self.assertEqual(self.held(self.benches[0].name), LEASE_COST)
+
+	def test_a_hold_is_not_a_charge(self):
+		"""No balance moves and no statement line appears for merely asking to deploy."""
+		self.enable_credits()
+		self.set_balance(10)
+		entries = frappe.db.count(LEDGER, {"account": USER})
+		admission.claim(USER, self.benches[0].name, 0, cost=LEASE_COST)
+		self.assertEqual(self.balance(), 10.0)
+		self.assertEqual(frappe.db.count(LEDGER, {"account": USER}), entries)
+
+	def test_what_one_admission_holds_the_next_cannot_spend(self):
+		"""The whole point of the field: the balance still reads 10, what is spendable does not."""
+		self.enable_credits()
+		self.set_balance(10)
+		admission.claim(USER, self.benches[0].name, 0, cost=6.0)
+		with self.assertRaises(frappe.ValidationError) as refusal:
+			admission.claim(USER, self.benches[1].name, 0, cost=6.0)
+		self.assertIn("Not enough credits", str(refusal.exception))
+		self.assertEqual(self.balance(), 10.0)
+
+	def test_the_same_call_is_admitted_with_nothing_in_the_way(self):
+		"""The positive control: the same cost against the same balance, no hold held."""
+		self.enable_credits()
+		self.set_balance(10)
+		self.assertTrue(admission.claim(USER, self.benches[1].name, 0, cost=6.0))
+
+	def test_exactly_what_is_left_over_a_hold_is_enough(self):
+		self.enable_credits()
+		self.set_balance(10)
+		admission.claim(USER, self.benches[0].name, 0, cost=6.0)
+		self.assertTrue(admission.claim(USER, self.benches[1].name, 0, cost=4.0))
+		self.assertEqual(self.reserved(), 10.0)
+
+	def test_a_suspended_account_starts_nothing_and_holds_nothing(self):
+		self.enable_credits()
+		self.set_balance(100)
+		frappe.db.set_value(ACCOUNT, USER, "is_suspended", 1, update_modified=False)
+		with self.assertRaises(frappe.ValidationError) as refusal:
+			admission.claim(USER, self.benches[0].name, 0, cost=LEASE_COST)
+		self.assertIn("suspended", str(refusal.exception))
+		self.assertEqual(self.rows(), [])
+
+	def test_a_start_that_costs_nothing_is_admitted_at_zero_credits(self):
+		"""A lab no lease plan reaches is free, and free is what it has to afford."""
+		self.enable_credits()
+		self.set_balance(0)
+		self.assertTrue(admission.claim(USER, self.benches[0].name, 0, cost=0.0))
+		self.assertEqual(self.reserved(), 0.0)
+
+	def test_nothing_is_held_with_credits_switched_off(self):
+		"""Concurrency is capacity; the hold is money, and there is no money on such a site."""
+		self.set_credits_enabled(0)
+		self.assertTrue(admission.claim(USER, self.benches[0].name, 0, cost=LEASE_COST))
+		self.assertEqual(self.reserved(), 0.0)
+		self.assertEqual(self.held(self.benches[0].name), 0.0)
+
+	def test_a_second_claim_for_one_bench_holds_no_more(self):
+		"""A retry re-uses the hold it already took, so it costs nothing to ask twice."""
+		self.enable_credits()
+		self.set_balance(LEASE_COST)
+		admission.claim(USER, self.benches[0].name, 0, cost=LEASE_COST)
+		self.assertFalse(admission.claim(USER, self.benches[0].name, 0, cost=LEASE_COST))
+		self.assertEqual(self.reserved(), LEASE_COST)
+
+	def test_a_bench_that_already_holds_a_slot_is_still_priced(self):
+		"""A redeploy takes no new slot, and would otherwise be the one start nobody can refuse."""
+		self.enable_credits()
+		self.set_balance(LEASE_COST)
+		admission.claim(USER, self.benches[0].name, 0, cost=LEASE_COST)
+		admission.release_hold(self.benches[0].name)
+		self.set_balance(LEASE_COST / 2)
+		with self.assertRaises(frappe.ValidationError) as refusal:
+			admission.claim(USER, self.benches[0].name, 0, cost=LEASE_COST)
+		self.assertIn("Not enough credits", str(refusal.exception))
+
+	# --- Giving the hold back -------------------------------------------------
+
+	def test_releasing_the_hold_keeps_the_slot(self):
+		self.enable_credits()
+		self.set_balance(10)
+		admission.claim(USER, self.benches[0].name, 0, cost=LEASE_COST)
+		self.assertEqual(admission.release_hold(self.benches[0].name), LEASE_COST)
+		self.assertEqual(self.reserved(), 0.0)
+		self.assertEqual(self.held(self.benches[0].name), 0.0)
+		self.assertEqual(self.rows(), [self.benches[0].name])
+		self.assertEqual(self.counter(), 1)
+		self.assertEqual(self.balance(), 10.0)
+
+	def test_releasing_the_hold_twice_returns_it_once(self):
+		self.enable_credits()
+		self.set_balance(10)
+		admission.claim(USER, self.benches[0].name, 0, cost=LEASE_COST)
+		admission.release_hold(self.benches[0].name)
+		self.assertEqual(admission.release_hold(self.benches[0].name), 0.0)
+		self.assertEqual(self.reserved(), 0.0)
+
+	def test_release_gives_back_the_hold_with_the_slot(self):
+		self.enable_credits()
+		self.set_balance(10)
+		admission.claim(USER, self.benches[0].name, 0, cost=LEASE_COST)
+		admission.release(self.benches[0].name)
+		self.assertEqual(self.reserved(), 0.0)
+		self.assertEqual(self.rows(), [])
+		self.assertEqual(self.balance(), 10.0, "a hold that comes back was never a charge")
+
+	def test_a_negative_hold_is_refused(self):
+		"""The tripwire for a hold returned twice, which would spend more than the account has."""
+		account = frappe.get_doc(ACCOUNT, self.opened_account())
+		account.reserved_credits = -1
+		self.assertRaises(frappe.ValidationError, account.save)
+
+	def test_reaching_running_turns_the_hold_into_a_charge(self):
+		"""The one transition the whole hold exists for, and the ledger row it finally writes."""
+		self.enable_credits()
+		self.set_balance(10)
+		admission.claim(USER, self.benches[0].name, 0, cost=LEASE_COST)
+		metering.on_bench_running(self.running_bench(self.benches[0]))
+		self.assertEqual(self.reserved(), 0.0)
+		self.assertEqual(self.balance(), 10.0 - LEASE_COST)
+		self.assertEqual(self.rows(), [self.benches[0].name], "the slot outlives the hold")
+
+	def test_a_failed_deploy_gives_the_hold_back_and_charges_nothing(self):
+		self.enable_credits()
+		self.set_balance(10)
+		bench = self.running_bench(self.benches[0])
+		admission.claim(USER, bench.name, 0, cost=LEASE_COST)
+		entries = frappe.db.count(LEDGER, {"account": USER})
+
+		metering.on_bench_stopped(bench)
+		admission.release(bench.name)
+
+		self.assertEqual(self.reserved(), 0.0)
+		self.assertEqual(self.balance(), 10.0)
+		self.assertEqual(frappe.db.count(LEDGER, {"account": USER}), entries)
+
 	# --- The gate -------------------------------------------------------------
 
 	def test_the_gate_claims_with_credits_switched_off(self):
@@ -248,6 +419,49 @@ class TestAdmission(IntegrationTestCase):
 				frappe.get_doc(BENCH, bench.name).enqueue_deploy()
 		frappe.set_user("Administrator")
 		self.assertEqual(len(self.rows()), len(self.benches))
+
+	def test_the_spa_start_path_is_behind_the_gate(self):
+		"""`api.bench_action` is how the SPA starts a bench, and it carried no limit at all."""
+		self.set_credits_enabled(0)
+		self.set_setting("max_concurrent_uncredited", 1)
+		admission.claim(USER, self.benches[0].name, 1)
+		self.running_bench(self.benches[1])
+		frappe.set_user(USER)
+		with self.assertRaises(frappe.ValidationError) as refusal:
+			api.bench_action(self.benches[1].name, "start")
+		self.assertIn("instances running", str(refusal.exception))
+
+	def test_the_spa_start_path_admits_one_under_the_cap(self):
+		self.set_credits_enabled(0)
+		self.set_setting("max_concurrent_uncredited", 2)
+		admission.claim(USER, self.benches[0].name, 2)
+		self.running_bench(self.benches[1])
+		frappe.set_user(USER)
+		with (
+			patch("benchpress.docker_manager.start_container"),
+			patch("benchpress.deploy_manager.enqueue_route_sync"),
+			patch("frappe.db.commit"),
+		):
+			api.bench_action(self.benches[1].name, "start")
+		frappe.set_user("Administrator")
+		self.assertIn(self.benches[1].name, self.rows())
+
+	def test_stopping_stays_outside_the_gate(self):
+		"""Stopping is what a refused caller is being told to do, so it cannot itself be refused."""
+		self.set_credits_enabled(0)
+		self.set_setting("max_concurrent_uncredited", 1)
+		bench = self.running_bench(self.benches[1])
+		admission.claim(USER, self.benches[0].name, 1)
+		admission.claim(USER, bench.name, 0)
+		frappe.set_user(USER)
+		with (
+			patch("benchpress.deploy_manager.stop_container"),
+			patch("frappe.enqueue"),
+			patch("frappe.db.commit"),
+		):
+			api.bench_action(bench.name, "stop")
+		frappe.set_user("Administrator")
+		self.assertNotIn(bench.name, self.rows())
 
 	# --- The reconciler -------------------------------------------------------
 
@@ -292,6 +506,24 @@ class TestAdmission(IntegrationTestCase):
 		frappe.db.set_value(ACCOUNT, USER, "active_instances", 7, update_modified=False)
 		admission_repair.reconcile_admissions()
 		self.assertEqual(self.counter(), 1)
+
+	def test_the_reconciler_heals_a_drifted_hold(self):
+		self.enable_credits()
+		self.set_balance(10)
+		admission.claim(USER, self.benches[0].name, 0, cost=LEASE_COST)
+		frappe.db.set_value(BENCH, self.benches[0].name, "status", "Running", update_modified=False)
+		frappe.db.set_value(ACCOUNT, USER, "reserved_credits", 99.0, update_modified=False)
+		admission_repair.reconcile_admissions()
+		self.assertEqual(self.reserved(), LEASE_COST)
+
+	def test_an_adopted_orphan_holds_nothing(self):
+		"""Its lease was charged when it started, so there is nothing left for a hold to cover."""
+		self.enable_credits()
+		self.set_balance(10)
+		frappe.db.set_value(BENCH, self.benches[0].name, "status", "Running", update_modified=False)
+		admission_repair.reconcile_admissions()
+		self.assertEqual(self.held(self.benches[0].name), 0.0)
+		self.assertEqual(self.reserved(), 0.0)
 
 	def test_the_drill_mints_a_token_the_harness_can_read(self):
 		"""`bench execute … ensure_drill_user` is how every drill run gets its credentials."""
@@ -344,6 +576,21 @@ class TestAdmission(IntegrationTestCase):
 
 	def counter(self) -> int:
 		return frappe.db.get_value(ACCOUNT, USER, "active_instances") or 0
+
+	def reserved(self) -> float:
+		return flt(frappe.db.get_value(ACCOUNT, USER, "reserved_credits"))
+
+	def balance(self) -> float:
+		return flt(frappe.db.get_value(ACCOUNT, USER, "balance"))
+
+	def held(self, bench_name: str) -> float:
+		return flt(frappe.db.get_value(ADMISSION, bench_name, "held_credits"))
+
+	def set_balance(self, credits) -> None:
+		frappe.db.set_value(ACCOUNT, self.opened_account(), "balance", credits, update_modified=False)
+
+	def enable_credits(self) -> None:
+		self.set_credits_enabled(1)
 
 	def rows(self) -> list[str]:
 		return sorted(frappe.get_all(ADMISSION, filters={"account": USER}, pluck="name"))

--- a/benchpress/tests/test_admission.py
+++ b/benchpress/tests/test_admission.py
@@ -1,0 +1,336 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+"""Admission: what a claim writes, what it refuses, and what gives it back.
+
+The unit tests here prove the logic. They cannot prove the property, because the suite never
+commits and a second connection would see nothing and then block on the first one's lock until
+`innodb_lock_wait_timeout`. `scripts/admission_drill.py` proves the property, against the
+shipped endpoint, with twelve processes and a barrier. That division is deliberate.
+
+Every refusal test has a positive control beside it: a claim that throws for everybody would
+pass a denial test perfectly.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+from frappe.utils import add_to_date, now_datetime
+
+from benchpress.benchpress.doctype.bench_instance import get_instance_id
+from benchpress.credits import admission, admission_repair, config
+from benchpress.credits.seed import seed_defaults
+
+ACCOUNT = "Credit Account"
+ADMISSION = "Bench Admission"
+BENCH = "Bench Instance"
+BENCHPRESS_SETTINGS = "BenchPress Settings"
+CREDIT_SETTINGS = "Credit Settings"
+LEDGER = "Credit Ledger Entry"
+
+USER = "admission-user@example.com"
+OTHER = "admission-other@example.com"
+LABS = ("admission-lab-a", "admission-lab-b", "admission-lab-c")
+
+TUNED_SETTINGS = ("max_concurrent_free", "max_concurrent_paid", "max_concurrent_uncredited")
+
+
+def _ensure_user(email: str) -> str:
+	if not frappe.db.exists("User", email):
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": "Admission",
+				"send_welcome_email": 0,
+				"roles": [{"role": "BenchPress User"}],
+			}
+		).insert(ignore_permissions=True)
+	return email
+
+
+def _ensure_lab(lab_id: str):
+	if frappe.db.exists("Lab", lab_id):
+		return frappe.get_doc("Lab", lab_id)
+	return frappe.get_doc(
+		{
+			"doctype": "Lab",
+			"lab_id": lab_id,
+			"title": f"Admission {lab_id}",
+			"frappe_version": "version-15",
+			"image_tag": "benchpress/test:latest",
+			"instance_size": "Small",
+		}
+	).insert(ignore_permissions=True)
+
+
+def _ensure_bench(lab, owner: str):
+	name = get_instance_id(owner, lab.name)
+	if frappe.db.exists(BENCH, name):
+		return frappe.get_doc(BENCH, name)
+	frappe.set_user(owner)
+	try:
+		return frappe.get_doc(
+			{
+				"doctype": BENCH,
+				"lab": lab.name,
+				"frappe_version": lab.frappe_version,
+				"status": "Draft",
+			}
+		).insert(ignore_permissions=True)
+	finally:
+		frappe.set_user("Administrator")
+
+
+class TestAdmission(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		seed_defaults()
+		cls.switch_at_start = frappe.db.get_single_value(BENCHPRESS_SETTINGS, "enable_credits")
+		cls.settings_at_start = {
+			field: frappe.db.get_single_value(CREDIT_SETTINGS, field) for field in TUNED_SETTINGS
+		}
+		cls.user = _ensure_user(USER)
+		cls.other = _ensure_user(OTHER)
+		cls.labs = [_ensure_lab(lab_id) for lab_id in LABS]
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self.set_credits_enabled(self.switch_at_start)
+		for field, value in self.settings_at_start.items():
+			self.set_setting(field, value)
+		self.wipe_admissions()
+		# Re-made rather than shared: one test deletes its instance, and the class rolls back
+		# once at the end rather than between methods.
+		self.benches = [_ensure_bench(lab, USER) for lab in self.labs]
+		for bench in self.benches:
+			frappe.db.set_value(
+				BENCH,
+				bench.name,
+				{"status": "Draft", "container_id": None, "expires_at_ts": 0, "lease_state": ""},
+				update_modified=False,
+			)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	# --- The claim ------------------------------------------------------------
+
+	def test_a_claim_writes_one_row_and_one_count(self):
+		self.assertTrue(admission.claim(USER, self.benches[0].name, 2))
+		self.assertEqual(self.rows(), [self.benches[0].name])
+		self.assertEqual(self.counter(), 1)
+
+	def test_the_cap_refuses_the_next_bench(self):
+		admission.claim(USER, self.benches[0].name, 1)
+		with self.assertRaises(frappe.ValidationError) as refusal:
+			admission.claim(USER, self.benches[1].name, 1)
+		self.assertIn("instances running", str(refusal.exception))
+		self.assertEqual(self.counter(), 1)
+
+	def test_one_under_the_cap_is_admitted(self):
+		admission.claim(USER, self.benches[0].name, 2)
+		self.assertTrue(admission.claim(USER, self.benches[1].name, 2))
+		self.assertEqual(self.counter(), 2)
+
+	def test_zero_means_unlimited_and_still_claims(self):
+		for bench in self.benches:
+			self.assertTrue(admission.claim(USER, bench.name, 0))
+		self.assertEqual(self.counter(), len(self.benches))
+
+	def test_another_caller_has_their_own_cap(self):
+		"""The contended row is the account, so one caller at their cap refuses nobody else."""
+		admission.claim(USER, self.benches[0].name, 1)
+		self.assertTrue(admission.claim(OTHER, "some-other-bench", 1))
+
+	def test_a_second_claim_for_one_bench_changes_nothing(self):
+		"""A redeploy, restart or retry re-uses the slot the bench already holds."""
+		admission.claim(USER, self.benches[0].name, 1)
+		claimed_at = frappe.db.get_value(ADMISSION, self.benches[0].name, "claimed_at")
+
+		self.assertFalse(admission.claim(USER, self.benches[0].name, 1))
+		self.assertEqual(self.counter(), 1)
+		self.assertEqual(frappe.db.get_value(ADMISSION, self.benches[0].name, "claimed_at"), claimed_at)
+
+	def test_a_call_about_no_instance_claims_nothing(self):
+		self.assertFalse(admission.claim(USER, None, 1))
+		self.assertEqual(self.rows(), [])
+
+	# --- Giving it back -------------------------------------------------------
+
+	def test_release_drops_the_row_and_the_count(self):
+		admission.claim(USER, self.benches[0].name, 1)
+		admission.release(self.benches[0].name)
+		self.assertEqual(self.rows(), [])
+		self.assertEqual(self.counter(), 0)
+
+	def test_releasing_twice_is_quiet(self):
+		admission.claim(USER, self.benches[0].name, 1)
+		admission.release(self.benches[0].name)
+		admission.release(self.benches[0].name)
+		self.assertEqual(self.counter(), 0)
+
+	def test_a_released_slot_can_be_claimed_again(self):
+		admission.claim(USER, self.benches[0].name, 1)
+		admission.release(self.benches[0].name)
+		self.assertTrue(admission.claim(USER, self.benches[1].name, 1))
+
+	def test_a_negative_count_is_refused(self):
+		"""The tripwire for a lost decrement, at the one place it would otherwise be invisible."""
+		account = frappe.get_doc(ACCOUNT, self.opened_account())
+		account.active_instances = -1
+		self.assertRaises(frappe.ValidationError, account.save)
+
+	# --- The lifecycle paths that must give it back ---------------------------
+
+	def test_stopping_a_bench_frees_its_slot(self):
+		from benchpress.deploy_manager import stop_bench
+
+		bench = self.running_bench(self.benches[0])
+		admission.claim(USER, bench.name, 1)
+		with patch("benchpress.deploy_manager.stop_container"), patch("frappe.enqueue"), patch(
+			"frappe.db.commit"
+		):
+			stop_bench(bench.name)
+		self.assertEqual(self.counter(), 0)
+
+	def test_tearing_a_bench_down_frees_its_slot(self):
+		bench = self.running_bench(self.benches[0])
+		admission.claim(USER, bench.name, 1)
+		self.teardown(bench)
+		self.assertEqual(self.counter(), 0)
+
+	def test_a_redeploy_keeps_the_slot_across_the_teardown(self):
+		"""Releasing halfway through hands the slot away and leaves the caller one over."""
+		bench = self.running_bench(self.benches[0])
+		admission.claim(USER, bench.name, 1)
+		self.teardown(bench, release_admission=False)
+		self.assertEqual(self.counter(), 1)
+
+	def test_deleting_a_bench_frees_its_slot(self):
+		bench = self.benches[0]
+		admission.claim(USER, bench.name, 1)
+		frappe.delete_doc(BENCH, bench.name, force=True, ignore_permissions=True)
+		self.assertEqual(self.counter(), 0)
+		self.assertEqual(self.rows(), [])
+
+	# --- The gate -------------------------------------------------------------
+
+	def test_the_gate_claims_with_credits_switched_off(self):
+		"""Concurrency is capacity, not economics: the claim runs whatever the switch says."""
+		self.set_credits_enabled(0)
+		self.set_setting("max_concurrent_uncredited", 1)
+		frappe.set_user(USER)
+		with patch("frappe.enqueue"):
+			frappe.get_doc(BENCH, self.benches[0].name).enqueue_deploy()
+		frappe.set_user("Administrator")
+		self.assertEqual(self.rows(), [self.benches[0].name])
+
+	def test_the_gate_refuses_at_the_uncredited_cap(self):
+		self.set_credits_enabled(0)
+		self.set_setting("max_concurrent_uncredited", 1)
+		admission.claim(USER, self.benches[0].name, 1)
+		frappe.set_user(USER)
+		with self.assertRaises(frappe.ValidationError), patch("frappe.enqueue"):
+			frappe.get_doc(BENCH, self.benches[1].name).enqueue_deploy()
+
+	def test_zero_uncredited_admits_everything_and_still_claims(self):
+		self.set_credits_enabled(0)
+		self.set_setting("max_concurrent_uncredited", 0)
+		frappe.set_user(USER)
+		with patch("frappe.enqueue"):
+			for bench in self.benches:
+				frappe.get_doc(BENCH, bench.name).enqueue_deploy()
+		frappe.set_user("Administrator")
+		self.assertEqual(len(self.rows()), len(self.benches))
+
+	# --- The reconciler -------------------------------------------------------
+
+	def test_the_reconciler_releases_a_claim_whose_bench_is_not_live(self):
+		admission.claim(USER, self.benches[0].name, 0)
+		frappe.db.set_value(BENCH, self.benches[0].name, "status", "Stopped", update_modified=False)
+		admission_repair.reconcile_admissions()
+		self.assertEqual(self.rows(), [])
+		self.assertEqual(self.counter(), 0)
+
+	def test_the_reconciler_keeps_a_claim_whose_bench_is_still_deploying(self):
+		admission.claim(USER, self.benches[0].name, 0)
+		frappe.db.set_value(BENCH, self.benches[0].name, "status", "Deploying", update_modified=False)
+		admission_repair.reconcile_admissions()
+		self.assertEqual(self.rows(), [self.benches[0].name])
+
+	def test_the_reconciler_errors_a_deploy_nobody_is_running(self):
+		"""A worker killed mid-deploy leaves a claim no `except` block will ever reach."""
+		admission.claim(USER, self.benches[0].name, 0)
+		frappe.db.set_value(BENCH, self.benches[0].name, "status", "Deploying", update_modified=False)
+		frappe.db.set_value(
+			ADMISSION,
+			self.benches[0].name,
+			"claimed_at",
+			add_to_date(now_datetime(), hours=-(admission_repair.STALE_DEPLOY_HOURS + 1)),
+			update_modified=False,
+		)
+		admission_repair.reconcile_admissions()
+		self.assertEqual(frappe.db.get_value(BENCH, self.benches[0].name, "status"), "Error")
+		self.assertEqual(self.rows(), [])
+
+	def test_the_reconciler_adopts_a_live_instance_holding_nothing(self):
+		frappe.db.set_value(BENCH, self.benches[0].name, "status", "Running", update_modified=False)
+		admission_repair.reconcile_admissions()
+		self.assertIn(self.benches[0].name, self.rows())
+		self.assertEqual(self.counter(), 1)
+
+	def test_the_reconciler_heals_a_drifted_counter(self):
+		admission.claim(USER, self.benches[0].name, 0)
+		frappe.db.set_value(BENCH, self.benches[0].name, "status", "Running", update_modified=False)
+		frappe.db.set_value(ACCOUNT, USER, "active_instances", 7, update_modified=False)
+		admission_repair.reconcile_admissions()
+		self.assertEqual(self.counter(), 1)
+
+	# --- Helpers --------------------------------------------------------------
+
+	def teardown(self, bench, **kwargs) -> None:
+		from benchpress.deploy_manager import teardown_bench
+
+		with patch("benchpress.deploy_manager.stop_container"), patch(
+			"benchpress.deploy_manager.remove_container"
+		), patch("benchpress.deploy_manager._drop_site_database"), patch(
+			"benchpress.deploy_manager._delete_instance_route"
+		), patch("frappe.db.commit"):
+			teardown_bench(frappe.get_doc(BENCH, bench.name), **kwargs)
+
+	def running_bench(self, bench):
+		frappe.db.set_value(
+			BENCH, bench.name, {"status": "Running", "container_id": "admission-container"}, update_modified=False
+		)
+		return frappe.get_doc(BENCH, bench.name)
+
+	def opened_account(self) -> str:
+		from benchpress.credits import account
+
+		return account.ensure_account(USER)
+
+	def counter(self) -> int:
+		return frappe.db.get_value(ACCOUNT, USER, "active_instances") or 0
+
+	def rows(self) -> list[str]:
+		return sorted(frappe.get_all(ADMISSION, filters={"account": USER}, pluck="name"))
+
+	def set_credits_enabled(self, value) -> None:
+		frappe.db.set_single_value(BENCHPRESS_SETTINGS, "enable_credits", value)
+		frappe.clear_cache(doctype=BENCHPRESS_SETTINGS)
+
+	def set_setting(self, field: str, value) -> None:
+		frappe.db.set_single_value(CREDIT_SETTINGS, field, value)
+		frappe.clear_cache(doctype=CREDIT_SETTINGS)
+		config.clear_size_index()
+
+	def wipe_admissions(self) -> None:
+		"""The ledger blocks updates, not deletes, and the suite still cleans up after itself."""
+		for email in (USER, OTHER):
+			frappe.db.delete(ADMISSION, {"account": email})
+			frappe.db.delete(LEDGER, {"account": email})
+			frappe.db.delete(ACCOUNT, {"user": email})

--- a/benchpress/tests/test_admission.py
+++ b/benchpress/tests/test_admission.py
@@ -293,6 +293,18 @@ class TestAdmission(IntegrationTestCase):
 		admission_repair.reconcile_admissions()
 		self.assertEqual(self.counter(), 1)
 
+	def test_the_drill_mints_a_token_the_harness_can_read(self):
+		"""`bench execute … ensure_drill_user` is how every drill run gets its credentials."""
+		from benchpress.credits import drill
+
+		with patch("frappe.db.commit"):
+			token = drill.ensure_drill_user()
+			self.assertEqual(drill.ensure_drill_user(), token, "the token must not rotate")
+
+		self.assertRegex(token, r"^[A-Za-z0-9]{8,}:[A-Za-z0-9]{8,}$")
+		key, _, _secret = token.partition(":")
+		self.assertEqual(key, frappe.db.get_value("User", drill.DRILL_USER, "api_key"))
+
 	# --- Helpers --------------------------------------------------------------
 
 	def backdate(self, bench_name: str, **age) -> None:

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -104,10 +104,21 @@ def _ensure_lab(lab_id, **extra):
 	).insert(ignore_permissions=True)
 
 
+def _drop_bench(bench_name):
+	"""Delete an instance and the site name its request claimed.
+
+	The claim is a `Bench Site` row keyed on the name, so an instance dropped without it leaves
+	the name taken for the rest of the run.
+	"""
+	for site in frappe.get_all("Bench Site", filters={"bench": bench_name}, pluck="name"):
+		frappe.delete_doc("Bench Site", site, force=True, ignore_permissions=True)
+	if frappe.db.exists("Bench Instance", bench_name):
+		frappe.delete_doc("Bench Instance", bench_name, force=True, ignore_permissions=True)
+
+
 def _ensure_bench(lab, **extra):
 	name = get_instance_id("Administrator", lab.name)
-	if frappe.db.exists("Bench Instance", name):
-		frappe.delete_doc("Bench Instance", name, force=True, ignore_permissions=True)
+	_drop_bench(name)
 	return frappe.get_doc(
 		{
 			"doctype": "Bench Instance",
@@ -580,9 +591,7 @@ class TestApi(IntegrationTestCase):
 		data = frappe.as_json({"lab": self.create_lab.name, "bench_name": "cli-bench"})
 		with patch("frappe.enqueue") as enqueue:
 			result, elapsed_ms = _timed(lambda: api.create_bench(data))
-		self.addCleanup(
-			frappe.delete_doc, "Bench Instance", result["name"], force=True, ignore_permissions=True
-		)
+		self.addCleanup(_drop_bench, result["name"])
 		enqueue.assert_called_once()
 		self.assertTrue(enqueue.call_args.kwargs["enqueue_after_commit"])
 		self.assertEqual(result["status"], "Deploying")
@@ -599,9 +608,7 @@ class TestApi(IntegrationTestCase):
 		data = frappe.as_json({"lab": self.create_lab.name, "site_name": "acme"})
 		with patch("frappe.enqueue"):
 			result = api.create_bench(data)
-		self.addCleanup(
-			frappe.delete_doc, "Bench Instance", result["name"], force=True, ignore_permissions=True
-		)
+		self.addCleanup(_drop_bench, result["name"])
 		self.assertEqual(
 			frappe.db.get_value("Bench Instance", result["name"], "site_name"), "acme.benchpress.cloud"
 		)
@@ -610,9 +617,7 @@ class TestApi(IntegrationTestCase):
 		self._set_base_domain("benchpress.cloud")
 		other_lab = _ensure_lab("api-timing-dup-site-lab")
 		other_bench = _ensure_bench(other_lab)
-		self.addCleanup(
-			frappe.delete_doc, "Bench Instance", other_bench.name, force=True, ignore_permissions=True
-		)
+		self.addCleanup(_drop_bench, other_bench.name)
 		self.addCleanup(frappe.delete_doc, "Lab", other_lab.name, force=True, ignore_permissions=True)
 		site = frappe.get_doc(
 			{
@@ -625,18 +630,24 @@ class TestApi(IntegrationTestCase):
 		self.addCleanup(frappe.delete_doc, "Bench Site", site.name, force=True, ignore_permissions=True)
 		frappe.db.commit()
 
+		self.addCleanup(_drop_bench, get_instance_id(frappe.session.user, self.create_lab.name))
+
 		data = frappe.as_json({"lab": self.create_lab.name, "site_name": "acme"})
 		with self.assertRaises(frappe.ValidationError):
 			api.create_bench(data)
-		instance_id = get_instance_id(frappe.session.user, self.create_lab.name)
-		self.assertFalse(frappe.db.exists("Bench Instance", instance_id))
+		# The name stays with the bench that claimed it. The instance this request wrote goes back
+		# with the request — `frappe.throw` rolls the transaction back — which a test cannot show
+		# without discarding its own fixtures.
+		self.assertEqual(
+			frappe.db.get_value("Bench Site", "acme.benchpress.cloud", "bench"), other_bench.name
+		)
 
 	def test_create_bench_refuses_to_rename_a_deployed_instance(self):
 		self._set_base_domain("benchpress.cloud")
 		lab = _ensure_lab("api-timing-rename-running-lab", apps=[_lab_app()])
 		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
 		bench = _ensure_bench(lab, status="Running", site_name="original.benchpress.cloud")
-		self.addCleanup(frappe.delete_doc, "Bench Instance", bench.name, force=True, ignore_permissions=True)
+		self.addCleanup(_drop_bench, bench.name)
 
 		data = frappe.as_json({"lab": lab.name, "site_name": "renamed"})
 		with self.assertRaises(frappe.ValidationError):
@@ -651,7 +662,7 @@ class TestApi(IntegrationTestCase):
 		lab = _ensure_lab("api-timing-rename-stopped-lab", apps=[_lab_app()])
 		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
 		bench = _ensure_bench(lab, status="Stopped", site_name="original.benchpress.cloud")
-		self.addCleanup(frappe.delete_doc, "Bench Instance", bench.name, force=True, ignore_permissions=True)
+		self.addCleanup(_drop_bench, bench.name)
 
 		data = frappe.as_json({"lab": lab.name, "site_name": "renamed"})
 		with self.assertRaises(frappe.ValidationError):
@@ -665,7 +676,7 @@ class TestApi(IntegrationTestCase):
 		lab = _ensure_lab("api-timing-rename-draft-lab", apps=[_lab_app()])
 		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
 		bench = _ensure_bench(lab, status="Draft", site_name="old.benchpress.cloud")
-		self.addCleanup(frappe.delete_doc, "Bench Instance", bench.name, force=True, ignore_permissions=True)
+		self.addCleanup(_drop_bench, bench.name)
 
 		data = frappe.as_json({"lab": lab.name, "site_name": "fresh"})
 		with patch("frappe.enqueue"):
@@ -680,7 +691,7 @@ class TestApi(IntegrationTestCase):
 		lab = _ensure_lab("api-timing-rename-noop-lab", apps=[_lab_app()])
 		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
 		bench = _ensure_bench(lab, status="Running", site_name="stable.benchpress.cloud")
-		self.addCleanup(frappe.delete_doc, "Bench Instance", bench.name, force=True, ignore_permissions=True)
+		self.addCleanup(_drop_bench, bench.name)
 
 		data = frappe.as_json({"lab": lab.name, "site_name": "stable"})
 		with patch("frappe.enqueue"):
@@ -701,9 +712,7 @@ class TestApi(IntegrationTestCase):
 		data = frappe.as_json({"lab": self.create_lab.name})
 		with patch("frappe.enqueue"):
 			result = api.create_bench(data)
-		self.addCleanup(
-			frappe.delete_doc, "Bench Instance", result["name"], force=True, ignore_permissions=True
-		)
+		self.addCleanup(_drop_bench, result["name"])
 		site_name = frappe.db.get_value("Bench Instance", result["name"], "site_name")
 		base_domain = frappe.get_cached_doc("BenchPress Settings").base_domain
 		suffix = base_domain if base_domain and base_domain != "localhost" else "localhost"
@@ -750,7 +759,7 @@ class TestApi(IntegrationTestCase):
 		lab = _ensure_lab("api-timing-no-container-lab")
 		bench = _ensure_bench(lab, status="Draft")
 		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
-		self.addCleanup(frappe.delete_doc, "Bench Instance", bench.name, force=True, ignore_permissions=True)
+		self.addCleanup(_drop_bench, bench.name)
 
 		for action in ("start", "stop", "restart"):
 			with (

--- a/benchpress/tests/test_api_authorization.py
+++ b/benchpress/tests/test_api_authorization.py
@@ -422,7 +422,7 @@ class TestApiAuthorization(IntegrationTestCase):
 	def test_the_credit_gate_never_precedes_an_endpoints_own_guard(self):
 		"""With credits armed, a role-less caller must still meet `PermissionError` — not a price.
 
-		`requires_credits` wraps these endpoints, so it runs before their `require_app_user()`. It
+		`requires_admission` wraps these endpoints, so it runs before their `require_app_user()`. It
 		passes a caller without an app role straight through for exactly this reason: a stranger
 		must not be answered with an accounting sentence, and must not have a `Credit Account`
 		opened in their name on the way to being refused.

--- a/benchpress/tests/test_credit_guard.py
+++ b/benchpress/tests/test_credit_guard.py
@@ -14,6 +14,9 @@ Two properties are asserted repeatedly because both are easy to lose in a refact
 
 The gate must also never be the first thing an unauthorised caller meets. `test_api_authorization`
 owns who may call what; this module only proves the gate does not get in front of that answer.
+
+The concurrency cap is not here either. It is a claim rather than a count now, and
+`test_admission` owns it.
 """
 
 import json
@@ -29,6 +32,7 @@ from benchpress.credits import account, config, guard
 from benchpress.credits.seed import seed_defaults
 
 ACCOUNT = "Credit Account"
+ADMISSION = "Bench Admission"
 BENCH = "Bench Instance"
 BENCHPRESS_SETTINGS = "BenchPress Settings"
 CREDIT_SETTINGS = "Credit Settings"
@@ -184,13 +188,18 @@ class TestCreditGuard(IntegrationTestCase):
 			self.switch_at_start,
 		)
 
-	def test_nothing_is_refused_and_no_account_opened_when_credits_are_off(self):
+	def test_nothing_is_refused_and_nothing_is_charged_when_credits_are_off(self):
+		"""The account row is opened by the slot claim, which runs whatever the switch says.
+
+		What must not exist with the switch off is money: no grant, no charge, no ledger at all.
+		`test_admission` owns the claim itself.
+		"""
 		self.set_credits_enabled(0)
 		frappe.set_user(self.user)
 		with patch("frappe.enqueue"):
 			self.assertEqual(api.create_bench(json.dumps({"lab": self.lab.name}))["status"], "Deploying")
 		frappe.set_user("Administrator")
-		self.assertFalse(frappe.db.exists(ACCOUNT, self.user))
+		self.assertEqual(frappe.db.count(LEDGER, {"account": self.user}), 0)
 
 	# --- Money: the shortfall, and its positive control ----------------------
 
@@ -246,50 +255,6 @@ class TestCreditGuard(IntegrationTestCase):
 			self.bench_document().enqueue_deploy()
 		frappe.set_user("Administrator")
 		self.assertEqual(account.summary(self.user)["balance"], GRANT)
-
-	# --- The concurrency cap --------------------------------------------------
-
-	def test_the_concurrency_cap_refuses_one_over(self):
-		self.enable_credits()
-		self.set_setting("max_concurrent_free", 1)
-		self.set_running(self.other_bench.name)
-		frappe.set_user(self.user)
-		with self.assertRaises(frappe.ValidationError) as refusal:
-			self.bench_document().enqueue_start()
-		self.assertIn("instances running", str(refusal.exception))
-
-	def test_the_concurrency_cap_allows_one_under(self):
-		self.enable_credits()
-		self.set_setting("max_concurrent_free", 2)
-		self.set_running(self.other_bench.name)
-		frappe.set_user(self.user)
-		guard.cap_concurrent_instances(self=self.bench_document())
-
-	def test_zero_means_unlimited_concurrency(self):
-		self.enable_credits()
-		self.set_setting("max_concurrent_free", 0)
-		self.set_running(self.other_bench.name)
-		self.set_running(self.bench.name)
-		frappe.set_user(self.user)
-		guard.cap_concurrent_instances(self=self.bench_document())
-
-	def test_the_concurrency_cap_does_not_count_the_instance_being_redeployed(self):
-		"""Otherwise the cap forbids exactly the people holding it from touching what they have."""
-		self.enable_credits()
-		self.set_setting("max_concurrent_free", 1)
-		self.set_running(self.bench.name)
-		frappe.set_user(self.user)
-		guard.cap_concurrent_instances(self=self.bench_document())
-
-	def test_a_purchase_raises_the_concurrency_cap(self):
-		"""Having paid is a Purchase row, not a balance: a refund leaves the row and clears the float."""
-		self.enable_credits()
-		self.set_setting("max_concurrent_free", 1)
-		self.set_setting("max_concurrent_paid", 3)
-		self.set_running(self.other_bench.name)
-		account.purchase(self.user, 200.0, "a credit pack", ("Lab", self.lab.name))
-		frappe.set_user(self.user)
-		guard.cap_concurrent_instances(self=self.bench_document())
 
 	# --- The sites-per-instance cap ------------------------------------------
 
@@ -423,6 +388,7 @@ class TestCreditGuard(IntegrationTestCase):
 
 	def reset_benches(self) -> None:
 		names = [self.bench.name, self.other_bench.name]
+		frappe.db.delete(ADMISSION, {"bench": ("in", names)})
 		for name in names:
 			frappe.db.set_value(
 				BENCH,
@@ -462,5 +428,6 @@ class TestCreditGuard(IntegrationTestCase):
 	def wipe_credits(cls) -> None:
 		"""The ledger blocks updates, not deletes — the suite still has to clean up after itself."""
 		for email in (USER, ADMIN):
+			frappe.db.delete(ADMISSION, {"account": email})
 			frappe.db.delete(LEDGER, {"account": email})
 			frappe.db.delete(ACCOUNT, {"user": email})

--- a/benchpress/tests/test_credit_guard.py
+++ b/benchpress/tests/test_credit_guard.py
@@ -214,7 +214,7 @@ class TestCreditGuard(IntegrationTestCase):
 		message = str(refusal.exception)
 		self.assertIn("Not enough credits", message)
 		self.assertIn("short", message, "a refusal that does not name the gap explains nothing")
-		self.assertIn(guard.TOP_UP_ROUTE, message, "a refusal must name the way out of it")
+		self.assertIn(config.TOP_UP_ROUTE, message, "a refusal must name the way out of it")
 
 	def test_a_funded_user_may_deploy(self):
 		"""The positive control: the same call, the only difference being a balance."""

--- a/benchpress/tests/test_docker_manager.py
+++ b/benchpress/tests/test_docker_manager.py
@@ -149,58 +149,6 @@ class TestResolveSiteName(unittest.TestCase):
 			docker_manager.resolve_site_name("a" * 64)
 
 
-class TestResolveSiteNameCollisions(IntegrationTestCase):
-	@classmethod
-	def setUpClass(cls):
-		super().setUpClass()
-		frappe.set_user("Administrator")
-		cls.lab = _make_lab("site-collision-lab")
-		cls.other_bench = frappe.get_doc(
-			{"doctype": "Bench Instance", "lab": cls.lab.name, "frappe_version": cls.lab.frappe_version}
-		).insert(ignore_permissions=True)
-		frappe.db.commit()
-
-	@classmethod
-	def tearDownClass(cls):
-		frappe.delete_doc("Bench Instance", cls.other_bench.name, force=True, ignore_permissions=True)
-		frappe.delete_doc("Lab", cls.lab.name, force=True, ignore_permissions=True)
-		frappe.db.commit()
-		super().tearDownClass()
-
-	def _make_site(self, site_name, status, bench=None):
-		site = frappe.get_doc(
-			{
-				"doctype": "Bench Site",
-				"bench": bench or self.other_bench.name,
-				"site_name": site_name,
-				"status": status,
-			}
-		).insert(ignore_permissions=True)
-		self.addCleanup(frappe.delete_doc, "Bench Site", site.name, force=True, ignore_permissions=True)
-		self.addCleanup(frappe.db.commit)
-		frappe.db.commit()
-		return site
-
-	@patch("benchpress.docker_manager.frappe.db.get_single_value", return_value="benchpress.cloud")
-	def test_resolve_site_name_throws_on_a_live_collision(self, get_single_value):
-		self._make_site("acme.benchpress.cloud", "Active")
-		with self.assertRaises(frappe.ValidationError):
-			docker_manager.resolve_site_name("acme")
-
-	@patch("benchpress.docker_manager.frappe.db.get_single_value", return_value="benchpress.cloud")
-	def test_resolve_site_name_ignores_an_inactive_collision(self, get_single_value):
-		self._make_site("acme.benchpress.cloud", "Inactive")
-		self.assertEqual(docker_manager.resolve_site_name("acme"), "acme.benchpress.cloud")
-
-	@patch("benchpress.docker_manager.frappe.db.get_single_value", return_value="benchpress.cloud")
-	def test_resolve_site_name_excludes_its_own_bench_from_the_collision_check(self, get_single_value):
-		self._make_site("acme.benchpress.cloud", "Active", bench=self.other_bench.name)
-		self.assertEqual(
-			docker_manager.resolve_site_name("acme", exclude_bench=self.other_bench.name),
-			"acme.benchpress.cloud",
-		)
-
-
 def _make_lab(lab_id, **extra):
 	if frappe.db.exists("Lab", lab_id):
 		frappe.delete_doc("Lab", lab_id, force=True, ignore_permissions=True)

--- a/benchpress/tests/test_doctype_scoping.py
+++ b/benchpress/tests/test_doctype_scoping.py
@@ -24,6 +24,7 @@ from benchpress.permissions import ADMIN_ROLES
 # Rows belong to one tenant. Both paths must be scoped: a list rule AND a document rule.
 TENANT_SCOPED = {
 	"Bench Instance",  # the deployment itself
+	"Bench Admission",  # the concurrency slot one deployment holds
 	"Bench Site",  # a site on somebody's deployment
 	"Credit Account",  # a balance
 	"Credit Ledger Entry",  # what that balance is made of

--- a/benchpress/tests/test_signup.py
+++ b/benchpress/tests/test_signup.py
@@ -29,7 +29,7 @@ import frappe
 from frappe.tests import IntegrationTestCase
 
 from benchpress import signup, waitlist
-from benchpress.credits import account, guard, onboarding
+from benchpress.credits import account, admission, guard, onboarding
 from benchpress.credits.onboarding import ACCESS_ROLE
 
 ACCOUNT = "Credit Account"
@@ -316,17 +316,18 @@ class TestSelfServeSignup(IntegrationTestCase):
 
 		frappe.set_user(EMAIL)
 
-		self.assertEqual(guard._concurrency_limit(), FREE_CEILING)
+		self.assertEqual(guard.concurrency_limit(), FREE_CEILING)
 
 	def test_the_free_ceiling_refusal_names_the_number(self):
-		"""`test_credit_guard` owns the counting; what matters here is that the user is told why."""
+		"""`test_admission` owns the claim; what matters here is that the user is told why."""
 		self.set_setting("max_concurrent_free", FREE_CEILING)
 		signup.sign_up(EMAIL, "Test Person")
 		frappe.set_user(EMAIL)
 
-		with patch("frappe.db.count", return_value=FREE_CEILING):
-			with self.assertRaises(frappe.ValidationError) as refusal:
-				guard.cap_concurrent_instances(data=json.dumps({}))
+		account.ensure_account(EMAIL)
+		frappe.db.set_value("Credit Account", EMAIL, "active_instances", FREE_CEILING, update_modified=False)
+		with self.assertRaises(frappe.ValidationError) as refusal:
+			admission.claim(EMAIL, "signup-ceiling-bench", FREE_CEILING)
 
 		self.assertIn(str(FREE_CEILING), str(refusal.exception))
 

--- a/benchpress/tests/test_site_claim.py
+++ b/benchpress/tests/test_site_claim.py
@@ -184,6 +184,15 @@ class TestSiteNameClaim(IntegrationTestCase):
 
 		self.assertEqual(frappe.db.get_value(SITE, bench.site_name, "owner"), "tenant@example.com")
 
+	def test_deleting_the_instance_frees_the_name(self):
+		"""The row cannot outlive its bench: nothing would ever drop the database it named."""
+		bench = self._bench(self.labs[0], f"freed.{DOMAIN}")
+		self._claimed(bench)
+
+		frappe.delete_doc(BENCH, bench.name, force=True, ignore_permissions=True)
+
+		self.assertFalse(frappe.db.exists(SITE, f"freed.{DOMAIN}"))
+
 	# --- The worker's last line of defence ------------------------------------
 
 	def test_recording_a_site_that_belongs_to_another_bench_raises(self):

--- a/benchpress/tests/test_site_claim.py
+++ b/benchpress/tests/test_site_claim.py
@@ -1,0 +1,304 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+"""The site name as an allocation: claimed by insert, refused by the primary key.
+
+`site_name` keys a MariaDB database through `sha1(site_name)[:16]`, created with
+`CREATE OR REPLACE DATABASE`, so two benches that win one name share one database and the
+second drops the first tenant's data. The check that used to guard it ran in the request and
+the row was written by a worker two minutes later.
+
+A uniqueness violation is the one concurrency property a single transaction can prove, because
+the second insert sees the first from the same connection. What twelve simultaneous callers do
+is `scripts/admission_drill.py --mode site-name`.
+"""
+
+import frappe
+from frappe.query_builder import DocType
+from frappe.tests import IntegrationTestCase
+
+from benchpress import api
+from benchpress.benchpress.doctype.bench_instance import get_instance_id
+from benchpress.credits import admission_repair
+from benchpress.patches.name_bench_sites_by_site_name import execute as name_bench_sites
+
+BENCH = "Bench Instance"
+SITE = "Bench Site"
+SETTINGS = "BenchPress Settings"
+
+DOMAIN = "benchpress.cloud"
+LABS = ("site-claim-lab-a", "site-claim-lab-b")
+
+
+def _ensure_lab(lab_id: str):
+	if frappe.db.exists("Lab", lab_id):
+		return frappe.get_doc("Lab", lab_id)
+	return frappe.get_doc(
+		{
+			"doctype": "Lab",
+			"lab_id": lab_id,
+			"title": f"Site claim {lab_id}",
+			"frappe_version": "version-15",
+			"image_tag": "benchpress/test:latest",
+		}
+	).insert(ignore_permissions=True)
+
+
+def _drop_site(site_name: str) -> None:
+	"""Every row that still carries this site name, including a suffixed duplicate."""
+	for name in frappe.get_all(SITE, filters={"site_name": ("like", f"{site_name}%")}, pluck="name"):
+		frappe.delete_doc(SITE, name, force=True, ignore_permissions=True)
+
+
+def _drop_bench(bench_name: str) -> None:
+	for site in frappe.get_all(SITE, filters={"bench": bench_name}, pluck="name"):
+		frappe.delete_doc(SITE, site, force=True, ignore_permissions=True)
+	if frappe.db.exists(BENCH, bench_name):
+		frappe.delete_doc(BENCH, bench_name, force=True, ignore_permissions=True)
+
+
+class TestSiteNameClaim(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.labs = [_ensure_lab(lab_id) for lab_id in LABS]
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self._set_single("base_domain", DOMAIN)
+		# Off for the whole class: `create_bench` is behind `requires_admission`, and a module
+		# about names has no business being refused by a cap or a balance.
+		self._set_single("enable_credits", 0)
+		for lab in self.labs:
+			_drop_bench(get_instance_id("Administrator", lab.name))
+
+	def _set_single(self, field: str, value) -> None:
+		before = frappe.db.get_single_value(SETTINGS, field)
+		frappe.db.set_single_value(SETTINGS, field, value)
+		frappe.clear_cache(doctype=SETTINGS)
+		self.addCleanup(frappe.clear_cache, doctype=SETTINGS)
+		self.addCleanup(frappe.db.set_single_value, SETTINGS, field, before)
+
+	def _bench(self, lab, site_name: str):
+		bench = frappe.get_doc(
+			{"doctype": BENCH, "lab": lab.name, "frappe_version": lab.frappe_version}
+		).insert(ignore_permissions=True)
+		frappe.db.set_value(BENCH, bench.name, "site_name", site_name, update_modified=False)
+		bench.site_name = site_name
+		self.addCleanup(_drop_bench, bench.name)
+		return bench
+
+	def _claimed(self, bench, status="Creating"):
+		site = frappe.get_doc(
+			{"doctype": SITE, "site_name": bench.site_name, "bench": bench.name, "status": status}
+		).insert(ignore_permissions=True)
+		self.addCleanup(frappe.delete_doc, SITE, site.name, force=True, ignore_permissions=True)
+		return site
+
+	# --- The key --------------------------------------------------------------
+
+	def test_the_row_is_named_by_its_site_name(self):
+		bench = self._bench(self.labs[0], f"named.{DOMAIN}")
+		self.assertEqual(self._claimed(bench).name, f"named.{DOMAIN}")
+
+	def test_a_second_row_for_one_name_is_refused_by_the_database(self):
+		first = self._bench(self.labs[0], f"contested.{DOMAIN}")
+		second = self._bench(self.labs[1], f"contested.{DOMAIN}")
+		self._claimed(first)
+
+		with self.assertRaises(frappe.DuplicateEntryError):
+			frappe.get_doc({"doctype": SITE, "site_name": second.site_name, "bench": second.name}).insert(
+				ignore_permissions=True
+			)
+
+	# --- The refusal ----------------------------------------------------------
+
+	def test_a_taken_name_is_refused_in_the_request(self):
+		taken = self._bench(self.labs[0], f"taken.{DOMAIN}")
+		self._claimed(taken, status="Active")
+
+		with self.assertRaises(frappe.ValidationError) as refusal:
+			api.create_bench(frappe.as_json({"lab": self.labs[1].name, "site_name": "taken"}))
+		self.assertIn("is already in use", str(refusal.exception))
+		self.assertEqual(frappe.db.get_value(SITE, f"taken.{DOMAIN}", "bench"), taken.name)
+
+	def test_the_refusal_carries_one_sentence_and_not_the_framework_s(self):
+		"""The framework msgprints "Bench Site X already exists" before it raises."""
+		taken = self._bench(self.labs[0], f"onesentence.{DOMAIN}")
+		self._claimed(taken, status="Active")
+		frappe.clear_messages()
+
+		with self.assertRaises(frappe.ValidationError):
+			api.create_bench(frappe.as_json({"lab": self.labs[1].name, "site_name": "onesentence"}))
+
+		self.assertNotIn("already exists", self._messages())
+
+	def test_a_redeploy_carries_no_message_of_its_own(self):
+		"""The duplicate its claim hits is expected, so nothing about it belongs in the reply."""
+		owner = self._bench(self.labs[0], f"quiet.{DOMAIN}")
+		self._claimed(owner, status="Active")
+		frappe.clear_messages()
+
+		api.create_bench(frappe.as_json({"lab": self.labs[0].name, "site_name": "quiet"}))
+
+		self.assertNotIn("already exists", self._messages())
+
+	def _messages(self) -> str:
+		return " ".join(str(entry) for entry in (frappe.local.message_log or []))
+
+	def test_an_inactive_name_is_still_claimed(self):
+		"""`stop_bench` deactivates without dropping, so the database is still on disk."""
+		stopped = self._bench(self.labs[0], f"stopped.{DOMAIN}")
+		self._claimed(stopped, status="Inactive")
+
+		with self.assertRaises(frappe.ValidationError):
+			api.create_bench(frappe.as_json({"lab": self.labs[1].name, "site_name": "stopped"}))
+
+	# --- The bench that owns it ----------------------------------------------
+
+	def test_a_redeploy_of_the_bench_that_owns_the_name_is_admitted(self):
+		owner = self._bench(self.labs[0], f"mine.{DOMAIN}")
+		self._claimed(owner, status="Active")
+
+		result = api.create_bench(frappe.as_json({"lab": self.labs[0].name, "site_name": "mine"}))
+
+		self.assertEqual(result["name"], owner.name)
+		self.assertEqual(result["status"], "Deploying")
+
+	def test_a_first_deploy_claims_the_name_before_any_worker_runs(self):
+		result = api.create_bench(frappe.as_json({"lab": self.labs[0].name, "site_name": "early"}))
+		self.addCleanup(_drop_bench, result["name"])
+
+		claimed = frappe.db.get_value(SITE, f"early.{DOMAIN}", ["bench", "status"], as_dict=True)
+		self.assertEqual(claimed.bench, result["name"])
+		self.assertEqual(claimed.status, "Creating")
+
+	def test_the_claim_is_owned_by_the_bench_and_not_by_the_session(self):
+		"""`Bench Site` is read `if_owner`: an admin deploying for a tenant must not take it over."""
+		bench = self._bench(self.labs[0], f"tenant.{DOMAIN}")
+		frappe.db.set_value(BENCH, bench.name, "owner", "tenant@example.com", update_modified=False)
+		bench.owner = "tenant@example.com"
+
+		api._claim_site_name(bench)
+
+		self.assertEqual(frappe.db.get_value(SITE, bench.site_name, "owner"), "tenant@example.com")
+
+	# --- The worker's last line of defence ------------------------------------
+
+	def test_recording_a_site_that_belongs_to_another_bench_raises(self):
+		from benchpress.deploy_manager import _record_primary_site
+
+		owner = self._bench(self.labs[0], f"defended.{DOMAIN}")
+		self._claimed(owner, status="Active")
+		intruder = self._bench(self.labs[1], f"defended.{DOMAIN}")
+
+		with self.assertRaises(Exception) as refusal:
+			_record_primary_site(intruder, self.labs[1], "secret")
+		self.assertIn(owner.name, str(refusal.exception))
+
+	def test_recording_activates_the_row_the_request_claimed(self):
+		from benchpress.deploy_manager import _record_primary_site
+
+		bench = self._bench(self.labs[0], f"activated.{DOMAIN}")
+		claimed = self._claimed(bench)
+
+		_record_primary_site(bench, self.labs[0], "secret")
+
+		self.assertEqual(frappe.db.get_value(SITE, claimed.name, "status"), "Active")
+		self.assertEqual(frappe.db.count(SITE, {"bench": bench.name}), 1)
+
+	# --- The standing rule ----------------------------------------------------
+
+	def test_a_claim_no_deploy_ever_answered_is_retired(self):
+		bench = self._bench(self.labs[0], f"stranded.{DOMAIN}")
+		site = self._claimed(bench)
+		frappe.db.set_value(SITE, site.name, "modified", "2020-01-01 00:00:00", update_modified=False)
+
+		admission_repair.reconcile_admissions()
+
+		self.assertEqual(frappe.db.get_value(SITE, site.name, "status"), "Inactive")
+
+	def test_a_claim_still_inside_the_deploy_window_is_left_alone(self):
+		bench = self._bench(self.labs[0], f"working.{DOMAIN}")
+		site = self._claimed(bench)
+
+		admission_repair.reconcile_admissions()
+
+		self.assertEqual(frappe.db.get_value(SITE, site.name, "status"), "Creating")
+
+
+class TestNameBenchSitesBySiteName(IntegrationTestCase):
+	"""The patch that moves existing rows onto the key, on data that predates it."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.lab = _ensure_lab("site-claim-patch-lab")
+		cls.bench = frappe.get_doc({"doctype": BENCH, "lab": cls.lab.name}).insert(ignore_permissions=True)
+
+	def _unkeyed_site(self, site_name: str, status: str = "Active"):
+		"""A row named the way Frappe named them before `autoname: field:site_name`.
+
+		The name is moved by query rather than by `rename_doc`, which syncs the autoname field to
+		the new name and so cannot produce the very shape the patch exists to repair. Two rows
+		share a name by being made one at a time, each moved off the key before the next.
+		"""
+		site = frappe.get_doc(
+			{"doctype": SITE, "site_name": site_name, "bench": self.bench.name, "status": status}
+		).insert(ignore_permissions=True)
+		table = DocType(SITE)
+		unkeyed = frappe.generate_hash(length=10)
+		frappe.qb.update(table).set(table.name, unkeyed).where(table.name == site.name).run()
+		self.addCleanup(_drop_site, site_name)
+		return frappe.get_doc(SITE, unkeyed)
+
+	def test_a_clean_row_is_renamed_onto_its_site_name(self):
+		site = self._unkeyed_site(f"clean.{DOMAIN}")
+		self.assertNotEqual(site.name, site.site_name)
+
+		name_bench_sites()
+
+		self.assertTrue(frappe.db.exists(SITE, f"clean.{DOMAIN}"))
+		self.assertFalse(frappe.db.exists(SITE, site.name))
+
+	def test_running_it_twice_changes_nothing(self):
+		self._unkeyed_site(f"twice.{DOMAIN}")
+		name_bench_sites()
+		modified = frappe.db.get_value(SITE, f"twice.{DOMAIN}", "modified")
+
+		name_bench_sites()
+
+		self.assertEqual(frappe.db.get_value(SITE, f"twice.{DOMAIN}", "modified"), modified)
+
+	def test_a_duplicate_loser_is_suffixed_and_deactivated_never_deleted(self):
+		winner = self._unkeyed_site(f"shared.{DOMAIN}", status="Active")
+		loser = self._unkeyed_site(f"shared.{DOMAIN}", status="Inactive")
+
+		name_bench_sites()
+
+		self.assertEqual(frappe.db.get_value(SITE, f"shared.{DOMAIN}", "bench"), winner.bench)
+		survivors = frappe.get_all(
+			SITE, filters={"site_name": ("like", f"shared.{DOMAIN}#dup-%")}, fields=["name", "status"]
+		)
+		self.assertEqual(len(survivors), 1)
+		self.assertEqual(survivors[0].status, "Inactive")
+		self.assertFalse(frappe.db.exists(SITE, loser.name))
+
+	def test_the_survivor_is_the_row_furthest_from_gone(self):
+		self._unkeyed_site(f"ranked.{DOMAIN}", status="Inactive")
+		live = self._unkeyed_site(f"ranked.{DOMAIN}", status="Active")
+
+		name_bench_sites()
+
+		self.assertEqual(frappe.db.get_value(SITE, f"ranked.{DOMAIN}", "creation"), live.creation)
+
+	def test_a_row_whose_bench_is_gone_is_still_renamed(self):
+		"""Staging has one. `rename_doc` must not validate, or the link check stops the migration."""
+		orphan = self._unkeyed_site(f"orphan.{DOMAIN}")
+		frappe.db.set_value(SITE, orphan.name, "bench", "a-bench-that-never-existed")
+
+		name_bench_sites()
+
+		self.assertTrue(frappe.db.exists(SITE, f"orphan.{DOMAIN}"))

--- a/scripts/admission_drill.py
+++ b/scripts/admission_drill.py
@@ -7,6 +7,9 @@ them came back admitted.
 
 Three properties make it safe to run against a host that is serving real tenants:
 
+- **It goes to the host's own nginx, not through the CDN.** The public name is behind
+  Cloudflare, which answers a dozen simultaneous machine clients with `1010` rather than with
+  the endpoint - so the drill would measure the CDN. `BENCHPRESS_URL` overrides it.
 - **`queue-long` is stopped for the run** unless `--allow-deploys`. Every deploy is enqueued
   with `enqueue_after_commit=True`, so nothing reaches Redis until the request commits and the
   whole admission decision is still measurable with no worker running. A broken gate then
@@ -34,7 +37,10 @@ import urllib.request
 
 SITE = os.environ.get("BENCHPRESS_SITE", "frontend")
 COMPOSE_DIR = os.environ.get("BENCHPRESS_COMPOSE_DIR", "/home/ubuntu/benchpress_devops")
-BASE_URL = os.environ.get("BENCHPRESS_URL", "https://staging.benchpress.cloud")
+BASE_URL = os.environ.get("BENCHPRESS_URL", "http://127.0.0.1:8080")
+# nginx routes by `FRAPPE_SITE_NAME_HEADER`, not by this, but a request that names the site it
+# means is the one worth measuring.
+HOST_HEADER = os.environ.get("BENCHPRESS_HOST", "staging.benchpress.cloud")
 DEPLOY_QUEUE = "queue-long"
 
 CREATE_BENCH = "/api/method/benchpress.api.create_bench"
@@ -69,11 +75,14 @@ def _run(args, setup) -> int:
 	stopped = _stop_deploy_queue(args.allow_deploys)
 	try:
 		results = _fire_all(setup)
+		# Both before the worker comes back: the counter is what the run produced, and the
+		# queued deploys are what the run must not let loose on the host.
+		report = _bench_execute("report")
+		if stopped:
+			print("purged:", json.dumps(_bench_execute("purge_deploy_jobs")))
 	finally:
 		if stopped:
 			_start_deploy_queue()
-
-	report = _bench_execute("report")
 	return _verdict(args, setup, results, report)
 
 
@@ -87,10 +96,7 @@ def _fire_all(setup) -> list[dict]:
 	context = multiprocessing.get_context("fork")
 	barrier = context.Barrier(len(setup["labs"]))
 	results = context.Queue()
-	headers = {
-		"Authorization": f"token {setup['api_key']}:{setup['api_secret']}",
-		"Content-Type": "application/json",
-	}
+	headers = {**_auth(setup), "Content-Type": "application/json"}
 	workers = [
 		context.Process(target=_fire, args=(index, lab, headers, barrier, results))
 		for index, lab in enumerate(setup["labs"])
@@ -116,7 +122,7 @@ def _fire(index: int, lab: str, headers: dict, barrier, results) -> None:
 			results.put(_outcome(index, lab, response.status, response.read()))
 	except urllib.error.HTTPError as refusal:
 		results.put(_outcome(index, lab, refusal.code, refusal.read()))
-	except Exception as failure:  # noqa: BLE001 - a transport failure is a drill result too
+	except Exception as failure:  # a transport failure is a drill result too
 		results.put({"index": index, "lab": lab, "verdict": "error", "detail": repr(failure)})
 
 
@@ -142,6 +148,7 @@ def _verdict(args, setup, results, report) -> int:
 	print(f"account: active_instances={report['active_instances']} rows={report['admission_rows']}")
 
 	broken = _broken(counts, expected, report)
+	sys.stdout.flush()
 	for line in broken:
 		print(f"FAIL: {line}", file=sys.stderr)
 	for result in results:
@@ -161,9 +168,7 @@ def _broken(counts: dict, expected: int, report: dict) -> list[str]:
 	if report["admission_rows"] != counts["admitted"]:
 		broken.append(f"{report['admission_rows']} admission rows for {counts['admitted']} admitted")
 	if report["active_instances"] != report["admission_rows"]:
-		broken.append(
-			f"counter says {report['active_instances']}, rows say {report['admission_rows']}"
-		)
+		broken.append(f"counter says {report['active_instances']}, rows say {report['admission_rows']}")
 	return broken
 
 
@@ -176,15 +181,19 @@ def _assert_right_site(claimed: str, setup: dict) -> None:
 
 
 def _logged_user(setup: dict) -> str | None:
-	request = urllib.request.Request(
-		BASE_URL + LOGGED_USER,
-		headers={"Authorization": f"token {setup['api_key']}:{setup['api_secret']}"},
-	)
+	request = urllib.request.Request(BASE_URL + LOGGED_USER, headers=_auth(setup))
 	try:
 		with urllib.request.urlopen(request, timeout=30) as response:
 			return json.loads(response.read()).get("message")
-	except Exception as failure:  # noqa: BLE001
+	except Exception as failure:
 		_refuse(f"{BASE_URL} would not authenticate the drill token: {failure!r}")
+
+
+def _auth(setup: dict) -> dict:
+	return {
+		"Authorization": f"token {setup['api_key']}:{setup['api_secret']}",
+		"Host": HOST_HEADER,
+	}
 
 
 def _refuse(reason: str) -> None:

--- a/scripts/admission_drill.py
+++ b/scripts/admission_drill.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Fire N parallel `create_bench` calls at one caller's cap and count what got in.
+
+The harness for `specs/.../atomic-admission`. It never reimplements the claim: every request
+goes over HTTP to the shipped endpoint, and the only thing this file decides is how many of
+them came back admitted.
+
+Three properties make it safe to run against a host that is serving real tenants:
+
+- **`queue-long` is stopped for the run** unless `--allow-deploys`. Every deploy is enqueued
+  with `enqueue_after_commit=True`, so nothing reaches Redis until the request commits and the
+  whole admission decision is still measurable with no worker running. A broken gate then
+  admits rows rather than containers.
+- **It refuses to run against the wrong site.** `--i-know-this-is` must match the site's own
+  `base_domain`, and the drill token must authenticate as the user the setup step just made -
+  a token minted on one site does not authenticate on another.
+- **Cleanup filters on the drill user and the `drill-` labs**, never on status and never on
+  owner alone.
+
+The labs are distinct on purpose. `get_instance_id` is `md5(email + lab)`, so N calls naming
+one lab all name one bench, and a same-lab drill would hold at the cap with nothing to admit.
+
+    python3 scripts/admission_drill.py --mode cap --workers 12 --i-know-this-is benchpress.cloud
+"""
+
+import argparse
+import json
+import multiprocessing
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+SITE = os.environ.get("BENCHPRESS_SITE", "frontend")
+COMPOSE_DIR = os.environ.get("BENCHPRESS_COMPOSE_DIR", "/home/ubuntu/benchpress_devops")
+BASE_URL = os.environ.get("BENCHPRESS_URL", "https://staging.benchpress.cloud")
+DEPLOY_QUEUE = "queue-long"
+
+CREATE_BENCH = "/api/method/benchpress.api.create_bench"
+LOGGED_USER = "/api/method/frappe.auth.get_logged_user"
+
+# The sentence `admission.claim` throws. Matched as text because that is all an HTTP client
+# gets: Frappe answers every refusal with 417 and the message inside `_server_messages`.
+CAP_SENTENCE = "the most your plan allows"
+
+REQUEST_TIMEOUT = 120
+BENCH_TIMEOUT = 600
+
+
+def main() -> int:
+	args = _parse_args()
+	if args.mode == "cleanup":
+		print("cleanup:", json.dumps(_bench_execute("cleanup")))
+		return 0
+
+	setup = _bench_execute("setup", workers=args.workers, cap=args.cap)
+	_assert_right_site(args.i_know_this_is, setup)
+
+	try:
+		return _run(args, setup)
+	finally:
+		print("restore:", json.dumps(_bench_execute("restore", **_restore_kwargs(setup))))
+		if args.cleanup:
+			print("cleanup:", json.dumps(_bench_execute("cleanup")))
+
+
+def _run(args, setup) -> int:
+	stopped = _stop_deploy_queue(args.allow_deploys)
+	try:
+		results = _fire_all(setup)
+	finally:
+		if stopped:
+			_start_deploy_queue()
+
+	report = _bench_execute("report")
+	return _verdict(args, setup, results, report)
+
+
+def _fire_all(setup) -> list[dict]:
+	"""One process per lab, all released by a barrier so the requests land together.
+
+	Processes rather than threads: `backend` is gunicorn with 2 workers x 4 threads, so eight
+	requests are genuinely in flight and the rest queue behind them - which is the contention
+	the claim has to survive.
+	"""
+	context = multiprocessing.get_context("fork")
+	barrier = context.Barrier(len(setup["labs"]))
+	results = context.Queue()
+	headers = {
+		"Authorization": f"token {setup['api_key']}:{setup['api_secret']}",
+		"Content-Type": "application/json",
+	}
+	workers = [
+		context.Process(target=_fire, args=(index, lab, headers, barrier, results))
+		for index, lab in enumerate(setup["labs"])
+	]
+	for worker in workers:
+		worker.start()
+	collected = [results.get(timeout=REQUEST_TIMEOUT + 60) for _ in workers]
+	for worker in workers:
+		worker.join(timeout=30)
+	return collected
+
+
+def _fire(index: int, lab: str, headers: dict, barrier, results) -> None:
+	request = urllib.request.Request(
+		BASE_URL + CREATE_BENCH,
+		data=json.dumps({"data": json.dumps({"lab": lab})}).encode(),
+		headers=headers,
+		method="POST",
+	)
+	barrier.wait()
+	try:
+		with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT) as response:
+			results.put(_outcome(index, lab, response.status, response.read()))
+	except urllib.error.HTTPError as refusal:
+		results.put(_outcome(index, lab, refusal.code, refusal.read()))
+	except Exception as failure:  # noqa: BLE001 - a transport failure is a drill result too
+		results.put({"index": index, "lab": lab, "verdict": "error", "detail": repr(failure)})
+
+
+def _outcome(index: int, lab: str, status: int, body: bytes) -> dict:
+	text = body.decode(errors="replace")
+	if status == 200:
+		return {"index": index, "lab": lab, "verdict": "admitted", "detail": text[:200]}
+	verdict = "refused_cap" if CAP_SENTENCE in text else "refused_other"
+	return {"index": index, "lab": lab, "verdict": verdict, "detail": text[:300]}
+
+
+def _verdict(args, setup, results, report) -> int:
+	counts = {verdict: 0 for verdict in ("admitted", "refused_cap", "refused_other", "error")}
+	for result in results:
+		counts[result["verdict"]] += 1
+	expected = args.cap or args.workers
+
+	print(
+		f"admitted {counts['admitted']} / attempted {args.workers} · cap {args.cap} · "
+		f"refused {counts['refused_cap']} (cap) {counts['refused_other']} (other) · "
+		f"{counts['error']} errors"
+	)
+	print(f"account: active_instances={report['active_instances']} rows={report['admission_rows']}")
+
+	broken = _broken(counts, expected, report)
+	for line in broken:
+		print(f"FAIL: {line}", file=sys.stderr)
+	for result in results:
+		if result["verdict"] in ("refused_other", "error"):
+			print(f"  {result['lab']}: {result['verdict']} {result['detail']}", file=sys.stderr)
+	return 1 if broken else 0
+
+
+def _broken(counts: dict, expected: int, report: dict) -> list[str]:
+	broken = []
+	if counts["admitted"] != expected:
+		broken.append(f"expected {expected} admitted, got {counts['admitted']}")
+	if counts["error"]:
+		broken.append(f"{counts['error']} requests failed to complete")
+	if counts["refused_other"]:
+		broken.append(f"{counts['refused_other']} refused for a reason that is not the cap")
+	if report["admission_rows"] != counts["admitted"]:
+		broken.append(f"{report['admission_rows']} admission rows for {counts['admitted']} admitted")
+	if report["active_instances"] != report["admission_rows"]:
+		broken.append(
+			f"counter says {report['active_instances']}, rows say {report['admission_rows']}"
+		)
+	return broken
+
+
+def _assert_right_site(claimed: str, setup: dict) -> None:
+	if claimed != setup["base_domain"]:
+		_refuse(f"this site is {setup['base_domain']!r}, not {claimed!r}")
+	logged_in = _logged_user(setup)
+	if logged_in != setup["user"]:
+		_refuse(f"{BASE_URL} authenticated the drill token as {logged_in!r}, not {setup['user']!r}")
+
+
+def _logged_user(setup: dict) -> str | None:
+	request = urllib.request.Request(
+		BASE_URL + LOGGED_USER,
+		headers={"Authorization": f"token {setup['api_key']}:{setup['api_secret']}"},
+	)
+	try:
+		with urllib.request.urlopen(request, timeout=30) as response:
+			return json.loads(response.read()).get("message")
+	except Exception as failure:  # noqa: BLE001
+		_refuse(f"{BASE_URL} would not authenticate the drill token: {failure!r}")
+
+
+def _refuse(reason: str) -> None:
+	print(f"refusing to run: {reason}", file=sys.stderr)
+	raise SystemExit(2)
+
+
+def _restore_kwargs(setup: dict) -> dict:
+	return {"cap_field": setup["cap_field"], "cap_before": setup["cap_before"]}
+
+
+def _stop_deploy_queue(allow_deploys: bool) -> bool:
+	if allow_deploys:
+		print(f"{DEPLOY_QUEUE}: left running (--allow-deploys)")
+		return False
+	_compose("stop", DEPLOY_QUEUE)
+	print(f"{DEPLOY_QUEUE}: stopped for the run")
+	return True
+
+
+def _start_deploy_queue() -> None:
+	_compose("start", DEPLOY_QUEUE)
+	print(f"{DEPLOY_QUEUE}: started again")
+
+
+def _compose(*arguments: str) -> None:
+	subprocess.run(
+		["docker", "compose", *arguments],
+		cwd=COMPOSE_DIR,
+		check=True,
+		stdin=subprocess.DEVNULL,
+		timeout=BENCH_TIMEOUT,
+	)
+
+
+def _bench_execute(function: str, **kwargs) -> dict:
+	"""Call one `benchpress.credits.drill` function inside the backend container.
+
+	`stdin` is closed deliberately: `docker compose exec` under a timeout hangs forever if it
+	inherits a terminal it can read from.
+	"""
+	command = [
+		"docker",
+		"compose",
+		"exec",
+		"-T",
+		"backend",
+		"bench",
+		"--site",
+		SITE,
+		"execute",
+		f"benchpress.credits.drill.{function}",
+	]
+	if kwargs:
+		command += ["--kwargs", json.dumps(kwargs)]
+	finished = subprocess.run(
+		command,
+		cwd=COMPOSE_DIR,
+		capture_output=True,
+		text=True,
+		stdin=subprocess.DEVNULL,
+		timeout=BENCH_TIMEOUT,
+	)
+	if finished.returncode:
+		_refuse(f"drill.{function} failed:\n{finished.stdout}\n{finished.stderr}")
+	return _last_json(finished.stdout, function)
+
+
+def _last_json(output: str, function: str) -> dict:
+	for line in reversed(output.splitlines()):
+		try:
+			parsed = json.loads(line)
+		except ValueError:
+			continue
+		if isinstance(parsed, dict):
+			return parsed
+	_refuse(f"drill.{function} printed nothing that parses:\n{output}")
+
+
+def _parse_args():
+	parser = argparse.ArgumentParser(description=__doc__)
+	parser.add_argument("--mode", choices=("cap", "cleanup"), default="cap")
+	parser.add_argument("--workers", type=int, default=12)
+	parser.add_argument("--cap", type=int, default=1, help="0 means unlimited")
+	parser.add_argument("--i-know-this-is", required=True, help="the site's base_domain")
+	parser.add_argument("--allow-deploys", action="store_true", help="leave queue-long running")
+	parser.add_argument("--cleanup", action="store_true", help="delete the drill's rows afterwards")
+	return parser.parse_args()
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/scripts/admission_drill.py
+++ b/scripts/admission_drill.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fire N parallel `create_bench` calls at one caller's cap and count what got in.
+"""Fire N parallel `create_bench` calls at one caller's limits and count what got in.
 
 The harness for `specs/.../atomic-admission`. It never reimplements the claim: every request
 goes over HTTP to the shipped endpoint, and the only thing this file decides is how many of
@@ -23,7 +23,13 @@ Three properties make it safe to run against a host that is serving real tenants
 The labs are distinct on purpose. `get_instance_id` is `md5(email + lab)`, so N calls naming
 one lab all name one bench, and a same-lab drill would hold at the cap with nothing to admit.
 
+`--mode cap` measures the concurrency claim: the cap is moved and the account is funded past
+anything else it could be refused for. `--mode credits` measures the hold: the cap is lifted and
+the account affords exactly three leases, so a pass means three admissions and nine shortfalls.
+Each mode fails if anything is refused for the other one's reason.
+
     python3 scripts/admission_drill.py --mode cap --workers 12 --i-know-this-is benchpress.cloud
+    python3 scripts/admission_drill.py --mode credits --workers 12 --i-know-this-is benchpress.cloud
 """
 
 import argparse
@@ -46,12 +52,18 @@ DEPLOY_QUEUE = "queue-long"
 CREATE_BENCH = "/api/method/benchpress.api.create_bench"
 LOGGED_USER = "/api/method/frappe.auth.get_logged_user"
 
-# The sentence `admission.claim` throws. Matched as text because that is all an HTTP client
+# The two sentences `admission.claim` throws. Matched as text because that is all an HTTP client
 # gets: Frappe answers every refusal with 417 and the message inside `_server_messages`.
 CAP_SENTENCE = "the most your plan allows"
+CREDIT_SENTENCE = "Not enough credits"
+
+VERDICTS = ("admitted", "refused_cap", "refused_credits", "refused_other", "error")
 
 REQUEST_TIMEOUT = 120
 BENCH_TIMEOUT = 600
+
+# Credits are floats at precision 6 on both sides of every comparison here.
+TOLERANCE = 1e-6
 
 
 def main() -> int:
@@ -60,10 +72,13 @@ def main() -> int:
 		print("cleanup:", json.dumps(_bench_execute("cleanup")))
 		return 0
 
-	setup = _bench_execute("setup", workers=args.workers, cap=args.cap)
-	_assert_right_site(args.i_know_this_is, setup)
-
+	setup = _bench_execute("setup", workers=args.workers, cap=args.cap, mode=args.mode)
+	# Inside the try: setup has already moved the site's cap, so every way out of here has to
+	# put it back, including the two refusals below.
 	try:
+		_assert_right_site(args.i_know_this_is, setup)
+		if args.mode == "credits" and not setup["credits_enabled"]:
+			_refuse("credits are switched off on this site, so there is no hold to measure")
 		return _run(args, setup)
 	finally:
 		print("restore:", json.dumps(_bench_execute("restore", **_restore_kwargs(setup))))
@@ -130,45 +145,76 @@ def _outcome(index: int, lab: str, status: int, body: bytes) -> dict:
 	text = body.decode(errors="replace")
 	if status == 200:
 		return {"index": index, "lab": lab, "verdict": "admitted", "detail": text[:200]}
-	verdict = "refused_cap" if CAP_SENTENCE in text else "refused_other"
-	return {"index": index, "lab": lab, "verdict": verdict, "detail": text[:300]}
+	return {"index": index, "lab": lab, "verdict": _refusal(text), "detail": text[:300]}
+
+
+def _refusal(text: str) -> str:
+	if CAP_SENTENCE in text:
+		return "refused_cap"
+	if CREDIT_SENTENCE in text:
+		return "refused_credits"
+	return "refused_other"
 
 
 def _verdict(args, setup, results, report) -> int:
-	counts = {verdict: 0 for verdict in ("admitted", "refused_cap", "refused_other", "error")}
+	counts = dict.fromkeys(VERDICTS, 0)
 	for result in results:
 		counts[result["verdict"]] += 1
-	expected = args.cap or args.workers
+	expected = _expected(args, setup)
 
 	print(
-		f"admitted {counts['admitted']} / attempted {args.workers} · cap {args.cap} · "
-		f"refused {counts['refused_cap']} (cap) {counts['refused_other']} (other) · "
-		f"{counts['error']} errors"
+		f"admitted {counts['admitted']} / attempted {args.workers} · cap {setup['cap']} · "
+		f"refused {counts['refused_cap']} (cap) {counts['refused_credits']} (credits) "
+		f"{counts['refused_other']} (other) · {counts['error']} errors"
 	)
-	print(f"account: active_instances={report['active_instances']} rows={report['admission_rows']}")
+	print(
+		f"account: active_instances={report['active_instances']} rows={report['admission_rows']} "
+		f"reserved={report['reserved_credits']} held={report['held_credits']} "
+		f"balance={report['balance']}"
+	)
 
-	broken = _broken(counts, expected, report)
+	broken = _broken(args, setup, counts, expected, report)
 	sys.stdout.flush()
 	for line in broken:
 		print(f"FAIL: {line}", file=sys.stderr)
+	unexplained = (_wrong_reason(args.mode), "refused_other", "error")
 	for result in results:
-		if result["verdict"] in ("refused_other", "error"):
+		if result["verdict"] in unexplained:
 			print(f"  {result['lab']}: {result['verdict']} {result['detail']}", file=sys.stderr)
 	return 1 if broken else 0
 
 
-def _broken(counts: dict, expected: int, report: dict) -> list[str]:
+def _expected(args, setup: dict) -> int:
+	"""How many of these requests should get in, from the limit the mode is measuring."""
+	if args.mode == "credits":
+		return int(setup["balance"] // setup["lease_price"])
+	return setup["cap"] or args.workers
+
+
+def _wrong_reason(mode: str) -> str:
+	"""The refusal that means this run measured something other than what it was aimed at."""
+	return "refused_credits" if mode == "cap" else "refused_cap"
+
+
+def _broken(args, setup: dict, counts: dict, expected: int, report: dict) -> list[str]:
+	wrong_reason = _wrong_reason(args.mode)
+	# Nothing is held on a site with credits off, where the claim is the whole of admission.
+	held = expected * setup["lease_price"] if setup["credits_enabled"] else 0.0
 	broken = []
 	if counts["admitted"] != expected:
 		broken.append(f"expected {expected} admitted, got {counts['admitted']}")
 	if counts["error"]:
 		broken.append(f"{counts['error']} requests failed to complete")
-	if counts["refused_other"]:
-		broken.append(f"{counts['refused_other']} refused for a reason that is not the cap")
+	if counts[wrong_reason] or counts["refused_other"]:
+		broken.append(f"{counts[wrong_reason] + counts['refused_other']} refused for the wrong reason")
 	if report["admission_rows"] != counts["admitted"]:
 		broken.append(f"{report['admission_rows']} admission rows for {counts['admitted']} admitted")
 	if report["active_instances"] != report["admission_rows"]:
 		broken.append(f"counter says {report['active_instances']}, rows say {report['admission_rows']}")
+	if abs(report["reserved_credits"] - report["held_credits"]) > TOLERANCE:
+		broken.append(f"account reserves {report['reserved_credits']}, rows hold {report['held_credits']}")
+	if abs(report["reserved_credits"] - held) > TOLERANCE:
+		broken.append(f"expected {held} credits held, account reserves {report['reserved_credits']}")
 	return broken
 
 
@@ -275,7 +321,7 @@ def _last_json(output: str, function: str) -> dict:
 
 def _parse_args():
 	parser = argparse.ArgumentParser(description=__doc__)
-	parser.add_argument("--mode", choices=("cap", "cleanup"), default="cap")
+	parser.add_argument("--mode", choices=("cap", "credits", "cleanup"), default="cap")
 	parser.add_argument("--workers", type=int, default=12)
 	parser.add_argument("--cap", type=int, default=1, help="0 means unlimited")
 	parser.add_argument("--i-know-this-is", required=True, help="the site's base_domain")

--- a/scripts/admission_drill.py
+++ b/scripts/admission_drill.py
@@ -26,10 +26,13 @@ one lab all name one bench, and a same-lab drill would hold at the cap with noth
 `--mode cap` measures the concurrency claim: the cap is moved and the account is funded past
 anything else it could be refused for. `--mode credits` measures the hold: the cap is lifted and
 the account affords exactly three leases, so a pass means three admissions and nine shortfalls.
-Each mode fails if anything is refused for the other one's reason.
+`--mode site-name` measures the allocation: the cap is lifted, the account is funded, and all N
+requests ask for the **same** site name, so a pass means one admission and N-1 refusals. Each
+mode fails if anything is refused for another one's reason.
 
     python3 scripts/admission_drill.py --mode cap --workers 12 --i-know-this-is benchpress.cloud
     python3 scripts/admission_drill.py --mode credits --workers 12 --i-know-this-is benchpress.cloud
+    python3 scripts/admission_drill.py --mode site-name --workers 12 --i-know-this-is benchpress.cloud
 """
 
 import argparse
@@ -52,12 +55,17 @@ DEPLOY_QUEUE = "queue-long"
 CREATE_BENCH = "/api/method/benchpress.api.create_bench"
 LOGGED_USER = "/api/method/frappe.auth.get_logged_user"
 
-# The two sentences `admission.claim` throws. Matched as text because that is all an HTTP client
+# The three sentences a refusal can carry. Matched as text because that is all an HTTP client
 # gets: Frappe answers every refusal with 417 and the message inside `_server_messages`.
 CAP_SENTENCE = "the most your plan allows"
 CREDIT_SENTENCE = "Not enough credits"
+SITE_SENTENCE = "is already in use"
 
-VERDICTS = ("admitted", "refused_cap", "refused_credits", "refused_other", "error")
+VERDICTS = ("admitted", "refused_cap", "refused_credits", "refused_site", "refused_other", "error")
+
+# The one refusal each mode came to measure. Anything else means the run measured something
+# other than what it was aimed at.
+EXPECTED_REFUSAL = {"cap": "refused_cap", "credits": "refused_credits", "site-name": "refused_site"}
 
 REQUEST_TIMEOUT = 120
 BENCH_TIMEOUT = 600
@@ -92,7 +100,7 @@ def _run(args, setup) -> int:
 		results = _fire_all(setup)
 		# Both before the worker comes back: the counter is what the run produced, and the
 		# queued deploys are what the run must not let loose on the host.
-		report = _bench_execute("report")
+		report = _bench_execute("report", site_name=setup["site_name"])
 		if stopped:
 			print("purged:", json.dumps(_bench_execute("purge_deploy_jobs")))
 	finally:
@@ -113,7 +121,7 @@ def _fire_all(setup) -> list[dict]:
 	results = context.Queue()
 	headers = {**_auth(setup), "Content-Type": "application/json"}
 	workers = [
-		context.Process(target=_fire, args=(index, lab, headers, barrier, results))
+		context.Process(target=_fire, args=(index, lab, setup["site_label"], headers, barrier, results))
 		for index, lab in enumerate(setup["labs"])
 	]
 	for worker in workers:
@@ -124,10 +132,13 @@ def _fire_all(setup) -> list[dict]:
 	return collected
 
 
-def _fire(index: int, lab: str, headers: dict, barrier, results) -> None:
+def _fire(index: int, lab: str, site_label: str | None, headers: dict, barrier, results) -> None:
+	payload = {"lab": lab}
+	if site_label:
+		payload["site_name"] = site_label
 	request = urllib.request.Request(
 		BASE_URL + CREATE_BENCH,
-		data=json.dumps({"data": json.dumps({"lab": lab})}).encode(),
+		data=json.dumps({"data": json.dumps(payload)}).encode(),
 		headers=headers,
 		method="POST",
 	)
@@ -153,6 +164,8 @@ def _refusal(text: str) -> str:
 		return "refused_cap"
 	if CREDIT_SENTENCE in text:
 		return "refused_credits"
+	if SITE_SENTENCE in text:
+		return "refused_site"
 	return "refused_other"
 
 
@@ -165,19 +178,25 @@ def _verdict(args, setup, results, report) -> int:
 	print(
 		f"admitted {counts['admitted']} / attempted {args.workers} · cap {setup['cap']} · "
 		f"refused {counts['refused_cap']} (cap) {counts['refused_credits']} (credits) "
-		f"{counts['refused_other']} (other) · {counts['error']} errors"
+		f"{counts['refused_site']} (site name) {counts['refused_other']} (other) · "
+		f"{counts['error']} errors"
 	)
 	print(
 		f"account: active_instances={report['active_instances']} rows={report['admission_rows']} "
 		f"reserved={report['reserved_credits']} held={report['held_credits']} "
 		f"balance={report['balance']}"
 	)
+	if setup["site_name"]:
+		print(
+			f"site '{setup['site_name']}': {report['named_sites']} rows · "
+			f"{report['named_benches']} instances claim it"
+		)
 
 	broken = _broken(args, setup, counts, expected, report)
 	sys.stdout.flush()
 	for line in broken:
 		print(f"FAIL: {line}", file=sys.stderr)
-	unexplained = (_wrong_reason(args.mode), "refused_other", "error")
+	unexplained = (*_wrong_reasons(args.mode), "error")
 	for result in results:
 		if result["verdict"] in unexplained:
 			print(f"  {result['lab']}: {result['verdict']} {result['detail']}", file=sys.stderr)
@@ -188,25 +207,32 @@ def _expected(args, setup: dict) -> int:
 	"""How many of these requests should get in, from the limit the mode is measuring."""
 	if args.mode == "credits":
 		return int(setup["balance"] // setup["lease_price"])
+	if args.mode == "site-name":
+		return 1  # one name, so one winner, whatever the cap says
 	return setup["cap"] or args.workers
 
 
-def _wrong_reason(mode: str) -> str:
-	"""The refusal that means this run measured something other than what it was aimed at."""
-	return "refused_credits" if mode == "cap" else "refused_cap"
+def _wrong_reasons(mode: str) -> tuple[str, ...]:
+	"""Every refusal that would mean this run measured something it was not aimed at."""
+	expected = EXPECTED_REFUSAL[mode]
+	return tuple(v for v in VERDICTS if v.startswith("refused_") and v != expected)
 
 
 def _broken(args, setup: dict, counts: dict, expected: int, report: dict) -> list[str]:
-	wrong_reason = _wrong_reason(args.mode)
 	# Nothing is held on a site with credits off, where the claim is the whole of admission.
 	held = expected * setup["lease_price"] if setup["credits_enabled"] else 0.0
+	wrong = sum(counts[verdict] for verdict in _wrong_reasons(args.mode))
 	broken = []
 	if counts["admitted"] != expected:
 		broken.append(f"expected {expected} admitted, got {counts['admitted']}")
 	if counts["error"]:
 		broken.append(f"{counts['error']} requests failed to complete")
-	if counts[wrong_reason] or counts["refused_other"]:
-		broken.append(f"{counts[wrong_reason] + counts['refused_other']} refused for the wrong reason")
+	if wrong:
+		broken.append(f"{wrong} refused for the wrong reason")
+	if setup["site_name"] and report["named_sites"] != counts["admitted"]:
+		broken.append(f"{report['named_sites']} rows own the drilled name, {counts['admitted']} admitted")
+	if setup["site_name"] and report["named_benches"] != counts["admitted"]:
+		broken.append(f"{report['named_benches']} instances claim the drilled name")
 	if report["admission_rows"] != counts["admitted"]:
 		broken.append(f"{report['admission_rows']} admission rows for {counts['admitted']} admitted")
 	if report["active_instances"] != report["admission_rows"]:
@@ -280,7 +306,11 @@ def _bench_execute(function: str, **kwargs) -> dict:
 
 	`stdin` is closed deliberately: `docker compose exec` under a timeout hangs forever if it
 	inherits a terminal it can read from.
+
+	A `None` argument is dropped rather than sent: `bench execute` evaluates `--kwargs` as Python,
+	where JSON's `null` is a NameError.
 	"""
+	kwargs = {name: value for name, value in kwargs.items() if value is not None}
 	command = [
 		"docker",
 		"compose",
@@ -321,7 +351,7 @@ def _last_json(output: str, function: str) -> dict:
 
 def _parse_args():
 	parser = argparse.ArgumentParser(description=__doc__)
-	parser.add_argument("--mode", choices=("cap", "credits", "cleanup"), default="cap")
+	parser.add_argument("--mode", choices=("cap", "credits", "site-name", "cleanup"), default="cap")
 	parser.add_argument("--workers", type=int, default=12)
 	parser.add_argument("--cap", type=int, default=1, help="0 means unlimited")
 	parser.add_argument("--i-know-this-is", required=True, help="the site's base_domain")


### PR DESCRIPTION
Phase 1 of the **atomic-admission** spec: admission becomes a write that can fail.

## What changed

`cap_concurrent_instances` counted the caller's `Running` benches and compared. Two requests that arrived together read the same count and both passed, and `create_bench` writes its row as `Draft` for the two minutes a deploy takes — so an in-flight deploy was invisible to the thing counting deploys.

A slot is now a row. `Bench Admission` autonames on the bench, which puts the claim on a primary key, and both the read and the write happen under `SELECT ... FOR UPDATE` on the caller's `Credit Account` — the one row every contender for that caller has to take.

- **`Credit Settings.max_concurrent_uncredited`**, default `0`. The cap that applies when credits are off. `0` means unlimited, so an install that has not opted in behaves exactly as it did.
- **The claim runs whatever the credits switch says**; only the balance check stays behind it. `requires_credits` is now `requires_admission`.
- **Every path that ends a bench gives the slot back**: deploy failure, `stop_bench`, `teardown_bench`, `on_trash`. `_redeploy_bench` passes `release_admission=False` so a redeploy keeps its own slot across the teardown.
- **`credits.admission_repair.reconcile_admissions`** on the `*/5` cron: expires stranded claims, adopts live instances holding none, heals the counter from the rows.
- `account._locked` is now `account.locked`, and the signup grant is idempotent by ledger reference, because admission opens accounts on sites with credits switched off.

## How to verify

Baseline, on the parent commit (behaviour files reverted, harness kept):

```
admitted 12 / attempted 12 · cap 1 · refused 0 (cap) 0 (other) · 0 errors
account: active_instances=0 rows=0
FAIL: expected 1 admitted, got 12          exit 1
```

Same command on this branch:

```
python3 scripts/admission_drill.py --mode cap --workers 12 --cap 1 --i-know-this-is benchpress.cloud

admitted 1 / attempted 12 · cap 1 · refused 11 (cap) 0 (other) · 0 errors
account: active_instances=1 rows=1         exit 0
```

Also measured against the live staging host:

- cap `2`, twelve workers -> `admitted 2`; cap `0` -> `admitted 12` with twelve `Bench Admission` rows, so `0` still claims.
- `SELECT active_instances FROM tabCredit Account` and `SELECT COUNT(*) FROM tabBench Admission` agree at every step, and both read `0` after `--cleanup`.
- A real deploy held one claim, with `claimed_at` unchanged, from the request through `Deploying` to `Running` and across two `enqueue_redeploy` calls.
- `queue-long` killed mid-deploy: no `except` block ran, and one `*/5` tick of the repair pass moved the bench to `Error`, dropped its row and returned the counter to `0`.

`bench run-tests --app benchpress`, `vitest run` and `uvx pre-commit@4.3.0 run --all-files` all pass. Two suite failures predate this branch and fail identically on `version-16`: `test_demo_data.test_a_seeded_run_lasts_minutes_not_weeks` and `test_signup.test_a_retirement_notice_goes_out_once_per_entry`.

## Two deviations from the phase spec, both deliberate

- The repair module is `credits/admission_repair.py`, not `credits/reconcile.py`. `test_meter_gone` asserts the name `credits.reconcile` never comes back — it was the burn meter's repair pass.
- The spec's worker-death check expects one tick to error an abandoned deploy, which contradicts its own `STALE_DEPLOY_HOURS = 3` rule. Verified with `claimed_at` back-dated past that window; the repair still came from the reconciler and from no `except` block.

Still open by design: the runway is a check rather than a hold, and `api.bench_action` is ungated (phase 2); two benches can still win the same `site_name` (phase 3).