### PR TITLE
chore(skills): extend issue-to-phases with a Ralph loop job

### DIFF
--- a/.claude/skills/issue-to-phases/SKILL.md
+++ b/.claude/skills/issue-to-phases/SKILL.md
@@ -1,241 +1,217 @@
 ---
 name: issue-to-phases
 description: >-
-  Decompose a single planning document (plan.md, a spec, or a GitHub issue) into incremental,
-  independently-shippable "tracer bullet" phases, write them as phase specs in a dedicated
-  subfolder under specs/, then drive a one-branch / per-phase-PR implementation workflow. Use this
-  whenever the user hands you a plan and wants it broken into phases, mentions "tracer bullets",
-  "phase 0/1/2", "build this in phases", "thin end-to-end slice first", or wants phased specs in the
-  specs/ folder — even if they don't say the word "phase". Also use it when the user asks an agent to
-  "implement / work on phase N" of an existing spec folder, so the branch and PR are handled the way
-  every other phase did it.
+  Decompose a planning document (plan.md, a spec, or a GitHub issue) into incremental,
+  independently-shippable "tracer bullet" phases, write them as phase specs under specs/, and
+  optionally generate a Ralph loop (ralph.sh + prompt.md) that implements them unattended. Use
+  this whenever the user hands you a plan and wants it broken into phases, mentions "tracer
+  bullets", "phase 0/1/2", "build this in phases", "thin end-to-end slice first", "ralph loop",
+  or wants phased specs in the specs/ folder — even if they never say the word "phase". Also use
+  it when the user asks to "implement / work on phase N" of an existing spec folder, so the
+  branch, the PR and the spec's status all move the way every earlier phase did.
 ---
 
-# issue-to-phases — plan.md → tracer-bullet phases → one-branch, per-phase PRs
+# issue-to-phases
 
-This skill does two jobs. Figure out which one the request is and do that one:
+Three jobs. Work out which one the request is, then do that one.
 
-- **Decompose** — the user has a `plan.md` (or a spec / GitHub issue) and wants it sliced into phases.
-  Produce a phase-spec folder under `specs/`. This is the default when a plan is provided.
-- **Implement a phase** — the user (or an agent) is starting "phase N" of an already-decomposed
-  feature. Reuse the one feature branch and the one PR, the same way the earlier phases did.
+| Job | Trigger | Output |
+|---|---|---|
+| **1. Decompose** | the user hands you a plan | a spec folder under `specs/` |
+| **2. Implement a phase** | "work on phase N" | a commit on the one branch, the one PR retitled, the spec's status moved |
+| **3. Build a Ralph loop** | "make a ralph script", or the work is long and unattended | `ralph.sh` + `prompt.md` in the spec folder |
 
-Both jobs are built around one idea, so internalize it first.
+Job 1 usually leads into Job 3. Do not start Job 2 straight after Job 1 unless
+asked — decomposition is its own step, and the user may want to read it first.
 
 ## The idea: tracer bullets
 
-> Tracer bullets for new features. Tracer bullets comes from the Pragmatic Programmer. When building
-> systems, you want to write code that gets you feedback as quickly as possible. Tracer bullets are
-> small slices of functionality that go through all layers of the system, allowing you to test and
-> validate your approach early. This helps in identifying potential issues and ensures that the
-> overall architecture is sound before investing significant time in development.
-> TL;DR - build a tiny, end-to-end slice of the feature first, then expand it out.
+> Tracer bullets come from *The Pragmatic Programmer*. When building systems you
+> want feedback as quickly as possible. A tracer bullet is a small slice of
+> functionality that goes through **all layers** of the system, letting you test
+> and validate the approach early — before investing significant time.
 
-Everything below is just the mechanics of applying that idea to a plan and to the git workflow that
-ships it. The whole point is fast, real feedback: each phase is a slice you can actually run and
-verify, not a horizontal layer (all the backend, then all the frontend) that proves nothing until
-the end.
-
----
+Everything below is mechanics. The point is real feedback: each phase is a slice
+you can run and verify, not a horizontal layer (all the backend, then all the
+frontend) that proves nothing until the end.
 
 ## Job 1 — Decompose a plan into phases
 
-### Step 1: Read the plan and map the layers
+**Read `references/spec-templates.md` before writing anything.** It carries the
+README and phase templates, and the code-snippet style contract that keeps
+generated implementations from drowning in comments.
 
-Read the plan.md in full. Then list every layer the finished feature has to touch in this codebase —
-for example: infra / docker-compose, a backend `*_manager.py`, the deploy pipeline, a DocType, the
-`api.py` whitelisted endpoint, the SPA in `frontend/src/`. You are looking for the seam that runs
-top-to-bottom through all of them.
+1. **Read the plan in full**, then list every layer the finished feature touches
+   — infra, a backend manager module, the deploy pipeline, a DocType, the
+   whitelisted API, the SPA. You are looking for the seam that runs top to bottom
+   through all of them.
 
-### Step 2: Find phase 1 — the thinnest end-to-end slice
+2. **Find phase 1 — the thinnest end-to-end slice.** Everything optional
+   stripped: no auth, no toggles, no polish. Its only job is to prove the
+   architecture and produce feedback. If phase 1 touches one layer it is not a
+   tracer bullet; widen it until a single user-visible action travels the whole
+   pipe.
 
-Phase 1 is the tracer bullet: the smallest thing that exercises **every** layer end-to-end with
-everything optional stripped away (no auth, no TLS, no toggles, no error handling beyond not
-crashing, no polish). Its only job is to prove the architecture is sound and give real feedback. If
-phase 1 touches only one layer, it isn't a tracer bullet — widen it until a single user-visible
-action travels the whole pipe.
+   Two halves that are individually unverifiable are **one** phase, not two. If
+   shipping half of it breaks production or changes nothing observable, it was
+   never a phase boundary.
 
-### Step 3: Slice the rest
+3. **Slice the rest.** Each later phase adds one coherent capability, is
+   independently shippable, and is independently verifiable. A phase is the wrong
+   size when you cannot write a concrete "Done when". Order so nothing depends on
+   a later phase. Most plans land at 3–5 phases; let the plan decide.
 
-Each later phase adds **one** coherent capability on top of the working slice, and each one must be
-independently shippable and independently verifiable. A phase is the wrong size if you can't write a
-concrete "Done when" for it, or if it can't be demoed without the next phase. Order them so nothing
-depends on a phase that comes later. Most plans land at 3–5 phases; let the plan decide, don't pad.
+4. **Write the folder**, using the templates:
 
-### Step 4: Write the spec folder
-
-`specs/` is organized into **status buckets** — `not-completed/`, `in-progress/`, `completed/`,
-`superseded/` — indexed by `specs/STATUS.md`. A feature moves through the buckets as it is built
-(Job 2 handles the moves). A **freshly decomposed spec has no implementation yet, so it is born in
-`not-completed/`.** Always create a dedicated subfolder for the feature and put every file inside it:
-
-```
-specs/not-completed/<feature-slug>/
-├── README.md            # overview + the phase table — read this first
-├── phase-1-<slug>.md
-├── phase-2-<slug>.md
-└── phase-N-<slug>.md
-```
-
-Then register it in the index: add a row for the feature under the **Not started** table in
-`specs/STATUS.md` (`| <feature-slug> | freshly authored — no branch yet |`) and bump that section's
-count + the totals line. (`specs/` is gitignored, so these are plain filesystem writes — nothing to
-commit.)
-
-`<feature-slug>` is a short kebab-case name for the feature (e.g. `public-browser-access`). Phases
-are numbered from **1** (phase 1 = the tracer bullet) so the numbers line up with the PR titles in
-Job 2. Use the existing files in `specs/` as the format reference — match their structure, depth, and
-tone rather than inventing a new layout. The two templates below capture that structure.
-
-**`README.md` template:** (the first line is the status banner — it moves in lockstep with the
-folder's bucket: `⬜ Not started` → `🟡 In progress` → `✅ Completed`)
-
-```markdown
-> **Status:** ⬜ Not started — spec authored, no implementation yet
-
-# Spec: <feature title>
-
-<One-paragraph what + why: the problem today and the outcome we want.>
-Branch: `feature/<feature-slug>` · Base: `<integration or default branch>`
-
-## Build strategy — tracer bullets
-
-<Restate the tracer-bullet idea in one or two sentences for this feature: thinnest end-to-end slice
-first, prove it, then widen. Each phase is independently shippable and verified before the next.>
-
-| Phase | Tracer-bullet capability | Proves |
-|------|---------------------------|--------|
-| **[1](phase-1-<slug>.md)** | <the thinnest end-to-end thing that works> | <what running it proves> |
-| **[2](phase-2-<slug>.md)** | <one capability added on top> | <what it proves> |
-| **[N](phase-N-<slug>.md)** | ... | ... |
-
-## Confirmed decisions (apply to all phases)
-
-- <decisions taken from the plan that constrain every phase>
-
-## Shared architecture facts (verified — referenced by every phase)
-
-- <the concrete files / functions / fields each phase will touch, so a phase doc can point here
-  instead of repeating it>
-
-## Conventions (from CLAUDE.md — apply to all phases)
-
-- <the repo conventions the implementer must follow>
-- **No hardcoded config.** Values an admin could change (accounts, cost centers, rates, thresholds,
-  default parties, recipients, toggles) are read from an admin-editable Settings DocType / Custom
-  Field / config record — never hardcoded in frontend or backend source. <List the specific values
-  this feature needs and where each is configured.>
-```
-
-**`phase-N-<slug>.md` template:**
-
-```markdown
-# Phase N — <short title>
-
-> Read [README.md](README.md) first for shared architecture facts and conventions.
-
-## Goal (the thinnest end-to-end slice)
-
-<What works when this phase ships, and explicitly what is NOT in scope yet (deferred to later
-phases). For phase 1, name the layers the single slice travels through.>
-
-## Changes by file
-
-### <Layer, e.g. Infra / Backend / API / DocType / Frontend>
-- **New/Modify `<path>`** — <the specific change>.
-
-## Verification
-
-1. <concrete, runnable steps to prove the slice works — commands, what to look for>
-
-## Done when
-
-<One paragraph: the observable end state. Include the graceful-degradation case where relevant
-(e.g. still works / no-ops cleanly when the feature is unconfigured).>
-```
-
-After writing the files, tell the user the folder path and the phase list, and confirm the branch
-name you'll use in Job 2. Don't start implementing unless they ask — decomposition is its own step.
-
----
-
-## Job 2 — Implement a phase (one branch, one rolling PR)
-
-The whole feature lives on **one branch**; every phase commits to that same branch, and there is
-**one PR** that walks forward phase by phase. This is deliberate: the reviewer watches the feature
-grow as a single coherent story instead of juggling a PR per phase. (GitHub also only allows one open
-PR per head→base pair, so "raise a PR" on phases after the first means *update the existing one*.)
-
-Derive the branch name from the spec README — `feature/<feature-slug>`. Base branch = the integration
-branch named in the plan/README, else the repo's default branch (`develop` here).
-
-### Phase 1
-
-1. **Promote the spec to `in-progress/`** (starting phase 1 = work has begun):
-   `mv specs/not-completed/<feature-slug> specs/in-progress/<feature-slug>`. Then flip its README
-   banner to `> **Status:** 🟡 In progress — P1 started` and move its row from the **Not started**
-   table to the **In progress** table in `specs/STATUS.md` (adjust both counts). Plain `mv` — `specs/`
-   is gitignored.
-2. Branch off the base: `git switch -c feature/<feature-slug> <base>`.
-3. Implement phase 1 from `specs/in-progress/<feature-slug>/phase-1-<slug>.md`. Follow the repo
-   conventions and run `pre-commit run --all-files` before committing.
-4. Commit and push: `git push -u origin feature/<feature-slug>`.
-5. Open the PR:
-   ```bash
-   gh pr create --base <base> --head feature/<feature-slug> \
-     --title "Implemented phase one" \
-     --body "<what phase one does + how to verify it, drawn from the phase spec>"
+   ```
+   specs/not-completed/<feature-slug>/
+   ├── README.md
+   ├── phase-1-<slug>.md … phase-N-<slug>.md
+   └── ralph.sh + prompt.md   (Job 3, optional)
    ```
 
-### Phase N (N ≥ 2)
+5. **Create the tree and register it — with the script, never by hand:**
 
-1. Reuse the branch: `git switch feature/<feature-slug>` (don't branch off it). The spec folder is in
-   `specs/in-progress/<feature-slug>/` for the whole implementation run.
-2. Implement phase N from its spec; `pre-commit run --all-files`; commit; `git push`.
-3. The PR already exists for this branch, so update it instead of creating a new one:
    ```bash
-   gh pr edit feature/<feature-slug> --title "Implemented phase <ordinal>"
-   gh pr comment feature/<feature-slug> \
-     --body "Phase <ordinal>: <what this phase added + how to verify it>"
+   python3 .claude/skills/issue-to-phases/scripts/promote_spec.py --init
+   python3 .claude/skills/issue-to-phases/scripts/promote_spec.py <slug> \
+     --to not-completed --note "freshly authored — no branch yet"
    ```
-4. **If this is the final phase** (the last row of the phase table just shipped and merged): promote
-   the spec to `completed/`. `mv specs/in-progress/<feature-slug> specs/completed/<feature-slug>`,
-   flip its README banner to `> **Status:** ✅ Completed — all phases in <base> (PR #<n>)`, and move
-   its row to the **Completed** table in `specs/STATUS.md` (adjust both counts). Keep the folder in
-   `in-progress/` until the final phase is actually merged — a half-shipped feature is not completed.
 
-Each phase therefore (a) commits to the same branch, (b) sets the PR title to **"Implemented phase
-&lt;ordinal&gt;"**, and (c) leaves a comment describing what that phase did. Title ordinals are
-spelled-out words: phase 1 → "one", 2 → "two", 3 → "three", 4 → "four", 5 → "five" (continue the
-pattern beyond that).
+   `--init` creates `specs/`, all four buckets and `STATUS.md` if any are
+   missing, so a repo that has never used `specs/` needs no setup. Run it first
+   whenever you are not certain the tree exists.
 
-**Example — titles across a 3-phase feature:**
+6. **Tell the user the folder path, the phase list, and the branch name**, then
+   stop unless they ask you to build or implement.
 
-Input: implementing phase 2 of `public-browser-access`
-Output:
-- branch stays `feature/public-browser-access`
-- PR title becomes `Implemented phase two`
-- new PR comment: `Phase two: HTTPS via Let's Encrypt on the same routed host. Verify: curl -I https://<bench>.<domain>/ returns 200 with a valid cert.`
+## Job 2 — Implement a phase
+
+One branch for the whole feature; every phase commits to it; **one** PR that
+walks forward phase by phase. The reviewer watches the feature grow as a single
+story, and GitHub allows only one open PR per head→base pair anyway.
+
+Branch name comes from the spec README. Base is the integration branch it names,
+else the repo default.
+
+**Phase 1**
+1. `promote_spec.py <slug> --to in-progress --detail "P1 started"`
+2. `git switch -c <branch> <base>`
+3. Implement from the phase spec. Follow the repo conventions, run the lint hook.
+4. Commit, `git push -u origin <branch>`
+5. `gh pr create --base <base> --head <branch> --title "Implemented phase one" --body "<what it does + how to verify>"`
+
+**Phase N ≥ 2**
+1. `git switch <branch>` — do **not** branch off it.
+2. Implement, lint, commit, push.
+3. `gh pr edit <branch> --title "Implemented phase <ordinal>"` and
+   `gh pr comment <branch> --body "Phase <ordinal>: <what it added + how to verify>"`
+4. `promote_spec.py <slug> --to in-progress --detail "P<n> done"`
+5. **If it was the final phase and it merged:**
+   `promote_spec.py <slug> --to completed --detail "all phases in <base> (PR #<n>)"`
+
+Ordinals are spelled out: one, two, three, four, five.
+
+## Job 3 — Build a Ralph loop
+
+**Read `references/ralph-loop.md` before writing the script.** Copy both
+templates into the spec folder and fill them in:
+
+```bash
+cp .claude/skills/issue-to-phases/assets/ralph.sh.template   specs/<bucket>/<slug>/ralph.sh
+cp .claude/skills/issue-to-phases/assets/prompt.md.template  specs/<bucket>/<slug>/prompt.md
+chmod +x specs/<bucket>/<slug>/ralph.sh
+```
+
+**A phase that touches the UI needs a browser, so make sure there is one.** Before
+writing the loop, check that `agent-browser` is installed and can launch:
+
+```bash
+agent-browser --version || npm i -g agent-browser && agent-browser install
+agent-browser skills get core     # the workflow guide; the CLI serves its own docs
+```
+
+If it cannot launch, fix that before the loop runs, not during it — an agent
+discovering a missing browser mid-phase burns an iteration on setup. On a
+container host Chrome usually needs `--args "--no-sandbox"`; record the working
+invocation in the spec README so every iteration inherits it instead of
+rediscovering it.
+
+A Ralph loop runs one **fresh** headless `claude -p` session per iteration, with
+the file system as its only memory, and runs phases strictly in order. The prompt
+lives in `prompt.md` so it can be tuned between runs without touching bash.
+
+The thing that makes it trustworthy: **the agent is not the only judge of its own
+work.** After the agent writes a `.done` marker the loop runs its own
+`smoke_check` against the real system, and deletes the marker if reality
+disagrees. Write gates that would fail today, before the feature exists — a gate
+that passes on an unmodified tree is testing nothing. `references/ralph-loop.md`
+covers gate design, preflight/rollback, and the sandbox check to run before
+handing the loop over.
+
+Not every spec needs one. A loop pays for itself when the work is long, has
+verifiable per-phase end states, and touches something you would rather not
+babysit.
+
+## Spec status: one script, three trackers
+
+A spec's status lives in three places that must agree — the **bucket folder**,
+the README **banner**, and its **row plus counts** in `STATUS.md`. By hand that
+is three edits and two counters, and it is reliably the step that gets skipped
+while you are concentrating on code. A shipped feature filed under "not started"
+is how a tracker stops being worth reading.
+
+So it is a script, not a ritual:
+
+```bash
+P=.claude/skills/issue-to-phases/scripts/promote_spec.py
+python3 $P --init                                          # create the tree
+python3 $P <slug> --to in-progress --detail "P1 started"
+python3 $P <slug> --to completed --detail "all phases in main (PR #12)" --note "<index line>"
+python3 $P <slug> --check                                  # verify; changes nothing
+```
+
+It is idempotent, recomputes every count, refuses a backwards move without
+`--force`, and `--check` exits non-zero on drift so a loop can gate on it — which
+the ralph template does.
+
+Buckets walk forward only: `not-completed/` → `in-progress/` → `completed/`.
+`superseded/` is a manual sideways move for an abandoned spec. Keep a spec in
+`in-progress/` until the final phase actually merges; half-shipped is not
+completed.
 
 ## Guardrails
 
-- **Never hardcode configurable values — make them admin-configurable.** Anything a business admin
-  could reasonably change over time — GL / expense / income accounts, cost centers, tax or fee rates,
-  thresholds, default parties, email recipients, feature toggles — must live in an admin-editable
-  config surface (a single-DocType Settings record, a Custom Field, or a config record read at
-  runtime), **never baked into frontend or backend source**. When a phase needs such a value, adding
-  the config surface is part of that phase's scope, and the code reads from it. This is the lesson
-  from the Partner fee-invoices feature, where the Expense account was hardcoded in the codebase — it
-  should have been an admin setting, because accounts change. When decomposing, flag every value like
-  this and give it a home in the spec.
-- One subfolder per feature, always filed inside a **status bucket** — never write phase files into
-  the flat `specs/` root or loose in a bucket root. New specs are born in `not-completed/`.
-- The folder lives in exactly one bucket at a time and walks forward only:
-  `not-completed/` → `in-progress/` (phase 1 starts) → `completed/` (final phase merged). Never skip
-  `in-progress/`. `superseded/` is a manual sideways move for abandoned specs.
-- Keep the three trackers in lockstep on every move: the folder's **bucket**, its README **status
-  banner** (first line), and its row + counts in **`specs/STATUS.md`**. If they disagree, the bucket
-  the folder physically sits in wins.
-- One branch and one PR per feature; never open a second PR for a later phase of the same feature.
-- Keep phase numbers and PR ordinals in lockstep — phase 1 is "Implemented phase one".
-- A phase that can't state a concrete "Done when" / "Verification" is too big or too vague — reslice it.
+- **Never hardcode configurable values.** Anything a business admin could
+  reasonably change — accounts, cost centers, rates, thresholds, default parties,
+  recipients, toggles — belongs in an admin-editable config surface (a Settings
+  DocType, a Custom Field, a config record read at runtime), never baked into
+  source. When a phase needs such a value, adding the config surface is part of
+  that phase. Flag every one of them while decomposing and give it a home in the
+  spec.
+- **A UI change is not done until it has been seen in a browser.** Tests passing
+  and a green smoke check say the code is right; they say nothing about whether a
+  user can see it. Any phase touching a page, component or form ends with
+  `agent-browser` driving the real deployment and a screenshot in the notes. Three
+  things make a correct, merged UI change invisible, and none of them fails a
+  test: **the built assets are older than the source**, **a feature flag hides
+  it**, and **no row exercises it** (the feature reads a column every existing row
+  has as `NULL`). Check those three before concluding the code is wrong.
+- One subfolder per feature, always inside a status bucket — never loose in
+  `specs/` or in a bucket root.
+- One branch and one PR per feature. Never a second PR for a later phase.
+- Phase numbers and PR ordinals stay in lockstep: phase 1 is "Implemented phase
+  one".
+- A phase with no concrete "Done when" is too big or too vague. Reslice it.
+- Keep the bucket, the banner and `STATUS.md` in agreement. When they disagree,
+  the bucket the folder physically sits in wins.
+
+## Files in this skill
+
+| Path | Read it when |
+|---|---|
+| `references/spec-templates.md` | writing or revising a spec folder (Job 1) |
+| `references/ralph-loop.md` | writing a `ralph.sh` (Job 3) |
+| `assets/ralph.sh.template` | the loop skeleton to copy |
+| `assets/prompt.md.template` | the phase prompt to copy |
+| `scripts/promote_spec.py` | any time spec status or the tree changes |

--- a/.claude/skills/issue-to-phases/assets/prompt.md.template
+++ b/.claude/skills/issue-to-phases/assets/prompt.md.template
@@ -1,0 +1,207 @@
+# Ralph phase prompt — {{SPEC_SLUG}}
+
+<!--
+This file IS the prompt. ralph.sh reads it, substitutes the {{PLACEHOLDERS}}
+below, and passes the result to `claude -p`. Edit it freely between runs — no
+change to ralph.sh is needed, and the next iteration picks it up.
+
+Everything above the first `<!-- PHASE n -->` marker is sent for every phase.
+Below the markers, only the block matching the current phase is appended.
+
+Placeholders ralph.sh substitutes:
+  {{PHASE_NUMBER}}    1, 2, 3 …          {{PHASE_ORDINAL}}   one, two, three …
+  {{PHASE_COUNT}}     total phases        {{PHASE_FILE}}      this phase's spec filename
+  {{SPEC_SLUG}}       folder name         {{SPEC_DIR}}        absolute path to the spec folder
+  {{NOTES_FILE}}      this phase's notes  {{NOTES_GLOB}}      all phases' notes
+  {{DONE_MARKER}}     write when finished {{BLOCKED_MARKER}}  write when stuck
+  {{APP_DIR}}         code repo           {{DEVOPS_DIR}}      sibling/infra repo
+  {{PROMOTE}}         promote_spec.py     {{SNAP_DIR}}        preflight snapshots
+  {{BRANCH}}          feature branch      {{BASE_BRANCH}}     PR base
+  {{APP_URL}}         the running UI      {{NOTES_DIR}}       where screenshots go
+Anything in double braces that ralph.sh does not know is left as-is, so a typo
+shows up in the log rather than silently vanishing.
+-->
+
+You are one iteration of a Ralph loop implementing the {{SPEC_SLUG}} spec. Fresh
+session, no memory of previous iterations — the file system is your memory. Work
+ONLY on phase {{PHASE_NUMBER}}. Do not start any other phase.
+
+## What this feature is
+
+{{FEATURE_SUMMARY}}
+
+## Read these first, in this order
+
+1. `{{SPEC_DIR}}/README.md` — verified facts, decisions, conventions
+2. `{{SPEC_DIR}}/{{PHASE_FILE}}` — your phase: goal, changes, Verification, Done when
+3. `{{NOTES_FILE}}` — prior iterations' log; may not exist yet
+4. Skim `{{NOTES_GLOB}}` from earlier phases for environment facts already learned
+5. {{CONTEXT_DOCS}}
+
+Then assess actual state on disk and on the live system, and continue from wherever
+the last iteration stopped. Never redo work that already verifies; re-verify cheaply
+instead.
+
+## Tests and lint
+
+```
+{{TEST_CMD}}
+{{LINT_CMD}}
+```
+
+{{EXTRA_RULES}}
+
+## How to write the code
+
+The phase spec shows code snippets. Treat them as the **shape** to implement, not
+as text to paste. Their prose exists to explain the design to a human reading the
+spec; most of it does not belong in the file.
+
+- Default to **no comment**. Code that reads clearly gets none.
+- A comment earns its place only when something is surprising, constrained from
+  elsewhere in the system, or would otherwise be "fixed" by the next reader. When
+  it earns it: **one to three lines, never more.**
+- **One-line docstrings for almost everything.** Reserve a multi-line docstring
+  for a real contract — a non-obvious parameter, a sentinel return, a raised
+  exception.
+- Never restate what the code says. Never explain a well-named constant. Never
+  narrate a sequence of obvious statements.
+- Match the density of the file you are editing. If the surrounding code is bare,
+  yours is bare too.
+
+Follow the repo's `code-style` skill; the above is the concrete limit for it.
+
+## Branch and PR
+
+One branch, one rolling PR, retitled each phase. Never a second PR.
+
+- Branch `{{BRANCH}}`, based on `{{BASE_BRANCH}}`.
+- **Phase 1:** `git switch -c {{BRANCH}} {{BASE_BRANCH}}` (or `git switch {{BRANCH}}`
+  if it already exists with no commits), implement, commit, push, then:
+  ```
+  gh pr create --base {{BASE_BRANCH}} --head {{BRANCH}} --title "Implemented phase one"
+  ```
+- **Phase 2 and later:** `git switch {{BRANCH}}` — do **not** branch off it.
+  Implement, commit, push, then:
+  ```
+  gh pr edit {{BRANCH}} --title "Implemented phase {{PHASE_ORDINAL}}"
+  gh pr comment {{BRANCH}} --body "<what this phase added + how to verify it>"
+  ```
+- Conventional Commits: `type(scope): summary`. Write the message with the
+  `technical-writing` skill.
+
+## Spec status — use the script, never edit by hand
+
+Status lives in three places that must agree: the bucket folder, the README
+banner, and the row plus counts in STATUS.md. By hand that is three edits and two
+counters, and it is the step that gets skipped while you are concentrating on
+code.
+
+```bash
+cd {{APP_DIR}}
+# Phase 1, BEFORE implementing:
+python3 {{PROMOTE}} {{SPEC_SLUG}} --to in-progress --detail "P{{PHASE_NUMBER}} started"
+# Every later phase, when it lands:
+python3 {{PROMOTE}} {{SPEC_SLUG}} --to in-progress --detail "P{{PHASE_NUMBER}} done"
+# The FINAL phase ({{PHASE_COUNT}}), once merged or the PR is ready:
+python3 {{PROMOTE}} {{SPEC_SLUG}} --to completed \
+  --detail "all phases in {{BASE_BRANCH}} (PR #<n>)" --note "<one line for the index>"
+# Verify before writing your done marker:
+python3 {{PROMOTE}} {{SPEC_SLUG}} --check
+```
+
+The loop gates on this. A phase that leaves the spec in the wrong bucket has its
+done marker retracted, so skipping it costs an iteration.
+
+{{SAFETY_RULES}}
+
+## Rollback
+
+{{ROLLBACK}}
+
+Restore first, diagnose after. A rolled-back iteration that leaves the system
+working is a good iteration.
+
+## Notes
+
+Every iteration, append to `{{NOTES_FILE}}`: what you did, what verified, what
+failed and why, and the exact next step. The next iteration starts from that file.
+
+## If this phase touches the UI
+
+Passing tests do not mean a user can see the change. Before the done marker, drive
+the real deployment:
+
+```bash
+agent-browser skills get core            # read this before the first command
+export AGENT_BROWSER_SESSION="$(agent-browser session id --prefix {{SPEC_SLUG}})"
+agent-browser open {{APP_URL}} --args "--no-sandbox"
+agent-browser snapshot -i                # refs go stale on every page change
+agent-browser screenshot {{NOTES_DIR}}/p{{PHASE_NUMBER}}-<what>.png
+```
+
+Put the screenshot path in your notes and say what it shows. "The component
+renders" is not a finding; "the countdown reads 28:45 on the Labs row" is.
+
+**When the change is invisible, suspect these three before the code.** None of
+them fails a test, and all three have cost a real iteration:
+
+1. **The build is older than the source.** A framework serves compiled assets, so
+   an un-rebuilt bundle hides a correct component completely. Compare the newest
+   file under the source tree against the newest built asset; rebuild and restart
+   the web tier if the source is newer.
+2. **A flag gates it.** Features that cost money or are half-built usually hang
+   off a settings toggle, and the whole surface renders as it did before when the
+   toggle is off. Read the flag before concluding anything.
+3. **No row exercises it.** A feature keyed on a new column shows nothing while
+   every existing row has that column `NULL`, because those rows predate the
+   migration. Create one that carries the data.
+
+Check the page the feature actually lives on. A dashboard or overview page that
+was never in scope will look untouched no matter how correct the work is.
+
+## How an iteration ends
+
+**Never end your turn waiting for something.** This is a headless session: there
+is no next turn to wake into, so a turn that ends on "waiting for the background
+job" ends the iteration with the work half-done and the system left mid-change.
+If something is running, poll it inline until it finishes, or stop it and record
+the exact resume step in your notes. A loop that ends this way looks identical to
+a crash from the outside.
+
+For the same reason, never leave a process running when you stop. Anything you
+started — a load harness, a watcher, a tail — outlives your session and keeps
+mutating the system that the next iteration's smoke check is about to read.
+
+## Completion contract
+
+Run your phase's Verification section for real, against the live system. ONLY when
+every item passes, write a one-line summary to `{{DONE_MARKER}}`.
+
+The loop then runs its **own** independent smoke check. If that fails it deletes
+your marker and the phase continues. Do not create the marker early or
+optimistically — an optimistic marker costs an iteration and proves nothing.
+
+## Escape hatch
+
+If you hit a blocker only the user can resolve — a decision that is theirs,
+credentials rejected, the system down in a way you cannot fix, or a rollback that
+itself failed — write the full explanation to `{{BLOCKED_MARKER}}` and stop. The
+loop halts and surfaces it.
+
+<!-- PHASE 1 -->
+## Phase 1 notes
+
+ADAPT: what makes this phase dangerous or easy to get wrong, and the order of
+operations, phrased as "do not reorder them".
+
+<!-- PHASE 2 -->
+## Phase 2 notes
+
+ADAPT.
+
+<!-- PHASE 3 -->
+## Phase 3 notes
+
+ADAPT. If this is the final phase, remind the agent to promote the spec to
+`completed/` and set the PR title to "Implemented phase three".

--- a/.claude/skills/issue-to-phases/assets/ralph.sh.template
+++ b/.claude/skills/issue-to-phases/assets/ralph.sh.template
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+# ralph.sh — Ralph loop for the {{SPEC_SLUG}} spec.
+#
+# TEMPLATE. Every {{PLACEHOLDER}} must be replaced, and every block marked
+# "ADAPT:" rewritten for this spec. A loop whose smoke_check does not actually
+# test this feature is worse than no loop: it grants an agent permission to
+# believe it succeeded.
+#
+# Each iteration is a FRESH headless Claude session (`claude -p`); state persists
+# only in files. Phases run strictly in order; phase N+1 starts only after phase
+# N's agent has verified its spec's "Done when", the loop's own independent smoke
+# check has passed, and a marker has been dropped.
+#
+# Usage:   ./ralph.sh            # runs phases 1→{{PHASE_COUNT}}
+#          ./ralph.sh 2          # start at phase 2 (1 already done)
+# Watch:   tail -f {{WORKDIR}}/.ralph/{{RALPH_NS}}/logs/<latest>.log
+# Abort:   Ctrl-C, or `touch {{WORKDIR}}/.ralph/{{RALPH_NS}}/STOP`
+#
+# Runs with --dangerously-skip-permissions: only run on a box you can break.
+
+set -euo pipefail
+
+MODEL="claude-opus-5"
+EFFORT="xhigh"
+MAX_ITER=5                 # per phase — safety guard against spinning forever
+ITER_TIMEOUT={{ITER_TIMEOUT}}        # seconds per session
+
+APP_DIR="{{APP_DIR}}"
+DEVOPS_DIR="{{DEVOPS_DIR}}"
+WORKDIR="{{WORKDIR}}"
+SPEC_SLUG="{{SPEC_SLUG}}"
+SPEC_REL="specs"           # the folder moves between buckets; find it each run
+RALPH_DIR="$WORKDIR/.ralph/{{RALPH_NS}}"
+LOG_DIR="$RALPH_DIR/logs"
+NOTES_DIR="$WORKDIR/notes"
+SNAP_DIR="$RALPH_DIR/preflight"
+NOTES_PREFIX="{{NOTES_PREFIX}}"      # keeps notes from colliding with other loops
+
+BRANCH="{{BRANCH}}"
+BASE_BRANCH="{{BASE_BRANCH}}"
+
+# The running UI, for the browser checks. Leave empty on a spec with no UI surface.
+APP_URL="{{APP_URL}}"
+
+PROMOTE="$APP_DIR/.claude/skills/issue-to-phases/scripts/promote_spec.py"
+
+PHASE_FILES=(
+{{PHASE_FILES}}
+)
+PHASE_COUNT=${#PHASE_FILES[@]}
+
+mkdir -p "$LOG_DIR" "$NOTES_DIR" "$SNAP_DIR"
+
+spec_dir() {
+  local d
+  for d in in-progress not-completed completed; do
+    if [ -d "$APP_DIR/$SPEC_REL/$d/$SPEC_SLUG" ]; then
+      echo "$APP_DIR/$SPEC_REL/$d/$SPEC_SLUG"
+      return
+    fi
+  done
+  echo "ERROR: $SPEC_SLUG spec folder not found under $APP_DIR/$SPEC_REL" >&2
+  exit 1
+}
+
+spec_bucket() {
+  basename "$(dirname "$(spec_dir)")"
+}
+
+# ─── Live-state helpers ──────────────────────────────────────────────────────
+# ADAPT: one helper per thing smoke_check needs to observe.
+#
+# Two rules that are not negotiable, both learned the hard way:
+#
+#  1. Every helper returns 0 even when it finds nothing. Under `set -euo pipefail`
+#     an unguarded grep miss aborts the whole loop instead of reporting the
+#     failure the gate exists to catch.
+#  2. Observe the real thing through the real path. A status code, an exit code,
+#     or a log line saying "done" is not evidence — six separate incidents in the
+#     source material were tools reporting success while doing nothing.
+
+# Built assets older than the source: the failure that hides a correct UI change
+# completely, fails no test, and reads to the operator as "the feature is missing".
+# ADAPT the two paths; delete this helper on a spec with no built frontend.
+assets_stale() {
+  local src
+  src="$(find {{SRC_GLOB}} -type f -newer {{BUILT_MARKER}} 2>/dev/null | head -1 || true)"
+  [ -n "$src" ]
+}
+
+browser_ready() {
+  [ -n "$APP_URL" ] || return 0          # no UI surface on this spec
+  command -v agent-browser >/dev/null 2>&1
+}
+
+{{HELPERS}}
+
+preflight() {
+  [ -f "$SNAP_DIR/.taken" ] && return 0
+  echo "[ralph] preflight: snapshotting state before anything changes"
+  if ! browser_ready; then
+    echo "[ralph] ERROR: APP_URL is set but agent-browser is not installed."
+    echo "[ralph] Install it before starting: npm i -g agent-browser && agent-browser install"
+    echo "[ralph] A phase that has to prove its UI cannot do it without a browser."
+    exit 1
+  fi
+  # ADAPT: snapshot whatever rollback needs, and whatever smoke_check compares
+  # against. Rollback should be a file copy, not an act of memory.
+{{PREFLIGHT}}
+  ( cd "$APP_DIR" && git rev-parse HEAD ) > "$SNAP_DIR/head.before" 2>/dev/null || true
+  touch "$SNAP_DIR/.taken"
+}
+
+# The independent gate. Non-zero means no phase may be declared complete.
+#
+# This is the part that makes a Ralph loop trustworthy: the agent does not get to
+# be the only judge of its own work. Write gates that would FAIL today, before the
+# feature exists — a gate that passes on an unmodified tree is testing nothing.
+smoke_check() {
+  local phase="$1" failed=0
+
+  # ADAPT: the feature's own correctness gates.
+{{SMOKE_CHECKS}}
+
+  # Ships-but-invisible. A correct component behind a stale bundle passes every
+  # test and shows the user nothing, so the loop checks it rather than trusting
+  # that someone remembered to rebuild. Delete this block on a spec with no
+  # built frontend.
+  if [ "$phase" -ge 1 ] && [ -n "$APP_URL" ]; then
+    if assets_stale; then
+      echo "[ralph]   FAIL source is newer than the built assets — the UI serves the old bundle"
+      failed=1
+    else
+      echo "[ralph]   ok   built assets are at least as new as the source"
+    fi
+  fi
+
+  # Status lockstep. The bucket, the README banner and STATUS.md must agree, and
+  # this is reliably the step an agent skips while concentrating on code — which
+  # leaves a shipped feature filed under "not started".
+  if [ "$phase" -ge 1 ]; then
+    if ( cd "$APP_DIR" && python3 "$PROMOTE" "$SPEC_SLUG" --check >/dev/null 2>&1 ); then
+      echo "[ralph]   ok   spec status trackers are in lockstep"
+    else
+      echo "[ralph]   FAIL spec status is out of sync:"
+      ( cd "$APP_DIR" && python3 "$PROMOTE" "$SPEC_SLUG" --check 2>&1 | sed 's/^/[ralph]        /' ) || true
+      failed=1
+    fi
+
+    local bucket; bucket="$(spec_bucket)"
+    if [ "$phase" -lt "$PHASE_COUNT" ] && [ "$bucket" != "in-progress" ]; then
+      echo "[ralph]   FAIL phase $phase is done but the spec sits in $bucket/ (expected in-progress/)"
+      failed=1
+    fi
+    if [ "$phase" -ge "$PHASE_COUNT" ] && [ "$bucket" != "completed" ]; then
+      echo "[ralph]   FAIL the final phase is done but the spec sits in $bucket/ (expected completed/)"
+      failed=1
+    fi
+  fi
+
+  return "$failed"
+}
+
+# ─── Prompt ──────────────────────────────────────────────────────────────────
+# The prompt lives in prompt.md beside this script, so it can be edited between
+# runs without touching bash and without re-reading 200 lines of heredoc.
+#
+# Substitution is bash parameter expansion, not eval and not sed: the prompt is
+# markdown full of backticks, quotes and $ signs, and both of those would either
+# execute it or mangle it. An unknown {{PLACEHOLDER}} is left in place so a typo
+# shows up in the log instead of silently becoming an empty string.
+
+phase_prompt() {
+  local n="$1" spec="$2" done_marker="$3" blocked_marker="$4"
+  local file="$spec/prompt.md"
+  [ -f "$file" ] || { echo "ERROR: $file not found — the prompt lives there" >&2; exit 1; }
+
+  local ordinal shared block text
+  ordinal=$(sed -n "${n}p" <<< $'one\ntwo\nthree\nfour\nfive\nsix\nseven\neight')
+
+  # Everything before the first phase marker is sent for every phase; then only
+  # the block for this phase.
+  shared="$(sed '/^<!-- PHASE [0-9][0-9]* -->$/,$d' "$file")"
+  block="$(awk -v n="$n" '
+    $0 == "<!-- PHASE " n " -->" { grab = 1; next }
+    /^<!-- PHASE [0-9]+ -->$/    { grab = 0 }
+    grab                          { print }
+  ' "$file")"
+  text="$shared"$'\n'"$block"
+
+  # HTML comments in prompt.md are notes to whoever edits it; the agent pays for
+  # them in tokens and gains nothing.
+  #
+  # A block comment is delimited by lines that are ONLY `<!--` and `-->`. Matching
+  # those tokens anywhere on a line looks simpler and is wrong: the notes describe
+  # the `<!-- PHASE n -->` markers, and that inline `-->` ended the strip early,
+  # leaking the rest of the notes into the prompt.
+  text="$(awk '
+    !c && /^[[:space:]]*<!--[[:space:]]*$/ { c = 1; next }
+    c  && /^[[:space:]]*-->[[:space:]]*$/  { c = 0; next }
+    c { next }
+    /^[[:space:]]*<!--.*-->[[:space:]]*$/  { next }
+    { print }
+  ' <<< "$text")"
+
+  text="${text//\{\{PHASE_NUMBER\}\}/$n}"
+  text="${text//\{\{PHASE_ORDINAL\}\}/$ordinal}"
+  text="${text//\{\{PHASE_COUNT\}\}/$PHASE_COUNT}"
+  text="${text//\{\{PHASE_FILE\}\}/${PHASE_FILES[$((n-1))]}}"
+  text="${text//\{\{SPEC_SLUG\}\}/$SPEC_SLUG}"
+  text="${text//\{\{SPEC_DIR\}\}/$spec}"
+  text="${text//\{\{NOTES_FILE\}\}/$NOTES_DIR/$NOTES_PREFIX-phase-$n.md}"
+  text="${text//\{\{NOTES_GLOB\}\}/$NOTES_DIR/$NOTES_PREFIX-phase-*.md}"
+  text="${text//\{\{DONE_MARKER\}\}/$done_marker}"
+  text="${text//\{\{BLOCKED_MARKER\}\}/$blocked_marker}"
+  text="${text//\{\{APP_DIR\}\}/$APP_DIR}"
+  text="${text//\{\{DEVOPS_DIR\}\}/$DEVOPS_DIR}"
+  text="${text//\{\{PROMOTE\}\}/$PROMOTE}"
+  text="${text//\{\{SNAP_DIR\}\}/$SNAP_DIR}"
+  text="${text//\{\{BRANCH\}\}/$BRANCH}"
+  text="${text//\{\{BASE_BRANCH\}\}/$BASE_BRANCH}"
+  text="${text//\{\{APP_URL\}\}/$APP_URL}"
+  text="${text//\{\{NOTES_DIR\}\}/$NOTES_DIR}"
+
+  printf '%s\n' "$text"
+}
+
+# ─── Loop ────────────────────────────────────────────────────────────────────
+
+run_phase() {
+  local n="$1"
+  local done_marker="$RALPH_DIR/phase-$n.done"
+  local blocked_marker="$RALPH_DIR/phase-$n.blocked"
+
+  if [ -f "$done_marker" ]; then
+    echo "[ralph] phase $n already done: $(cat "$done_marker")"
+    return 0
+  fi
+  rm -f "$blocked_marker"
+
+  local iter=1
+  while [ "$iter" -le "$MAX_ITER" ]; do
+    [ -f "$RALPH_DIR/STOP" ] && { echo "[ralph] STOP file found, exiting."; exit 130; }
+
+    local spec log ts
+    spec="$(spec_dir)"
+    ts="$(date +%Y%m%d-%H%M%S)"
+    log="$LOG_DIR/phase-$n-iter-$iter-$ts.log"
+    echo "[ralph] phase $n, iteration $iter/$MAX_ITER — fresh session ($MODEL, effort=$EFFORT)"
+    echo "[ralph] log: $log"
+
+    ( cd "$APP_DIR" && timeout "$ITER_TIMEOUT" claude -p "$(phase_prompt "$n" "$spec" "$done_marker" "$blocked_marker")" \
+        --model "$MODEL" \
+        --effort "$EFFORT" \
+        --dangerously-skip-permissions \
+        --add-dir "$DEVOPS_DIR" \
+        --add-dir "$WORKDIR" \
+      ) 2>&1 | tee "$log" || echo "[ralph] iteration exited non-zero (timeout or error) — looping"
+
+    if [ -f "$blocked_marker" ]; then
+      echo "[ralph] phase $n BLOCKED — needs you:"
+      cat "$blocked_marker"
+      exit 2
+    fi
+
+    if [ -f "$done_marker" ]; then
+      echo "[ralph] agent claims phase $n complete — verifying independently:"
+      if smoke_check "$n"; then
+        echo "[ralph] phase $n COMPLETE: $(cat "$done_marker")"
+        return 0
+      fi
+      echo "[ralph] smoke check FAILED — retracting the done marker and continuing phase $n"
+      {
+        echo "## Iteration $iter — done marker RETRACTED by the loop"
+        echo "The agent wrote a done marker but the loop's independent smoke check failed."
+        echo "Re-read the failures above. The system must be correct in reality, not only"
+        echo "in the tests."
+      } >> "$NOTES_DIR/$NOTES_PREFIX-phase-$n.md"
+      rm -f "$done_marker"
+    fi
+
+    iter=$((iter+1))
+    sleep 5
+  done
+
+  echo "[ralph] phase $n did not complete in $MAX_ITER iterations — stopping so phase $((n+1)) never starts on a bad base."
+  echo "[ralph] read $NOTES_DIR/$NOTES_PREFIX-phase-$n.md and the logs, then re-run: ./ralph.sh $n"
+  exit 1
+}
+
+START_PHASE="${1:-1}"
+echo "[ralph] $SPEC_SLUG Ralph loop — phases $START_PHASE..$PHASE_COUNT, model=$MODEL, effort=$EFFORT"
+echo "[ralph] code lands in $APP_DIR on $BRANCH (base $BASE_BRANCH)"
+
+[ -d "$APP_DIR/.git" ] || { echo "[ralph] ERROR: $APP_DIR is not a git checkout." >&2; exit 1; }
+[ -f "$PROMOTE" ] || { echo "[ralph] ERROR: $PROMOTE not found." >&2; exit 1; }
+
+preflight
+
+echo "[ralph] baseline check before starting:"
+if ! smoke_check 0; then
+  echo "[ralph] ERROR: already unhealthy before this loop has changed anything."
+  echo "[ralph] Fix that first — a loop that starts from a broken baseline cannot tell its"
+  echo "[ralph] own damage apart from what it inherited."
+  exit 1
+fi
+
+echo "[ralph] NOTE: {{RISK_LINE}}"
+echo "[ralph]       Rollback snapshot is in $SNAP_DIR. Ctrl-C now if this is a bad moment."
+sleep 5
+
+for phase in $(seq "$START_PHASE" "$PHASE_COUNT"); do
+  run_phase "$phase"
+done
+
+echo "[ralph] all phases complete."
+( cd "$APP_DIR" && python3 "$PROMOTE" "$SPEC_SLUG" --check ) || true
+echo "[ralph] PR: $(cd "$APP_DIR" && gh pr view "$BRANCH" --json url -q .url 2>/dev/null || echo '(none found)')"

--- a/.claude/skills/issue-to-phases/references/ralph-loop.md
+++ b/.claude/skills/issue-to-phases/references/ralph-loop.md
@@ -1,0 +1,307 @@
+# Authoring the Ralph loop
+
+Read this when writing a spec's `ralph.sh` (Job 3). Start from
+`assets/ralph.sh.template` and replace every `{{PLACEHOLDER}}` and every `ADAPT:`
+block.
+
+## Contents
+
+- [What a Ralph loop is](#what-a-ralph-loop-is)
+- [The one idea that makes it work](#the-one-idea-that-makes-it-work)
+- [Designing smoke_check](#designing-smoke_check)
+- [Proving the UI](#proving-the-ui)
+- [Why a loop stalls](#why-a-loop-stalls)
+- [Preflight and rollback](#preflight-and-rollback)
+- [The phase prompt](#the-phase-prompt)
+- [Filling in the template](#filling-in-the-template)
+- [Before you hand it over](#before-you-hand-it-over)
+
+## What a Ralph loop is
+
+A bash loop that runs one **fresh** headless `claude -p` session per iteration.
+Nothing carries between iterations except the file system: the spec, a notes file
+per phase, and marker files. Phases run strictly in order; phase N+1 starts only
+once phase N is genuinely finished.
+
+Fresh sessions are the point. An agent that has been arguing with a problem for
+two hours has a context full of failed approaches; an agent that starts from the
+spec plus a notes file has the conclusions without the wreckage.
+
+Not every spec wants one. A loop pays for itself when the work is long, has
+verifiable per-phase end states, and touches something you would rather not
+babysit. A two-file refactor does not need one.
+
+## The one idea that makes it work
+
+**The agent does not get to be the only judge of its own work.**
+
+Every phase ends with the agent writing a `.done` marker. The loop then runs
+`smoke_check` — its own verification, in bash, against the real system — and if
+that disagrees it **deletes the marker** and the phase continues. The agent
+cannot declare success past a broken system, and phase N+1 can never start on a
+bad base.
+
+This is worth the effort because "reported success while doing nothing" is the
+single most common failure in this kind of automation. An exit code is not
+evidence.
+
+## Designing smoke_check
+
+The gates are the hard part and the part worth thinking about. Rules:
+
+**Write gates that fail today.** Before the feature exists, `smoke_check <phase>`
+should fail. If it passes on an unmodified tree it is testing nothing. Run it and
+confirm, then keep the output — it is proof the gate has teeth.
+
+**The baseline must pass.** `smoke_check 0` runs before the first iteration. It
+must pass on the current system, or the loop refuses to start — deliberately, so
+the loop can tell its own damage apart from what it inherited. If the baseline
+fails, either the system is genuinely broken or the gate is wrong; both need a
+human.
+
+**Gate the incumbent, not just the new thing.** Name whatever is serving users
+today and check it every single time, at every phase including phase 0. Most
+damage from this kind of work is collateral.
+
+**Gate on the property, not the symptom.** If the feature exists to stop
+certificates being issued, gate on "no new certificate appeared" — not on the
+site loading. A system can look perfect while quietly doing the thing you built
+the feature to prevent.
+
+**Find a real discriminator.** Two different services can both return 200 with a
+page titled "Login". Status codes and titles usually prove nothing. Find the
+field that actually differs — a header, a site name in a payload, a certificate
+subject — and verify it by hand before trusting it.
+
+> A worked example: an earlier loop discriminated the control plane from a tenant
+> site by reading `"sitename"` out of the boot payload. A later release replaced
+> that page with an SPA that never emits it, so the check returned empty for a
+> perfectly healthy system and the loop aborted at baseline every run. The `server`
+> header — nginx versus Werkzeug — was the durable discriminator. Test every helper
+> against the live system before shipping the loop.
+
+**Every helper returns 0 even when it finds nothing.** Under `set -euo pipefail`
+an unguarded `grep` miss aborts the whole loop instead of reporting the failure
+the gate exists to catch. End helpers with `|| true` and an explicit `return 0`.
+
+**Redirect stdin on every `docker compose exec`, or the loop hangs forever.**
+GNU `timeout` calls `setpgid()` to put its child in its own process group so it
+can kill the group. That group is *background* relative to the terminal, so the
+Compose CLI touching the controlling terminal takes SIGTTIN and stops — and
+because `timeout` is stopped alongside it, the timeout never fires. A
+one-second query then sits frozen for hours, reading to the operator as a hung
+phase. `-T` is not enough: it disables TTY allocation for the exec'd process,
+not the CLI's own terminal access.
+
+```bash
+( cd "$DEVOPS_DIR" && </dev/null timeout 120 docker compose exec -T db sh -c '...' )
+```
+
+Leave off only where stdin is already a pipe (`printf ... | timeout ...`), where
+the redirect would override the pipe and break the query. The signature when it
+happens: `ps -o pid,pgid,tpgid,stat` shows `T`/`Tl` with `PGID != TPGID`.
+SIGCONT does not help — the kernel re-stops it.
+
+**Include the status-lockstep gate.** The template ships it: phases before the
+last must leave the spec in `in-progress/`, the final phase in `completed/`, and
+`promote_spec.py --check` must pass. Keep it. Spec bookkeeping is what an agent
+drops first when it is concentrating on code, and a shipped feature filed under
+"not started" is how a tracker stops being worth reading.
+
+## Proving the UI
+
+A green smoke check says the code is right. It says nothing about whether anyone
+can see it. If the spec touches a page, the loop needs a browser, and
+`agent-browser` is the one to use — check it launches **before** handing the loop
+over, because an agent discovering a missing browser mid-phase spends an
+iteration on setup instead of the feature.
+
+Set `APP_URL` in the config block. The template's `preflight` refuses to start
+when `APP_URL` is set and `agent-browser` is missing, which is the right moment
+to find out.
+
+Three things hide a correct, merged UI change. None of them fails a test, and all
+three have cost real iterations:
+
+| What | Why it hides the change | How the loop catches it |
+|---|---|---|
+| **Built assets older than the source** | the server ships compiled bundles, so the browser gets the previous build | `assets_stale` in `smoke_check` — a gate, not a habit |
+| **A feature flag is off** | money-touching and half-built features hang off a settings toggle, and the whole surface renders exactly as it did before | read the flag in a helper and gate on it |
+| **No row exercises it** | a feature keyed on a new column shows nothing while every row predating the migration has it `NULL` | the phase's verification has to create a row that carries the data |
+
+The first is worth a gate rather than a note because it is invisible from inside
+the code: every test passes, the component is correct, the diff is merged, and the
+user sees the old page. Only a timestamp comparison catches it.
+
+One more that wastes a whole debugging session: **check the page the feature
+actually lives on**. A dashboard or overview that was never in the spec's scope
+looks untouched no matter how right the work is.
+
+## Why a loop stalls
+
+Three causes, all observed, all silent — a stalled loop and a working loop look
+identical from the terminal.
+
+**The agent ends its turn waiting.** A headless `claude -p` session has no next
+turn, so "I've started the drill in the background and will report when it
+finishes" ends the iteration with the work half-done and the switches unrestored.
+Say this in the prompt explicitly; it does not occur to an agent that has spent
+its whole existence in interactive sessions. The template's *How an iteration
+ends* section carries the wording.
+
+**A `docker compose exec` under `timeout` takes SIGTTIN.** Covered in
+[Designing smoke_check](#designing-smoke_check) — the fix is `</dev/null`. The
+diagnosis is `ps -o pid,pgid,tpgid,stat`: `T`/`Tl` with `PGID != TPGID`, and
+Ctrl-C cannot clear it because the stuck process is not in the terminal's
+foreground group.
+
+**A process outlives the session that started it.** A load harness or watcher an
+agent backgrounded keeps mutating the system after its session dies, so the next
+iteration's smoke check reads state nobody is maintaining. Tell the agent to stop
+what it starts, and when a phase ends badly, check for orphans before re-running:
+`ps -eo pid,ppid,etime,args | grep <your harness>`.
+
+## Preflight and rollback
+
+`preflight()` snapshots, once, everything that:
+
+1. rollback needs — so recovering is a file copy rather than an act of memory, and
+2. `smoke_check` compares against — counts, identity sets, the list of things that
+   existed before.
+
+Then write the rollback command into the phase prompt verbatim. Not "restore the
+config" — the actual command, with paths. An agent mid-incident should not be
+composing it.
+
+State the order plainly: **restore first, diagnose after.** A rolled-back
+iteration that leaves the system working is a good iteration.
+
+## The phase prompt
+
+**The prompt is not in ralph.sh.** It lives in `prompt.md` beside it, copied from
+`assets/prompt.md.template`. `ralph.sh` reads that file, substitutes
+`{{PLACEHOLDERS}}`, and passes the result to `claude -p`.
+
+This split exists because the prompt is the part you actually tune. Buried in a
+200-line bash heredoc it is unreadable and every edit risks the script; as
+markdown it can be revised between runs with no change to ralph.sh, and the next
+iteration picks it up.
+
+How the file is laid out:
+
+- Everything **above** the first `<!-- PHASE n -->` marker is sent for every phase.
+- Below the markers, only the block matching the current phase is appended — this
+  replaces the old `phase_extra()` bash function.
+- Block comments are stripped before sending, so notes to whoever edits the file
+  cost no tokens. A block comment is delimited by lines that are **only** `<!--`
+  and `-->`; keep it that way, because prose mentioning `-->` inline on a
+  delimiter line would end the comment early.
+- Substitution is bash parameter expansion, never `eval` or `sed` — the prompt is
+  markdown full of backticks, quotes and `$`, and both of those would execute or
+  mangle it. An unrecognised `{{PLACEHOLDER}}` is left in place, so a typo shows
+  up in the log instead of silently becoming an empty string.
+
+The shared half already carries the parts that generalise: read order, branch/PR
+flow, spec-status commands, comment discipline, notes contract, completion
+contract, escape hatch. What you write per spec:
+
+- **`{{FEATURE_SUMMARY}}`** — two or three sentences on what is broken and what
+  the outcome is. The agent has no memory; this is its orientation.
+- **`{{SAFETY_RULES}}`** — the irreversible things, stated as prohibitions with
+  reasons. "Never X" alone invites a clever exception; "Never X, because Y" does
+  not. Cover: what must never be deleted, what must never be restarted, which
+  commands are out of bounds and why, and anything with a rate limit or a cost.
+- **`{{EXTRA_RULES}}`** — repo-specific traps. Which lint command is wrong to run.
+  Which services hold a stale module until restarted. Anything that has bitten
+  someone.
+- **the `<!-- PHASE n -->` blocks** — per-phase warnings. Put the destructive
+  phase's order of operations here, phrased as "do not reorder them".
+
+Write prohibitions where the agent will be when it needs them, and give the
+reason. An agent that understands why a rule exists will not route around it.
+
+## Filling in the template
+
+Copy both files into the spec folder, then fill them in:
+
+```bash
+cp .claude/skills/issue-to-phases/assets/ralph.sh.template   specs/not-completed/<slug>/ralph.sh
+cp .claude/skills/issue-to-phases/assets/prompt.md.template  specs/not-completed/<slug>/prompt.md
+chmod +x specs/not-completed/<slug>/ralph.sh
+```
+
+In **`ralph.sh`** — the wiring:
+
+| Placeholder | What goes in |
+|---|---|
+| `{{SPEC_SLUG}}` | folder name, e.g. `wildcard-cert-routing` |
+| `{{RALPH_NS}}` | short namespace for markers/logs, e.g. `wildcard-cert` |
+| `{{NOTES_PREFIX}}` | short prefix for notes files, e.g. `wc` |
+| `{{APP_DIR}}` / `{{DEVOPS_DIR}}` / `{{WORKDIR}}` | absolute paths |
+| `{{BRANCH}}` / `{{BASE_BRANCH}}` | from the spec README |
+| `{{PHASE_FILES}}` | one quoted filename per line, in order |
+| `{{ITER_TIMEOUT}}` | seconds per session; size it to the slowest phase |
+| `{{APP_URL}}` | the running UI, for the browser checks — empty on a spec with no UI |
+| `{{SRC_GLOB}}` / `{{BUILT_MARKER}}` | frontend source tree and one built asset, for `assets_stale` |
+| `{{RISK_LINE}}` | one line telling the user what this loop will change |
+| `{{HELPERS}}`, `{{PREFLIGHT}}`, `{{SMOKE_CHECKS}}` | bash, per above |
+
+In **`prompt.md`** — the words:
+
+| Placeholder | What goes in |
+|---|---|
+| `{{FEATURE_SUMMARY}}` | two or three sentences of orientation |
+| `{{CONTEXT_DOCS}}` | the CLAUDE.md / design docs worth reading |
+| `{{TEST_CMD}}` / `{{LINT_CMD}}` | the repo's real commands |
+| `{{EXTRA_RULES}}` | repo-specific traps |
+| `{{SAFETY_RULES}}` | the irreversible things, each with its reason |
+| `{{ROLLBACK}}` | the exact restore command, with paths |
+| `<!-- PHASE n -->` blocks | per-phase warnings |
+
+Everything else in `prompt.md` — phase number, ordinal, paths, markers, branch —
+is substituted by `ralph.sh` at run time. Leave those alone.
+
+Leave `{{APP_URL}}` empty on a backend-only spec and delete the `assets_stale`
+helper with its gate — an empty `find` glob matches the whole tree and the gate
+then fails on every run.
+
+`RALPH_NS` and `NOTES_PREFIX` must be unique per spec. Two loops sharing a
+namespace makes the second one skip every phase as "already done" and overwrite
+the first one's notes.
+
+## Before you hand it over
+
+Five checks, all cheap, and each has caught a real bug:
+
+```bash
+bash -n ralph.sh                      # 1. syntax
+```
+
+2. **Run every helper by hand** against the live system and confirm each returns
+   what you assumed. This is where a stale discriminator shows up. If the spec has
+   a UI, launch the browser once too — `agent-browser open "$APP_URL"` — so a
+   missing binary or a sandbox flag surfaces now rather than mid-phase.
+
+3. **Execute `smoke_check` in a sandbox**, without starting the loop. Extract the
+   config and function block into a scratch file, point `WORKDIR` at a temp
+   directory, and call `preflight` then `smoke_check 0` and `smoke_check 1`:
+
+```bash
+sed -n '/^set -euo pipefail/,/^# ─── Prompt/p' ralph.sh | sed '$d' > /tmp/harness.sh
+cat >> /tmp/harness.sh <<'EOS'
+preflight
+smoke_check 0 && echo "BASELINE PASS" || echo "BASELINE FAIL"
+smoke_check 1 && echo "PHASE-1 GATE PASS" || echo "PHASE-1 GATE FAIL"
+EOS
+sed -i 's|^WORKDIR=.*|WORKDIR="/tmp/ralphtest"|' /tmp/harness.sh
+bash /tmp/harness.sh
+```
+
+   Baseline must pass and the phase-1 gate must **fail** — on today's unmodified
+   tree, naming the specific things the phase will fix. That pair is the
+   calibration. Paste the output when you hand the loop over.
+
+4. **`chmod +x ralph.sh`.**
+
+Then tell the user how to watch it and how to stop it, and say plainly what it
+will change.

--- a/.claude/skills/issue-to-phases/references/spec-templates.md
+++ b/.claude/skills/issue-to-phases/references/spec-templates.md
@@ -1,0 +1,210 @@
+# Spec templates and the code-snippet style contract
+
+Read this when writing or revising a spec folder (Job 1).
+
+## Contents
+
+- [The folder](#the-folder)
+- [README.md template](#readmemd-template)
+- [phase-N.md template](#phase-nmd-template)
+- [The code-snippet style contract](#the-code-snippet-style-contract) — read this one even if you skim the rest
+- [Verification sections that are worth writing](#verification-sections-that-are-worth-writing)
+
+## The folder
+
+```
+specs/not-completed/<feature-slug>/
+├── README.md            # overview, verified facts, decisions, the phase table
+├── phase-1-<slug>.md
+├── phase-N-<slug>.md
+└── ralph.sh             # optional; see references/ralph-loop.md
+```
+
+A freshly decomposed spec is born in `not-completed/`, because nothing is built
+yet. Register it in `specs/STATUS.md` with the script — never by hand:
+
+```bash
+python3 .claude/skills/issue-to-phases/scripts/promote_spec.py <slug> --to not-completed \
+  --note "freshly authored — no branch yet"
+```
+
+## README.md template
+
+The first line is the status banner. `promote_spec.py` owns it after creation —
+do not hand-edit it later, or the three trackers drift.
+
+```markdown
+> **Status:** ⬜ Not started — spec authored, no implementation yet
+
+# Spec: <feature title>
+
+<One or two paragraphs: the problem today, and the outcome we want. Lead with what
+is broken or missing, not with the solution.>
+
+Branch: `<branch>` · Base: `<integration or default branch>`
+
+## What was verified before this spec was written
+
+<A table of facts MEASURED against the real system, with the evidence. This is the
+most valuable section in the file: it is what stops a phase being planned against
+an assumption. If you did not check it, do not list it.>
+
+| Fact | Evidence |
+|---|---|
+| <fact> | <the command run and what it returned> |
+
+## Build strategy — tracer bullets
+
+<Thinnest end-to-end slice first, prove it, then widen. Each phase independently
+shippable and verified before the next.>
+
+| Phase | Tracer-bullet capability | Proves |
+|------|---------------------------|--------|
+| **[1](phase-1-<slug>.md)** | <the thinnest end-to-end thing that works> | <what running it proves> |
+| **[N](phase-N-<slug>.md)** | <one capability added on top> | <what it proves> |
+
+## Confirmed decisions (apply to all phases)
+
+- <decisions from the plan that constrain every phase, each with its reason>
+
+## Shared architecture facts (verified — referenced by every phase)
+
+- <concrete files, functions, fields each phase touches, so a phase doc can point
+  here instead of repeating it>
+
+## Conventions (from CLAUDE.md — apply to all phases)
+
+- <the repo conventions the implementer must follow>
+- **No hardcoded config.** Values an admin could change (accounts, rates,
+  thresholds, recipients, toggles) are read from an admin-editable Settings
+  DocType / config record — never hardcoded. <Name the specific values this
+  feature needs and where each is configured.>
+```
+
+If the feature has a trap — two things that look independent but collide — give
+it its own `## The trap that decides the slicing` section. That section is
+usually the reason the phases are ordered the way they are, and the next reader
+needs it more than they need the phase table.
+
+## phase-N.md template
+
+```markdown
+# Phase N — <short title>
+
+> Read [README.md](README.md) first for shared architecture facts and conventions.
+
+## Goal (the thinnest end-to-end slice)
+
+<What works when this phase ships. For phase 1, name the layers the slice travels
+through. Then, explicitly:>
+
+**Not in scope for phase N:** <what a reader will expect and not find, and which
+later phase owns it. Naming these is what stops a reviewer reading a deliberate
+boundary as an oversight.>
+
+## Changes by file
+
+### <path>
+- <the specific change, with a code snippet where the shape is not obvious>
+
+## Verification
+
+1. <concrete, runnable steps — commands, and what the output must say>
+
+**Rollback**, if step <n> fails: <the exact command. Restore first, diagnose after.>
+
+## Done when
+
+<One paragraph: the observable end state, including the graceful-degradation case
+(still works / no-ops cleanly when unconfigured), and a sentence naming the known
+gaps this phase deliberately leaves for later phases.>
+```
+
+## The code-snippet style contract
+
+**This is the section that matters most, because of how the snippets get used.**
+
+A phase spec's code snippets are not illustrations. The implementing agent pastes
+them. Whatever density of comment you write into the spec is the density that
+lands in the merged file — a thirteen-line docstring in a spec becomes a
+thirteen-line docstring in production, and the reviewer sees a file where the
+prose outweighs the code.
+
+So the snippets in a spec obey the same limit the code does:
+
+- **Default to no comment.** Code that reads clearly gets none.
+- **A comment earns its place** only when something is surprising, constrained
+  from elsewhere in the system, or would otherwise be "fixed" by the next reader.
+  When it earns it: **one to three lines, never more.**
+- **One-line docstrings for almost everything.** Reserve a multi-line docstring
+  for a real contract — a non-obvious parameter, a sentinel return, a raised
+  exception.
+- **Never restate the code.** Never explain a well-named constant. Never narrate
+  a sequence of obvious statements.
+- **Match the file being edited.** If the surrounding code is bare, the new code
+  is bare.
+
+The design reasoning still has to live somewhere — it is the most valuable thing
+in the spec. Put it in the **prose around the snippet**, where a reader who wants
+the argument will find it and a reader of the source will not have to wade
+through it.
+
+**Before** — this shipped, and it is the failure mode:
+
+```python
+# One file, one router, one identity set — the only place in this app that names a
+# certificate resolver. Fixed name so it is idempotently overwritten and can never
+# collide with an instance file, which is always a 32-character hex id.
+WILDCARD_ANCHOR_FILE = "wildcard-anchor.yml"
+
+def _ensure_wildcard_anchor(base_domain: str | None) -> bool:
+	"""Put the bench-zone wildcard in Traefik's certificate store, once.
+
+	Returns True when the file was written. Rewrites only on a real change: Traefik
+	reloads on mtime, and a deploy has no business making it reload to say nothing.
+
+	Never deleted at teardown — it has to outlive every bench, because it is what keeps
+	the certificate renewing.
+	"""
+```
+
+**After** — same design, same information available, comment budget spent where
+it buys something:
+
+```python
+WILDCARD_ANCHOR_FILE = "wildcard-anchor.yml"
+
+def _ensure_wildcard_anchor(base_domain: str | None) -> bool:
+	"""Write the wildcard anchor if it is missing or stale; True when written."""
+	# Rewriting unchanged content would touch mtime, and Traefik reloads on mtime.
+```
+
+The "never deleted at teardown" fact did not disappear — it belongs in the
+teardown function, next to the code that would otherwise delete it, and in the
+spec's prose. Facts go where someone would act on them, not where they were
+discovered.
+
+Write the surrounding prose with the `technical-writing` skill and the code with
+`code-style`. This section is the concrete limit for `code-style`'s "do not
+narrate obvious code".
+
+## Verification sections that are worth writing
+
+A phase whose Verification is "run the tests" is not sliced yet — it has no
+observable end state, which means it is a horizontal layer rather than a tracer
+bullet.
+
+Good verification steps share three properties:
+
+1. **They observe the real thing through the real path.** An exit code, a 200,
+   or a log line saying "done" is not evidence. Name the discriminator: the
+   header, the field, the certificate subject, the row count.
+2. **They can fail.** Write a step whose expected output you could not produce
+   today, before the phase is built.
+3. **They say what to do when the step fails**, when the step touches something
+   live. Restore first, diagnose after — a rolled-back attempt that leaves the
+   system working beats a forward-debugged outage.
+
+Include a negative control wherever one is cheap: a name that should *not*
+resolve, a user who should *not* have access, a file that should *not* be
+deleted. A gate that only ever sees passing input is not a gate.

--- a/.claude/skills/issue-to-phases/scripts/promote_spec.py
+++ b/.claude/skills/issue-to-phases/scripts/promote_spec.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Create the specs/ tree and move specs between status buckets, in lockstep.
+
+A spec's status lives in three places that must agree: the bucket folder it sits
+in, its README banner, and its row plus counts in STATUS.md. Doing that by hand
+is three edits and two counter updates, and it is reliably the step an agent
+skips when it is concentrating on code — which leaves a shipped feature filed
+under "not started".
+
+This does all of it in one idempotent command, and `--check` verifies the three
+agree without changing anything, so a loop can gate on it.
+
+    promote_spec.py --init                        # create specs/, all buckets, STATUS.md
+    promote_spec.py <slug> --to in-progress --detail "P1 started"
+    promote_spec.py <slug> --to completed --detail "all phases in version-16 (PR #157)"
+    promote_spec.py <slug> --check
+
+Any run that files a spec also creates whatever part of the tree is missing, so a
+repo that has never used specs/ — or one missing a bucket it has never needed —
+needs no setup step.
+
+Exit codes: 0 success or in sync, 1 usage/not-found, 2 --check found drift.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import sys
+from pathlib import Path
+
+BUCKETS = {
+	"not-completed": ("Not started", "⬜ Not started", "spec authored, no implementation yet"),
+	"in-progress": ("In progress", "🟡 In progress", "implementation started"),
+	"completed": ("Completed", "✅ Completed", "all phases merged"),
+	"superseded": ("Superseded", "⏹️ Superseded", "replaced by a later spec"),
+}
+
+# Forward only. Superseded is a manual sideways move from anywhere, so it is not
+# listed as a successor — the guard exists to catch a spec being filed backwards,
+# not to police an abandonment.
+FORWARD = {"not-completed": 1, "in-progress": 2, "completed": 3}
+
+BANNER_RE = re.compile(r"^>\s*\*\*Status:\*\*.*$", re.M)
+COUNT_RE = re.compile(r"^Count:\s*\d+\s*$", re.M)
+TOTALS_RE = re.compile(r"^Totals:.*$", re.M)
+EMPTY_MARKER = "_None._"
+
+
+STATUS_HEADER = """# Spec status
+
+Tracks every feature spec under `specs/`, bucketed by implementation state.
+A feature moves forward only: `not-completed/` → `in-progress/` →
+`completed/` (or sideways to `superseded/` if abandoned). Keep this file, the
+folder's location, and its README status banner in lockstep.
+"""
+
+
+def die(message: str, code: int = 1) -> None:
+	print(f"error: {message}", file=sys.stderr)
+	raise SystemExit(code)
+
+
+def ensure_tree(specs_dir: Path) -> list[str]:
+	"""Create specs/, every bucket, and STATUS.md. Returns what was created."""
+	created = []
+	if not specs_dir.exists():
+		specs_dir.mkdir(parents=True)
+		created.append(f"{specs_dir}/")
+	for bucket in BUCKETS:
+		d = specs_dir / bucket
+		if not d.is_dir():
+			d.mkdir(parents=True, exist_ok=True)
+			created.append(f"{specs_dir}/{bucket}/")
+		# Buckets are often empty for a while, and an empty directory does not
+		# survive a clone. .gitkeep costs nothing and keeps the shape visible.
+		keep = d / ".gitkeep"
+		if not any(d.iterdir()):
+			keep.touch(exist_ok=True)
+
+	status_path = specs_dir / "STATUS.md"
+	if not status_path.exists():
+		body = STATUS_HEADER
+		for bucket, (heading, _, _) in BUCKETS.items():
+			body += f"\n## {heading}\n" + render_section([])
+		body += (
+			"\n---\n\nTotals: 0 specs tracked (0 not started, 0 in progress, "
+			"0 completed, 0 superseded).\n"
+		)
+		status_path.write_text(body)
+		created.append(f"{status_path}")
+	else:
+		# An existing STATUS.md may predate a bucket. Add any missing section so
+		# section_bounds() never dies on a tree this script just finished creating.
+		text = status_path.read_text()
+		added = False
+		for bucket, (heading, _, _) in BUCKETS.items():
+			if not re.search(rf"^##\s+{re.escape(heading)}\s*$", text, re.M):
+				insert_at = TOTALS_RE.search(text)
+				section = f"\n## {heading}\n" + render_section([])
+				if insert_at:
+					cut = text.rfind("---", 0, insert_at.start())
+					cut = cut if cut != -1 else insert_at.start()
+					text = text[:cut] + section + "\n" + text[cut:]
+				else:
+					text = text.rstrip() + "\n" + section
+				added = True
+				created.append(f"{status_path} '## {heading}' section")
+		if added:
+			status_path.write_text(text)
+	return created
+
+
+def find_spec(specs_dir: Path, slug: str) -> tuple[str, Path]:
+	for bucket in BUCKETS:
+		candidate = specs_dir / bucket / slug
+		if candidate.is_dir():
+			return bucket, candidate
+	die(f"no spec folder named {slug!r} under {specs_dir}/<bucket>/")
+
+
+def section_bounds(text: str, heading: str) -> tuple[int, int]:
+	"""Character range of one `## <heading>` section, excluding the next heading."""
+	start = re.search(rf"^##\s+{re.escape(heading)}\s*$", text, re.M)
+	if not start:
+		die(f"STATUS.md has no '## {heading}' section")
+	nxt = re.search(r"^(##\s+|---\s*$)", text[start.end():], re.M)
+	end = start.end() + (nxt.start() if nxt else len(text) - start.end())
+	return start.end(), end
+
+
+def row_slug(row: str) -> str | None:
+	m = re.match(r"\|\s*\[([^\]]+)\]", row)
+	return m.group(1) if m else None
+
+
+def split_rows(block: str) -> tuple[list[str], list[str]]:
+	"""Separate table data rows from everything else in a section."""
+	rows, other = [], []
+	for line in block.splitlines():
+		s = line.strip()
+		if s.startswith("|") and not re.match(r"\|\s*-{2,}", s) and not s.startswith("| Feature"):
+			rows.append(s)
+		else:
+			other.append(line)
+	return rows, other
+
+
+def render_section(rows: list[str]) -> str:
+	if not rows:
+		return f"\n{EMPTY_MARKER}\n\nCount: 0\n"
+	body = "\n".join(rows)
+	return f"\n| Feature | Notes |\n|---|---|\n{body}\n\nCount: {len(rows)}\n"
+
+
+def read_row(text: str, slug: str) -> tuple[str | None, str | None]:
+	"""Return (bucket, note) for the slug's existing STATUS.md row, if any."""
+	for bucket, (heading, _, _) in BUCKETS.items():
+		lo, hi = section_bounds(text, heading)
+		for row in split_rows(text[lo:hi])[0]:
+			if row_slug(row) == slug:
+				parts = [p.strip() for p in row.strip("|").split("|")]
+				return bucket, (parts[1] if len(parts) > 1 else "")
+	return None, None
+
+
+def update_status(status_path: Path, slug: str, target: str, note: str | None) -> str:
+	text = status_path.read_text()
+	_, existing_note = read_row(text, slug)
+	note = note or existing_note or BUCKETS[target][2]
+	new_row = f"| [{slug}]({target}/{slug}/README.md) | {note} |"
+
+	counts: dict[str, int] = {}
+	for bucket, (heading, _, _) in BUCKETS.items():
+		lo, hi = section_bounds(text, heading)
+		rows = [r for r in split_rows(text[lo:hi])[0] if row_slug(r) != slug]
+		if bucket == target:
+			rows.append(new_row)
+		counts[bucket] = len(rows)
+		text = text[:lo] + render_section(rows) + text[hi:]
+
+	total = sum(counts.values())
+	totals = (
+		f"Totals: {total} specs tracked ({counts['not-completed']} not started, "
+		f"{counts['in-progress']} in progress, {counts['completed']} completed, "
+		f"{counts['superseded']} superseded)."
+	)
+	if TOTALS_RE.search(text):
+		text = TOTALS_RE.sub(totals, text, count=1)
+	else:
+		text = text.rstrip() + f"\n\n---\n\n{totals}\n"
+
+	status_path.write_text(text)
+	return note
+
+
+def set_banner(readme: Path, target: str, detail: str | None) -> str:
+	label = BUCKETS[target][1]
+	banner = f"> **Status:** {label} — {detail or BUCKETS[target][2]}"
+	text = readme.read_text() if readme.exists() else ""
+	if BANNER_RE.search(text):
+		text = BANNER_RE.sub(banner, text, count=1)
+	else:
+		text = f"{banner}\n\n{text}"
+	readme.write_text(text)
+	return banner
+
+
+def check(specs_dir: Path, slug: str) -> int:
+	bucket, folder = find_spec(specs_dir, slug)
+	status_path = specs_dir / "STATUS.md"
+	problems = []
+
+	readme = folder / "README.md"
+	if not readme.exists():
+		problems.append("README.md is missing")
+	else:
+		m = BANNER_RE.search(readme.read_text())
+		if not m:
+			problems.append("README.md has no status banner")
+		elif BUCKETS[bucket][1] not in m.group(0):
+			problems.append(f"banner says {m.group(0).strip()!r} but the folder is in {bucket}/")
+
+	if not status_path.exists():
+		problems.append("STATUS.md is missing")
+	else:
+		text = status_path.read_text()
+		row_bucket, _ = read_row(text, slug)
+		if row_bucket is None:
+			problems.append(f"STATUS.md has no row for {slug}")
+		elif row_bucket != bucket:
+			problems.append(f"STATUS.md files it under {row_bucket} but the folder is in {bucket}/")
+		for b, (heading, _, _) in BUCKETS.items():
+			lo, hi = section_bounds(text, heading)
+			block = text[lo:hi]
+			rows, _ = split_rows(block)
+			declared = COUNT_RE.search(block)
+			if declared and int(declared.group(0).split(":")[1]) != len(rows):
+				problems.append(f"'{heading}' says {declared.group(0).strip()} but lists {len(rows)} rows")
+
+	if problems:
+		print(f"{slug}: OUT OF SYNC")
+		for p in problems:
+			print(f"  - {p}")
+		return 2
+	print(f"{slug}: in sync — folder {bucket}/, banner and STATUS.md agree")
+	return 0
+
+
+def main() -> int:
+	ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+	ap.add_argument("slug", nargs="?", help="the spec folder name, e.g. wildcard-cert-routing")
+	ap.add_argument("--to", choices=sorted(BUCKETS), help="bucket to move into")
+	ap.add_argument("--detail", help="text after the em dash in the README banner")
+	ap.add_argument("--note", help="the Notes cell in STATUS.md (kept from the existing row if omitted)")
+	ap.add_argument("--specs-dir", default="specs", help="path to specs/ (default: specs)")
+	ap.add_argument("--check", action="store_true", help="verify the three trackers agree; change nothing")
+	ap.add_argument("--init", action="store_true", help="create specs/, every bucket and STATUS.md, then exit")
+	ap.add_argument("--force", action="store_true", help="allow a backwards move")
+	args = ap.parse_args()
+
+	specs_dir = Path(args.specs_dir)
+
+	if args.init:
+		created = ensure_tree(specs_dir)
+		print("\n".join(f"created {c}" for c in created) if created else f"{specs_dir} tree already complete")
+		return 0
+
+	if not args.slug:
+		die("a spec slug is required unless --init is given")
+
+	if args.check:
+		if not specs_dir.is_dir():
+			die(f"{specs_dir} does not exist — run with --init first")
+		return check(specs_dir, args.slug)
+	if not args.to:
+		die("--to is required unless --check or --init is given")
+
+	# Filing a spec into a tree that does not exist yet should just work.
+	ensure_tree(specs_dir)
+
+	current, folder = find_spec(specs_dir, args.slug)
+	if current != args.to and FORWARD.get(args.to, 99) < FORWARD.get(current, 0) and not args.force:
+		die(
+			f"{args.slug} is in {current}/ and {args.to}/ is backwards. "
+			"A spec moves forward only; pass --force if this is a deliberate correction."
+		)
+
+	target_dir = specs_dir / args.to / args.slug
+	if current != args.to:
+		target_dir.parent.mkdir(parents=True, exist_ok=True)
+		if target_dir.exists():
+			die(f"{target_dir} already exists — resolve by hand")
+		shutil.move(str(folder), str(target_dir))
+		print(f"moved {current}/{args.slug} -> {args.to}/{args.slug}")
+	else:
+		print(f"{args.slug} already in {args.to}/ — reconciling banner and STATUS.md")
+
+	print(f"banner: {set_banner(target_dir / 'README.md', args.to, args.detail)}")
+	print(f"STATUS.md note: {update_status(specs_dir / 'STATUS.md', args.slug, args.to, args.note)}")
+	return check(specs_dir, args.slug)
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())


### PR DESCRIPTION
## What

The `issue-to-phases` skill now covers three jobs instead of two: decompose a plan into phases, implement a phase, and build a Ralph loop that runs those phases unattended.

## Changes

`SKILL.md` is rewritten around the three jobs and keeps only the decision-making. The long-form material moves into support files it reads on demand:

| File | Holds |
|---|---|
| `assets/ralph.sh.template` | the loop, with placeholders to fill per spec |
| `assets/prompt.md.template` | the per-phase prompt the loop feeds each iteration |
| `references/ralph-loop.md` | how to author the loop, design `smoke_check`, diagnose a stall |
| `references/spec-templates.md` | README and phase spec templates, plus the code-snippet style contract |
| `scripts/promote_spec.py` | creates the `specs/` tree and moves a spec between status buckets |

`promote_spec.py` exists because a spec's status lives in three places that must agree — the bucket folder, the README banner, and its row and counts in `STATUS.md`. It does all three in one idempotent command, and `--check` verifies they agree without changing anything, so a loop can gate on it.

## Scope

Tooling under `.claude/` only. No application code, no doctypes, no frontend.