### PR TITLE
Implemented phase three

### DIFF
--- a/.claude/skills/issue-to-phases/SKILL.md
+++ b/.claude/skills/issue-to-phases/SKILL.md
@@ -100,15 +100,21 @@ else the repo default.
 3. Implement from the phase spec. Follow the repo conventions, run the lint hook.
 4. Commit, `git push -u origin <branch>`
 5. `gh pr create --base <base> --head <branch> --title "Implemented phase one" --body "<what it does + how to verify>"`
+6. `gh pr checks <branch> --watch` — fix whatever is red before calling the phase done.
 
 **Phase N ≥ 2**
 1. `git switch <branch>` — do **not** branch off it.
 2. Implement, lint, commit, push.
-3. `gh pr edit <branch> --title "Implemented phase <ordinal>"` and
+3. `gh pr checks <branch> --watch`, and fix what it reports.
+4. `gh pr edit <branch> --title "Implemented phase <ordinal>"` and
    `gh pr comment <branch> --body "Phase <ordinal>: <what it added + how to verify>"`
-4. `promote_spec.py <slug> --to in-progress --detail "P<n> done"`
-5. **If it was the final phase and it merged:**
+5. `promote_spec.py <slug> --to in-progress --detail "P<n> done"`
+6. **If it was the final phase, CI is green and it merged:**
    `promote_spec.py <slug> --to completed --detail "all phases in <base> (PR #<n>)"`
+
+**CI is a gate, not a report.** A phase whose tests pass locally and fail on the
+runner is unfinished, and a check that was already red before the branch is still
+the branch's problem — nothing merges past it. Fix it in its own commit.
 
 Ordinals are spelled out: one, two, three, four, five.
 
@@ -200,6 +206,9 @@ completed.
 - One subfolder per feature, always inside a status bucket — never loose in
   `specs/` or in a bucket root.
 - One branch and one PR per feature. Never a second PR for a later phase.
+- **A spec reaches `completed/` only with a green CI run behind it.** The bucket
+  is a claim about shippability; a red PR filed under "completed" is the same lie
+  as a shipped feature filed under "not started".
 - Phase numbers and PR ordinals stay in lockstep: phase 1 is "Implemented phase
   one".
 - A phase with no concrete "Done when" is too big or too vague. Reslice it.

--- a/.claude/skills/issue-to-phases/assets/prompt.md.template
+++ b/.claude/skills/issue-to-phases/assets/prompt.md.template
@@ -90,6 +90,29 @@ One branch, one rolling PR, retitled each phase. Never a second PR.
 - Conventional Commits: `type(scope): summary`. Write the message with the
   `technical-writing` skill.
 
+## CI is part of the work, not a report on it
+
+Every push runs the repo's checks on the PR. **A phase is not finished until they
+are green**, and you find that out inside your own iteration rather than leaving
+it for whoever opens the PR.
+
+```bash
+gh pr checks {{BRANCH}}                     # bucket per check
+gh pr checks {{BRANCH}} --watch             # block until the run finishes
+gh run view --job <id> --log-failed         # the actual failure, not the summary
+```
+
+Three rules, each of which has cost a real iteration:
+
+- **Push, then wait.** The run takes minutes. Ending your turn on "CI is running"
+  ends it with the outcome unknown, and the loop's own gate will retract your
+  marker while you are not there to fix it.
+- **A check that was already red is yours.** "It was failing before my branch" is
+  not a defence: nothing merges past a red check, so the branch that needs it green
+  is the branch in front of you. Fix it in its own commit and say so in the message.
+- **Reproduce locally before pushing again.** The lint command in *Tests and lint*
+  is the one the runner uses. A push-and-see loop burns ten minutes per guess.
+
 ## Spec status — use the script, never edit by hand
 
 Status lives in three places that must agree: the bucket folder, the README
@@ -103,7 +126,7 @@ cd {{APP_DIR}}
 python3 {{PROMOTE}} {{SPEC_SLUG}} --to in-progress --detail "P{{PHASE_NUMBER}} started"
 # Every later phase, when it lands:
 python3 {{PROMOTE}} {{SPEC_SLUG}} --to in-progress --detail "P{{PHASE_NUMBER}} done"
-# The FINAL phase ({{PHASE_COUNT}}), once merged or the PR is ready:
+# The FINAL phase ({{PHASE_COUNT}}) — ONLY once `gh pr checks {{BRANCH}}` is all green:
 python3 {{PROMOTE}} {{SPEC_SLUG}} --to completed \
   --detail "all phases in {{BASE_BRANCH}} (PR #<n>)" --note "<one line for the index>"
 # Verify before writing your done marker:
@@ -112,6 +135,10 @@ python3 {{PROMOTE}} {{SPEC_SLUG}} --check
 
 The loop gates on this. A phase that leaves the spec in the wrong bucket has its
 done marker retracted, so skipping it costs an iteration.
+
+`completed/` means the whole feature is shippable, so a spec moves there only with
+a green CI run behind it. A red PR filed under "completed" is the same lie as a
+shipped feature filed under "not started".
 
 {{SAFETY_RULES}}
 
@@ -175,8 +202,9 @@ mutating the system that the next iteration's smoke check is about to read.
 
 ## Completion contract
 
-Run your phase's Verification section for real, against the live system. ONLY when
-every item passes, write a one-line summary to `{{DONE_MARKER}}`.
+Run your phase's Verification section for real, against the live system, and wait
+for the PR's checks to come back green. ONLY when every item passes **and CI is
+green**, write a one-line summary to `{{DONE_MARKER}}`.
 
 The loop then runs its **own** independent smoke check. If that fails it deletes
 your marker and the phase continues. Do not create the marker early or

--- a/.claude/skills/issue-to-phases/assets/ralph.sh.template
+++ b/.claude/skills/issue-to-phases/assets/ralph.sh.template
@@ -39,6 +39,10 @@ NOTES_PREFIX="{{NOTES_PREFIX}}"      # keeps notes from colliding with other loo
 BRANCH="{{BRANCH}}"
 BASE_BRANCH="{{BASE_BRANCH}}"
 
+# How long smoke_check waits for the PR's checks to finish before calling the
+# phase incomplete. Size it to the slowest workflow on the repo, not the fastest.
+CI_WAIT_SECONDS=1800
+
 # The running UI, for the browser checks. Leave empty on a spec with no UI surface.
 APP_URL="{{APP_URL}}"
 
@@ -93,6 +97,51 @@ browser_ready() {
   command -v agent-browser >/dev/null 2>&1
 }
 
+# The PR's checks as one word: green | red | pending | none.
+#
+# `gh pr checks` exits non-zero whenever anything is failing OR pending, so its
+# exit code cannot tell "still running" from "broken". The buckets can.
+ci_status() {
+  local json
+  json="$( cd "$APP_DIR" && timeout 120 gh pr checks "$BRANCH" --json bucket 2>/dev/null || true )"
+  if [ -z "$json" ] || [ "$json" = "[]" ]; then
+    # No checks reported yet is not the same as no PR: a workflow takes ~30s to
+    # register after a push, and failing on that would retract a good marker.
+    ( cd "$APP_DIR" && timeout 60 gh pr view "$BRANCH" --json number >/dev/null 2>&1 ) \
+      && echo pending || echo none
+    return 0
+  fi
+  printf '%s' "$json" | python3 -c '
+import json, sys
+buckets = [c.get("bucket") for c in json.load(sys.stdin)]
+if not buckets:            print("pending")
+elif "fail" in buckets or "cancel" in buckets: print("red")
+elif "pending" in buckets: print("pending")
+else:                      print("green")
+' 2>/dev/null || echo pending
+  return 0
+}
+
+# A phase is not done while CI is still deciding, and not done at all if CI is red.
+# Polls rather than `--watch`, so the wait is bounded and the log says what it is
+# waiting for.
+ci_green() {
+  local waited=0 status
+  while [ "$waited" -lt "$CI_WAIT_SECONDS" ]; do
+    status="$(ci_status)"
+    case "$status" in
+      green) return 0 ;;
+      red)   echo "[ralph]        CI is red — see: gh pr checks $BRANCH" ; return 1 ;;
+      none)  echo "[ralph]        no pull request for $BRANCH" ; return 1 ;;
+    esac
+    echo "[ralph]        CI pending, waited ${waited}s of ${CI_WAIT_SECONDS}s"
+    sleep 60
+    waited=$((waited + 60))
+  done
+  echo "[ralph]        CI did not finish within ${CI_WAIT_SECONDS}s"
+  return 1
+}
+
 {{HELPERS}}
 
 preflight() {
@@ -132,6 +181,20 @@ smoke_check() {
       failed=1
     else
       echo "[ralph]   ok   built assets are at least as new as the source"
+    fi
+  fi
+
+  # CI. A phase whose tests pass on this host and fail on the runner is not
+  # finished — and a lint hook that has been red since before this branch is
+  # still this branch's problem, because nothing merges past it.
+  # Delete this block, ci_status and ci_green on a repo with no workflows: with
+  # nothing to report, the gate waits out its whole budget and fails every phase.
+  if [ "$phase" -ge 1 ]; then
+    if ci_green; then
+      echo "[ralph]   ok   every check on the $BRANCH pull request is green"
+    else
+      echo "[ralph]   FAIL the $BRANCH pull request does not have a green CI run"
+      failed=1
     fi
   fi
 

--- a/.claude/skills/issue-to-phases/references/ralph-loop.md
+++ b/.claude/skills/issue-to-phases/references/ralph-loop.md
@@ -102,6 +102,21 @@ the redirect would override the pipe and break the query. The signature when it
 happens: `ps -o pid,pgid,tpgid,stat` shows `T`/`Tl` with `PGID != TPGID`.
 SIGCONT does not help — the kernel re-stops it.
 
+**Gate on CI, and let the gate wait.** The template ships `ci_status` and
+`ci_green`: a phase is not done while the PR's checks are pending, and not done at
+all while any is failing. Two things make this worth its own helper rather than an
+instruction in the prompt. `gh pr checks` exits non-zero for *pending* as well as
+*failing*, so the exit code cannot tell "still running" from "broken" — read the
+buckets. And an agent that pushes at the end of its turn never sees the run
+finish, so the loop is the only thing still present when the answer arrives.
+
+Size `CI_WAIT_SECONDS` to the slowest workflow in the repo. A gate that gives up
+after two minutes on a fifteen-minute test suite fails every good phase.
+
+On a repo with **no** workflows, delete the gate and both helpers. `gh pr checks`
+reports nothing there, so the gate would wait out its entire budget and fail every
+phase for the absence of a thing that does not exist.
+
 **Include the status-lockstep gate.** The template ships it: phases before the
 last must leave the spec in `in-progress/`, the final phase in `completed/`, and
 `promote_spec.py --check` must pass. Keep it. Spec bookkeeping is what an agent

--- a/.claude/skills/issue-to-phases/scripts/promote_spec.py
+++ b/.claude/skills/issue-to-phases/scripts/promote_spec.py
@@ -82,11 +82,10 @@ def ensure_tree(specs_dir: Path) -> list[str]:
 	status_path = specs_dir / "STATUS.md"
 	if not status_path.exists():
 		body = STATUS_HEADER
-		for bucket, (heading, _, _) in BUCKETS.items():
+		for _bucket, (heading, _, _) in BUCKETS.items():
 			body += f"\n## {heading}\n" + render_section([])
 		body += (
-			"\n---\n\nTotals: 0 specs tracked (0 not started, 0 in progress, "
-			"0 completed, 0 superseded).\n"
+			"\n---\n\nTotals: 0 specs tracked (0 not started, 0 in progress, 0 completed, 0 superseded).\n"
 		)
 		status_path.write_text(body)
 		created.append(f"{status_path}")
@@ -95,7 +94,7 @@ def ensure_tree(specs_dir: Path) -> list[str]:
 		# section_bounds() never dies on a tree this script just finished creating.
 		text = status_path.read_text()
 		added = False
-		for bucket, (heading, _, _) in BUCKETS.items():
+		for _bucket, (heading, _, _) in BUCKETS.items():
 			if not re.search(rf"^##\s+{re.escape(heading)}\s*$", text, re.M):
 				insert_at = TOTALS_RE.search(text)
 				section = f"\n## {heading}\n" + render_section([])
@@ -125,7 +124,7 @@ def section_bounds(text: str, heading: str) -> tuple[int, int]:
 	start = re.search(rf"^##\s+{re.escape(heading)}\s*$", text, re.M)
 	if not start:
 		die(f"STATUS.md has no '## {heading}' section")
-	nxt = re.search(r"^(##\s+|---\s*$)", text[start.end():], re.M)
+	nxt = re.search(r"^(##\s+|---\s*$)", text[start.end() :], re.M)
 	end = start.end() + (nxt.start() if nxt else len(text) - start.end())
 	return start.end(), end
 
@@ -231,7 +230,7 @@ def check(specs_dir: Path, slug: str) -> int:
 			problems.append(f"STATUS.md has no row for {slug}")
 		elif row_bucket != bucket:
 			problems.append(f"STATUS.md files it under {row_bucket} but the folder is in {bucket}/")
-		for b, (heading, _, _) in BUCKETS.items():
+		for _b, (heading, _, _) in BUCKETS.items():
 			lo, hi = section_bounds(text, heading)
 			block = text[lo:hi]
 			rows, _ = split_rows(block)
@@ -256,7 +255,9 @@ def main() -> int:
 	ap.add_argument("--note", help="the Notes cell in STATUS.md (kept from the existing row if omitted)")
 	ap.add_argument("--specs-dir", default="specs", help="path to specs/ (default: specs)")
 	ap.add_argument("--check", action="store_true", help="verify the three trackers agree; change nothing")
-	ap.add_argument("--init", action="store_true", help="create specs/, every bucket and STATUS.md, then exit")
+	ap.add_argument(
+		"--init", action="store_true", help="create specs/, every bucket and STATUS.md, then exit"
+	)
 	ap.add_argument("--force", action="store_true", help="allow a backwards move")
 	args = ap.parse_args()
 

--- a/benchpress/benchpress/doctype/bench_instance/bench_instance.json
+++ b/benchpress/benchpress/doctype/bench_instance/bench_instance.json
@@ -28,6 +28,7 @@
   "runtime",
   "column_break_container",
   "container_ip",
+  "bridge_network",
   "started_at",
   "database_server",
   "stats_section",
@@ -174,6 +175,14 @@
    "fieldname": "container_ip",
    "fieldtype": "Data",
    "label": "Container IP",
+   "read_only": 1
+  },
+  {
+   "description": "Docker network the container was created on. Fixed at create time; benches predating the bridge family read 'benchpress'.",
+   "fieldname": "bridge_network",
+   "fieldtype": "Data",
+   "label": "Bridge Network",
+   "permlevel": 1,
    "read_only": 1
   },
   {

--- a/benchpress/benchpress/doctype/bench_instance/bench_instance.py
+++ b/benchpress/benchpress/doctype/bench_instance/bench_instance.py
@@ -14,6 +14,9 @@ from benchpress.permissions import is_admin
 
 DEPLOY_JOB_TIMEOUT = 7200
 
+# Permlevel-1 fields a container is built from, and the noun each refusal names.
+FIXED_AT_CREATE = {"runtime": "runtime", "bridge_network": "network"}
+
 
 class BenchInstance(Document):
 	def before_insert(self):
@@ -27,23 +30,17 @@ class BenchInstance(Document):
 
 	def validate(self):
 		if self.is_new():
-			# Not in `before_insert`: `runtime` is permlevel 1, and Frappe resets a permlevel field
+			# Not in `before_insert`: these are permlevel 1, and Frappe resets a permlevel field
 			# to its new-doc value in between the two, discarding whatever was chosen there. That
-			# value is the Select's empty first option, which is why it carries one.
+			# value is the Select's empty first option, which is why `runtime` carries one.
 			if not self.runtime:
 				self.runtime = self._default_runtime()
+			if not self.bridge_network:
+				self.bridge_network = self._default_bridge_network()
 			return
-		if not self.has_value_changed("runtime"):
-			return
-		if not is_admin():
-			frappe.throw(_("Only an administrator can change a bench's runtime."), frappe.PermissionError)
-		if self.status != "Draft":
-			frappe.throw(
-				_(
-					"'{0}' is already deployed. A container's runtime is fixed when it is created — "
-					"delete this instance and deploy again to change it."
-				).format(self.name)
-			)
+		for fieldname, noun in FIXED_AT_CREATE.items():
+			if self.has_value_changed(fieldname):
+				self._assert_fixed_field_changeable(noun)
 
 	def before_save(self):
 		"""The lease fields belong to `lease._write`; never let a stale document write them back.
@@ -74,18 +71,42 @@ class BenchInstance(Document):
 			frappe.delete_doc("Bench Site", site, force=True, ignore_permissions=True)
 
 	def validate_higher_perm_levels(self):
-		"""Refuse a runtime the caller may not set, where Frappe would silently drop it.
+		"""Refuse a create-time field the caller may not set, where Frappe would silently drop it.
 
 		The base method resets a permlevel field the caller cannot write back to its stored value
 		and says nothing, so a tenant lowering their own isolation would read as success.
 		"""
-		requested = self.runtime
+		requested = {fieldname: self.get(fieldname) for fieldname in FIXED_AT_CREATE}
 		super().validate_higher_perm_levels()
-		if not self.is_new() and self.runtime != requested:
-			frappe.throw(_("Only an administrator can change a bench's runtime."), frappe.PermissionError)
+		if self.is_new():
+			return
+		for fieldname, noun in FIXED_AT_CREATE.items():
+			if self.get(fieldname) != requested[fieldname]:
+				frappe.throw(
+					_("Only an administrator can change a bench's {0}.").format(noun),
+					frappe.PermissionError,
+				)
+
+	def _assert_fixed_field_changeable(self, noun: str) -> None:
+		if not is_admin():
+			frappe.throw(
+				_("Only an administrator can change a bench's {0}.").format(noun), frappe.PermissionError
+			)
+		if self.status != "Draft":
+			frappe.throw(
+				_(
+					"'{0}' is already deployed. A container's {1} is fixed when it is created — "
+					"delete this instance and deploy again to change it."
+				).format(self.name, noun)
+			)
 
 	def _default_runtime(self) -> str:
 		return frappe.get_cached_doc("BenchPress Settings").default_bench_runtime or "runc"
+
+	def _default_bridge_network(self) -> str:
+		from benchpress.docker_manager import bench_network_spec
+
+		return bench_network_spec(0)["name"]
 
 	def autoname(self):
 		self.name = self.bench_name

--- a/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
+++ b/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
@@ -13,6 +13,7 @@
   "column_break_docker",
   "base_domain",
   "traefik_network",
+  "bench_subnet_base",
   "resource_section",
   "container_memory_limit",
   "column_break_resource",
@@ -64,6 +65,13 @@
    "fieldname": "traefik_network",
    "fieldtype": "Data",
    "label": "Traefik Network"
+  },
+  {
+   "default": "10.20",
+   "description": "First two octets of the bench bridge family. Bridge i is <base>.<i*16>.0/20. Changing it renames no existing network.",
+   "fieldname": "bench_subnet_base",
+   "fieldtype": "Data",
+   "label": "Bench Subnet Base"
   },
   {
    "fieldname": "resource_section",

--- a/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
+++ b/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
@@ -14,6 +14,8 @@
   "base_domain",
   "traefik_network",
   "bench_subnet_base",
+  "bench_bridge_count",
+  "bench_slots_per_bridge",
   "resource_section",
   "container_memory_limit",
   "column_break_resource",
@@ -72,6 +74,20 @@
    "fieldname": "bench_subnet_base",
    "fieldtype": "Data",
    "label": "Bench Subnet Base"
+  },
+  {
+   "default": "16",
+   "description": "How many bench bridges the family may grow to. Bridges are created lazily, so this is a maximum and not a startup cost.",
+   "fieldname": "bench_bridge_count",
+   "fieldtype": "Int",
+   "label": "Bench Bridge Count"
+  },
+  {
+   "default": "1000",
+   "description": "Benches a bridge takes before the next one is preferred. A Linux bridge caps at 1024 ports and three of them are infrastructure.",
+   "fieldname": "bench_slots_per_bridge",
+   "fieldtype": "Int",
+   "label": "Bench Slots Per Bridge"
   },
   {
    "fieldname": "resource_section",

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -15,18 +15,19 @@ from frappe import _
 from frappe.utils.file_lock import LockTimeoutError
 from frappe.utils.synchronization import filelock
 
-from benchpress import image_cache
+from benchpress import docker_manager, image_cache, placement
 from benchpress.credits import admission, lease, metering
 from benchpress.deploy_pipeline import DeployLogWriter, DeployPipeline
 from benchpress.docker_manager import (
 	build_lab_image,
+	container_network,
 	container_runtime,
 	create_bench_container,
 	exec_in_container,
 	host_runtimes,
 	remove_container,
 	resolve_runtime,
-	start_container,
+	start_bench_container,
 	stop_container,
 	wait_for_container_running,
 	write_file_to_container,
@@ -332,12 +333,16 @@ def reconcile_instance_routes() -> dict:
 	Run it by hand with:
 	    bench --site frontend execute benchpress.deploy_manager.reconcile_instance_routes
 	"""
+	# Ahead of the base_domain guard because this half is about container networking rather
+	# than routing: a bench that cannot reach MariaDB is broken on a dev checkout too.
+	attached = _reconcile_bridge_attachments()
+
 	base_domain = frappe.get_cached_doc("BenchPress Settings").base_domain
 	anchored = _ensure_wildcard_anchor(base_domain)
 	if not base_domain or base_domain == "localhost":
 		# A dev checkout has no route directory and must stay byte-for-byte unaffected —
 		# skipped silently, exactly as the writers skip it.
-		return {"anchored": anchored, "written": 0, "deleted": 0, "kept": 0}
+		return {"anchored": anchored, "written": 0, "deleted": 0, "kept": 0, **attached}
 
 	routable = _routable_instance_ips()
 	for instance_id in routable:
@@ -353,7 +358,47 @@ def reconcile_instance_routes() -> dict:
 		_delete_instance_route(path.stem)
 		deleted += 1
 
-	return {"anchored": anchored, "written": len(routable), "deleted": deleted, "kept": kept}
+	return {"anchored": anchored, "written": len(routable), "deleted": deleted, "kept": kept, **attached}
+
+
+def _reconcile_bridge_attachments() -> dict[str, dict[str, list[str]]]:
+	"""Put the three infrastructure containers back on every bench bridge that lost one.
+
+	`docker compose up -d traefik` recreates the proxy holding only its compose networks, so
+	every bridge this app made itself silently loses its ingress and the benches on it start
+	answering 502. Reattaching is hot, which is the whole reason this belongs on the pass
+	that already runs `*/5` rather than in a restart nobody wants to schedule.
+
+	A bridge that does not exist reports nothing missing, so the pass never grows the family
+	on a timer; only a deploy does that.
+	"""
+	restored = {}
+	for index in range(placement.bridge_count()):
+		network = docker_manager.bench_network_spec(index)["name"]
+		missing = docker_manager.missing_infrastructure(network)
+		if not missing:
+			continue
+		now_on = docker_manager.attach_infrastructure(network)
+		reattached = [name for name in missing if name in now_on]
+		if reattached:
+			restored[network] = reattached
+	if restored:
+		frappe.logger("benchpress").info(f"reattached infrastructure: {restored}")
+	return {"attached": restored}
+
+
+def _record_bridge_network(bench, network: str) -> None:
+	"""Stamp the bridge onto the row, around the refusal that guards the field.
+
+	`Bench Instance.validate` refuses a `bridge_network` change to anyone but an admin and to
+	anything but a `Draft` — and a deploy job runs as the tenant and has to write one more
+	time after the container exists. Writing the column directly is the honest way through:
+	this is the system recording where Docker put the container, not a caller choosing.
+	"""
+	if bench.bridge_network == network:
+		return
+	frappe.db.set_value("Bench Instance", bench.name, "bridge_network", network, update_modified=False)
+	bench.bridge_network = network
 
 
 def _routable_instance_ips() -> dict[str, str]:
@@ -566,6 +611,10 @@ def _deploy_bench(bench_name: str) -> None:
 
 	created_container_id = None
 	try:
+		if bench.status == "Draft":
+			# Not the value `validate` defaulted: a bench can sit in Draft for days, and the
+			# bridge with room then is not the bridge with room now.
+			_record_bridge_network(bench, placement.pick_network())
 		bench.status = "Deploying"
 		bench.save(ignore_permissions=True)
 		frappe.db.commit()
@@ -606,13 +655,17 @@ def _deploy_bench(bench_name: str) -> None:
 		# Read back rather than assumed: the stored log answers what a bench was
 		# isolated by long after the run.
 		pipeline.log(f"container runtime {container_runtime(container_id)}")
+
+		container_id = created_container_id = start_bench_container(container_id, bench, lab)
+		_record_bridge_network(bench, container_network(container_id))
+		pipeline.log(f"bench bridge {bench.bridge_network}")
+
 		bench.container_id = container_id
 		bench.node = lease.local_node()
 		bench.container_image = lab.image_tag
 		bench.save(ignore_permissions=True)
 		frappe.db.commit()
 
-		start_container(container_id)
 		pipeline.step("container_ip")
 		container_ip = wait_for_container_running(container_id, bench.bridge_network, timeout=60)
 		bench.container_ip = container_ip

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -614,7 +614,7 @@ def _deploy_bench(bench_name: str) -> None:
 
 		start_container(container_id)
 		pipeline.step("container_ip")
-		container_ip = wait_for_container_running(container_id, timeout=60)
+		container_ip = wait_for_container_running(container_id, bench.bridge_network, timeout=60)
 		bench.container_ip = container_ip
 		pipeline.log(f"container_ip {container_ip}")
 		bench.save(ignore_permissions=True)
@@ -862,7 +862,7 @@ def _setup_container_vpn(bench, container_id: str, pipeline) -> None:
 	bench.save(ignore_permissions=True)
 	frappe.db.commit()
 	pipeline.log(f"VPN peer {peer['peer']} registered, claimed IP {peer['assigned_ip']}")
-	configure_container(container_id, peer["private_key"], peer["assigned_ip"])
+	configure_container(container_id, peer["private_key"], peer["assigned_ip"], bench.bridge_network)
 	pipeline.log(f"Container VPN: {peer['assigned_ip']}")
 
 

--- a/benchpress/diagnostics.py
+++ b/benchpress/diagnostics.py
@@ -8,12 +8,19 @@ starts, or repairs anything. `run_diagnostics` structurally cannot throw:
 each check catches its own exceptions and reports them as a fail row.
 """
 
+from pathlib import Path
+
 import docker
 import frappe
 from frappe.query_builder.functions import Now
 
 from benchpress import placement
-from benchpress.docker_manager import CONTAINER_RUNTIMES, get_client, host_runtimes
+from benchpress.docker_manager import (
+	CONTAINER_RUNTIMES,
+	DEFAULT_PIDS_LIMIT,
+	get_client,
+	host_runtimes,
+)
 from benchpress.mariadb_manager import check_mariadb_health
 from benchpress.vpn_adapter import DEFAULT_INTERFACE
 
@@ -23,6 +30,16 @@ REDIS_CONTAINER_NAME = "benchpress-redis"
 # Two seconds absorbs MariaDB truncating NOW() to whole seconds; what it catches
 # is a timezone difference, which is hours, not drift.
 SKEW_TOLERANCE_SECONDS = 2
+
+PROC_SYS = Path("/proc/sys")
+
+# The kernel ceilings a container can read. The neighbour table is not among them:
+# /proc/sys/net/ipv4/neigh/default/ does not exist in this network namespace, and a row
+# that silently left it out would read as checked and fine.
+CONTAINER_VISIBLE_CEILINGS = ("kernel.pty.max", "kernel.pid_max", "net.netfilter.nf_conntrack_max")
+TERMINALS_PER_BENCH = 8
+PTY_ROOT_RESERVE = 1024
+CONNTRACK_PER_BENCH = 256
 
 
 def check_row(check: str, ok: bool, hint: str) -> dict:
@@ -49,6 +66,7 @@ def run_diagnostics() -> list[dict]:
 		_check_docker_socket(),
 		_check_docker_network(),
 		_check_bridge_capacity(),
+		_check_kernel_ceilings(),
 		_check_mariadb(),
 		_check_clock_skew(),
 		_check_redis(),
@@ -94,6 +112,51 @@ def _check_bridge_capacity() -> dict:
 		return check_row("bridge_capacity", headroom > 0, f"{per_bridge} — {headroom} benches of headroom")
 	except Exception as e:
 		return check_row("bridge_capacity", False, f"Could not measure bridge capacity: {e}")
+
+
+def _read_sysctl(name: str) -> int | None:
+	"""A knob's running value from /proc/sys, or None when it is not in this namespace."""
+	try:
+		return int(PROC_SYS.joinpath(*name.split(".")).read_text().split()[0])
+	except (OSError, ValueError, IndexError):
+		return None
+
+
+def _check_kernel_ceilings() -> dict:
+	"""Host-wide limits a dense fleet runs into, read from /proc/sys rather than assumed.
+
+	The targets are `benchpress_devops/host_tuning.py`'s arithmetic sized against one
+	bridge's worth of benches, which is what `sudo scripts/tune-host.sh` writes by default.
+	Only that script can raise them, and only from the host.
+	"""
+	try:
+		benches = placement.slots_per_bridge()
+		targets = {
+			"kernel.pty.max": benches * TERMINALS_PER_BENCH + PTY_ROOT_RESERVE,
+			"kernel.pid_max": benches * DEFAULT_PIDS_LIMIT,
+			"net.netfilter.nf_conntrack_max": benches * CONNTRACK_PER_BENCH,
+		}
+		running = {name: _read_sysctl(name) for name in CONTAINER_VISIBLE_CEILINGS}
+		blind_spot = (
+			"The neighbour table is not visible from inside a container — read it on the host "
+			"with ./entry.py --check-host"
+		)
+		low = [
+			f"{name} is {running[name] if running[name] is not None else 'unreadable'}, below {targets[name]}"
+			for name in CONTAINER_VISIBLE_CEILINGS
+			if running[name] is None or running[name] < targets[name]
+		]
+		if low:
+			return check_row(
+				"kernel_ceilings",
+				False,
+				f"{'; '.join(low)} for {benches} benches — raise it on the host with "
+				f"sudo scripts/tune-host.sh --benches {benches}. {blind_spot}",
+			)
+		measured = ", ".join(f"{name} {running[name]}" for name in CONTAINER_VISIBLE_CEILINGS)
+		return check_row("kernel_ceilings", True, f"{measured} — enough for {benches} benches. {blind_spot}")
+	except Exception as e:
+		return check_row("kernel_ceilings", False, f"Could not read kernel ceilings: {e}")
 
 
 def _check_mariadb() -> dict:

--- a/benchpress/diagnostics.py
+++ b/benchpress/diagnostics.py
@@ -12,6 +12,7 @@ import docker
 import frappe
 from frappe.query_builder.functions import Now
 
+from benchpress import placement
 from benchpress.docker_manager import CONTAINER_RUNTIMES, get_client, host_runtimes
 from benchpress.mariadb_manager import check_mariadb_health
 from benchpress.vpn_adapter import DEFAULT_INTERFACE
@@ -47,6 +48,7 @@ def run_diagnostics() -> list[dict]:
 	return [
 		_check_docker_socket(),
 		_check_docker_network(),
+		_check_bridge_capacity(),
 		_check_mariadb(),
 		_check_clock_skew(),
 		_check_redis(),
@@ -75,6 +77,23 @@ def _check_docker_network() -> dict:
 		)
 	except Exception as e:
 		return check_row("docker_network", False, f"Could not inspect networks: {e}")
+
+
+def _check_bridge_capacity() -> dict:
+	"""How much room the bench bridge family has left, counted rather than assumed.
+
+	Inspects and nothing else: a bridge that does not exist yet is absent from the report
+	rather than created, which is what this module promises and what keeps the family lazy.
+	"""
+	try:
+		usage = placement.bridge_usage()
+		if not usage:
+			return check_row("bridge_capacity", True, "No bench bridge exists yet")
+		per_bridge = ", ".join(f"{row['network']} {row['used']} used / {row['free']} free" for row in usage)
+		headroom = placement.headroom(usage)
+		return check_row("bridge_capacity", headroom > 0, f"{per_bridge} — {headroom} benches of headroom")
+	except Exception as e:
+		return check_row("bridge_capacity", False, f"Could not measure bridge capacity: {e}")
 
 
 def _check_mariadb() -> dict:

--- a/benchpress/docker_manager.py
+++ b/benchpress/docker_manager.py
@@ -27,6 +27,18 @@ CONTAINER_RUNTIMES = {"runc": None, "sysbox": "sysbox-runc"}
 HOST_RUNTIMES_ATTRIBUTE = "benchpress_host_runtimes"
 PREFLIGHT_IMAGE = "alpine"
 
+# The network every bench predating the bridge family sits on. It keeps receiving
+# MariaDB, Redis and Traefik as their primary network; it stops receiving benches.
+LEGACY_NETWORK = "benchpress"
+NETWORK_PREFIX = "benchpress-"
+BRIDGE_DEVICE_PREFIX = "bpbr"
+DEFAULT_SUBNET_BASE = "10.20"
+
+# Attached to every bench bridge so Docker's embedded DNS answers in both
+# directions. The control plane's own db and redis are deliberately absent: a
+# tenant bridge that reaches them is a breach, not a convenience.
+INFRASTRUCTURE_CONTAINERS = ("benchpress_traefik", "benchpress-mariadb", "benchpress-redis")
+
 
 def resolve_runtime(bench_doc) -> str | None:
 	"""The daemon runtime name for a bench, or None to use the daemon default."""
@@ -155,13 +167,104 @@ def ensure_network(client: docker.DockerClient | None = None) -> None:
 	"""Create the benchpress Docker network if it does not exist."""
 	client = client or get_client()
 	try:
-		client.networks.get("benchpress")
+		client.networks.get(LEGACY_NETWORK)
 	except docker.errors.NotFound:
 		client.networks.create(
-			"benchpress",
+			LEGACY_NETWORK,
 			driver="bridge",
 			ipam=docker.types.IPAMConfig(pool_configs=[docker.types.IPAMPool(subnet="172.30.0.0/24")]),
 		)
+
+
+def subnet_base() -> str:
+	return frappe.get_cached_doc("BenchPress Settings").bench_subnet_base or DEFAULT_SUBNET_BASE
+
+
+def bench_network_spec(index: int, base: str | None = None) -> dict:
+	"""Name, bridge device, subnet and gateway for one bench bridge.
+
+	`index * 16` in the third octet starts every /20 on its own boundary, so a later
+	per-node /16 scheme renumbers nothing.
+	"""
+	base = base or DEFAULT_SUBNET_BASE
+	octet = index * 16
+	return {
+		"name": f"{NETWORK_PREFIX}{index}",
+		"device": f"{BRIDGE_DEVICE_PREFIX}{index}",
+		"subnet": f"{base}.{octet}.0/20",
+		"gateway": f"{base}.{octet}.1",
+	}
+
+
+def bench_network_index(network: str) -> int | None:
+	"""The family index a network name encodes, or None if the name is not one of ours."""
+	if not network.startswith(NETWORK_PREFIX):
+		return None
+	suffix = network[len(NETWORK_PREFIX) :]
+	return int(suffix) if suffix.isdigit() else None
+
+
+def ensure_bench_network(index: int, client: docker.DockerClient | None = None) -> str:
+	"""Create bench bridge `index` if absent, attach infrastructure, return its name."""
+	client = client or get_client()
+	spec = bench_network_spec(index, subnet_base())
+	try:
+		client.networks.get(spec["name"])
+	except docker.errors.NotFound:
+		client.networks.create(
+			spec["name"],
+			driver="bridge",
+			ipam=docker.types.IPAMConfig(
+				pool_configs=[docker.types.IPAMPool(subnet=spec["subnet"], gateway=spec["gateway"])]
+			),
+			options={
+				# Honoured only at create. A network that already exists without it
+				# keeps its br-<hex> device forever, and phase 3's per-device
+				# proxy_arp sysctl has no stable path to write.
+				"com.docker.network.bridge.name": spec["device"],
+				"com.docker.network.bridge.enable_icc": "true",
+				"com.docker.network.bridge.enable_ip_masquerade": "true",
+			},
+		)
+	attach_infrastructure(spec["name"], client)
+	return spec["name"]
+
+
+def ensure_bench_network_for(network: str, client: docker.DockerClient | None = None) -> str:
+	"""Ensure the network a bench row names, whether legacy or one of the family."""
+	client = client or get_client()
+	if network == LEGACY_NETWORK:
+		ensure_network(client)
+		return network
+	index = bench_network_index(network)
+	if index is None:
+		frappe.throw(_("'{0}' is not a BenchPress bench network.").format(network))
+	return ensure_bench_network(index, client)
+
+
+def attach_infrastructure(network: str, client: docker.DockerClient | None = None) -> list[str]:
+	"""Connect the three infrastructure containers to `network`; returns those now on it.
+
+	Only INFRASTRUCTURE_CONTAINERS is ever attachable. The tuple is a security
+	boundary: an attachment reaches `Network.connect`, and putting the control
+	plane's own database on a network tenants share is a breach.
+	"""
+	client = client or get_client()
+	net = client.networks.get(network)
+	present = {c.get("Name") for c in net.attrs.get("Containers", {}).values()}
+	attached = []
+	for name in INFRASTRUCTURE_CONTAINERS:
+		if name in present:
+			attached.append(name)
+			continue
+		try:
+			net.connect(name)
+			attached.append(name)
+		except docker.errors.NotFound:
+			continue  # a dev checkout has no Traefik
+		except docker.errors.APIError as e:
+			frappe.logger("benchpress").warning(f"could not attach {name} to {network}: {e}")
+	return attached
 
 
 def build_lab_image(lab_doc, log_fn=None, no_cache: bool = False) -> str:
@@ -221,7 +324,8 @@ def create_bench_container(bench_doc, lab_doc) -> str:
 	Does NOT start the container. Returns the container ID.
 	"""
 	client = get_client()
-	ensure_network(client)
+	network = getattr(bench_doc, "bridge_network", None) or LEGACY_NETWORK
+	ensure_bench_network_for(network, client)
 
 	name = bench_doc.bench_name
 
@@ -270,7 +374,7 @@ def create_bench_container(bench_doc, lab_doc) -> str:
 		device_write_iops=device_write_iops or None,
 		device_read_bps=device_read_bps or None,
 		device_write_bps=device_write_bps or None,
-		network="benchpress",
+		network=network,
 		**runtime_kwargs,
 	)
 
@@ -282,13 +386,14 @@ def container_runtime(container_id: str) -> str:
 	return get_client().containers.get(container_id).attrs["HostConfig"]["Runtime"]
 
 
-def get_container_ip(container_id: str) -> str:
-	"""The container's bridge IP on the benchpress network."""
+def get_container_ip(container_id: str, network: str | None = None) -> str:
+	"""The container's bridge IP on `network`, defaulting to the legacy bench network."""
 	client = get_client()
 	container = client.containers.get(container_id)
 	networks = container.attrs["NetworkSettings"]["Networks"]
-	if "benchpress" in networks:
-		return networks["benchpress"]["IPAddress"]
+	network = network or LEGACY_NETWORK
+	if network in networks:
+		return networks[network]["IPAddress"]
 	return container.attrs["NetworkSettings"]["IPAddress"]
 
 
@@ -297,17 +402,18 @@ def start_container(container_id: str) -> None:
 	client.containers.get(container_id).start()
 
 
-def wait_for_container_running(container_id: str, timeout: int = 60) -> str:
-	"""Poll until the container reports status "running" and has an IP on the
-	benchpress network. Returns the container IP. Mirrors wait_for_mariadb.
+def wait_for_container_running(container_id: str, network: str | None = None, timeout: int = 60) -> str:
+	"""Poll until the container reports status "running" and has an IP on `network`.
+	Returns the container IP. Mirrors wait_for_mariadb.
 	"""
 	client = get_client()
 	container = client.containers.get(container_id)
+	network = network or LEGACY_NETWORK
 	for _attempt in range(timeout // 2):
 		container.reload()
 		if container.status == "running":
 			networks = container.attrs.get("NetworkSettings", {}).get("Networks", {})
-			ip = networks.get("benchpress", {}).get("IPAddress", "") or container.attrs.get(
+			ip = networks.get(network, {}).get("IPAddress", "") or container.attrs.get(
 				"NetworkSettings", {}
 			).get("IPAddress", "")
 			if ip:

--- a/benchpress/docker_manager.py
+++ b/benchpress/docker_manager.py
@@ -251,12 +251,9 @@ def attach_infrastructure(network: str, client: docker.DockerClient | None = Non
 	"""
 	client = client or get_client()
 	net = client.networks.get(network)
-	present = {c.get("Name") for c in net.attrs.get("Containers", {}).values()}
-	attached = []
-	for name in INFRASTRUCTURE_CONTAINERS:
-		if name in present:
-			attached.append(name)
-			continue
+	missing = missing_infrastructure(network, client)
+	attached = [name for name in INFRASTRUCTURE_CONTAINERS if name not in missing]
+	for name in missing:
 		try:
 			net.connect(name)
 			attached.append(name)
@@ -265,6 +262,17 @@ def attach_infrastructure(network: str, client: docker.DockerClient | None = Non
 		except docker.errors.APIError as e:
 			frappe.logger("benchpress").warning(f"could not attach {name} to {network}: {e}")
 	return attached
+
+
+def missing_infrastructure(network: str, client: docker.DockerClient | None = None) -> list[str]:
+	"""Infrastructure containers absent from `network`; empty when the bridge does not exist."""
+	client = client or get_client()
+	try:
+		net = client.networks.get(network)
+	except docker.errors.NotFound:
+		return []
+	present = {c.get("Name") for c in net.attrs.get("Containers", {}).values()}
+	return [name for name in INFRASTRUCTURE_CONTAINERS if name not in present]
 
 
 def build_lab_image(lab_doc, log_fn=None, no_cache: bool = False) -> str:
@@ -319,12 +327,15 @@ def build_lab_image(lab_doc, log_fn=None, no_cache: bool = False) -> str:
 	return image_tag
 
 
-def create_bench_container(bench_doc, lab_doc) -> str:
+def create_bench_container(bench_doc, lab_doc, network: str | None = None) -> str:
 	"""Create a container from a lab image with resource limits.
 	Does NOT start the container. Returns the container ID.
+
+	`network` overrides the bench's recorded bridge, which is what a roll onto the next
+	bridge needs: the row still names the bridge Docker refused.
 	"""
 	client = get_client()
-	network = getattr(bench_doc, "bridge_network", None) or LEGACY_NETWORK
+	network = network or getattr(bench_doc, "bridge_network", None) or LEGACY_NETWORK
 	ensure_bench_network_for(network, client)
 
 	name = bench_doc.bench_name
@@ -384,6 +395,50 @@ def create_bench_container(bench_doc, lab_doc) -> str:
 def container_runtime(container_id: str) -> str:
 	"""The runtime the daemon actually created this container under."""
 	return get_client().containers.get(container_id).attrs["HostConfig"]["Runtime"]
+
+
+def container_network(container_id: str) -> str:
+	"""The bench network the daemon actually put this container on."""
+	return get_client().containers.get(container_id).attrs["HostConfig"]["NetworkMode"]
+
+
+def start_bench_container(container_id: str, bench_doc, lab_doc) -> str:
+	"""Start the bench, moving it to the next bridge if this one has no address left.
+
+	Returns the id of the container that is now running — a roll recreates it, so it is
+	not always the one passed in.
+
+	Docker allocates the address at start and not at create (measured on 29.7.2), so a
+	full bridge refuses here rather than in `create_bench_container`. One retry, never a
+	loop: a second refusal means the recorded count disagrees with the daemon, and a loop
+	would hide that.
+	"""
+	from benchpress import placement  # placement imports this module
+
+	try:
+		start_container(container_id)
+		return container_id
+	except docker.errors.APIError as error:
+		if not _address_pool_exhausted(error):
+			raise
+
+	# Recreated rather than reconnected: the endpoint on the full bridge is fixed at create,
+	# and the new container has to take the name the old one is still holding.
+	rolled_to = placement.next_network(container_network(container_id))
+	remove_container(container_id)
+	container_id = create_bench_container(bench_doc, lab_doc, rolled_to)
+	start_container(container_id)
+	return container_id
+
+
+def _address_pool_exhausted(error: docker.errors.APIError) -> bool:
+	"""True when the daemon refused because the network has no free address.
+
+	Matched as text: the daemon answers 500 for this, the same status as every other start
+	failure. `tests/test_docker_manager.py` pins the wording this host really emits, so a
+	daemon upgrade that reworded it fails a test rather than a deploy.
+	"""
+	return "no available ipv4 addresses" in str(error).lower()
 
 
 def get_container_ip(container_id: str, network: str | None = None) -> str:

--- a/benchpress/overview.py
+++ b/benchpress/overview.py
@@ -31,6 +31,7 @@ INFRASTRUCTURE_LABELS = {
 	"docker_socket": "Docker socket",
 	"docker_network": "Docker network",
 	"bridge_capacity": "Bridge capacity",
+	"kernel_ceilings": "Kernel ceilings",
 	"mariadb": "MariaDB",
 	"clock_skew": "Clock skew",
 	"redis": "Redis",
@@ -268,7 +269,7 @@ def _bench_labels(bench_names: list[str]) -> dict:
 
 
 def _infrastructure(admin: bool) -> list[dict] | None:
-	"""The eight real diagnostics checks — admins only, never a placeholder."""
+	"""The nine real diagnostics checks — admins only, never a placeholder."""
 	if not admin:
 		return None
 	from benchpress.diagnostics import display_row, run_diagnostics

--- a/benchpress/overview.py
+++ b/benchpress/overview.py
@@ -30,6 +30,7 @@ LOG_RETENTION_DAYS = default_log_clearing_doctypes["Deploy Log"]
 INFRASTRUCTURE_LABELS = {
 	"docker_socket": "Docker socket",
 	"docker_network": "Docker network",
+	"bridge_capacity": "Bridge capacity",
 	"mariadb": "MariaDB",
 	"clock_skew": "Clock skew",
 	"redis": "Redis",
@@ -267,7 +268,7 @@ def _bench_labels(bench_names: list[str]) -> dict:
 
 
 def _infrastructure(admin: bool) -> list[dict] | None:
-	"""The seven real diagnostics checks — admins only, never a placeholder."""
+	"""The eight real diagnostics checks — admins only, never a placeholder."""
 	if not admin:
 		return None
 	from benchpress.diagnostics import display_row, run_diagnostics

--- a/benchpress/patches.txt
+++ b/benchpress/patches.txt
@@ -25,3 +25,4 @@ benchpress.patches.seed_lease_plans
 benchpress.patches.index_ledger_request_id
 benchpress.patches.drop_burn_fields
 benchpress.patches.name_bench_sites_by_site_name
+benchpress.patches.backfill_bench_bridge_network

--- a/benchpress/patches/backfill_bench_bridge_network.py
+++ b/benchpress/patches/backfill_bench_bridge_network.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""Name the Docker network every existing bench is already attached to.
+
+Every container that predates the bridge family sits on `benchpress`. A row stamped
+`benchpress-0` would send its own IP read-back and its WireGuard gateway to a network
+its container is not on, and the deploy that follows would read an empty address and
+time out. Nothing is migrated: the legacy network drains as its benches are destroyed.
+"""
+
+import frappe
+
+from benchpress.docker_manager import LEGACY_NETWORK
+
+
+def execute():
+	for name in frappe.get_all(
+		"Bench Instance", filters={"bridge_network": ("in", ["", None])}, pluck="name"
+	):
+		frappe.db.set_value(
+			"Bench Instance", name, "bridge_network", LEGACY_NETWORK, update_modified=False
+		)

--- a/benchpress/patches/backfill_bench_bridge_network.py
+++ b/benchpress/patches/backfill_bench_bridge_network.py
@@ -18,6 +18,4 @@ def execute():
 	for name in frappe.get_all(
 		"Bench Instance", filters={"bridge_network": ("in", ["", None])}, pluck="name"
 	):
-		frappe.db.set_value(
-			"Bench Instance", name, "bridge_network", LEGACY_NETWORK, update_modified=False
-		)
+		frappe.db.set_value("Bench Instance", name, "bridge_network", LEGACY_NETWORK, update_modified=False)

--- a/benchpress/placement.py
+++ b/benchpress/placement.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""Which bench bridge a new bench prefers.
+
+Advisory only. Placement asks how many endpoints a bridge already holds, which can go
+stale between the count and the create; the arbiter is Docker, which refuses the create
+when the address pool is empty and lets `docker_manager.start_bench_container` roll on.
+Nothing here takes a lock, so it cannot invert the `Bench Instance` -> `Credit Account`
+-> `Bench Admission` order `credits/admission.py` depends on.
+"""
+
+import docker
+import frappe
+from frappe import _
+from frappe.utils import cint
+
+from benchpress import docker_manager
+
+DEFAULT_BRIDGE_COUNT = 16
+DEFAULT_SLOTS_PER_BRIDGE = 1000
+
+
+def bridge_count() -> int:
+	return _setting("bench_bridge_count", DEFAULT_BRIDGE_COUNT)
+
+
+def slots_per_bridge() -> int:
+	return _setting("bench_slots_per_bridge", DEFAULT_SLOTS_PER_BRIDGE)
+
+
+def _setting(fieldname: str, fallback: int) -> int:
+	"""`.get` rather than attribute access: a Single holds only the fields somebody has saved,
+	so a knob nobody has touched since the migration is absent, not empty."""
+	return cint(frappe.get_cached_doc("BenchPress Settings").get(fieldname)) or fallback
+
+
+def pick_network() -> str:
+	"""The lowest-index bench bridge with room.
+
+	Names a bridge; does not create one. `create_bench_container` ensures whatever
+	network it is handed, so a bridge appears when a bench actually reaches it and a
+	Draft bench that is never deployed costs nothing.
+	"""
+	client = docker_manager.get_client()
+	cap = slots_per_bridge()
+	for index in range(bridge_count()):
+		if used_addresses(index, client) < cap:
+			return docker_manager.bench_network_spec(index)["name"]
+	frappe.throw(
+		_("Every bench bridge is full: {0} bridges at {1} benches each.").format(bridge_count(), cap)
+	)
+
+
+def next_network(network: str) -> str:
+	"""The bridge after `network`, for a create Docker has already refused."""
+	index = docker_manager.bench_network_index(network)
+	if index is None:
+		index = -1  # a legacy bench has nowhere to advance to but the family's base
+	if index + 1 >= bridge_count():
+		frappe.throw(
+			_("Bench bridge '{0}' is full and it is the last of {1}.").format(network, bridge_count())
+		)
+	return docker_manager.bench_network_spec(index + 1)["name"]
+
+
+def used_addresses(index: int, client: docker.DockerClient | None = None) -> int:
+	"""Endpoints on bench bridge `index`, infrastructure included; 0 if it does not exist.
+
+	Infrastructure counts because it holds both an address and a bridge port. Three
+	endpoints against a cap of a thousand is not worth modelling separately, and
+	pretending otherwise is how a soft cap quietly becomes a hard one.
+	"""
+	network = _network(index, client or docker_manager.get_client())
+	return _endpoints(network) if network else 0
+
+
+def bridge_usage(client: docker.DockerClient | None = None) -> list[dict]:
+	"""Used and free slots on every bench bridge that exists, lowest index first."""
+	client = client or docker_manager.get_client()
+	cap = slots_per_bridge()
+	usage = []
+	for index in range(bridge_count()):
+		network = _network(index, client)
+		if network is None:
+			continue
+		used = _endpoints(network)
+		usage.append(
+			{
+				"network": docker_manager.bench_network_spec(index)["name"],
+				"used": used,
+				"free": max(cap - used, 0),
+			}
+		)
+	return usage
+
+
+def headroom(usage: list[dict] | None = None) -> int:
+	"""Benches the family could still take, counting bridges that do not exist yet."""
+	usage = bridge_usage() if usage is None else usage
+	return bridge_count() * slots_per_bridge() - sum(bridge["used"] for bridge in usage)
+
+
+def _network(index: int, client: docker.DockerClient):
+	try:
+		return client.networks.get(docker_manager.bench_network_spec(index)["name"])
+	except docker.errors.NotFound:
+		return None
+
+
+def _endpoints(network) -> int:
+	return len(network.attrs.get("Containers") or {})

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -46,12 +46,13 @@ BUDGETS_MS = {
 	"get_deploy_history": 600,
 }
 
-# The eight rows benchpress.diagnostics always returns; the real checks talk to
+# The nine rows benchpress.diagnostics always returns; the real checks talk to
 # Docker and MariaDB, so the Overview timing test never runs them.
 DIAGNOSTICS_ROWS = [
 	{"check": "docker_socket", "status": "pass", "hint": "Docker daemon reachable"},
 	{"check": "docker_network", "status": "pass", "hint": "benchpress network exists"},
 	{"check": "bridge_capacity", "status": "pass", "hint": "benchpress-0 4 used / 996 free"},
+	{"check": "kernel_ceilings", "status": "pass", "hint": "kernel.pty.max 9024"},
 	{"check": "mariadb", "status": "pass", "hint": "MariaDB responding"},
 	{"check": "clock_skew", "status": "pass", "hint": "App and database clocks agree"},
 	{"check": "redis", "status": "fail", "hint": "benchpress-redis container not found"},

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -46,11 +46,12 @@ BUDGETS_MS = {
 	"get_deploy_history": 600,
 }
 
-# The seven rows benchpress.diagnostics always returns; the real checks talk to
+# The eight rows benchpress.diagnostics always returns; the real checks talk to
 # Docker and MariaDB, so the Overview timing test never runs them.
 DIAGNOSTICS_ROWS = [
 	{"check": "docker_socket", "status": "pass", "hint": "Docker daemon reachable"},
 	{"check": "docker_network", "status": "pass", "hint": "benchpress network exists"},
+	{"check": "bridge_capacity", "status": "pass", "hint": "benchpress-0 4 used / 996 free"},
 	{"check": "mariadb", "status": "pass", "hint": "MariaDB responding"},
 	{"check": "clock_skew", "status": "pass", "hint": "App and database clocks agree"},
 	{"check": "redis", "status": "fail", "hint": "benchpress-redis container not found"},

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -9,10 +9,12 @@ from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import docker
 import frappe
 import yaml
 from frappe.tests import IntegrationTestCase
 
+from benchpress import docker_manager
 from benchpress.benchpress.doctype.bench_instance import get_instance_id
 
 # Any dotted quad, anywhere in the rendered file. The property routes must hold is that no
@@ -400,7 +402,10 @@ class TestDeployManager(IntegrationTestCase):
 			patch.object(deploy_manager, "host_runtimes", autospec=True) as mock_runtimes,
 			patch.object(deploy_manager, "container_runtime", autospec=True) as mock_runtime_of,
 			patch.object(deploy_manager, "create_bench_container", autospec=True) as mock_create,
-			patch.object(deploy_manager, "start_container", autospec=True),
+			# The deploy starts through the roll wrapper, so the bridge it lands on is a
+			# read-back rather than the id that went in.
+			patch.object(deploy_manager, "start_bench_container", new=lambda cid, bench, lab: cid),
+			patch.object(deploy_manager, "container_network", new=lambda cid: "benchpress-0"),
 			patch.object(deploy_manager, "wait_for_container_running", autospec=True) as mock_wait,
 			patch.object(deploy_manager, "remove_container", autospec=True) as mock_remove_container,
 			patch.object(deploy_manager, "_notify_owner", autospec=True),
@@ -618,7 +623,10 @@ class TestDeployStepMarkers(IntegrationTestCase):
 			patch.object(deploy_manager, "host_runtimes", autospec=True) as mock_runtimes,
 			patch.object(deploy_manager, "container_runtime", autospec=True) as mock_runtime_of,
 			patch.object(deploy_manager, "create_bench_container", autospec=True) as mock_create,
-			patch.object(deploy_manager, "start_container", autospec=True),
+			# The deploy starts through the roll wrapper, so the bridge it lands on is a
+			# read-back rather than the id that went in.
+			patch.object(deploy_manager, "start_bench_container", new=lambda cid, bench, lab: cid),
+			patch.object(deploy_manager, "container_network", new=lambda cid: "benchpress-0"),
 			patch.object(deploy_manager, "wait_for_container_running", autospec=True) as mock_wait,
 			# Only the socket is mocked, not the reporting around it: a unit test must not
 			# depend on a running Traefik, but the log line must still be the real one.
@@ -1116,7 +1124,10 @@ class TestTerminalStateNotifications(IntegrationTestCase):
 			patch.object(deploy_manager, "host_runtimes", autospec=True) as mock_runtimes,
 			patch.object(deploy_manager, "container_runtime", autospec=True) as mock_runtime_of,
 			patch.object(deploy_manager, "create_bench_container", autospec=True) as mock_create,
-			patch.object(deploy_manager, "start_container", autospec=True),
+			# The deploy starts through the roll wrapper, so the bridge it lands on is a
+			# read-back rather than the id that went in.
+			patch.object(deploy_manager, "start_bench_container", new=lambda cid, bench, lab: cid),
+			patch.object(deploy_manager, "container_network", new=lambda cid: "benchpress-0"),
 			patch.object(deploy_manager, "wait_for_container_running", autospec=True) as mock_wait,
 			patch.object(deploy_manager, "_write_instance_route", autospec=True),
 			patch.object(deploy_manager, "_ensure_wildcard_anchor", autospec=True),
@@ -1983,7 +1994,67 @@ class TestReconcileInstanceRoutes(IntegrationTestCase):
 				result = deploy_manager.reconcile_instance_routes()
 
 				self.assertTrue(survivor.exists())
-				self.assertEqual(result, {"anchored": False, "written": 0, "deleted": 0, "kept": 0})
+				self.assertEqual(
+					result, {"anchored": False, "written": 0, "deleted": 0, "kept": 0, "attached": {}}
+				)
+
+
+class TestReconcileBridgeAttachments(IntegrationTestCase):
+	"""The half of the `*/5` pass that owns which containers can reach a bench bridge.
+
+	`docker compose up -d traefik` recreates the proxy with only its compose networks, so
+	every bridge this app made loses its ingress and says nothing about it.
+	"""
+
+	def _reconcile(self, present: dict[str, list[str]], bridges=2):
+		"""Run the pass against a daemon whose bridges hold `present`; returns (result, connects)."""
+		from benchpress import deploy_manager
+
+		client = MagicMock()
+		connects = []
+
+		def get(name):
+			if name not in present:
+				raise docker.errors.NotFound(name)
+			network = MagicMock()
+			network.attrs = {"Containers": {n: {"Name": n} for n in present[name]}}
+			network.connect.side_effect = lambda container: connects.append((name, container))
+			return network
+
+		client.networks.get.side_effect = get
+		with (
+			patch("benchpress.docker_manager.get_client", return_value=client),
+			patch("benchpress.placement.bridge_count", return_value=bridges),
+		):
+			return deploy_manager._reconcile_bridge_attachments(), connects
+
+	def test_a_recreated_proxy_is_put_back_without_being_restarted(self):
+		result, connects = self._reconcile(
+			{"benchpress-0": ["benchpress-mariadb", "benchpress-redis", "a-bench"]}
+		)
+
+		self.assertEqual(connects, [("benchpress-0", "benchpress_traefik")])
+		self.assertEqual(result, {"attached": {"benchpress-0": ["benchpress_traefik"]}})
+
+	def test_a_quiet_tick_reports_nothing(self):
+		result, connects = self._reconcile({"benchpress-0": list(docker_manager.INFRASTRUCTURE_CONTAINERS)})
+
+		self.assertEqual(connects, [])
+		self.assertEqual(result, {"attached": {}})
+
+	def test_a_bridge_that_does_not_exist_is_not_created(self):
+		"""The family grows on a deploy, never on a timer."""
+		_result, connects = self._reconcile({})
+
+		self.assertEqual(connects, [])
+
+	def test_only_the_three_infrastructure_containers_are_ever_connected(self):
+		_result, connects = self._reconcile({"benchpress-0": [], "benchpress-1": []})
+
+		self.assertEqual(
+			{container for _network, container in connects},
+			set(docker_manager.INFRASTRUCTURE_CONTAINERS),
+		)
 
 
 class TestSettingsReAnchor(IntegrationTestCase):

--- a/benchpress/tests/test_diagnostics.py
+++ b/benchpress/tests/test_diagnostics.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Venkatesh and Contributors
 # See license.txt
 
-"""run_diagnostics contract: eight rows, fixed order, never raises, never mutates."""
+"""run_diagnostics contract: nine rows, fixed order, never raises, never mutates."""
 
 import inspect
 import unittest
@@ -17,6 +17,7 @@ CHECK_ORDER = [
 	"docker_socket",
 	"docker_network",
 	"bridge_capacity",
+	"kernel_ceilings",
 	"mariadb",
 	"clock_skew",
 	"redis",
@@ -29,6 +30,12 @@ HOST_RUNTIMES = {"names": {"runc", "sysbox-runc"}, "default": "runc"}
 # way `bridge_capacity` reports a fail.
 BRIDGE_COUNT = 2
 BRIDGE_SLOTS = 1000
+# What a tuned host reads back for the three ceilings a container can see.
+HEALTHY_CEILINGS = {
+	"kernel.pty.max": BRIDGE_SLOTS * 8 + 1024,
+	"kernel.pid_max": 4194304,
+	"net.netfilter.nf_conntrack_max": 1048576,
+}
 DB_ROW = frappe._dict(name="db-server-1", status="Running", container_name="benchpress-mariadb")
 
 # What this host really answers: MariaDB is UTC, Python is Asia/Calcutta.
@@ -59,11 +66,13 @@ class TestDiagnostics(unittest.TestCase):
 		app_clock=None,
 		db_clock=None,
 		db_clock_error=None,
+		ceilings=None,
 	):
 		"""Run run_diagnostics with everything healthy unless overridden.
 
 		Returns ({check: row}, ordered rows)."""
 		client = client or _healthy_client()
+		ceilings = HEALTHY_CEILINGS if ceilings is None else ceilings
 		with (
 			patch("benchpress.diagnostics.get_client", side_effect=client_error, return_value=client),
 			# A separate patch, because the runtime check reads `docker info` through
@@ -80,6 +89,7 @@ class TestDiagnostics(unittest.TestCase):
 			patch("benchpress.docker_manager.get_client", side_effect=client_error, return_value=client),
 			patch("benchpress.placement.bridge_count", return_value=BRIDGE_COUNT),
 			patch("benchpress.placement.slots_per_bridge", return_value=BRIDGE_SLOTS),
+			patch("benchpress.diagnostics._read_sysctl", side_effect=ceilings.get),
 			patch("benchpress.diagnostics.frappe") as frappe_mock,
 		):
 			frappe_mock.get_all.return_value = [DB_ROW] if db_rows is None else db_rows
@@ -160,6 +170,7 @@ class TestDiagnostics(unittest.TestCase):
 			db_rows=[],
 			installed_apps=["frappe"],
 			db_clock_error=Exception("down"),
+			ceilings={},
 		)
 		# Capacity is the one exception: a family with no bridge yet is the lazy-creation
 		# invariant, not a broken environment.
@@ -204,6 +215,24 @@ class TestDiagnostics(unittest.TestCase):
 		client.networks.get.side_effect = docker.errors.NotFound("no network")
 		by_check, _rows = self._run(client=client)
 		self.assertEqual(by_check["bridge_capacity"]["status"], "pass")
+
+	def test_kernel_ceilings_names_the_low_knob_and_what_raises_it(self):
+		by_check, _rows = self._run(ceilings={**HEALTHY_CEILINGS, "kernel.pty.max": 4096})
+		hint = by_check["kernel_ceilings"]["hint"]
+		self.assertEqual(by_check["kernel_ceilings"]["status"], "fail")
+		self.assertIn("kernel.pty.max is 4096, below 9024", hint)
+		self.assertIn("tune-host.sh", hint)
+
+	def test_kernel_ceilings_says_the_neighbour_table_is_not_visible_from_here(self):
+		"""A row that quietly omitted it would read as checked and fine."""
+		by_check, _rows = self._run()
+		self.assertEqual(by_check["kernel_ceilings"]["status"], "pass")
+		self.assertIn("neighbour table is not visible", by_check["kernel_ceilings"]["hint"])
+
+	def test_a_knob_this_namespace_cannot_read_is_a_fail_not_a_pass(self):
+		by_check, _rows = self._run(ceilings={})
+		self.assertEqual(by_check["kernel_ceilings"]["status"], "fail")
+		self.assertIn("unreadable", by_check["kernel_ceilings"]["hint"])
 
 	def test_the_diagnostics_row_count_moved_in_both_places(self):
 		"""One count, stated twice: the test_api fixture and the overview docstring."""

--- a/benchpress/tests/test_diagnostics.py
+++ b/benchpress/tests/test_diagnostics.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Venkatesh and Contributors
 # See license.txt
 
-"""run_diagnostics contract: seven rows, fixed order, never raises, never mutates."""
+"""run_diagnostics contract: eight rows, fixed order, never raises, never mutates."""
 
 import inspect
 import unittest
@@ -16,6 +16,7 @@ from benchpress.diagnostics import run_diagnostics
 CHECK_ORDER = [
 	"docker_socket",
 	"docker_network",
+	"bridge_capacity",
 	"mariadb",
 	"clock_skew",
 	"redis",
@@ -24,6 +25,10 @@ CHECK_ORDER = [
 ]
 COUNT_WORDS = {6: "six", 7: "seven", 8: "eight", 9: "nine", 10: "ten"}
 HOST_RUNTIMES = {"names": {"runc", "sysbox-runc"}, "default": "runc"}
+# Small enough that a full bridge leaves the family with no headroom, which is the only
+# way `bridge_capacity` reports a fail.
+BRIDGE_COUNT = 2
+BRIDGE_SLOTS = 1000
 DB_ROW = frappe._dict(name="db-server-1", status="Running", container_name="benchpress-mariadb")
 
 # What this host really answers: MariaDB is UTC, Python is Asia/Calcutta.
@@ -31,9 +36,12 @@ DB_CLOCK = datetime(2026, 8, 24, 23, 11, 53)
 IST_OFFSET = timedelta(hours=5, minutes=30)
 
 
-def _healthy_client():
+def _healthy_client(bridge_endpoints=4):
 	client = MagicMock()
 	client.containers.get.return_value = MagicMock(status="running")
+	network = MagicMock()
+	network.attrs = {"Containers": {f"c{i}": {"Name": f"c{i}"} for i in range(bridge_endpoints)}}
+	client.networks.get.return_value = network
 	return client
 
 
@@ -66,6 +74,12 @@ class TestDiagnostics(unittest.TestCase):
 				return_value=HOST_RUNTIMES if runtimes is None else runtimes,
 			),
 			patch("benchpress.diagnostics.check_mariadb_health", return_value=mariadb_healthy),
+			# The capacity check reaches the daemon through docker_manager's own client rather
+			# than the one above, so the same client is injected there — and left unmocked
+			# beyond that, so `networks.create.assert_not_called()` really covers it.
+			patch("benchpress.docker_manager.get_client", side_effect=client_error, return_value=client),
+			patch("benchpress.placement.bridge_count", return_value=BRIDGE_COUNT),
+			patch("benchpress.placement.slots_per_bridge", return_value=BRIDGE_SLOTS),
 			patch("benchpress.diagnostics.frappe") as frappe_mock,
 		):
 			frappe_mock.get_all.return_value = [DB_ROW] if db_rows is None else db_rows
@@ -93,7 +107,7 @@ class TestDiagnostics(unittest.TestCase):
 		# completing without an exception IS the core assertion
 		by_check, rows = self._run(client_error=Exception("socket unreachable"))
 		self.assertEqual(len(rows), len(CHECK_ORDER))
-		for check in ("docker_socket", "docker_network", "redis"):
+		for check in ("docker_socket", "docker_network", "bridge_capacity", "redis"):
 			self.assertEqual(by_check[check]["status"], "fail")
 
 	def test_missing_network_fails_with_hint(self):
@@ -147,7 +161,12 @@ class TestDiagnostics(unittest.TestCase):
 			installed_apps=["frappe"],
 			db_clock_error=Exception("down"),
 		)
-		self.assertEqual([row["status"] for row in rows], ["fail"] * len(CHECK_ORDER))
+		# Capacity is the one exception: a family with no bridge yet is the lazy-creation
+		# invariant, not a broken environment.
+		self.assertEqual(
+			[row["status"] for row in rows if row["check"] != "bridge_capacity"],
+			["fail"] * (len(CHECK_ORDER) - 1),
+		)
 		client.networks.create.assert_not_called()
 		client.containers.create.assert_not_called()
 		client.containers.run.assert_not_called()
@@ -173,6 +192,18 @@ class TestDiagnostics(unittest.TestCase):
 		self.assertEqual(len(rows), len(CHECK_ORDER))
 		self.assertEqual(by_check["clock_skew"]["status"], "fail")
 		self.assertIn("db refuses the query", by_check["clock_skew"]["hint"])
+
+	def test_a_family_with_no_room_left_is_a_fail_row(self):
+		by_check, _rows = self._run(client=_healthy_client(bridge_endpoints=BRIDGE_SLOTS))
+		self.assertEqual(by_check["bridge_capacity"]["status"], "fail")
+		self.assertIn(f"{BRIDGE_SLOTS} used / 0 free", by_check["bridge_capacity"]["hint"])
+
+	def test_a_family_with_no_bridge_yet_is_not_a_failure(self):
+		"""Bridges are lazy, so an install that has never deployed reports room, not a problem."""
+		client = _healthy_client()
+		client.networks.get.side_effect = docker.errors.NotFound("no network")
+		by_check, _rows = self._run(client=client)
+		self.assertEqual(by_check["bridge_capacity"]["status"], "pass")
 
 	def test_the_diagnostics_row_count_moved_in_both_places(self):
 		"""One count, stated twice: the test_api fixture and the overview docstring."""

--- a/benchpress/tests/test_docker_manager.py
+++ b/benchpress/tests/test_docker_manager.py
@@ -537,3 +537,62 @@ class TestReadBacksTakeTheirNetwork(unittest.TestCase):
 		get_client.return_value.containers.get.return_value = container
 
 		self.assertEqual(wait_for_container_running("abc123", "benchpress-0"), "10.20.0.5")
+
+
+# The message this daemon really emits, copied from a live refusal on Docker 29.7.2 with a
+# /29 scratch network. The create succeeded and the *start* raised it.
+LIVE_EXHAUSTION = (
+	"500 Server Error for http+docker://localhost/v1.55/containers/abc123/start: "
+	'Internal Server Error ("failed to set up container networking: no available IPv4 '
+	"addresses on this network's address pools: benchpress-0 (fd8f9346a771)\")"
+)
+
+
+class TestAddressPoolExhausted(unittest.TestCase):
+	def test_the_live_refusal_is_recognised(self):
+		self.assertTrue(docker_manager._address_pool_exhausted(docker.errors.APIError(LIVE_EXHAUSTION)))
+
+	def test_another_five_hundred_is_not_a_full_bridge(self):
+		"""The daemon answers 500 for everything, so only the wording separates the two."""
+		error = docker.errors.APIError('500 Server Error: Internal Server Error ("no such image")')
+		self.assertFalse(docker_manager._address_pool_exhausted(error))
+
+
+class TestStartBenchContainer(unittest.TestCase):
+	@patch("benchpress.docker_manager.start_container")
+	def test_a_bridge_with_room_starts_the_container_it_was_given(self, start):
+		self.assertEqual(docker_manager.start_bench_container("abc123", MagicMock(), MagicMock()), "abc123")
+		start.assert_called_once_with("abc123")
+
+	@patch("benchpress.placement.next_network", return_value="benchpress-1")
+	@patch("benchpress.docker_manager.create_bench_container", return_value="def456")
+	@patch("benchpress.docker_manager.remove_container")
+	@patch("benchpress.docker_manager.container_network", return_value="benchpress-0")
+	@patch("benchpress.docker_manager.start_container")
+	def test_a_full_bridge_rolls_once_onto_the_next(self, start, _network, remove, create, _next):
+		start.side_effect = [docker.errors.APIError(LIVE_EXHAUSTION), None]
+		bench, lab = MagicMock(), MagicMock()
+
+		self.assertEqual(docker_manager.start_bench_container("abc123", bench, lab), "def456")
+
+		remove.assert_called_once_with("abc123")
+		create.assert_called_once_with(bench, lab, "benchpress-1")
+
+	@patch("benchpress.placement.next_network", return_value="benchpress-1")
+	@patch("benchpress.docker_manager.create_bench_container", return_value="def456")
+	@patch("benchpress.docker_manager.remove_container")
+	@patch("benchpress.docker_manager.container_network", return_value="benchpress-0")
+	@patch("benchpress.docker_manager.start_container")
+	def test_a_second_refusal_is_raised_rather_than_looped_on(self, start, _network, _remove, _create, _next):
+		"""Two bridges refusing in a row means the count disagrees with the daemon."""
+		start.side_effect = docker.errors.APIError(LIVE_EXHAUSTION)
+
+		with self.assertRaises(docker.errors.APIError):
+			docker_manager.start_bench_container("abc123", MagicMock(), MagicMock())
+
+	@patch("benchpress.docker_manager.start_container")
+	def test_any_other_docker_error_is_not_rolled(self, start):
+		start.side_effect = docker.errors.APIError("no such image")
+
+		with self.assertRaises(docker.errors.APIError):
+			docker_manager.start_bench_container("abc123", MagicMock(), MagicMock())

--- a/benchpress/tests/test_docker_manager.py
+++ b/benchpress/tests/test_docker_manager.py
@@ -172,13 +172,15 @@ class TestDockerManagerBlockIO(IntegrationTestCase):
 		super().setUpClass()
 		frappe.set_user("Administrator")
 
-	def _container_create_kwargs(self, lab, runtime="runc"):
+	def _container_create_kwargs(self, lab, runtime="runc", bridge_network="benchpress-0"):
 		"""Run create_bench_container with Docker mocked and return the
 		kwargs passed to client.containers.create."""
-		bench = types.SimpleNamespace(bench_name="blockio-test-bench", runtime=runtime)
+		bench = types.SimpleNamespace(
+			bench_name="blockio-test-bench", runtime=runtime, bridge_network=bridge_network
+		)
 		with (
 			patch("benchpress.docker_manager.get_client") as mock_client,
-			patch("benchpress.docker_manager.ensure_network"),
+			patch("benchpress.docker_manager.ensure_bench_network_for"),
 			patch("benchpress.docker_manager._get_host_block_devices", return_value=["/dev/sda"]),
 		):
 			mock_client.return_value.containers.create.return_value = MagicMock(id="cid")
@@ -231,6 +233,23 @@ class TestDockerManagerBlockIO(IntegrationTestCase):
 		kwargs = self._container_create_kwargs(lab)
 
 		self.assertEqual(kwargs["pids_limit"], DEFAULT_PIDS_LIMIT)
+
+	def test_the_container_is_created_on_the_bench_own_network(self):
+		lab = _make_lab("network-family")
+		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
+
+		kwargs = self._container_create_kwargs(lab, bridge_network="benchpress-1")
+
+		self.assertEqual(kwargs["network"], "benchpress-1")
+
+	def test_a_bench_with_no_network_falls_back_to_the_legacy_one(self):
+		"""A row the backfill has not reached must not be sent to a bridge it is not on."""
+		lab = _make_lab("network-legacy")
+		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
+
+		kwargs = self._container_create_kwargs(lab, bridge_network="")
+
+		self.assertEqual(kwargs["network"], "benchpress")
 
 	def test_runc_passes_no_runtime_kwarg(self):
 		"""A runc bench must produce the call it produced before runtimes existed."""
@@ -346,3 +365,175 @@ class TestContainerRuntime(unittest.TestCase):
 		get_client.return_value = client
 
 		self.assertEqual(container_runtime("cid"), "sysbox-runc")
+
+
+class TestBenchNetworkSpec(unittest.TestCase):
+	def test_index_zero_is_the_base_of_the_family(self):
+		spec = docker_manager.bench_network_spec(0, "10.20")
+
+		self.assertEqual(spec["name"], "benchpress-0")
+		self.assertEqual(spec["device"], "bpbr0")
+		self.assertEqual(spec["subnet"], "10.20.0.0/20")
+		self.assertEqual(spec["gateway"], "10.20.0.1")
+
+	def test_each_index_starts_on_its_own_slash_20_boundary(self):
+		"""A /20 spans 16 third octets, so overlapping ones would share addresses."""
+		subnets = [docker_manager.bench_network_spec(i, "10.20")["subnet"] for i in range(4)]
+
+		self.assertEqual(subnets, ["10.20.0.0/20", "10.20.16.0/20", "10.20.32.0/20", "10.20.48.0/20"])
+
+	def test_the_device_name_fits_ifnamsiz(self):
+		self.assertLess(len(docker_manager.bench_network_spec(15, "10.20")["device"]), 16)
+
+	def test_a_subnet_base_moves_only_the_addresses(self):
+		spec = docker_manager.bench_network_spec(1, "10.40")
+
+		self.assertEqual(spec["name"], "benchpress-1")
+		self.assertEqual(spec["subnet"], "10.40.16.0/20")
+
+	def test_index_round_trips_through_the_name(self):
+		for index in (0, 1, 7):
+			name = docker_manager.bench_network_spec(index)["name"]
+			self.assertEqual(docker_manager.bench_network_index(name), index)
+
+	def test_a_foreign_name_has_no_index(self):
+		for name in ("benchpress", "benchpress_frappe_network", "benchpress-labs", "bridge"):
+			self.assertIsNone(docker_manager.bench_network_index(name))
+
+
+def _network_holding(*container_names):
+	network = MagicMock()
+	network.attrs = {"Containers": {f"cid{i}": {"Name": n} for i, n in enumerate(container_names)}}
+	return network
+
+
+class TestAttachInfrastructure(unittest.TestCase):
+	@patch("benchpress.docker_manager.get_client")
+	def test_attaches_exactly_the_three_infrastructure_containers(self, get_client):
+		network = _network_holding()
+		get_client.return_value.networks.get.return_value = network
+
+		attached = docker_manager.attach_infrastructure("benchpress-0")
+
+		self.assertEqual(attached, list(docker_manager.INFRASTRUCTURE_CONTAINERS))
+		self.assertEqual(
+			[call.args[0] for call in network.connect.call_args_list],
+			list(docker_manager.INFRASTRUCTURE_CONTAINERS),
+		)
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_the_control_plane_is_never_attached(self, get_client):
+		"""A tenant bridge that reaches the control plane's own database is a breach."""
+		network = _network_holding()
+		get_client.return_value.networks.get.return_value = network
+
+		docker_manager.attach_infrastructure("benchpress-0")
+
+		connected = {call.args[0] for call in network.connect.call_args_list}
+		self.assertTrue(
+			connected.isdisjoint({"benchpress_db", "benchpress_redis-cache", "benchpress_redis-queue"})
+		)
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_an_already_connected_container_is_not_reconnected(self, get_client):
+		network = _network_holding("benchpress_traefik")
+		get_client.return_value.networks.get.return_value = network
+
+		attached = docker_manager.attach_infrastructure("benchpress-0")
+
+		self.assertIn("benchpress_traefik", attached)
+		self.assertNotIn("benchpress_traefik", [call.args[0] for call in network.connect.call_args_list])
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_a_missing_container_is_skipped(self, get_client):
+		"""A dev checkout has no Traefik, and the deploy must still complete."""
+		network = _network_holding()
+		network.connect.side_effect = [docker.errors.NotFound("no such container"), None, None]
+		get_client.return_value.networks.get.return_value = network
+
+		attached = docker_manager.attach_infrastructure("benchpress-0")
+
+		self.assertEqual(attached, ["benchpress-mariadb", "benchpress-redis"])
+
+
+class TestEnsureBenchNetwork(unittest.TestCase):
+	def _client_without(self, network_name):
+		client = MagicMock()
+
+		def get(name):
+			if name == network_name:
+				raise docker.errors.NotFound(name)
+			return _network_holding()
+
+		client.networks.get.side_effect = get
+		return client
+
+	@patch("benchpress.docker_manager.subnet_base", return_value="10.20")
+	@patch("benchpress.docker_manager.attach_infrastructure")
+	@patch("benchpress.docker_manager.get_client")
+	def test_creates_the_bridge_with_a_pinned_device(self, get_client, _attach, _base):
+		"""The device option is honoured only at create; a later one keeps br-<hex>."""
+		client = self._client_without("benchpress-0")
+		get_client.return_value = client
+
+		docker_manager.ensure_bench_network(0)
+
+		kwargs = client.networks.create.call_args.kwargs
+		self.assertEqual(kwargs["options"]["com.docker.network.bridge.name"], "bpbr0")
+		pool = kwargs["ipam"]["Config"][0]
+		self.assertEqual(pool["Subnet"], "10.20.0.0/20")
+		self.assertEqual(pool["Gateway"], "10.20.0.1")
+
+	@patch("benchpress.docker_manager.subnet_base", return_value="10.20")
+	@patch("benchpress.docker_manager.attach_infrastructure")
+	@patch("benchpress.docker_manager.get_client")
+	def test_an_existing_bridge_is_not_recreated_but_is_reattached(self, get_client, attach, _base):
+		client = MagicMock()
+		client.networks.get.return_value = _network_holding()
+		get_client.return_value = client
+
+		self.assertEqual(docker_manager.ensure_bench_network(0), "benchpress-0")
+
+		client.networks.create.assert_not_called()
+		attach.assert_called_once_with("benchpress-0", client)
+
+	@patch("benchpress.docker_manager.ensure_network")
+	@patch("benchpress.docker_manager.get_client")
+	def test_the_legacy_name_ensures_the_legacy_network(self, get_client, ensure_network):
+		"""Benches that predate the family stay where their containers already are."""
+		self.assertEqual(docker_manager.ensure_bench_network_for("benchpress"), "benchpress")
+
+		ensure_network.assert_called_once()
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_a_network_outside_the_family_is_refused(self, get_client):
+		with self.assertRaises(frappe.ValidationError):
+			docker_manager.ensure_bench_network_for("benchpress_frappe_network")
+
+
+class TestReadBacksTakeTheirNetwork(unittest.TestCase):
+	@patch("benchpress.docker_manager.get_client")
+	def test_the_ip_is_read_from_the_named_network(self, get_client):
+		container = MagicMock()
+		container.attrs = {
+			"NetworkSettings": {
+				"Networks": {
+					"benchpress": {"IPAddress": "172.30.0.5"},
+					"benchpress-0": {"IPAddress": "10.20.0.5"},
+				},
+				"IPAddress": "",
+			}
+		}
+		get_client.return_value.containers.get.return_value = container
+
+		self.assertEqual(docker_manager.get_container_ip("abc123", "benchpress-0"), "10.20.0.5")
+		self.assertEqual(docker_manager.get_container_ip("abc123"), "172.30.0.5")
+
+	@patch("benchpress.docker_manager.time.sleep")
+	@patch("benchpress.docker_manager.get_client")
+	def test_waiting_polls_the_named_network(self, get_client, _sleep):
+		attrs = {"NetworkSettings": {"Networks": {"benchpress-0": {"IPAddress": "10.20.0.5"}}}}
+		container = _reloading_container([("running", attrs)])
+		get_client.return_value.containers.get.return_value = container
+
+		self.assertEqual(wait_for_container_running("abc123", "benchpress-0"), "10.20.0.5")

--- a/benchpress/tests/test_image_cache.py
+++ b/benchpress/tests/test_image_cache.py
@@ -225,7 +225,10 @@ class TestDeployReusesTheSharedImage(IntegrationTestCase):
 			patch.object(deploy_manager, "wait_for_mariadb", autospec=True),
 			patch.object(deploy_manager, "_remove_stale_container", autospec=True),
 			patch.object(deploy_manager, "create_bench_container", autospec=True) as mock_create,
-			patch.object(deploy_manager, "start_container", autospec=True),
+			# The deploy starts through the roll wrapper, so the bridge it lands on is a
+			# read-back rather than the id that went in.
+			patch.object(deploy_manager, "start_bench_container", new=lambda cid, bench, lab: cid),
+			patch.object(deploy_manager, "container_network", new=lambda cid: "benchpress-0"),
 			patch.object(deploy_manager, "wait_for_container_running", autospec=True) as mock_wait,
 			patch.object(deploy_manager, "_setup_container_vpn", autospec=True),
 			patch.object(deploy_manager, "write_file_to_container", autospec=True),

--- a/benchpress/tests/test_placement.py
+++ b/benchpress/tests/test_placement.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+"""Which bridge a bench prefers, and the one tuple that is allowed to reach a bench bridge."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import docker
+import frappe
+
+from benchpress import docker_manager, placement
+
+BRIDGE_COUNT = 3
+SLOTS = 10
+
+
+def _network(endpoints: int):
+	network = MagicMock()
+	network.attrs = {"Containers": {f"c{i}": {"Name": f"c{i}"} for i in range(endpoints)}}
+	return network
+
+
+def _client(sizes: dict[str, int]):
+	"""A Docker client whose bench bridges hold the given endpoint counts; the rest are absent."""
+	client = MagicMock()
+
+	def get(name):
+		if name not in sizes:
+			raise docker.errors.NotFound(name)
+		return _network(sizes[name])
+
+	client.networks.get.side_effect = get
+	return client
+
+
+class PlacementTestCase(unittest.TestCase):
+	def _pick(self, sizes: dict[str, int], count=BRIDGE_COUNT, slots=SLOTS):
+		with (
+			patch("benchpress.docker_manager.get_client", return_value=_client(sizes)),
+			patch("benchpress.placement.bridge_count", return_value=count),
+			patch("benchpress.placement.slots_per_bridge", return_value=slots),
+		):
+			return placement.pick_network()
+
+	def _usage(self, sizes: dict[str, int], count=BRIDGE_COUNT, slots=SLOTS):
+		with (
+			patch("benchpress.docker_manager.get_client", return_value=_client(sizes)),
+			patch("benchpress.placement.bridge_count", return_value=count),
+			patch("benchpress.placement.slots_per_bridge", return_value=slots),
+		):
+			return placement.bridge_usage()
+
+
+class TestPickNetwork(PlacementTestCase):
+	def test_a_family_with_no_bridge_yet_prefers_index_zero(self):
+		"""A missing bridge is empty, not unusable — that is what makes creation lazy."""
+		self.assertEqual(self._pick({}), "benchpress-0")
+
+	def test_the_lowest_bridge_with_room_wins(self):
+		self.assertEqual(self._pick({"benchpress-0": 3}), "benchpress-0")
+
+	def test_a_full_bridge_is_skipped(self):
+		self.assertEqual(self._pick({"benchpress-0": SLOTS}), "benchpress-1")
+
+	def test_the_next_bridge_need_not_exist(self):
+		self.assertEqual(self._pick({"benchpress-0": SLOTS, "benchpress-1": SLOTS}), "benchpress-2")
+
+	def test_infrastructure_counts_against_the_cap(self):
+		"""Three endpoints hold three addresses and three bridge ports like any other."""
+		self.assertEqual(self._pick({"benchpress-0": SLOTS - 3}), "benchpress-0")
+		self.assertEqual(self._pick({"benchpress-0": SLOTS - 2}), "benchpress-0")
+
+	def test_a_full_family_is_refused_with_a_sentence(self):
+		full = {f"benchpress-{i}": SLOTS for i in range(BRIDGE_COUNT)}
+		with self.assertRaises(frappe.ValidationError) as refusal:
+			self._pick(full)
+		self.assertIn(str(BRIDGE_COUNT), str(refusal.exception))
+		self.assertIn(str(SLOTS), str(refusal.exception))
+
+
+class TestNextNetwork(PlacementTestCase):
+	def _next(self, network, count=BRIDGE_COUNT):
+		with patch("benchpress.placement.bridge_count", return_value=count):
+			return placement.next_network(network)
+
+	def test_a_refused_bridge_rolls_to_the_one_after_it(self):
+		self.assertEqual(self._next("benchpress-0"), "benchpress-1")
+
+	def test_a_legacy_bench_rolls_into_the_base_of_the_family(self):
+		self.assertEqual(self._next(docker_manager.LEGACY_NETWORK), "benchpress-0")
+
+	def test_the_last_bridge_has_nowhere_to_roll(self):
+		with self.assertRaises(frappe.ValidationError) as refusal:
+			self._next(f"benchpress-{BRIDGE_COUNT - 1}")
+		self.assertIn(f"benchpress-{BRIDGE_COUNT - 1}", str(refusal.exception))
+
+
+class TestBridgeUsage(PlacementTestCase):
+	def test_only_bridges_that_exist_are_reported(self):
+		usage = self._usage({"benchpress-0": 4, "benchpress-2": 1})
+		self.assertEqual([row["network"] for row in usage], ["benchpress-0", "benchpress-2"])
+
+	def test_used_and_free_add_up_to_the_cap(self):
+		[row] = self._usage({"benchpress-0": 4})
+		self.assertEqual((row["used"], row["free"]), (4, SLOTS - 4))
+
+	def test_an_overfull_bridge_reports_no_free_slots_rather_than_a_negative(self):
+		[row] = self._usage({"benchpress-0": SLOTS + 2})
+		self.assertEqual(row["free"], 0)
+
+	def test_headroom_counts_the_bridges_that_do_not_exist_yet(self):
+		usage = self._usage({"benchpress-0": 4})
+		with (
+			patch("benchpress.placement.bridge_count", return_value=BRIDGE_COUNT),
+			patch("benchpress.placement.slots_per_bridge", return_value=SLOTS),
+		):
+			self.assertEqual(placement.headroom(usage), BRIDGE_COUNT * SLOTS - 4)
+
+
+class TestInfrastructureIsolation(unittest.TestCase):
+	"""The tuple that decides what may reach a tenant bridge.
+
+	labs-devops swept its control-plane database onto all sixteen tenant bridges and did not
+	notice for 107 days. Adding a fourth name here has to be a deliberate act with a failing
+	test in front of it.
+	"""
+
+	def test_exactly_the_three_infrastructure_containers_are_attachable(self):
+		self.assertEqual(
+			docker_manager.INFRASTRUCTURE_CONTAINERS,
+			("benchpress_traefik", "benchpress-mariadb", "benchpress-redis"),
+		)
+
+	def test_the_control_plane_is_never_attachable(self):
+		for name in ("benchpress_db", "benchpress_redis-cache", "benchpress_redis-queue"):
+			self.assertNotIn(name, docker_manager.INFRASTRUCTURE_CONTAINERS)

--- a/benchpress/tests/test_vpn_adapter.py
+++ b/benchpress/tests/test_vpn_adapter.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from frappe.tests import IntegrationTestCase
 
+from benchpress import vpn_adapter
 from benchpress.deploy_pipeline import DeployPipeline
 from benchpress.vpn_adapter import (
 	configure_container,
@@ -158,7 +159,7 @@ class TestSetupContainerVpn(IntegrationTestCase):
 			"private_key": "PRIV==",
 			"public_key": "PUB==",
 		}
-		bench = MagicMock()
+		bench = MagicMock(bridge_network="benchpress-0")
 		flow = MagicMock()
 		flow.attach_mock(mock_remove, "remove")
 		flow.attach_mock(mock_create, "create")
@@ -174,7 +175,7 @@ class TestSetupContainerVpn(IntegrationTestCase):
 		# before the container is configured so a failure cannot orphan it.
 		call_order = [name for name, _args, _kwargs in flow.mock_calls]
 		self.assertEqual(call_order, ["remove", "create", "save", "configure"])
-		mock_configure.assert_called_once_with("cid123", "PRIV==", "172.27.0.2")
+		mock_configure.assert_called_once_with("cid123", "PRIV==", "172.27.0.2", "benchpress-0")
 
 
 class TestRenderContainerConfig(IntegrationTestCase):
@@ -243,3 +244,27 @@ class TestConfigureContainer(IntegrationTestCase):
 			configure_container("cid123", "PRIV==", "172.27.0.5")
 
 		self.assertIn("wg-quick up failed", str(caught.exception))
+
+
+class TestDockerGateway(IntegrationTestCase):
+	@patch("benchpress.docker_manager.get_client")
+	def test_reads_the_gateway_the_network_reports(self, get_client):
+		get_client.return_value.networks.get.return_value.attrs = {
+			"IPAM": {"Config": [{"Gateway": "10.20.16.1"}]}
+		}
+
+		self.assertEqual(vpn_adapter._get_docker_gateway("benchpress-1"), "10.20.16.1")
+
+	@patch("benchpress.docker_manager.subnet_base", return_value="10.20")
+	@patch("benchpress.docker_manager.get_client")
+	def test_an_unreachable_daemon_falls_back_to_the_family_arithmetic(self, get_client, _base):
+		"""A bench on bridge 1 given bridge 0's gateway has no route to the host."""
+		get_client.side_effect = Exception("docker socket gone")
+
+		self.assertEqual(vpn_adapter._get_docker_gateway("benchpress-1"), "10.20.16.1")
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_the_legacy_network_keeps_its_own_fallback(self, get_client):
+		get_client.side_effect = Exception("docker socket gone")
+
+		self.assertEqual(vpn_adapter._get_docker_gateway(), "172.30.0.1")

--- a/benchpress/vpn_adapter.py
+++ b/benchpress/vpn_adapter.py
@@ -23,6 +23,8 @@ from frappe.utils.data import cint, now_datetime, time_diff_in_seconds
 
 DEFAULT_INTERFACE = "wg0"
 CONTAINER_KEEPALIVE_SECONDS = 25
+# The legacy bench network's gateway, for a bench predating the bridge family.
+LEGACY_GATEWAY = "172.30.0.1"
 # Fallback when VPN Settings has never been saved; matches its own default.
 DEFAULT_STATUS_POLL_MINUTES = 5
 DEVICE_TYPES = ["Mobile", "Laptop", "Desktop", "Tablet", "Server", "IoT", "Embedded"]
@@ -86,7 +88,9 @@ def remove_bench_peer(bench) -> None:
 		frappe.delete_doc("VPN Peer", peer_name, ignore_permissions=True)
 
 
-def configure_container(container_id: str, private_key: str, assigned_ip: str) -> None:
+def configure_container(
+	container_id: str, private_key: str, assigned_ip: str, network: str | None = None
+) -> None:
 	"""Write the client conf into the container and bring its tunnel up.
 
 	Taken down first, tolerating failure: `wg-quick up` refuses to run when the interface
@@ -94,7 +98,7 @@ def configure_container(container_id: str, private_key: str, assigned_ip: str) -
 	"""
 	from benchpress.docker_manager import exec_in_container, write_file_to_container
 
-	config = render_container_config(private_key, assigned_ip)
+	config = render_container_config(private_key, assigned_ip, network)
 	write_file_to_container(container_id, config, "/etc/wireguard/wg0.conf")
 	exit_code, output = exec_in_container(container_id, "chmod 600 /etc/wireguard/wg0.conf", user="root")
 	if exit_code != 0:
@@ -107,8 +111,8 @@ def configure_container(container_id: str, private_key: str, assigned_ip: str) -
 		raise Exception(f"wg-quick up failed inside container: {output}")
 
 
-def render_container_config(private_key: str, assigned_ip: str) -> str:
-	"""Client conf for a bench container: it reaches wg0 via the Docker gateway."""
+def render_container_config(private_key: str, assigned_ip: str, network: str | None = None) -> str:
+	"""Client conf for a bench container: it reaches wg0 via its own bridge's gateway."""
 	server = frappe.get_cached_doc("WireGuard Server", DEFAULT_INTERFACE)
 	pool_network = ipaddress.ip_network(server.address_cidr, strict=False)
 	return (
@@ -119,25 +123,38 @@ def render_container_config(private_key: str, assigned_ip: str) -> str:
 		"[Peer]\n"
 		f"PublicKey = {server.server_public_key}\n"
 		f"AllowedIPs = {pool_network}\n"
-		f"Endpoint = {_get_docker_gateway()}:{server.listen_port}\n"
+		f"Endpoint = {_get_docker_gateway(network)}:{server.listen_port}\n"
 		f"PersistentKeepalive = {CONTAINER_KEEPALIVE_SECONDS}\n"
 	)
 
 
-def _get_docker_gateway() -> str:
-	"""The host's gateway IP on the benchpress Docker network."""
-	from benchpress.docker_manager import get_client
+def _get_docker_gateway(network: str | None = None) -> str:
+	"""The host's gateway IP on `network`, defaulting to the legacy bench network."""
+	from benchpress import docker_manager
 
-	client = get_client()
+	network = network or docker_manager.LEGACY_NETWORK
 	try:
-		network = client.networks.get("benchpress")
-		ipam = network.attrs.get("IPAM", {})
-		configs = ipam.get("Config", [])
+		attrs = docker_manager.get_client().networks.get(network).attrs
+		configs = attrs.get("IPAM", {}).get("Config", [])
 		if configs and "Gateway" in configs[0]:
 			return configs[0]["Gateway"]
 	except Exception:
 		pass  # best-effort
-	return "172.30.0.1"
+	return _fallback_gateway(network)
+
+
+def _fallback_gateway(network: str) -> str:
+	"""The gateway `network` is defined to have, when Docker could not be asked.
+
+	A bench on bridge 1 whose endpoint reads bridge 0's gateway has no route to the
+	host, and `wg-quick` reports nothing about it.
+	"""
+	from benchpress import docker_manager
+
+	index = docker_manager.bench_network_index(network)
+	if index is None:
+		return LEGACY_GATEWAY
+	return docker_manager.bench_network_spec(index, docker_manager.subnet_base())["gateway"]
 
 
 def register_device(device_name: str, device_type: str, public_key: str | None = None) -> dict:

--- a/frontend/src/data/benchpressSettings.js
+++ b/frontend/src/data/benchpressSettings.js
@@ -4,6 +4,7 @@ import { computed, reactive, ref } from "vue";
 import ContainerIcon from "~icons/lucide/container";
 import CpuIcon from "~icons/lucide/cpu";
 import GlobeIcon from "~icons/lucide/globe";
+import NetworkIcon from "~icons/lucide/network";
 
 /** Each group is one nav item and one panel in the settings dialog. */
 export const SETTINGS_GROUPS = [
@@ -42,6 +43,33 @@ export const SETTINGS_GROUPS = [
 				label: "Traefik network",
 				mono: true,
 				help: "Containers join this network",
+			},
+		],
+	},
+	{
+		key: "group-network",
+		tab: "network",
+		title: "Bench network",
+		icon: NetworkIcon,
+		note: "The bridge family new benches are placed on. Bridges are created as they are needed.",
+		fields: [
+			{
+				key: "bench_subnet_base",
+				label: "Subnet base",
+				mono: true,
+				help: "Bridge i is <base>.<i×16>.0/20",
+			},
+			{
+				key: "bench_bridge_count",
+				label: "Bridge count",
+				type: "number",
+				help: "The most bridges the family may grow to",
+			},
+			{
+				key: "bench_slots_per_bridge",
+				label: "Slots per bridge",
+				type: "number",
+				help: "Benches a bridge takes before the next one is preferred — a Linux bridge caps at 1024 ports",
 			},
 		],
 	},

--- a/scripts/density_drill.py
+++ b/scripts/density_drill.py
@@ -85,7 +85,9 @@ def _fill(network: str, cap: int, created: list[str]) -> int | None:
 
 def _verdict(args, usable: int, refused_at: int | None, attempted: int) -> int:
 	if refused_at is None:
-		print(f"/{args.subnet_size}: {attempted} endpoints up, no refusal — the cap of {args.endpoints} was hit first")
+		print(
+			f"/{args.subnet_size}: {attempted} endpoints up, no refusal — the cap of {args.endpoints} was hit first"
+		)
 		return 0
 	held = refused_at - 1
 	print(f"/{args.subnet_size}: {held} endpoints held, refused at {refused_at}, {usable} addresses usable")
@@ -125,9 +127,18 @@ def _base_domain() -> str:
 	"""The site's own `base_domain`, read through bench rather than off this host's disk."""
 	finished = subprocess.run(
 		[
-			"docker", "compose", "exec", "-T", "backend",
-			"bench", "--site", SITE, "execute", "frappe.client.get_value",
-			"--kwargs", json.dumps({"doctype": "BenchPress Settings", "fieldname": "base_domain"}),
+			"docker",
+			"compose",
+			"exec",
+			"-T",
+			"backend",
+			"bench",
+			"--site",
+			SITE,
+			"execute",
+			"frappe.client.get_value",
+			"--kwargs",
+			json.dumps({"doctype": "BenchPress Settings", "fieldname": "base_domain"}),
 		],
 		cwd=COMPOSE_DIR,
 		capture_output=True,

--- a/scripts/density_drill.py
+++ b/scripts/density_drill.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Fill a scratch Docker bridge until the daemon refuses, and report the number it refused at.
+
+The harness for `specs/.../density-kernel-limits`. It answers one question the control plane
+can only guess at: how many endpoints a bridge of a given prefix length really takes. Nothing
+here reimplements the app's arithmetic — the daemon is the arbiter, exactly as it is in
+`docker_manager.start_bench_container`.
+
+Three properties make it safe to run against a host serving real tenants:
+
+- **It fills a network it made, never a live one.** The target is always `bpdrill-<n>`, and
+  the name is asserted before the first create. A drill that filled `benchpress-0` would take
+  every bench on it offline at the moment the run believed it was measuring capacity.
+- **It cleans up in a `finally`,** removing every container it created and then the network,
+  and the run ends by asserting `docker network inspect` no longer finds it.
+- **It refuses to run against the wrong site.** `--i-know-this-is` must match the site's own
+  `base_domain`, read back from the control plane rather than from a file on this host.
+
+The address is allocated at *start*, not at create (measured on Docker 29.7.2), so the drill
+starts every endpoint. `--endpoints` caps the run: a /20 is 4094 addresses and this box has
+2 vCPU and 7 GB, so the full-subnet run is opt-in and the default is small.
+
+    python3 scripts/density_drill.py --subnet-size 24 --i-know-this-is benchpress.cloud
+    python3 scripts/density_drill.py --subnet-size 20 --endpoints 4200 --i-know-this-is benchpress.cloud
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+SITE = os.environ.get("BENCHPRESS_SITE", "frontend")
+COMPOSE_DIR = os.environ.get("BENCHPRESS_COMPOSE_DIR", "/home/ubuntu/benchpress_devops")
+
+# Never a bench bridge. `_assert_scratch_network` is the guard; this is only the default.
+NETWORK_PREFIX = "bpdrill-"
+CONTAINER_PREFIX = "bpdrill-endpoint-"
+IMAGE = "busybox:latest"
+# 10.99 is unrouted here: the host carries 172.17, 172.27, 172.28, 172.30 and 172.31, and the
+# bench family owns 10.20. Overlapping any of them would blackhole live traffic.
+SUBNET_BASE = "10.99.0.0"
+
+DOCKER_TIMEOUT = 120
+BENCH_TIMEOUT = 300
+
+EXHAUSTED = "no available ipv4 addresses"
+
+
+def main() -> int:
+	args = _parse_args()
+	_assert_scratch_network(args.network)
+	_assert_right_site(args.i_know_this_is)
+
+	subnet = f"{SUBNET_BASE}/{args.subnet_size}"
+	usable = 2 ** (32 - args.subnet_size) - 3  # network, broadcast, gateway
+	print(f"drilling {args.network} on {subnet} — {usable} usable addresses, capped at {args.endpoints}")
+
+	created = []
+	try:
+		_create_network(args.network, subnet)
+		refused_at = _fill(args.network, args.endpoints, created)
+		return _verdict(args, usable, refused_at, len(created))
+	finally:
+		_cleanup(args.network, created)
+
+
+def _fill(network: str, cap: int, created: list[str]) -> int | None:
+	"""Start endpoints until the daemon refuses; returns the attempt number it refused at."""
+	for attempt in range(1, cap + 1):
+		name = f"{CONTAINER_PREFIX}{attempt}"
+		_docker("create", "--name", name, "--network", network, IMAGE, "sleep", "3600")
+		created.append(name)
+		failure = _docker("start", name, allow_failure=True)
+		if failure is None:
+			if attempt % 50 == 0:
+				print(f"  {attempt} endpoints up")
+			continue
+		if EXHAUSTED not in failure.lower():
+			_refuse(f"the daemon refused endpoint {attempt} for another reason:\n{failure}")
+		print(f"  refused at endpoint {attempt}")
+		return attempt
+	return None
+
+
+def _verdict(args, usable: int, refused_at: int | None, attempted: int) -> int:
+	if refused_at is None:
+		print(f"/{args.subnet_size}: {attempted} endpoints up, no refusal — the cap of {args.endpoints} was hit first")
+		return 0
+	held = refused_at - 1
+	print(f"/{args.subnet_size}: {held} endpoints held, refused at {refused_at}, {usable} addresses usable")
+	if held != usable:
+		# Not a failure: infrastructure and any earlier tenant hold addresses too. It is the
+		# number worth reading, so it is stated rather than folded into a pass.
+		print(f"note: {usable - held} addresses were not reachable by this run")
+	return 0
+
+
+def _create_network(network: str, subnet: str) -> None:
+	_docker("network", "create", "--driver", "bridge", "--subnet", subnet, network)
+
+
+def _cleanup(network: str, created: list[str]) -> None:
+	"""Remove everything this run made, then prove the scratch network is gone."""
+	for name in created:
+		_docker("rm", "-f", name, allow_failure=True)
+	_docker("network", "rm", network, allow_failure=True)
+	if _docker("network", "inspect", network, allow_failure=True) is None:
+		_refuse(f"{network} still exists after cleanup — remove it by hand before drilling again")
+	print(f"cleaned up: {len(created)} containers and {network}")
+
+
+def _assert_scratch_network(network: str) -> None:
+	if not network.startswith(NETWORK_PREFIX):
+		_refuse(f"{network!r} is not a scratch network — the name must start with {NETWORK_PREFIX!r}")
+
+
+def _assert_right_site(claimed: str) -> None:
+	base_domain = _base_domain()
+	if claimed != base_domain:
+		_refuse(f"this site is {base_domain!r}, not {claimed!r}")
+
+
+def _base_domain() -> str:
+	"""The site's own `base_domain`, read through bench rather than off this host's disk."""
+	finished = subprocess.run(
+		[
+			"docker", "compose", "exec", "-T", "backend",
+			"bench", "--site", SITE, "execute", "frappe.client.get_value",
+			"--kwargs", json.dumps({"doctype": "BenchPress Settings", "fieldname": "base_domain"}),
+		],
+		cwd=COMPOSE_DIR,
+		capture_output=True,
+		text=True,
+		# Closed deliberately: `docker compose exec` under a timeout hangs forever if it
+		# inherits a terminal it can read from.
+		stdin=subprocess.DEVNULL,
+		timeout=BENCH_TIMEOUT,
+	)
+	if finished.returncode:
+		_refuse(f"could not read base_domain:\n{finished.stdout}\n{finished.stderr}")
+	for line in reversed(finished.stdout.splitlines()):
+		if "base_domain" in line:
+			return line.split("base_domain")[-1].strip(" ':\"},")
+	_refuse(f"bench printed no base_domain:\n{finished.stdout}")
+
+
+def _docker(*arguments: str, allow_failure: bool = False) -> str | None:
+	"""Run one docker command; returns None on success and stderr on an allowed failure."""
+	finished = subprocess.run(
+		["docker", *arguments],
+		capture_output=True,
+		text=True,
+		stdin=subprocess.DEVNULL,
+		timeout=DOCKER_TIMEOUT,
+	)
+	if not finished.returncode:
+		return None
+	if allow_failure:
+		return finished.stderr or finished.stdout
+	_refuse(f"docker {' '.join(arguments)} failed:\n{finished.stderr}")
+
+
+def _refuse(reason: str) -> None:
+	print(f"refusing to run: {reason}", file=sys.stderr)
+	raise SystemExit(2)
+
+
+def _parse_args():
+	parser = argparse.ArgumentParser(description=__doc__)
+	parser.add_argument("--network", default="bpdrill-0", help="scratch network name; must be bpdrill-*")
+	parser.add_argument("--subnet-size", type=int, default=24, help="prefix length of the scratch subnet")
+	parser.add_argument("--endpoints", type=int, default=60, help="stop after this many, refusal or not")
+	parser.add_argument("--i-know-this-is", required=True, help="the site's base_domain")
+	return parser.parse_args()
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())


### PR DESCRIPTION
## Phase 1 — a bench lands on a named bridge

Every bench joined one Docker network, `benchpress` on `172.30.0.0/24` — 253
addresses shared with Traefik, MariaDB and Redis, behind a bridge device whose
name changes whenever the network is recreated. This is the first slice of the
`density-kernel-limits` spec.

### What changed

- `docker_manager` gains the family arithmetic: `bench_network_spec(i)` →
  network `benchpress-<i>`, device `bpbr<i>`, subnet `10.20.<i*16>.0/20`,
  gateway `.1`. `ensure_bench_network` creates a bridge and attaches the three
  infrastructure containers; `attach_infrastructure` tolerates a missing
  container so a dev checkout with no Traefik still deploys.
- `Bench Instance.bridge_network` — `Data`, `permlevel: 1`, read-only, defaulted
  in `validate` and refused outside `Draft`, copying the `runtime` pattern.
- The container create, both IP read-backs and the WireGuard endpoint take the
  network they act on instead of naming `benchpress`.
- `backfill_bench_bridge_network` stamps existing rows with `benchpress`, the
  network their containers are actually on. Nothing migrates.
- `entry.py` creates `benchpress-0`, and Traefik declares it as
  `benchpress-bench-0` (in `benchpress_devops`, branch of the same name).

`INFRASTRUCTURE_CONTAINERS` is a closed tuple rather than a setting: the control
plane's own database and caches must never sit on a network tenants share.

### How to verify

```bash
docker network inspect benchpress-0 --format '{{range .Containers}}{{.Name}} {{.IPv4Address}}{{"\n"}}{{end}}'
ip -br link | grep bpbr0
ip -br route | grep 10.20.0.0/20
curl -sI https://<instance_id>.<base_domain>/api/method/ping    # 200
docker exec <id> getent hosts benchpress-mariadb benchpress-redis
docker exec <id> getent hosts benchpress_db                     # must resolve nothing
docker exec <id> grep Endpoint /etc/wireguard/wg0.conf          # 10.20.0.1
```

Verified live on staging: a bench deployed onto `benchpress-0` at `10.20.0.5`
behind `bpbr0`, served `{"message":"pong"}` over HTTPS through Traefik, resolved
both infrastructure containers, did not resolve `benchpress_db`, and held a
WireGuard handshake against `10.20.0.1`. `benchpress-0` carries exactly four
endpoints. A bench pinned to the legacy `benchpress` network deployed and served
alongside it, and all six pre-existing rows read `benchpress`.

### Known gaps (phases 2 and 3)

Index 0 is the only bridge anything chooses, nothing reports how full it is,
nothing re-attaches infrastructure after a `compose up` recreates Traefik, and
no kernel ceiling has moved.