### PR TITLE
Implemented phase three

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -160,7 +160,29 @@ Layer 5: Create site (create-site.sh)
 
 **Container entrypoint** (`entry.sh`): Starts MariaDB, Redis, SSH, then `tail -f /dev/null` to keep alive.
 
-**Post-deploy site creation** (`setup-site.sh`): Used when creating additional sites in a running container.
+**Site creation on deploy** (`setup-site.sh`): the deploy execs this inside the new container,
+and it takes one of three paths.
+
+| Path | When | Cost on a CRM lab |
+|------|------|-------------------|
+| **Adopt** | The container already has `sites/<site>/site_config.json` — a redeploy that kept its data | Re-sets the admin password, nothing else |
+| **Restore** | The image carries `/opt/benchpress/golden/site.sql.gz` and the deploy allows it | `bench new-site --source-sql`, **9.1 s** |
+| **Create** | Anything else | `bench new-site` plus `install-app` per app, **37.2 s** |
+
+The golden dump is baked by `benchpress/golden.py` at the end of every image build: it runs the
+lab's site once in a throwaway container, dumps that database, restores the dump into a scratch
+database to prove it before trusting it, and appends one `FROM <tag>` + `COPY` layer to the tag
+the build just produced. It never rebuilds the image.
+
+Two switches in **BenchPress Settings** govern it, and they are separate on purpose:
+`enable_golden_images` decides whether a build bakes one, `restore_from_golden` whether a deploy
+reads one. A host that turns baking off keeps restoring from the images it already has.
+
+`deploy_manager._golden_matches_server` is the last gate. The dump is the one artefact in an
+image whose validity depends on something outside it, so a deploy compares the MariaDB **major**
+version the dump came from against the server it is restoring into and takes the create path
+with the reason in the log when they differ. A patch-level difference is not a mismatch —
+refusing on one would take every golden on the host out of service on a routine server update.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ flowchart LR
 - **Resource Controls** -- CPU cores and memory limits per lab, enforced by Docker `--cpus` and `--memory` flags
 - **Container Management** -- Start, stop, restart, redeploy, and delete benches from the dashboard
 - **Automatic Site Provisioning** -- Each bench gets its Frappe site created automatically on deploy, with the lab's apps installed
+- **Golden Images** -- A lab's build bakes the finished site's database into the lab's own image, so a deploy restores it instead of creating 281 tables through the ORM. Measured on a 2-vCPU host, a CRM lab's site step goes from **37.2 s to 9.1 s** and the whole deploy from 43.3 s to 13.3 s. Re-run it yourself with `python3 scripts/golden_drill.py --lab crm --runs 3 --i-know-this-is <your base domain>`, and add `--cold` for the control. A lab with no golden still deploys -- it is just slower
 - **VPN Device Management** -- Register persistent devices (Laptop, Mobile, etc.), generate WireGuard configs per device, and manage device lifecycle from a dedicated page
 - **Confirmation Dialogs** -- Destructive actions (deploy, stop, delete) require explicit confirmation before execution
 - **Stats Monitoring** -- CPU and memory usage polled every minute from the Docker stats API, displayed as progress bars

--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -96,6 +96,26 @@ def build_lab_image(lab_name: str) -> dict:
 
 
 @frappe.whitelist()
+def build_lab_golden(lab_name: str) -> dict:
+	"""Queue the golden build for one lab, appending it to the image the lab already has."""
+	require_admin()
+	lab = frappe.get_doc("Lab", lab_name)
+	tag, hit = image_cache.resolve(lab)
+	if lab.status != "Ready" or not hit or lab.image_tag != tag:
+		frappe.throw(_("No built image for lab '{0}'. Build it first from the Lab record.").format(lab.title))
+	frappe.enqueue(
+		"benchpress.golden.build_golden_job",
+		lab_name=lab_name,
+		user=frappe.session.user,
+		queue="long",
+		timeout=image_cache.BUILD_TIMEOUT,
+		job_id=f"golden:{lab_name}",
+		deduplicate=True,
+	)
+	return {"name": lab_name, "status": "Queued"}
+
+
+@frappe.whitelist()
 def prewarm_catalog() -> dict:
 	"""Build the shared image for every catalog template that has none yet.
 

--- a/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
+++ b/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
@@ -10,6 +10,7 @@
   "docker_socket",
   "default_image",
   "default_bench_runtime",
+  "enable_golden_images",
   "column_break_docker",
   "base_domain",
   "traefik_network",
@@ -50,6 +51,13 @@
    "fieldtype": "Select",
    "label": "Default Bench Runtime",
    "options": "runc\nsysbox"
+  },
+  {
+   "default": "1",
+   "description": "Bake a lab's finished site into its image on every build, so a deploy restores the database instead of creating it. Turning it off shortens builds on a disk-constrained host; images that already carry a golden keep restoring from it.",
+   "fieldname": "enable_golden_images",
+   "fieldtype": "Check",
+   "label": "Enable Golden Images"
   },
   {
    "fieldname": "column_break_docker",

--- a/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
+++ b/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
@@ -11,6 +11,7 @@
   "default_image",
   "default_bench_runtime",
   "enable_golden_images",
+  "restore_from_golden",
   "column_break_docker",
   "base_domain",
   "traefik_network",
@@ -58,6 +59,13 @@
    "fieldname": "enable_golden_images",
    "fieldtype": "Check",
    "label": "Enable Golden Images"
+  },
+  {
+   "default": "1",
+   "description": "Restore a bench's site from its lab image's golden dump when the image carries one. Turning it off makes every deploy build the site from scratch, which is how a suspect golden is taken out of service without rebuilding anything.",
+   "fieldname": "restore_from_golden",
+   "fieldtype": "Check",
+   "label": "Restore From Golden"
   },
   {
    "fieldname": "column_break_docker",

--- a/benchpress/benchpress/doctype/lab/lab.json
+++ b/benchpress/benchpress/doctype/lab/lab.json
@@ -29,6 +29,7 @@
   "shell",
   "image_section",
   "image_tag",
+  "golden_manifest",
   "lease_section",
   "default_lease_plan",
   "max_lease_minutes",
@@ -172,6 +173,14 @@
    "fieldname": "image_tag",
    "fieldtype": "Data",
    "label": "Image Tag",
+   "read_only": 1
+  },
+  {
+   "description": "The golden dump baked into the image this lab last built. A record of what was built, never an instruction: a deploy reads the image's own labels.",
+   "fieldname": "golden_manifest",
+   "fieldtype": "Code",
+   "label": "Golden Manifest",
+   "options": "JSON",
    "read_only": 1
   },
   {

--- a/benchpress/benchpress/doctype/lab/lab.py
+++ b/benchpress/benchpress/doctype/lab/lab.py
@@ -18,6 +18,7 @@ class Lab(Document):
 		self.apply_instance_size()
 		self.validate_cpu_cores()
 		self.reset_status_if_spec_changed()
+		self.clear_golden_manifest_if_image_changed()
 
 	def reset_status_if_spec_changed(self):
 		"""A `Ready` lab's image tag is static now (`benchpress/<lab_id>:lab`, not a content
@@ -29,7 +30,16 @@ class Lab(Document):
 		before = self.get_doc_before_save()
 		if before and build_spec(self) != build_spec(before):
 			self.status = "Draft"
+			# The golden in the old image was built from the old spec, so it no longer describes
+			# what this lab asks for.
+			self.golden_manifest = None
 			frappe.msgprint(_("Lab spec changed — rebuild the image before deploying."))
+
+	def clear_golden_manifest_if_image_changed(self):
+		"""The manifest describes one image. A different tag has its own golden, or none."""
+		before = self.get_doc_before_save()
+		if before and before.image_tag != self.image_tag:
+			self.golden_manifest = None
 
 	def apply_instance_size(self):
 		"""Copy the chosen size's resources onto the two fields Docker actually reads.

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import re
 import secrets
 import shlex
 import socket
@@ -36,6 +37,7 @@ from benchpress.mariadb_manager import (
 	create_mariadb_user,
 	drop_mariadb_user,
 	ensure_infrastructure,
+	server_version,
 	wait_for_mariadb,
 )
 from benchpress.notifications import notify_owner
@@ -84,6 +86,8 @@ SITE_HTTP_PORT = 8000
 
 ADOPTED_MARKER = "already exists — adopting it"
 GOLDEN_MARKER = "Restored from golden dump"
+# What the Deploy Log says when the golden branch ran. `golden_drill` reads runs back by it.
+GOLDEN_RESTORED = "restored from the image's golden dump"
 
 # Module constant, not inlined, so tests can monkeypatch it to a tmp path.
 # Flat, not a subdirectory: Traefik's file provider does not recurse, so this must be the
@@ -571,10 +575,50 @@ def create_site_in_container(
 		drop_mariadb_user(db_server.name, site_name, db_name)
 
 
+def _golden_matches_server(tag: str, db_server) -> tuple[bool, str]:
+	"""Whether this image's dump may be restored into this server, and why not.
+
+	The dump is the one artefact in the image whose validity depends on something outside it,
+	so this is where a golden is refused. Every refusal is a slow deploy, never a failed one.
+	"""
+	from benchpress import golden
+
+	if not golden.restore_enabled():
+		return (
+			False,
+			"Restoring from a golden dump is turned off in BenchPress Settings — creating the site instead",
+		)
+	dump = golden.golden_mariadb_version(tag)
+	if not dump:
+		return False, ""  # the image step already named the missing golden and its remedy
+	server = server_version(db_server.name)
+	if not _major_version(dump) or not _major_version(server):
+		return False, (
+			f"Could not compare the golden dump's MariaDB ({dump or 'unknown'}) with this "
+			f"server's ({server or 'unknown'}) — creating the site instead"
+		)
+	if _major_version(dump) != _major_version(server):
+		return False, (
+			f"Golden dump was taken from MariaDB {_major_version(dump)} and this server is "
+			f"{_major_version(server)} — creating the site instead"
+		)
+	return True, ""
+
+
+def _major_version(version: str) -> str:
+	"""`10.6` out of `10.6.28-MariaDB-ubu2204`, or empty when there is no version in there.
+
+	Major only: a patch bump is the same schema contract, and refusing on one would take every
+	golden on the host out of service the next time the server is updated.
+	"""
+	match = re.match(r"\d+\.\d+", version or "")
+	return match[0] if match else ""
+
+
 def _site_outcome(output: str, site_name: str) -> str:
 	"""Which of setup-site.sh's three branches ran. The Deploy Log is where that answer survives."""
 	if GOLDEN_MARKER in output:
-		return f"Site {site_name} restored from the image's golden dump"
+		return f"Site {site_name} {GOLDEN_RESTORED}"
 	if ADOPTED_MARKER in output:
 		return "Existing site adopted"
 	return "Site created successfully"
@@ -726,8 +770,11 @@ def _deploy_bench(bench_name: str) -> None:
 		pipeline.step("site")
 		apps_csv = ",".join(a.app_name for a in lab.apps if a.app_name.lower() != "frappe")
 		pipeline.log(f"Site {site_name} with {apps_csv or 'frappe'}")
+		use_golden, refusal = _golden_matches_server(lab.image_tag, db_server)
+		if refusal:
+			pipeline.log(refusal)
 		exit_code, output = create_site_in_container(
-			container_id, db_server, site_name, admin_password, apps_csv
+			container_id, db_server, site_name, admin_password, apps_csv, use_golden=use_golden
 		)
 		if exit_code != 0:
 			raise Exception(f"Site setup failed (exit {exit_code}): {output}")

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -83,6 +83,7 @@ NOTHING_TO_ROLL_BACK = "Cleanup: nothing to roll back — no container was creat
 SITE_HTTP_PORT = 8000
 
 ADOPTED_MARKER = "already exists — adopting it"
+GOLDEN_MARKER = "Restored from golden dump"
 
 # Module constant, not inlined, so tests can monkeypatch it to a tmp path.
 # Flat, not a subdirectory: Traefik's file provider does not recurse, so this must be the
@@ -533,11 +534,22 @@ _notify_owner = notify_owner
 
 
 def create_site_in_container(
-	container_id: str, db_server, site_name: str, admin_password: str, apps_csv: str
+	container_id: str,
+	db_server,
+	site_name: str,
+	admin_password: str,
+	apps_csv: str,
+	database: str | None = None,
+	use_golden: bool = True,
 ) -> tuple[int, str]:
-	"""Run setup-site.sh inside a bench container using a temporary MariaDB user."""
+	"""Run setup-site.sh inside a bench container using a temporary MariaDB user.
+
+	`database` overrides the name derived from the site, which the golden build needs so its
+	scratch database is one this app is allowed to drop. `use_golden=False` makes the script
+	create the site even in an image that carries a golden dump.
+	"""
 	bench_dir = "/home/frappe/frappe-bench"
-	db_name, temp_user, temp_password = create_mariadb_user(db_server.name, site_name)
+	db_name, temp_user, temp_password = create_mariadb_user(db_server.name, site_name, database)
 	try:
 		return exec_in_container(
 			container_id,
@@ -552,10 +564,20 @@ def create_site_in_container(
 				"DB_NAME": db_name,
 				"MARIADB_ROOT_USERNAME": temp_user,
 				"MARIADB_ROOT_PASSWORD": temp_password,
+				"USE_GOLDEN": "1" if use_golden else "0",
 			},
 		)
 	finally:
 		drop_mariadb_user(db_server.name, site_name, db_name)
+
+
+def _site_outcome(output: str, site_name: str) -> str:
+	"""Which of setup-site.sh's three branches ran. The Deploy Log is where that answer survives."""
+	if GOLDEN_MARKER in output:
+		return f"Site {site_name} restored from the image's golden dump"
+	if ADOPTED_MARKER in output:
+		return "Existing site adopted"
+	return "Site created successfully"
 
 
 def _log_deploy_skipped(bench_name: str) -> None:
@@ -648,7 +670,11 @@ def _deploy_bench(bench_name: str) -> None:
 		pipeline.step("image")
 		_prepare_lab_image(lab, pipeline, bench.owner)
 
+		# Both halves of the previous deploy go together, and before the new container
+		# exists: the site database is the other thing a redeploy replaces, and dropping a
+		# few hundred tables is teardown, not part of creating the site that follows.
 		_remove_stale_container(bench)
+		_drop_site_database(bench)
 		pipeline.step("container")
 		container_id = create_bench_container(bench, lab)
 		created_container_id = container_id
@@ -689,6 +715,7 @@ def _deploy_bench(bench_name: str) -> None:
 			"socketio_port": 9000,
 			"webserver_port": SITE_HTTP_PORT,
 			"default_site": site_name,
+			"developer_mode": 1,
 		}
 		pipeline.step("site_config")
 		write_file_to_container(
@@ -697,8 +724,6 @@ def _deploy_bench(bench_name: str) -> None:
 		pipeline.log(f"{bench_dir}/sites/common_site_config.json written")
 
 		pipeline.step("site")
-		# Drop the leftover of an interrupted run; `bench new-site` refuses to overwrite it.
-		_drop_site_database(bench)
 		apps_csv = ",".join(a.app_name for a in lab.apps if a.app_name.lower() != "frappe")
 		pipeline.log(f"Site {site_name} with {apps_csv or 'frappe'}")
 		exit_code, output = create_site_in_container(
@@ -706,7 +731,7 @@ def _deploy_bench(bench_name: str) -> None:
 		)
 		if exit_code != 0:
 			raise Exception(f"Site setup failed (exit {exit_code}): {output}")
-		pipeline.log("Existing site adopted" if ADOPTED_MARKER in output else "Site created successfully")
+		pipeline.log(_site_outcome(output, site_name))
 		_record_primary_site(bench, lab, admin_password)
 
 		pipeline.step("assets")

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -1036,10 +1036,17 @@ def _prepare_lab_image(lab, pipeline, user: str) -> None:
 	`Lab.reset_status_if_spec_changed`), throws right away instead of eating a 10-40 minute build
 	inside what the caller expects to be a fast operation.
 	"""
+	from benchpress.golden import image_has_golden
+
 	tag, hit = image_cache.resolve(lab)
 	if not hit or lab.status != "Ready" or lab.image_tag != tag:
 		frappe.throw(_("No built image for lab '{0}'. Build it first from the Lab record.").format(lab.title))
 	pipeline.log(f"Using built image {tag}")
+	if not image_has_golden(tag):
+		pipeline.log(
+			f"No golden dump in {tag} — this site is built from scratch. "
+			"Rebuild the lab, or run Build golden, to make its deploys ~5x faster."
+		)
 
 
 def _build_lab_with_logs(lab, log_fn) -> None:
@@ -1060,6 +1067,32 @@ def _build_lab_with_logs(lab, log_fn) -> None:
 	frappe.db.commit()
 	if log_fn:
 		log_fn(f"Lab image ready: {image_tag}")
+
+	# After the lab is Ready with its tag saved: the golden step appends a layer to that tag,
+	# and needs the row that names it.
+	_add_golden(lab, log_fn)
+
+
+def _add_golden(lab, log_fn) -> None:
+	"""Bake the golden into the image this build just produced, and record what was baked.
+
+	Never raises, and the `except` is not belt and braces: everything above it has already been
+	committed, so letting the row write escape would make `_run_build` mark a finished image as a
+	failed build and put the lab's status back.
+	"""
+	from benchpress import golden
+
+	try:
+		manifest = golden.add_golden(lab, log_fn)
+		lab.reload()
+		# Written either way: this build replaced the image under the same tag, so a manifest left
+		# over from the last one would claim a golden that is no longer in there.
+		lab.golden_manifest = json.dumps(manifest, indent=2) if manifest else None
+		lab.save(ignore_permissions=True)
+		frappe.db.commit()
+	except Exception:
+		frappe.db.rollback()
+		frappe.log_error(title=f"Golden manifest not recorded: {lab.name}", message=frappe.get_traceback())
 
 
 def _open_build_log(lab, user: str) -> tuple[DeployLogWriter, str]:

--- a/benchpress/diagnostics.py
+++ b/benchpress/diagnostics.py
@@ -42,9 +42,13 @@ PTY_ROOT_RESERVE = 1024
 CONNTRACK_PER_BENCH = 256
 
 
-def check_row(check: str, ok: bool, hint: str) -> dict:
-	"""One check result. Shared by every caller so the shape cannot drift."""
-	return {"check": check, "status": "pass" if ok else "fail", "hint": hint}
+def check_row(check: str, ok: bool, hint: str, severity: str = "Error") -> dict:
+	"""One check result. Shared by every caller so the shape cannot drift.
+
+	`severity` is what a failed row reads as on screen. It exists for the checks whose failure is
+	a degraded state rather than a broken one, and only `display_row` looks at it.
+	"""
+	return {"check": check, "status": "pass" if ok else "fail", "hint": hint, "severity": severity}
 
 
 def display_row(check: dict, label: str) -> dict:
@@ -52,13 +56,13 @@ def display_row(check: dict, label: str) -> dict:
 	return {
 		"check": check["check"],
 		"label": label,
-		"status": "Active" if check["status"] == "pass" else "Error",
+		"status": "Active" if check["status"] == "pass" else check.get("severity", "Error"),
 		"hint": check["hint"],
 	}
 
 
 def run_diagnostics() -> list[dict]:
-	"""Read-only environment checks. Each row: {check, status: pass|fail, hint}.
+	"""Read-only environment checks. Each row: {check, status: pass|fail, hint, severity}.
 
 	Never raises and never mutates infrastructure.
 	"""
@@ -71,6 +75,7 @@ def run_diagnostics() -> list[dict]:
 		_check_clock_skew(),
 		_check_redis(),
 		_check_container_runtimes(),
+		_check_golden_images(),
 		check_vpn_server(),
 	]
 
@@ -237,6 +242,34 @@ def _check_container_runtimes() -> dict:
 		return check_row("container_runtimes", True, f"Docker has {', '.join(required)} registered")
 	except Exception as e:
 		return check_row("container_runtimes", False, f"Could not read Docker runtimes: {e}")
+
+
+def _check_golden_images() -> dict:
+	"""How much of the catalog restores its site instead of creating it.
+
+	Warning, never Error: a lab with no golden deploys exactly as it always has, just slowly.
+	The labels come off the image list `cached_tags` already asks Docker for.
+	"""
+	try:
+		from benchpress.golden import golden_tags
+		from benchpress.image_cache import cached_tags
+
+		tags = cached_tags()
+		if not tags:
+			return check_row("golden_images", True, "No lab image is built yet")
+		missing = sorted(tags - golden_tags())
+		coverage = f"{len(tags) - len(missing)} of {len(tags)} built labs carry a golden dump"
+		if missing:
+			return check_row(
+				"golden_images",
+				False,
+				f"{coverage} — {', '.join(missing)} build their site from scratch on every deploy. "
+				"Rebuild those labs, or run Build golden on each.",
+				severity="Warning",
+			)
+		return check_row("golden_images", True, coverage)
+	except Exception as e:
+		return check_row("golden_images", False, f"Could not read golden image labels: {e}")
 
 
 def check_vpn_server() -> dict:

--- a/benchpress/golden.py
+++ b/benchpress/golden.py
@@ -1,0 +1,299 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""A lab's finished site, baked into the lab's own image as a database dump.
+
+A spawn creates 281 tables through the ORM for a CRM lab and 1055 for a seven-app one, every
+time, for every tenant — 92% and 97% of the deploy. With a golden in the image, `setup-site.sh`
+restores that database instead of installing it.
+
+The dump ships **inside** the image so it can never drift from the code that produced it, and
+the layer carrying it is appended over the existing tag: lab images are 5.5-19.7 GB and a
+rebuild does not fit on this host.
+"""
+
+import hashlib
+import io
+import json
+import tarfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+import docker
+import frappe
+from frappe import _
+
+from benchpress import deploy_manager, docker_manager, image_cache, placement
+from benchpress.image_cache import clear_cached_tags
+from benchpress.mariadb_manager import drop_site_database, ensure_infrastructure
+
+GOLDEN_DIR = "/opt/benchpress/golden"
+DUMP_PATH = f"{GOLDEN_DIR}/site.sql.gz"
+MANIFEST_PATH = f"{GOLDEN_DIR}/manifest.json"
+
+# The three names this feature owns, and the only ones it ever drops or removes. A tenant's
+# database is `_<sha1>` from `mariadb_manager.get_database_name` and stays unreachable from here.
+GOLDEN_SITE_PREFIX = "bpgolden-"
+GOLDEN_CONTAINER_PREFIX = "bpgolden-"
+GOLDEN_DB_PREFIX = "_bpgolden"
+
+BENCH_DIR = "/home/frappe/frappe-bench"
+SETUP_SITE_PATH = "/opt/benchpress/scripts/setup-site.sh"
+
+# The dump exec reports itself on one marked line, because a MariaDB client warning on stderr
+# lands in the same stream as the output.
+META_MARKER = "GOLDEN_META"
+
+# The restore is DDL-bound: a schema-only dump of the same site restores in the same time as
+# the full one, because the cost is 281 `CREATE TABLE`s. These three drop the statements that
+# are pure overhead against the empty database `bench new-site` has just created.
+LEAN_DUMP_FLAGS = "--skip-add-drop-table --skip-add-locks --skip-disable-keys"
+
+
+def build_golden(lab_doc, log_fn=None) -> dict:
+	"""Create this lab's site once and bake its database dump into the lab's image."""
+	if not lab_doc.image_tag:
+		frappe.throw(_("Lab '{0}' has no image to append a golden to.").format(lab_doc.title))
+
+	db_server = frappe.get_doc("Database Server", ensure_infrastructure())
+	site = f"{GOLDEN_SITE_PREFIX}{lab_doc.lab_id}"
+	database = golden_database(site)
+	container = _start_scratch_container(lab_doc)
+	_log(log_fn, f"Scratch container {container.name} from {lab_doc.image_tag}")
+	try:
+		_create_site(container.id, db_server, site, database, lab_doc, log_fn)
+		manifest = _dump_site(container.id, db_server, site, lab_doc, log_fn)
+		_append_layer(container.id, lab_doc.image_tag, manifest, log_fn)
+		return manifest
+	finally:
+		# Both outlive a failed run, and a leaked database sits in the server every tenant shares.
+		drop_site_database(db_server.name, site, database)
+		container.remove(force=True)
+
+
+def golden_database(site: str) -> str:
+	"""The scratch database for a golden site — the one name shape this feature may drop."""
+	return GOLDEN_DB_PREFIX + hashlib.sha1(site.encode()).hexdigest()[:16]
+
+
+def build_golden_job(lab_name: str, user: str | None = None) -> None:
+	"""Run the golden build into its own `Build Log`, the way an image build streams."""
+	lab = frappe.get_doc("Lab", lab_name)
+	append_log, build_log_name = deploy_manager._open_build_log(lab, user or lab.owner)
+	try:
+		manifest = build_golden(lab, log_fn=append_log)
+	except Exception as e:
+		append_log(f"=== Build failed: {e!s} ===", "error")
+		frappe.db.set_value("Build Log", build_log_name, "log_type", "error")
+		frappe.db.commit()  # nosemgrep -- the run's outcome must survive its failure
+		frappe.log_error(title=f"Golden build failed: {lab_name}", message=frappe.get_traceback())
+		raise
+
+	append_log(json.dumps(manifest))
+	append_log(f"=== Build complete: golden in {lab.image_tag} ===", "success")
+	frappe.db.set_value("Build Log", build_log_name, "log_type", "success")
+	frappe.db.commit()  # nosemgrep -- the log records a finished run
+
+
+def _start_scratch_container(lab_doc):
+	"""Run the lab's existing image with no entrypoint, on the network a bench would get.
+
+	Docker's embedded DNS answers `benchpress-mariadb` only across a shared network, and a
+	container on the wrong one fails with a name-resolution error that names neither.
+	"""
+	client = docker_manager.get_client()
+	name = f"{GOLDEN_CONTAINER_PREFIX}{lab_doc.lab_id}"
+	_remove_stale(client, name)
+	network = docker_manager.ensure_bench_network_for(placement.pick_network(), client)
+	return client.containers.run(
+		lab_doc.image_tag,
+		command=["sleep", "infinity"],
+		name=name,
+		network=network,
+		detach=True,
+		mem_limit=lab_doc.memory_limit or "512m",
+	)
+
+
+def _remove_stale(client, name: str) -> None:
+	try:
+		client.containers.get(name).remove(force=True)
+	except docker.errors.NotFound:
+		pass
+
+
+def _create_site(container_id: str, db_server, site: str, database: str, lab_doc, log_fn) -> None:
+	"""Create the golden site with the same script a deploy runs, and never from a golden.
+
+	`use_golden=False` because a second run against an image that already carries one would
+	otherwise restore the last dump and bake a copy of a copy.
+	"""
+	config = {
+		**db_server.get_connection_config(),
+		"redis_cache": "redis://benchpress-redis:6379/0",
+		"redis_queue": "redis://benchpress-redis:6379/1",
+		"redis_socketio": "redis://benchpress-redis:6379/2",
+		"socketio_port": 9000,
+		"webserver_port": deploy_manager.SITE_HTTP_PORT,
+		"default_site": site,
+		"developer_mode": 1,
+	}
+	docker_manager.write_file_to_container(
+		container_id, json.dumps(config, indent=2), f"{BENCH_DIR}/sites/common_site_config.json"
+	)
+	apps_csv = ",".join(a.app_name for a in lab_doc.apps if a.app_name.lower() != "frappe")
+	exit_code, output = deploy_manager.create_site_in_container(
+		container_id,
+		db_server,
+		site,
+		frappe.generate_hash(length=16),
+		apps_csv,
+		database=database,
+		use_golden=False,
+	)
+	if exit_code != 0:
+		raise Exception(f"Golden site setup failed (exit {exit_code}): {output}")
+	_log(log_fn, f"Golden site {site} created with {apps_csv or 'frappe'}")
+
+
+def _dump_site(container_id: str, db_server, site: str, lab_doc, log_fn) -> dict:
+	"""Dump the golden site's database inside the container; return the manifest describing it."""
+	# Emptied, not reused: the image may already carry a golden, and its root-owned dump would
+	# both refuse the write and travel into the new layer beside this run's own.
+	exit_code, output = docker_manager.exec_in_container(
+		container_id,
+		f"rm -rf {GOLDEN_DIR} && mkdir -p {GOLDEN_DIR} && chown frappe:frappe {GOLDEN_DIR}",
+		user="root",
+	)
+	if exit_code != 0:
+		raise Exception(f"Could not create {GOLDEN_DIR} (exit {exit_code}): {output}")
+
+	exit_code, output = docker_manager.exec_in_container(
+		container_id, _dump_command(db_server, site), user="frappe", workdir=BENCH_DIR
+	)
+	if exit_code != 0:
+		raise Exception(f"Golden dump failed (exit {exit_code}): {output}")
+
+	manifest = _manifest(lab_doc, _read_meta(output))
+	_log(log_fn, f"Dumped {manifest['dump_bytes']} bytes from MariaDB {manifest['mariadb_version']}")
+	return manifest
+
+
+def _dump_command(db_server, site: str) -> str:
+	"""Dump through gzip with the site's own credentials, read out of its site_config.json.
+
+	`pipefail` because gzip succeeds on a truncated stream, and a dump that fails silently is
+	the one failure this feature must never ship into an image.
+	"""
+	connection = db_server.get_connection_config()
+	host, port = connection["db_host"], connection["db_port"]
+	read_credentials = (
+		"python3 -c 'import json; "
+		f'c = json.load(open("sites/{site}/site_config.json")); '
+		'print(c["db_name"], c.get("db_user") or c["db_name"], c["db_password"])\''
+	)
+	return "\n".join(
+		[
+			"set -euo pipefail",
+			f'credentials="$({read_credentials})"',
+			'read -r db user password <<< "$credentials"',
+			'export MYSQL_PWD="$password"',
+			f'mariadb-dump -h {host} -P {port} -u "$user" --single-transaction --quick'
+			f" --default-character-set=utf8mb4 {LEAN_DUMP_FLAGS}"
+			f' "$db" | gzip -c > {DUMP_PATH}',
+			f"version=$(mariadb -h {host} -P {port} -u \"$user\" -N -B -e 'SELECT VERSION()')",
+			f'echo "{META_MARKER} $(stat -c %s {DUMP_PATH})'
+			f' $(sha256sum {DUMP_PATH} | cut -d" " -f1) $version"',
+		]
+	)
+
+
+def _read_meta(output: str) -> tuple[int, str, str]:
+	"""`(bytes, sha256, mariadb_version)` off the dump exec's one marked line."""
+	for line in reversed(output.splitlines()):
+		if line.startswith(META_MARKER):
+			_marker, size, digest, version = line.split()
+			return int(size), digest, version
+	raise Exception(f"Golden dump reported no {META_MARKER} line: {output}")
+
+
+def _manifest(lab_doc, meta: tuple[int, str, str]) -> dict:
+	"""What the dump is, and what it was taken from.
+
+	`apps` and `frappe_version` come from `image_cache.build_spec`, so the manifest and the
+	image tag describe the same recipe. `mariadb_version` is the one fact whose validity lives
+	outside the image: the dump is restored into a different server than it came from.
+	"""
+	dump_bytes, dump_sha256, mariadb_version = meta
+	spec = image_cache.build_spec(lab_doc)
+	return {
+		"lab_id": lab_doc.lab_id,
+		"image_tag": lab_doc.image_tag,
+		"frappe_version": spec["frappe_version"],
+		"apps": spec["apps"],
+		"mariadb_version": mariadb_version,
+		"dump_bytes": dump_bytes,
+		"dump_sha256": dump_sha256,
+		"created_at": datetime.now(UTC).isoformat(timespec="seconds"),
+	}
+
+
+def _append_layer(container_id: str, image_tag: str, manifest: dict, log_fn=None) -> None:
+	"""Rebuild `image_tag` from itself with the golden directory copied in.
+
+	`FROM` the tag this build produces is intended: the previous image keeps its layers and
+	becomes the parent of the new one, losing only the tag. Nothing below the appended layer
+	is rebuilt.
+	"""
+	context = _build_context(container_id, image_tag, manifest)
+	for chunk in docker_manager.get_client().api.build(
+		fileobj=context, custom_context=True, tag=image_tag, rm=True, decode=True
+	):
+		if "error" in chunk:
+			raise Exception(f"Golden layer build failed: {chunk['error'].strip()}")
+		line = (chunk.get("stream") or "").strip()
+		if line:
+			_log(log_fn, line)
+	clear_cached_tags()
+
+
+def _build_context(container_id: str, image_tag: str, manifest: dict) -> io.BytesIO:
+	"""The build context as an in-memory tar; nothing is written to the worker's filesystem."""
+	stream, _stat = docker_manager.get_client().containers.get(container_id).get_archive(GOLDEN_DIR)
+	context = io.BytesIO()
+	with tarfile.open(fileobj=context, mode="w") as out:
+		with tarfile.open(fileobj=io.BytesIO(b"".join(stream))) as golden:
+			for member in golden:
+				out.addfile(member, golden.extractfile(member) if member.isfile() else None)
+		_add_file(out, "golden/manifest.json", json.dumps(manifest, indent=2).encode())
+		_add_file(out, "Dockerfile", _dockerfile(image_tag).encode())
+		_add_file(out, "setup-site.sh", _setup_site_source().encode(), mode=0o755)
+	context.seek(0)
+	return context
+
+
+def _dockerfile(image_tag: str) -> str:
+	"""The appended layer: the dump, and the branch of setup-site.sh that reads it.
+
+	The script travels with the dump because every lab image on this host predates the restore
+	branch, and this feature never rebuilds one.
+	"""
+	return f"FROM {image_tag}\nCOPY golden {GOLDEN_DIR}\nCOPY setup-site.sh {SETUP_SITE_PATH}\n"
+
+
+def _setup_site_source() -> str:
+	return (
+		Path(frappe.get_app_path("benchpress")) / "lab-templates" / "scripts" / "setup-site.sh"
+	).read_text()
+
+
+def _add_file(tar: tarfile.TarFile, name: str, data: bytes, mode: int = 0o644) -> None:
+	info = tarfile.TarInfo(name)
+	info.size = len(data)
+	info.mode = mode
+	tar.addfile(info, io.BytesIO(data))
+
+
+def _log(log_fn, line: str) -> None:
+	if log_fn:
+		log_fn(line)

--- a/benchpress/golden.py
+++ b/benchpress/golden.py
@@ -16,6 +16,7 @@ import hashlib
 import io
 import json
 import tarfile
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -25,7 +26,13 @@ from frappe import _
 
 from benchpress import deploy_manager, docker_manager, image_cache, placement
 from benchpress.image_cache import clear_cached_tags
-from benchpress.mariadb_manager import drop_site_database, ensure_infrastructure
+from benchpress.mariadb_manager import (
+	create_mariadb_user,
+	drop_mariadb_user,
+	drop_site_database,
+	ensure_infrastructure,
+	execute_sql,
+)
 
 GOLDEN_DIR = "/opt/benchpress/golden"
 DUMP_PATH = f"{GOLDEN_DIR}/site.sql.gz"
@@ -41,13 +48,15 @@ GOLDEN_MARIADB_LABEL = "benchpress.golden.mariadb"
 GOLDEN_SITE_PREFIX = "bpgolden-"
 GOLDEN_CONTAINER_PREFIX = "bpgolden-"
 GOLDEN_DB_PREFIX = "_bpgolden"
+VERIFY_DB_PREFIX = "_bpgolden_verify_"
 
 BENCH_DIR = "/home/frappe/frappe-bench"
 SETUP_SITE_PATH = "/opt/benchpress/scripts/setup-site.sh"
 
-# The dump exec reports itself on one marked line, because a MariaDB client warning on stderr
-# lands in the same stream as the output.
+# The dump and the verification restore each report themselves on one marked line, because a
+# MariaDB client warning on stderr lands in the same stream as the output.
 META_MARKER = "GOLDEN_META"
+VERIFY_MARKER = "GOLDEN_VERIFY"
 
 # The restore is DDL-bound: a schema-only dump of the same site restores in the same time as
 # the full one, because the cost is 281 `CREATE TABLE`s. These three drop the statements that
@@ -68,6 +77,7 @@ def build_golden(lab_doc, log_fn=None) -> dict:
 	try:
 		_create_site(container.id, db_server, site, database, lab_doc, log_fn)
 		manifest = _dump_site(container.id, db_server, site, lab_doc, log_fn)
+		manifest.update(_verify_dump(container.id, db_server, lab_doc, log_fn))
 		_append_layer(container.id, lab_doc.image_tag, manifest, log_fn)
 		return manifest
 	finally:
@@ -131,16 +141,31 @@ def golden_images_enabled() -> bool:
 	return bool(frappe.get_cached_value("BenchPress Settings", "BenchPress Settings", "enable_golden_images"))
 
 
-def image_has_golden(tag: str) -> bool:
-	"""Whether this image carries a golden dump, asked of the image and not of the `Lab` row.
+def restore_enabled() -> bool:
+	"""Whether a deploy restores from a golden — `BenchPress Settings.restore_from_golden`."""
+	return bool(frappe.get_cached_value("BenchPress Settings", "BenchPress Settings", "restore_from_golden"))
 
-	False on any Docker error, a missing image included. Every caller's safe direction is the
-	cold path, and no deploy may fail because an optimisation could not be checked for.
+
+def image_has_golden(tag: str) -> bool:
+	"""Whether this image carries a golden dump, asked of the image and not of the `Lab` row."""
+	return _image_labels(tag).get(GOLDEN_LABEL) == "1"
+
+
+def golden_mariadb_version(tag: str) -> str:
+	"""The MariaDB server this image's dump was taken from; empty when it carries no golden."""
+	return _image_labels(tag).get(GOLDEN_MARIADB_LABEL, "")
+
+
+def _image_labels(tag: str) -> dict:
+	"""One image's labels, empty on any Docker error — a missing image included.
+
+	Every caller's safe direction is the cold path, and no deploy may fail because an
+	optimisation could not be checked for.
 	"""
 	try:
-		return docker_manager.get_client().images.get(tag).labels.get(GOLDEN_LABEL) == "1"
+		return docker_manager.get_client().images.get(tag).labels or {}
 	except Exception:
-		return False
+		return {}
 
 
 def golden_tags() -> set[str]:
@@ -233,6 +258,96 @@ def _dump_site(container_id: str, db_server, site: str, lab_doc, log_fn) -> dict
 	manifest = _manifest(lab_doc, _read_meta(output))
 	_log(log_fn, f"Dumped {manifest['dump_bytes']} bytes from MariaDB {manifest['mariadb_version']}")
 	return manifest
+
+
+def _verify_dump(container_id: str, db_server, lab_doc, log_fn) -> dict:
+	"""Restore the dump into a scratch database and report what came back.
+
+	Raises when the restore brings back no tables, or fewer apps than the lab installs. The
+	golden is then never appended and the image keeps the cold path, which works.
+	"""
+	site = f"{GOLDEN_SITE_PREFIX}verify-{lab_doc.lab_id}"
+	database = f"{VERIFY_DB_PREFIX}{lab_doc.lab_id}"
+	_database, user, password = create_mariadb_user(db_server.name, site, database)
+	try:
+		exit_code, output = execute_sql(db_server.name, f"CREATE OR REPLACE DATABASE `{database}`;\n")
+		if exit_code != 0:
+			raise Exception(f"Could not create {database} (exit {exit_code}): {output}")
+		started = time.monotonic()
+		exit_code, output = docker_manager.exec_in_container(
+			container_id,
+			_restore_command(db_server, database),
+			user="frappe",
+			environment={"MYSQL_PWD": password, "GOLDEN_USER": user},
+		)
+		restore_seconds = round(time.monotonic() - started, 1)
+		if exit_code != 0:
+			raise Exception(f"Golden dump would not restore (exit {exit_code}): {output}")
+		exit_code, output = docker_manager.exec_in_container(
+			container_id,
+			_restored_command(db_server, database),
+			user="frappe",
+			environment={"MYSQL_PWD": password, "GOLDEN_USER": user},
+		)
+		if exit_code != 0:
+			raise Exception(f"Could not read the restored database (exit {exit_code}): {output}")
+		tables, installed_apps = _read_verified(output)
+	finally:
+		# The scratch database and its limited user both sit in the server every tenant shares.
+		drop_site_database(db_server.name, site, database)
+		drop_mariadb_user(db_server.name, site, database)
+
+	_assert_restored(lab_doc, tables, installed_apps)
+	_log(log_fn, f"Restored {tables} tables and {', '.join(installed_apps)} in {restore_seconds}s")
+	return {"tables": tables, "installed_apps": sorted(installed_apps), "restore_seconds": restore_seconds}
+
+
+def _restore_command(db_server, database: str) -> str:
+	"""Pipe the dump back in through gzip, the way `bench new-site --source-sql` will."""
+	connection = db_server.get_connection_config()
+	return "\n".join(
+		[
+			"set -euo pipefail",
+			f"gzip -cd {DUMP_PATH} | mariadb -h {connection['db_host']} -P {connection['db_port']}"
+			f' -u "$GOLDEN_USER" --default-character-set=utf8mb4 {database}',
+		]
+	)
+
+
+def _restored_command(db_server, database: str) -> str:
+	"""Count what the restore brought back, on one marked line."""
+	connection = db_server.get_connection_config()
+	client = f'mariadb -h {connection["db_host"]} -P {connection["db_port"]} -u "$GOLDEN_USER" -N -B'
+	tables = (
+		f'tables=$({client} -e "SELECT COUNT(*) FROM information_schema.tables'
+		f" WHERE table_schema='{database}'\")"
+	)
+	# `app_name`, not `name`: a row in this child table is named by a hash.
+	apps = f"apps=$({client} {database} -e 'SELECT app_name FROM `tabInstalled Application`' | tr '\\n' ' ')"
+	return "\n".join(["set -euo pipefail", tables, apps, f'echo "{VERIFY_MARKER} $tables $apps"'])
+
+
+def _read_verified(output: str) -> tuple[int, list[str]]:
+	"""`(tables, apps)` off the read-back exec's one marked line."""
+	for line in reversed(output.splitlines()):
+		if line.startswith(VERIFY_MARKER):
+			_marker, tables, *apps = line.split()
+			return int(tables), apps
+	raise Exception(f"The restored database reported no {VERIFY_MARKER} line: {output}")
+
+
+def _assert_restored(lab_doc, tables: int, installed_apps: list[str]) -> None:
+	"""Refuse a dump that came back empty or short of the lab's own apps.
+
+	`bench new-site --source-sql` reports success on an empty restore, so the exit code proves
+	nothing and this is the only place the dump is ever asked what it contains.
+	"""
+	if not tables:
+		raise Exception("Golden dump restored no tables")
+	expected = {row.app_name.strip().lower() for row in lab_doc.apps} | {"frappe"}
+	missing = expected - {app.lower() for app in installed_apps}
+	if missing:
+		raise Exception(f"Golden dump restored without {', '.join(sorted(missing))}")
 
 
 def _dump_command(db_server, site: str) -> str:

--- a/benchpress/golden.py
+++ b/benchpress/golden.py
@@ -31,6 +31,11 @@ GOLDEN_DIR = "/opt/benchpress/golden"
 DUMP_PATH = f"{GOLDEN_DIR}/site.sql.gz"
 MANIFEST_PATH = f"{GOLDEN_DIR}/manifest.json"
 
+# Whether a tag carries a golden is read from these, never from `Lab.golden_manifest`: the row is
+# a claim about an image, and the image is the artefact a deploy actually runs.
+GOLDEN_LABEL = "benchpress.golden"
+GOLDEN_MARIADB_LABEL = "benchpress.golden.mariadb"
+
 # The three names this feature owns, and the only ones it ever drops or removes. A tenant's
 # database is `_<sha1>` from `mariadb_manager.get_database_name` and stays unreachable from here.
 GOLDEN_SITE_PREFIX = "bpgolden-"
@@ -93,6 +98,50 @@ def build_golden_job(lab_name: str, user: str | None = None) -> None:
 	append_log(f"=== Build complete: golden in {lab.image_tag} ===", "success")
 	frappe.db.set_value("Build Log", build_log_name, "log_type", "success")
 	frappe.db.commit()  # nosemgrep -- the log records a finished run
+
+
+def add_golden(lab_doc, log_fn=None) -> dict | None:
+	"""Build this lab's golden as part of something larger, and never fail that something.
+
+	Returns the manifest, or None when the setting is off or the golden step failed. A lab whose
+	image built and whose golden did not is a working lab with a slow deploy; raising here would
+	take a working image away from every tenant of that lab because an optimisation failed.
+	"""
+	if not golden_images_enabled():
+		_log(log_fn, "Golden images are turned off in BenchPress Settings — skipping the golden step")
+		return None
+
+	_log(log_fn, f"=== Baking the golden site into {lab_doc.image_tag} ===")
+	try:
+		manifest = build_golden(lab_doc, log_fn=log_fn)
+	except Exception as e:
+		_log(log_fn, f"Golden step failed: {e!s} — the image is usable and deploys will be slow")
+		frappe.log_error(title=f"Golden step failed: {lab_doc.lab_id}", message=frappe.get_traceback())
+		return None
+
+	_log(log_fn, json.dumps(manifest))
+	return manifest
+
+
+def golden_images_enabled() -> bool:
+	"""Whether a build also bakes a golden — `BenchPress Settings.enable_golden_images`."""
+	return bool(frappe.get_cached_value("BenchPress Settings", "BenchPress Settings", "enable_golden_images"))
+
+
+def image_has_golden(tag: str) -> bool:
+	"""Whether this image carries a golden dump, asked of the image and not of the `Lab` row."""
+	try:
+		return docker_manager.get_client().images.get(tag).labels.get(GOLDEN_LABEL) == "1"
+	except docker.errors.ImageNotFound:
+		return False
+
+
+def golden_tags() -> set[str]:
+	"""Every lab tag on this host carrying a golden, in the one round trip `cached_tags` makes."""
+	images = docker_manager.get_client().images.list(name=f"{image_cache.CACHE_REPOSITORY}/*")
+	return {
+		tag for image in images if (image.labels or {}).get(GOLDEN_LABEL) == "1" for tag in (image.tags or [])
+	}
 
 
 def _start_scratch_container(lab_doc):
@@ -269,19 +318,25 @@ def _build_context(container_id: str, image_tag: str, manifest: dict) -> io.Byte
 			for member in golden:
 				out.addfile(member, golden.extractfile(member) if member.isfile() else None)
 		_add_file(out, "golden/manifest.json", json.dumps(manifest, indent=2).encode())
-		_add_file(out, "Dockerfile", _dockerfile(image_tag).encode())
+		_add_file(out, "Dockerfile", _dockerfile(image_tag, manifest).encode())
 		_add_file(out, "setup-site.sh", _setup_site_source().encode(), mode=0o755)
 	context.seek(0)
 	return context
 
 
-def _dockerfile(image_tag: str) -> str:
-	"""The appended layer: the dump, and the branch of setup-site.sh that reads it.
+def _dockerfile(image_tag: str, manifest: dict) -> str:
+	"""The appended layer: the dump, the branch of setup-site.sh that reads it, and the labels.
 
 	The script travels with the dump because every lab image on this host predates the restore
-	branch, and this feature never rebuilds one.
+	branch, and this feature never rebuilds one. The labels are how a deploy asks the image
+	itself whether it has a golden.
 	"""
-	return f"FROM {image_tag}\nCOPY golden {GOLDEN_DIR}\nCOPY setup-site.sh {SETUP_SITE_PATH}\n"
+	return (
+		f"FROM {image_tag}\n"
+		f"COPY golden {GOLDEN_DIR}\n"
+		f"COPY setup-site.sh {SETUP_SITE_PATH}\n"
+		f'LABEL {GOLDEN_LABEL}="1" {GOLDEN_MARIADB_LABEL}="{manifest["mariadb_version"]}"\n'
+	)
 
 
 def _setup_site_source() -> str:

--- a/benchpress/golden.py
+++ b/benchpress/golden.py
@@ -302,29 +302,29 @@ def _verify_dump(container_id: str, db_server, lab_doc, log_fn) -> dict:
 	return {"tables": tables, "installed_apps": sorted(installed_apps), "restore_seconds": restore_seconds}
 
 
+def _verify_client(db_server) -> str:
+	"""The client both verification steps run, as the scratch user the restore is granted to."""
+	connection = db_server.get_connection_config()
+	return f'mariadb -h {connection["db_host"]} -P {connection["db_port"]} -u "$GOLDEN_USER"'
+
+
 def _restore_command(db_server, database: str) -> str:
 	"""Pipe the dump back in through gzip, the way `bench new-site --source-sql` will."""
-	connection = db_server.get_connection_config()
-	return "\n".join(
-		[
-			"set -euo pipefail",
-			f"gzip -cd {DUMP_PATH} | mariadb -h {connection['db_host']} -P {connection['db_port']}"
-			f' -u "$GOLDEN_USER" --default-character-set=utf8mb4 {database}',
-		]
-	)
+	client = _verify_client(db_server)
+	restore = f"gzip -cd {DUMP_PATH} | {client} --default-character-set=utf8mb4 {database}"
+	return "\n".join(["set -euo pipefail", restore])
 
 
 def _restored_command(db_server, database: str) -> str:
 	"""Count what the restore brought back, on one marked line."""
-	connection = db_server.get_connection_config()
-	client = f'mariadb -h {connection["db_host"]} -P {connection["db_port"]} -u "$GOLDEN_USER" -N -B'
-	tables = (
-		f'tables=$({client} -e "SELECT COUNT(*) FROM information_schema.tables'
-		f" WHERE table_schema='{database}'\")"
-	)
+	client = f"{_verify_client(db_server)} -N -B"
+	count = f"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='{database}'"
+	tables = f'tables=$({client} -e "{count}")'
 	# `app_name`, not `name`: a row in this child table is named by a hash.
-	apps = f"apps=$({client} {database} -e 'SELECT app_name FROM `tabInstalled Application`' | tr '\\n' ' ')"
-	return "\n".join(["set -euo pipefail", tables, apps, f'echo "{VERIFY_MARKER} $tables $apps"'])
+	names = "SELECT app_name FROM `tabInstalled Application`"
+	apps = f"apps=$({client} {database} -e '{names}' | tr '\\n' ' ')"
+	report = f'echo "{VERIFY_MARKER} $tables $apps"'
+	return "\n".join(["set -euo pipefail", tables, apps, report])
 
 
 def _read_verified(output: str) -> tuple[int, list[str]]:

--- a/benchpress/golden.py
+++ b/benchpress/golden.py
@@ -192,18 +192,21 @@ def _dump_command(db_server, site: str) -> str:
 		f'c = json.load(open("sites/{site}/site_config.json")); '
 		'print(c["db_name"], c.get("db_user") or c["db_name"], c["db_password"])\''
 	)
+	dump = (
+		f'mariadb-dump -h {host} -P {port} -u "$user" --single-transaction --quick'
+		f' --default-character-set=utf8mb4 {LEAN_DUMP_FLAGS} "$db" | gzip -c > {DUMP_PATH}'
+	)
+	version = f"version=$(mariadb -h {host} -P {port} -u \"$user\" -N -B -e 'SELECT VERSION()')"
+	meta = f'echo "{META_MARKER} $(stat -c %s {DUMP_PATH}) $(sha256sum {DUMP_PATH} | cut -d" " -f1) $version"'
 	return "\n".join(
 		[
 			"set -euo pipefail",
 			f'credentials="$({read_credentials})"',
 			'read -r db user password <<< "$credentials"',
 			'export MYSQL_PWD="$password"',
-			f'mariadb-dump -h {host} -P {port} -u "$user" --single-transaction --quick'
-			f" --default-character-set=utf8mb4 {LEAN_DUMP_FLAGS}"
-			f' "$db" | gzip -c > {DUMP_PATH}',
-			f"version=$(mariadb -h {host} -P {port} -u \"$user\" -N -B -e 'SELECT VERSION()')",
-			f'echo "{META_MARKER} $(stat -c %s {DUMP_PATH})'
-			f' $(sha256sum {DUMP_PATH} | cut -d" " -f1) $version"',
+			dump,
+			version,
+			meta,
 		]
 	)
 

--- a/benchpress/golden.py
+++ b/benchpress/golden.py
@@ -97,6 +97,9 @@ def build_golden_job(lab_name: str, user: str | None = None) -> None:
 	append_log(json.dumps(manifest))
 	append_log(f"=== Build complete: golden in {lab.image_tag} ===", "success")
 	frappe.db.set_value("Build Log", build_log_name, "log_type", "success")
+	# The row is only ever a record, so it is written the same way whether the golden came from
+	# a build or from this action — otherwise the admin screen reads empty for a lab that has one.
+	frappe.db.set_value("Lab", lab_name, "golden_manifest", json.dumps(manifest, indent=2))
 	frappe.db.commit()  # nosemgrep -- the log records a finished run
 
 
@@ -129,10 +132,14 @@ def golden_images_enabled() -> bool:
 
 
 def image_has_golden(tag: str) -> bool:
-	"""Whether this image carries a golden dump, asked of the image and not of the `Lab` row."""
+	"""Whether this image carries a golden dump, asked of the image and not of the `Lab` row.
+
+	False on any Docker error, a missing image included. Every caller's safe direction is the
+	cold path, and no deploy may fail because an optimisation could not be checked for.
+	"""
 	try:
 		return docker_manager.get_client().images.get(tag).labels.get(GOLDEN_LABEL) == "1"
-	except docker.errors.ImageNotFound:
+	except Exception:
 		return False
 
 

--- a/benchpress/golden_drill.py
+++ b/benchpress/golden_drill.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""Setup, measurement and teardown for `scripts/golden_drill.py`, the golden drill.
+
+Nothing here is whitelisted, and nothing here may become whitelisted: `cleanup` deletes with
+`force=True` and has no business being reachable over HTTP. The harness reaches it through
+`bench --site frontend execute benchpress.golden_drill.<fn>`, and deploys through the shipped
+`create_bench` endpoint.
+
+The two arms of the drill run the **same lab**, so the image, the apps, the host and the minute
+are held still and the only difference is whether the site is restored or created.
+`BenchPress Settings.restore_from_golden` is what switches them, which is a site setting rather
+than something the drill owns: `setup` hands its previous value back and the harness puts it
+back in a `finally`.
+
+Cleanup filters on `golden-drill@example.com`, a user this module is the only thing that mints.
+Nothing else on the site ever owns a bench under it, which is what makes an owner filter safe
+here where it would not be on a real account.
+"""
+
+import frappe
+from frappe.utils import cint, flt
+from frappe.utils.password import get_decrypted_password
+
+from benchpress.credits import account
+from benchpress.deploy_manager import GOLDEN_RESTORED
+from benchpress.deploy_pipeline import parse_step_line
+
+ACCOUNT = "Credit Account"
+ADMISSION = "Bench Admission"
+BENCH = "Bench Instance"
+DEPLOY_LOG = "Deploy Log"
+LEDGER = "Credit Ledger Entry"
+SETTINGS = "BenchPress Settings"
+
+DRILL_USER = "golden-drill@example.com"
+DRILL_ROLE = "BenchPress User"
+
+# The label every drilled site is named from, so a row this drill made says so.
+SITE_PREFIX = "golddrill-"
+
+# Funded past anything a deploy could be refused for: the drill measures how long a site takes,
+# not what it costs, and a shortfall halfway through a run would measure nothing at all.
+DRILL_BALANCE = 100000.0
+
+
+def setup(lab: str, cold: int = 0) -> dict:
+	"""Open the drill account, point it at a real lab, and set the arm this run measures."""
+	lab_doc = frappe.get_doc("Lab", lab)
+	if lab_doc.status != "Ready" or not lab_doc.image_tag:
+		frappe.throw(f"Lab '{lab}' has no built image to drill.")
+
+	user = _ensure_user()
+	_fund(user)
+	restore_before = cint(frappe.db.get_single_value(SETTINGS, "restore_from_golden"))
+	_set_restore(0 if cint(cold) else restore_before)
+	frappe.db.commit()  # nosemgrep -- the deploy runs in a worker that cannot see uncommitted fixtures
+	return {
+		"user": user,
+		"api_key": frappe.db.get_value("User", user, "api_key"),
+		"api_secret": _api_secret(user),
+		"base_domain": frappe.db.get_single_value(SETTINGS, "base_domain"),
+		"lab": lab,
+		"image_tag": lab_doc.image_tag,
+		"site_label": f"{SITE_PREFIX}{lab_doc.lab_id}",
+		"restore_before": restore_before,
+		"restoring": bool(0 if cint(cold) else restore_before),
+	}
+
+
+def restore(restore_before: int) -> dict:
+	"""Put the site's own golden switch back."""
+	_set_restore(cint(restore_before))
+	frappe.db.commit()  # nosemgrep -- the switch must go back even if the harness dies mid-run
+	return {"restore_from_golden": cint(restore_before)}
+
+
+def measure(bench: str) -> dict:
+	"""One bench's newest Deploy Log, as the numbers the drill compares.
+
+	`site_seconds` is the gap between the `site` and `assets` markers, which is the site step's
+	own duration and the only place it survives after the run.
+	"""
+	rows = frappe.get_all(
+		DEPLOY_LOG,
+		filters={"bench": bench},
+		fields=["name", "message"],
+		order_by="creation desc",
+		limit=1,
+	)
+	if not rows:
+		return {"deploy_log": None}
+	message = rows[0].message or ""
+	marks = {}
+	for line in message.splitlines():
+		step = parse_step_line(line)
+		if step:
+			marks[step["step_key"]] = step["step_elapsed"]
+	return {
+		"deploy_log": rows[0].name,
+		"site_seconds": _gap(marks, "site", "assets"),
+		"total_seconds": marks.get("complete"),
+		"restored": GOLDEN_RESTORED in message,
+	}
+
+
+def cleanup() -> dict:
+	"""Remove every bench the drill deployed, through the same teardown the delete action runs."""
+	from benchpress.api import _delete_bench
+
+	removed = []
+	for name in _drill_benches():
+		try:
+			_delete_bench(frappe.get_doc(BENCH, name))
+			removed.append(name)
+		except Exception:
+			# Named rather than swallowed: a drill container the harness cannot reach is an
+			# operator's problem, not a silent leak.
+			frappe.logger("benchpress").warning(f"golden drill: could not tear down {name}")
+	frappe.db.delete(ADMISSION, {"account": DRILL_USER})
+	frappe.db.delete(LEDGER, {"account": DRILL_USER})
+	frappe.db.delete(ACCOUNT, {"user": DRILL_USER})
+	frappe.db.commit()  # nosemgrep -- cleanup on a host serving real tenants must be durable
+	return {"removed": removed, "left": _drill_benches()}
+
+
+def _gap(marks: dict, start: str, end: str) -> float | None:
+	if start not in marks or end not in marks:
+		return None
+	return round(marks[end] - marks[start], 1)
+
+
+def _set_restore(value: int) -> None:
+	frappe.db.set_single_value(SETTINGS, "restore_from_golden", cint(value))
+	frappe.clear_document_cache(SETTINGS, SETTINGS)
+
+
+def _drill_benches() -> list[str]:
+	return frappe.get_all(BENCH, filters={"owner": DRILL_USER}, pluck="name")
+
+
+def _ensure_user() -> str:
+	if not frappe.db.exists("User", DRILL_USER):
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": DRILL_USER,
+				"first_name": "Golden",
+				"last_name": "Drill",
+				"send_welcome_email": 0,
+				"roles": [{"role": DRILL_ROLE}],
+			}
+		).insert(ignore_permissions=True)
+	user = frappe.get_doc("User", DRILL_USER)
+	if DRILL_ROLE not in {row.role for row in user.roles}:
+		user.append("roles", {"role": DRILL_ROLE})
+	user.api_key = user.api_key or frappe.generate_hash(length=15)
+	if not _api_secret(user.name):
+		user.api_secret = frappe.generate_hash(length=15)
+	user.save(ignore_permissions=True)
+	return user.name
+
+
+def _api_secret(user: str) -> str | None:
+	# Absent rather than an exception: the row exists before its key does.
+	return get_decrypted_password("User", user, "api_secret", raise_exception=False)
+
+
+def _fund(user: str) -> None:
+	account.ensure_account(user)
+	frappe.db.set_value(
+		ACCOUNT, user, {"balance": flt(DRILL_BALANCE), "reserved_credits": 0.0}, update_modified=False
+	)

--- a/benchpress/image_cache.py
+++ b/benchpress/image_cache.py
@@ -93,6 +93,7 @@ def template_spec(template: dict):
 		lab_id=template["key"],
 		title=template["title"],
 		frappe_version=template["frappe_version"],
+		memory_limit=template.get("memory_limit"),
 		apps=[frappe._dict(app) for app in template["apps"]],
 	)
 
@@ -117,12 +118,20 @@ def prewarm_catalog() -> dict:
 
 
 def build_template_image(template_key: str) -> str:
-	"""Build one catalog template under its content hash, with no Lab document involved."""
+	"""Build one catalog template under its content hash, with no Lab document involved.
+
+	The golden runs in this same job, so a fresh host's catalog comes out golden rather than
+	needing a second pass. There is no `Lab` row to record the manifest on — the image's own
+	labels are what a deploy reads anyway.
+	"""
+	from benchpress import golden
 	from benchpress.docker_manager import build_lab_image
 
-	tag = build_lab_image(template_spec(lab_templates.get_template(template_key)))
-	frappe.logger("benchpress").info(f"Pre-warmed {tag} for template {template_key}")
-	return tag
+	spec = template_spec(lab_templates.get_template(template_key))
+	spec.image_tag = build_lab_image(spec)
+	golden.add_golden(spec)
+	frappe.logger("benchpress").info(f"Pre-warmed {spec.image_tag} for template {template_key}")
+	return spec.image_tag
 
 
 def sweep_cached_images() -> dict:

--- a/benchpress/lab-templates/scripts/setup-site.sh
+++ b/benchpress/lab-templates/scripts/setup-site.sh
@@ -4,6 +4,9 @@ set -e
 # The caller (deploy_manager) already sets workdir to the bench dir; this cd is a fallback.
 cd /home/frappe/frappe-bench || true
 
+GOLDEN=/opt/benchpress/golden/site.sql.gz
+MANIFEST=/opt/benchpress/golden/manifest.json
+
 # A deploy preserves the data volume, so an instance deployed before already has its
 # site. Adopted rather than recreated; nothing here destroys a site.
 if [ -f "sites/${SITE_NAME}/site_config.json" ]; then
@@ -14,6 +17,23 @@ if [ -f "sites/${SITE_NAME}/site_config.json" ]; then
     # password. Moving it to stdin means `getpass` with no controlling terminal, which hangs the
     # deploy if a TTY ever is attached.
     bench --site "${SITE_NAME}" set-admin-password "${ADMIN_PASSWORD}"
+# -s rather than -f: a zero-byte dump is a failed copy, and restoring one leaves a site with
+# no tables and no error.
+elif [ "${USE_GOLDEN:-1}" = "1" ] && [ -s "$GOLDEN" ]; then
+    echo "[*] Restoring ${SITE_NAME} from the image's golden dump..."
+    bench new-site "${SITE_NAME}" \
+        --source-sql "$GOLDEN" \
+        --admin-password "${ADMIN_PASSWORD}" \
+        --db-host "${DB_HOST}" \
+        --db-name "${DB_NAME}" \
+        --mariadb-root-username "${MARIADB_ROOT_USERNAME}" \
+        --mariadb-root-password "${MARIADB_ROOT_PASSWORD}" \
+        --mariadb-user-host-login-scope='%'
+    # Every tenant of this lab restores the same bytes, so the dump's own Administrator hash
+    # must never be what one of them logs in with.
+    bench --site "${SITE_NAME}" set-admin-password "${ADMIN_PASSWORD}"
+    RESTORED=1
+    echo "[*] Restored from golden dump"
 else
     echo "[*] Creating site ${SITE_NAME}..."
     bench new-site "${SITE_NAME}" \
@@ -27,7 +47,14 @@ fi
 
 if [ -n "${APPS}" ]; then
     # install-app errors on an already-installed app, which the adopt path makes normal.
-    INSTALLED=$(bench --site "${SITE_NAME}" list-apps 2>/dev/null | awk '{print $1}')
+    if [ -n "${RESTORED:-}" ]; then
+        # The manifest is the dump's own statement of what it carries, and reading it costs a
+        # file read against half a second of `bench` startup. An app the lab gained since the
+        # golden was baked is still absent from this list, so it is still installed below.
+        INSTALLED=$(python3 -c "import json; print('\n'.join(['frappe'] + [a[0] for a in json.load(open('${MANIFEST}'))['apps']]))")
+    else
+        INSTALLED=$(bench --site "${SITE_NAME}" list-apps 2>/dev/null | awk '{print $1}')
+    fi
     IFS=',' read -ra APP_LIST <<< "${APPS}"
     for app in "${APP_LIST[@]}"; do
         # -F: an app name is a literal, not a pattern. A name carrying regex metacharacters
@@ -41,8 +68,8 @@ if [ -n "${APPS}" ]; then
     done
 fi
 
-bench --site "${SITE_NAME}" set-config developer_mode 1
-bench use "${SITE_NAME}"
+# No `set-config developer_mode` and no `bench use` here: the control plane writes both keys
+# into common_site_config.json before this runs, and each was half a second of `bench` startup.
 
 # Create localhost alias so port-forwarded access works without matching Host header
 cd sites

--- a/benchpress/mariadb_manager.py
+++ b/benchpress/mariadb_manager.py
@@ -268,6 +268,23 @@ def drop_site_database(db_server_name: str, site_name: str, database: str | None
 	)
 
 
+def server_version(db_server_name: str) -> str:
+	"""The server's own `SELECT VERSION()`, or empty when it cannot be read.
+
+	Empty rather than a raise: the caller compares this with the version a golden dump was taken
+	from, and its safe direction is to create the site instead of restoring into a server it
+	could not identify.
+	"""
+	try:
+		exit_code, output = execute_sql(db_server_name, "SELECT VERSION()")
+	except Exception:
+		return ""
+	if exit_code != 0:
+		return ""
+	# Last line first: the client prints its own deprecation warning into the same stream.
+	return next((line.strip() for line in reversed(output.splitlines()) if line[:1].isdigit()), "")
+
+
 def check_mariadb_health(db_server_name: str) -> bool:
 	"""Check if MariaDB is responding."""
 	try:

--- a/benchpress/mariadb_manager.py
+++ b/benchpress/mariadb_manager.py
@@ -9,7 +9,6 @@ import secrets
 import subprocess
 import tarfile
 import time
-import uuid
 from pathlib import Path
 
 import frappe
@@ -54,26 +53,27 @@ def _random_string(length: int = 16) -> str:
 
 
 def execute_sql(db_server_name: str, sql: str) -> tuple[int, str]:
-	"""Execute SQL on MariaDB container via temp file (injection-safe).
+	"""Execute SQL on the MariaDB container, piped in base64 so nothing is shell-interpolated.
 
-	Uses base64 encoding to avoid shell interpolation of SQL content.
+	One `docker exec`, not three: a round trip costs over a hundred milliseconds, and site
+	creation makes several of these calls inside a step this app measures in seconds. Piping
+	also leaves no temp file to clean up on the failure path.
 	"""
 	db_server = frappe.get_doc("Database Server", db_server_name)
 	client = get_client()
 	container = client.containers.get(db_server.container_id)
-	root_pw = db_server.get_root_password()
 
-	tmp = f"/tmp/_bp_query_{uuid.uuid4().hex}.sql"
 	encoded = base64.b64encode(sql.encode()).decode()
-	try:
-		container.exec_run(cmd=["bash", "-c", f"echo '{encoded}' | base64 -d > {tmp}"])
-		exit_code, output = container.exec_run(
-			cmd=["bash", "-c", f"mariadb -u root < {tmp}"],
-			environment={"MYSQL_PWD": root_pw},
-		)
-	finally:
-		container.exec_run(cmd=["rm", "-f", tmp])
+	exit_code, output = container.exec_run(
+		cmd=["bash", "-c", f"echo '{encoded}' | base64 -d | mariadb -u root"],
+		environment={"MYSQL_PWD": db_server.get_root_password()},
+	)
 	return exit_code, output.decode("utf-8", errors="replace")
+
+
+def _script(*statements: str) -> str:
+	"""Several statements as one `execute_sql`, so a sequence costs one round trip and not one each."""
+	return ";\n".join(statements) + ";\n"
 
 
 def _write_env_file(root_password: str, version: str = "10.6", mem_limit: str = "1g") -> None:
@@ -220,18 +220,19 @@ def create_mariadb_user(
 	database = database or get_database_name(site_name)
 	user = f"{database}_limited"
 	password = _random_string(16)
-	queries = [
-		f"CREATE OR REPLACE USER '{user}'@'%' IDENTIFIED BY '{password}'",
-		f"CREATE OR REPLACE DATABASE `{user}`",
-		f"GRANT ALL ON `{user}`.* TO '{user}'@'%'",
-		f"GRANT RELOAD, CREATE USER ON *.* TO '{user}'@'%'",
-		f"GRANT ALL ON `{database}`.* TO '{user}'@'%' WITH GRANT OPTION",
-		"FLUSH PRIVILEGES",
-	]
-	for query in queries:
-		exit_code, output = execute_sql(db_server_name, query)
-		if exit_code != 0:
-			frappe.throw(_("Failed to create temp user: {0}").format(output))
+	exit_code, output = execute_sql(
+		db_server_name,
+		_script(
+			f"CREATE OR REPLACE USER '{user}'@'%' IDENTIFIED BY '{password}'",
+			f"CREATE OR REPLACE DATABASE `{user}`",
+			f"GRANT ALL ON `{user}`.* TO '{user}'@'%'",
+			f"GRANT RELOAD, CREATE USER ON *.* TO '{user}'@'%'",
+			f"GRANT ALL ON `{database}`.* TO '{user}'@'%' WITH GRANT OPTION",
+			"FLUSH PRIVILEGES",
+		),
+	)
+	if exit_code != 0:
+		frappe.throw(_("Failed to create temp user: {0}").format(output))
 	return database, user, password
 
 
@@ -241,25 +242,30 @@ def drop_mariadb_user(db_server_name: str, site_name: str, database: str | None 
 	"""
 	database = database or get_database_name(site_name)
 	user = f"{database}_limited"
-	queries = [
-		f"DROP DATABASE IF EXISTS `{user}`",
-		f"DROP USER IF EXISTS '{user}'@'%'",
-		"FLUSH PRIVILEGES",
-	]
-	for query in queries:
-		execute_sql(db_server_name, query)
+	execute_sql(
+		db_server_name,
+		_script(
+			f"DROP DATABASE IF EXISTS `{user}`",
+			f"DROP USER IF EXISTS '{user}'@'%'",
+			"FLUSH PRIVILEGES",
+		),
+	)
 
 
-def drop_site_database(db_server_name: str, site_name: str) -> None:
-	"""Drop site database and user when a bench/site is deleted."""
-	db_name = get_database_name(site_name)
-	queries = [
-		f"DROP DATABASE IF EXISTS `{db_name}`",
-		f"DROP USER IF EXISTS '{db_name}'@'%'",
-		"FLUSH PRIVILEGES",
-	]
-	for query in queries:
-		execute_sql(db_server_name, query)
+def drop_site_database(db_server_name: str, site_name: str, database: str | None = None) -> None:
+	"""Drop site database and user when a bench/site is deleted.
+
+	`database` overrides the name derived from the site, for a caller that chose its own.
+	"""
+	db_name = database or get_database_name(site_name)
+	execute_sql(
+		db_server_name,
+		_script(
+			f"DROP DATABASE IF EXISTS `{db_name}`",
+			f"DROP USER IF EXISTS '{db_name}'@'%'",
+			"FLUSH PRIVILEGES",
+		),
+	)
 
 
 def check_mariadb_health(db_server_name: str) -> bool:

--- a/benchpress/overview.py
+++ b/benchpress/overview.py
@@ -36,6 +36,7 @@ INFRASTRUCTURE_LABELS = {
 	"clock_skew": "Clock skew",
 	"redis": "Redis",
 	"container_runtimes": "Container runtimes",
+	"golden_images": "Golden images",
 	"vpn_server": "WireGuard",
 }
 
@@ -269,7 +270,7 @@ def _bench_labels(bench_names: list[str]) -> dict:
 
 
 def _infrastructure(admin: bool) -> list[dict] | None:
-	"""The nine real diagnostics checks — admins only, never a placeholder."""
+	"""The ten real diagnostics checks — admins only, never a placeholder."""
 	if not admin:
 		return None
 	from benchpress.diagnostics import display_row, run_diagnostics

--- a/benchpress/patches.txt
+++ b/benchpress/patches.txt
@@ -26,3 +26,4 @@ benchpress.patches.index_ledger_request_id
 benchpress.patches.drop_burn_fields
 benchpress.patches.name_bench_sites_by_site_name
 benchpress.patches.backfill_bench_bridge_network
+benchpress.patches.default_golden_switches

--- a/benchpress/patches/default_golden_switches.py
+++ b/benchpress/patches/default_golden_switches.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""Write the golden switches' defaults, which a `Check` field's default alone does not.
+
+A Single stores only the values something has set, so a field added to the DocType reads back as
+`None` until the settings form is saved once. Both of these default to on, and unset would mean
+off: builds that quietly skip the golden step, and deploys that quietly build every site from
+scratch. Neither says anything in a log.
+"""
+
+import frappe
+
+SETTINGS = "BenchPress Settings"
+FIELDS = ("enable_golden_images", "restore_from_golden")
+
+
+def execute():
+	stored = frappe.db.get_singles_dict(SETTINGS)
+	for field in FIELDS:
+		if field not in stored:
+			frappe.db.set_single_value(SETTINGS, field, 1)

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -46,7 +46,7 @@ BUDGETS_MS = {
 	"get_deploy_history": 600,
 }
 
-# The nine rows benchpress.diagnostics always returns; the real checks talk to
+# The ten rows benchpress.diagnostics always returns; the real checks talk to
 # Docker and MariaDB, so the Overview timing test never runs them.
 DIAGNOSTICS_ROWS = [
 	{"check": "docker_socket", "status": "pass", "hint": "Docker daemon reachable"},
@@ -57,6 +57,7 @@ DIAGNOSTICS_ROWS = [
 	{"check": "clock_skew", "status": "pass", "hint": "App and database clocks agree"},
 	{"check": "redis", "status": "fail", "hint": "benchpress-redis container not found"},
 	{"check": "container_runtimes", "status": "pass", "hint": "Docker has sysbox-runc registered"},
+	{"check": "golden_images", "status": "pass", "hint": "8 of 8 built labs carry a golden dump"},
 	{"check": "vpn_server", "status": "pass", "hint": "WireGuard server 'wg0' configured"},
 ]
 

--- a/benchpress/tests/test_diagnostics.py
+++ b/benchpress/tests/test_diagnostics.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Venkatesh and Contributors
 # See license.txt
 
-"""run_diagnostics contract: nine rows, fixed order, never raises, never mutates."""
+"""run_diagnostics contract: ten rows, fixed order, never raises, never mutates."""
 
 import inspect
 import unittest
@@ -11,7 +11,8 @@ from unittest.mock import MagicMock, patch
 import docker
 import frappe
 
-from benchpress.diagnostics import run_diagnostics
+from benchpress.diagnostics import check_row, display_row, run_diagnostics
+from benchpress.image_cache import clear_cached_tags
 
 CHECK_ORDER = [
 	"docker_socket",
@@ -22,6 +23,7 @@ CHECK_ORDER = [
 	"clock_skew",
 	"redis",
 	"container_runtimes",
+	"golden_images",
 	"vpn_server",
 ]
 COUNT_WORDS = {6: "six", 7: "seven", 8: "eight", 9: "nine", 10: "ten"}
@@ -43,9 +45,14 @@ DB_CLOCK = datetime(2026, 8, 24, 23, 11, 53)
 IST_OFFSET = timedelta(hours=5, minutes=30)
 
 
+def _lab_image(tag, golden=True):
+	return MagicMock(tags=[tag], labels={"benchpress.golden": "1"} if golden else {})
+
+
 def _healthy_client(bridge_endpoints=4):
 	client = MagicMock()
 	client.containers.get.return_value = MagicMock(status="running")
+	client.images.list.return_value = [_lab_image("benchpress/crm:lab")]
 	network = MagicMock()
 	network.attrs = {"Containers": {f"c{i}": {"Name": f"c{i}"} for i in range(bridge_endpoints)}}
 	client.networks.get.return_value = network
@@ -103,6 +110,8 @@ class TestDiagnostics(unittest.TestCase):
 			frappe_mock.utils.now_datetime.return_value = app_clock or DB_CLOCK
 			frappe_mock.qb.select.side_effect = db_clock_error
 			frappe_mock.qb.select.return_value.run.return_value = ((db_clock or DB_CLOCK,),)
+			# The golden row reads the memoised image list, which outlives one `_run`.
+			clear_cached_tags()
 			rows = run_diagnostics()
 		return {row["check"]: row for row in rows}, rows
 
@@ -111,7 +120,7 @@ class TestDiagnostics(unittest.TestCase):
 		self.assertEqual([row["check"] for row in rows], CHECK_ORDER)
 		for row in rows:
 			self.assertEqual(row["status"], "pass")
-			self.assertEqual(set(row), {"check", "status", "hint"})
+			self.assertEqual(set(row), {"check", "status", "hint", "severity"})
 
 	def test_docker_down_marks_docker_checks_failed_without_raising(self):
 		# completing without an exception IS the core assertion
@@ -163,6 +172,7 @@ class TestDiagnostics(unittest.TestCase):
 		client.ping.side_effect = Exception("down")
 		client.networks.get.side_effect = docker.errors.NotFound("no network")
 		client.containers.get.side_effect = docker.errors.NotFound("gone")
+		client.images.list.side_effect = Exception("down")
 		_by_check, rows = self._run(
 			client=client,
 			runtimes={"names": set(), "default": "runc"},
@@ -233,6 +243,31 @@ class TestDiagnostics(unittest.TestCase):
 		by_check, _rows = self._run(ceilings={})
 		self.assertEqual(by_check["kernel_ceilings"]["status"], "fail")
 		self.assertIn("unreadable", by_check["kernel_ceilings"]["hint"])
+
+	def test_a_lab_with_no_golden_is_named_and_is_never_an_error(self):
+		client = _healthy_client()
+		client.images.list.return_value = [
+			_lab_image("benchpress/crm:lab"),
+			_lab_image("benchpress/erpnext:lab", golden=False),
+		]
+
+		by_check, _rows = self._run(client=client)
+
+		row = by_check["golden_images"]
+		self.assertEqual(row["status"], "fail")
+		self.assertEqual(row["severity"], "Warning")
+		self.assertIn("1 of 2 built labs carry a golden dump", row["hint"])
+		self.assertIn("benchpress/erpnext:lab", row["hint"])
+
+	def test_a_warning_row_reaches_the_screen_as_a_warning(self):
+		row = check_row("golden_images", False, "1 of 2", severity="Warning")
+
+		self.assertEqual(display_row(row, "Golden images")["status"], "Warning")
+
+	def test_a_failed_check_with_no_severity_still_reads_as_an_error(self):
+		self.assertEqual(
+			display_row({"check": "redis", "status": "fail", "hint": ""}, "Redis")["status"], "Error"
+		)
 
 	def test_the_diagnostics_row_count_moved_in_both_places(self):
 		"""One count, stated twice: the test_api fixture and the overview docstring."""

--- a/benchpress/tests/test_golden.py
+++ b/benchpress/tests/test_golden.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+import io
+import json
+import tarfile
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from benchpress import golden
+from benchpress.golden import GOLDEN_DB_PREFIX, GOLDEN_DIR, build_golden, golden_database
+
+
+def _lab(**extra):
+	fields = {
+		"lab_id": "crm",
+		"title": "CRM",
+		"image_tag": "benchpress/crm:lab",
+		"frappe_version": "version-16",
+		"memory_limit": "1g",
+		"apps": [frappe._dict(app_name="crm", git_url="https://github.com/frappe/crm", branch="main")],
+	}
+	return types.SimpleNamespace(**{**fields, **extra})
+
+
+def _db_server():
+	return types.SimpleNamespace(
+		name="benchpress-mariadb",
+		container_name="benchpress-mariadb",
+		get_connection_config=lambda: {"db_host": "benchpress-mariadb", "db_port": 3306},
+	)
+
+
+def _golden_archive() -> tuple[list[bytes], dict]:
+	"""What `container.get_archive(GOLDEN_DIR)` returns for a finished dump."""
+	buffer = io.BytesIO()
+	with tarfile.open(fileobj=buffer, mode="w") as tar:
+		info = tarfile.TarInfo("golden/site.sql.gz")
+		info.size = 3
+		tar.addfile(info, io.BytesIO(b"gz!"))
+	return [buffer.getvalue()], {}
+
+
+class TestGoldenNames(unittest.TestCase):
+	def test_golden_database_is_the_only_name_shape_this_feature_drops(self):
+		self.assertTrue(golden_database("bpgolden-crm").startswith(GOLDEN_DB_PREFIX))
+
+	def test_a_tenant_site_never_produces_a_golden_database_name(self):
+		from benchpress.mariadb_manager import get_database_name
+
+		self.assertFalse(get_database_name("tenant.benchpress.cloud").startswith(GOLDEN_DB_PREFIX))
+
+
+class TestGoldenDump(unittest.TestCase):
+	def test_dump_names_the_sites_own_database_and_pipes_through_gzip(self):
+		command = golden._dump_command(_db_server(), "bpgolden-crm")
+
+		self.assertIn("sites/bpgolden-crm/site_config.json", command)
+		self.assertIn('mariadb-dump -h benchpress-mariadb -P 3306 -u "$user"', command)
+		self.assertIn("| gzip -c > /opt/benchpress/golden/site.sql.gz", command)
+		self.assertIn("set -euo pipefail", command)
+
+	def test_meta_is_read_off_the_marked_line_and_not_off_a_client_warning(self):
+		output = "mariadb: Deprecated program name\nGOLDEN_META 314572 abc123 10.6.28-MariaDB\n"
+
+		self.assertEqual(golden._read_meta(output), (314572, "abc123", "10.6.28-MariaDB"))
+
+	def test_a_dump_that_reported_nothing_raises(self):
+		with self.assertRaises(Exception):
+			golden._read_meta("mariadb-dump: connection refused\n")
+
+
+class TestGoldenBuildContext(unittest.TestCase):
+	def _context_members(self) -> dict[str, bytes]:
+		manifest = {"lab_id": "crm", "dump_bytes": 3}
+		with patch.object(golden.docker_manager, "get_client") as get_client:
+			container = get_client.return_value.containers.get.return_value
+			container.get_archive.return_value = _golden_archive()
+			context = golden._build_context("cid", "benchpress/crm:lab", manifest)
+		with tarfile.open(fileobj=context) as tar:
+			return {m.name: tar.extractfile(m).read() for m in tar if m.isfile()}
+
+	def test_dockerfile_appends_a_layer_to_the_labs_own_tag(self):
+		dockerfile = self._context_members()["Dockerfile"].decode()
+
+		self.assertIn("FROM benchpress/crm:lab\n", dockerfile)
+		self.assertIn(f"COPY golden {GOLDEN_DIR}\n", dockerfile)
+
+	def test_the_dump_and_the_script_that_reads_it_travel_together(self):
+		members = self._context_members()
+
+		self.assertEqual(members["golden/site.sql.gz"], b"gz!")
+		self.assertIn("--source-sql", members["setup-site.sh"].decode())
+
+	def test_the_manifest_is_in_the_context(self):
+		manifest = json.loads(self._context_members()["golden/manifest.json"])
+
+		self.assertEqual(manifest["lab_id"], "crm")
+
+
+class TestGoldenManifest(IntegrationTestCase):
+	def test_manifest_describes_the_same_recipe_as_the_image_tag(self):
+		from benchpress import image_cache
+
+		lab = _lab()
+		manifest = golden._manifest(lab, (314572, "abc123", "10.6.28-MariaDB"))
+		spec = image_cache.build_spec(lab)
+
+		self.assertEqual(manifest["frappe_version"], spec["frappe_version"])
+		self.assertEqual(manifest["apps"], spec["apps"])
+		self.assertEqual(manifest["image_tag"], "benchpress/crm:lab")
+		self.assertEqual(manifest["mariadb_version"], "10.6.28-MariaDB")
+
+
+class TestGoldenCleanup(IntegrationTestCase):
+	def test_a_lab_with_no_image_is_refused(self):
+		with self.assertRaises(frappe.ValidationError):
+			build_golden(_lab(image_tag=None))
+
+	def test_the_database_and_the_container_go_even_when_the_layer_build_fails(self):
+		container = MagicMock()
+		with (
+			patch.object(golden, "ensure_infrastructure", return_value="benchpress-mariadb"),
+			patch.object(frappe, "get_doc", return_value=_db_server()),
+			patch.object(golden, "_start_scratch_container", return_value=container),
+			patch.object(golden, "_create_site"),
+			patch.object(golden, "_dump_site", return_value={}),
+			patch.object(golden, "_append_layer", side_effect=Exception("build failed")),
+			patch.object(golden, "drop_site_database") as drop,
+		):
+			with self.assertRaises(Exception):
+				build_golden(_lab())
+
+		drop.assert_called_once_with("benchpress-mariadb", "bpgolden-crm", golden_database("bpgolden-crm"))
+		container.remove.assert_called_once_with(force=True)

--- a/benchpress/tests/test_golden.py
+++ b/benchpress/tests/test_golden.py
@@ -162,6 +162,13 @@ class TestGoldenLabels(unittest.TestCase):
 		with patch.object(golden.docker_manager, "get_client", return_value=client):
 			self.assertFalse(golden.image_has_golden("benchpress/ghost:lab"))
 
+	def test_a_docker_that_cannot_answer_sends_the_deploy_down_the_cold_path(self):
+		"""The alternative is a deploy that fails because an optimisation could not be checked."""
+		client = MagicMock()
+		client.images.get.side_effect = docker.errors.APIError("daemon busy")
+		with patch.object(golden.docker_manager, "get_client", return_value=client):
+			self.assertFalse(golden.image_has_golden("benchpress/crm:lab"))
+
 	def test_coverage_counts_the_labelled_tags_only(self):
 		client = MagicMock()
 		client.images.list.return_value = [

--- a/benchpress/tests/test_golden.py
+++ b/benchpress/tests/test_golden.py
@@ -8,11 +8,14 @@ import types
 import unittest
 from unittest.mock import MagicMock, patch
 
+import docker
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from benchpress import golden
+from benchpress import deploy_manager, golden
 from benchpress.golden import GOLDEN_DB_PREFIX, GOLDEN_DIR, build_golden, golden_database
+
+MANIFEST = {"lab_id": "crm", "mariadb_version": "10.6.28-MariaDB", "dump_bytes": 3}
 
 
 def _lab(**extra):
@@ -76,11 +79,10 @@ class TestGoldenDump(unittest.TestCase):
 
 class TestGoldenBuildContext(unittest.TestCase):
 	def _context_members(self) -> dict[str, bytes]:
-		manifest = {"lab_id": "crm", "dump_bytes": 3}
 		with patch.object(golden.docker_manager, "get_client") as get_client:
 			container = get_client.return_value.containers.get.return_value
 			container.get_archive.return_value = _golden_archive()
-			context = golden._build_context("cid", "benchpress/crm:lab", manifest)
+			context = golden._build_context("cid", "benchpress/crm:lab", MANIFEST)
 		with tarfile.open(fileobj=context) as tar:
 			return {m.name: tar.extractfile(m).read() for m in tar if m.isfile()}
 
@@ -137,3 +139,147 @@ class TestGoldenCleanup(IntegrationTestCase):
 
 		drop.assert_called_once_with("benchpress-mariadb", "bpgolden-crm", golden_database("bpgolden-crm"))
 		container.remove.assert_called_once_with(force=True)
+
+
+class TestGoldenLabels(unittest.TestCase):
+	"""A deploy asks the image whether it has a golden; the `Lab` row is only ever a claim."""
+
+	def test_the_appended_layer_stamps_what_a_deploy_reads_back(self):
+		dockerfile = golden._dockerfile("benchpress/crm:lab", MANIFEST)
+
+		self.assertIn('LABEL benchpress.golden="1"', dockerfile)
+		self.assertIn('benchpress.golden.mariadb="10.6.28-MariaDB"', dockerfile)
+
+	def test_an_unlabelled_image_has_no_golden_however_the_row_reads(self):
+		client = MagicMock()
+		client.images.get.return_value.labels = {}
+		with patch.object(golden.docker_manager, "get_client", return_value=client):
+			self.assertFalse(golden.image_has_golden("benchpress/crm:lab"))
+
+	def test_an_image_that_is_not_on_this_host_has_no_golden(self):
+		client = MagicMock()
+		client.images.get.side_effect = docker.errors.ImageNotFound("gone")
+		with patch.object(golden.docker_manager, "get_client", return_value=client):
+			self.assertFalse(golden.image_has_golden("benchpress/ghost:lab"))
+
+	def test_coverage_counts_the_labelled_tags_only(self):
+		client = MagicMock()
+		client.images.list.return_value = [
+			MagicMock(tags=["benchpress/crm:lab"], labels={golden.GOLDEN_LABEL: "1"}),
+			MagicMock(tags=["benchpress/erpnext:lab"], labels={}),
+		]
+		with patch.object(golden.docker_manager, "get_client", return_value=client):
+			self.assertEqual(golden.golden_tags(), {"benchpress/crm:lab"})
+
+
+class TestAddGolden(unittest.TestCase):
+	"""The wrapper a build calls. Its whole job is to have no failure mode of its own."""
+
+	def test_the_switch_off_means_the_step_never_runs(self):
+		with (
+			patch.object(golden, "golden_images_enabled", return_value=False),
+			patch.object(golden, "build_golden") as build,
+		):
+			self.assertIsNone(golden.add_golden(_lab()))
+
+		build.assert_not_called()
+
+	def test_a_golden_that_raises_comes_back_as_no_manifest(self):
+		with (
+			patch.object(golden, "golden_images_enabled", return_value=True),
+			patch.object(golden, "build_golden", side_effect=Exception("out of disk")),
+			patch.object(frappe, "log_error") as log_error,
+		):
+			self.assertIsNone(golden.add_golden(_lab()))
+
+		log_error.assert_called_once()
+
+	def test_a_finished_golden_hands_its_manifest_back(self):
+		with (
+			patch.object(golden, "golden_images_enabled", return_value=True),
+			patch.object(golden, "build_golden", return_value=MANIFEST),
+		):
+			self.assertEqual(golden.add_golden(_lab()), MANIFEST)
+
+
+class TestGoldenOnEveryBuild(IntegrationTestCase):
+	"""The golden is a property of a build — and a build's outcome never depends on it."""
+
+	LAB_ID = "golden-on-build"
+	TAG = f"benchpress/{LAB_ID}:lab"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		if frappe.db.exists("Lab", cls.LAB_ID):
+			frappe.delete_doc("Lab", cls.LAB_ID, force=True, ignore_permissions=True)
+		frappe.get_doc(
+			{
+				"doctype": "Lab",
+				"lab_id": cls.LAB_ID,
+				"title": "Golden On Build",
+				"frappe_version": "version-15",
+				"apps": [{"app_name": "crm", "git_url": "https://github.com/frappe/crm", "branch": "main"}],
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		frappe.delete_doc("Lab", cls.LAB_ID, force=True, ignore_permissions=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def _build(self, enabled=True, **build_golden_kwargs):
+		lab = frappe.get_doc("Lab", self.LAB_ID)
+		with (
+			patch.object(deploy_manager, "build_lab_image", return_value=self.TAG),
+			patch.object(deploy_manager.metering, "on_image_built"),
+			patch.object(golden, "golden_images_enabled", return_value=enabled),
+			patch.object(golden, "build_golden", **build_golden_kwargs) as build,
+		):
+			deploy_manager._build_lab_with_logs(lab, None)
+		return frappe.get_doc("Lab", self.LAB_ID), build
+
+	def test_a_build_bakes_the_golden_and_records_what_it_baked(self):
+		lab, build = self._build(return_value=MANIFEST)
+
+		build.assert_called_once()
+		self.assertEqual(lab.status, "Ready")
+		self.assertEqual(json.loads(lab.golden_manifest)["lab_id"], "crm")
+
+	def test_the_switch_off_leaves_the_build_exactly_as_it_was(self):
+		lab, build = self._build(enabled=False, return_value=MANIFEST)
+
+		build.assert_not_called()
+		self.assertEqual(lab.status, "Ready")
+		self.assertEqual(lab.image_tag, self.TAG)
+		self.assertFalse(lab.golden_manifest)
+
+	def test_a_failed_golden_still_leaves_a_ready_lab_and_a_usable_image(self):
+		lab, _build = self._build(side_effect=Exception("scratch container died"))
+
+		self.assertEqual(lab.status, "Ready")
+		self.assertEqual(lab.image_tag, self.TAG)
+		self.assertFalse(lab.golden_manifest)
+
+	def test_a_spec_change_takes_the_manifest_with_the_status(self):
+		lab, _build = self._build(return_value=MANIFEST)
+
+		lab.append(
+			"apps", {"app_name": "hrms", "git_url": "https://github.com/frappe/hrms", "branch": "main"}
+		)
+		lab.save(ignore_permissions=True)
+
+		self.assertEqual(lab.status, "Draft")
+		self.assertFalse(lab.golden_manifest)
+
+	def test_a_new_image_tag_takes_the_manifest_with_it(self):
+		lab, _build = self._build(return_value=MANIFEST)
+
+		lab.image_tag = "benchpress/somewhere-else:lab"
+		lab.save(ignore_permissions=True)
+
+		self.assertFalse(lab.golden_manifest)

--- a/benchpress/tests/test_golden.py
+++ b/benchpress/tests/test_golden.py
@@ -12,10 +12,12 @@ import docker
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from benchpress import deploy_manager, golden
+from benchpress import deploy_manager, golden, golden_drill
 from benchpress.golden import GOLDEN_DB_PREFIX, GOLDEN_DIR, build_golden, golden_database
 
 MANIFEST = {"lab_id": "crm", "mariadb_version": "10.6.28-MariaDB", "dump_bytes": 3}
+
+VERIFY_OUTPUT = "mariadb: Deprecated program name\nGOLDEN_VERIFY 281 frappe crm\n"
 
 
 def _lab(**extra):
@@ -290,3 +292,197 @@ class TestGoldenOnEveryBuild(IntegrationTestCase):
 		lab.save(ignore_permissions=True)
 
 		self.assertFalse(lab.golden_manifest)
+
+
+class TestGoldenVerification(unittest.TestCase):
+	"""A dump is never appended on the strength of an exit code — `--source-sql` exits 0 on nothing."""
+
+	def test_the_read_back_is_taken_off_the_marked_line(self):
+		self.assertEqual(golden._read_verified(VERIFY_OUTPUT), (281, ["frappe", "crm"]))
+
+	def test_a_read_back_that_reported_nothing_raises(self):
+		with self.assertRaises(Exception):
+			golden._read_verified("ERROR 1146: Table 'tabInstalled Application' doesn't exist\n")
+
+	def test_an_empty_restore_is_refused(self):
+		with self.assertRaises(Exception):
+			golden._assert_restored(_lab(), 0, ["frappe", "crm"])
+
+	def test_a_restore_without_the_labs_apps_is_refused(self):
+		with self.assertRaises(Exception):
+			golden._assert_restored(_lab(), 281, ["frappe"])
+
+	def test_a_restore_carrying_more_than_the_lab_asked_for_passes(self):
+		golden._assert_restored(_lab(), 281, ["Frappe", "crm", "erpnext"])
+
+	def test_the_restore_reads_the_dump_the_deploy_will_read(self):
+		command = golden._restore_command(_db_server(), "_bpgolden_verify_crm")
+
+		self.assertIn(f"gzip -cd {golden.DUMP_PATH}", command)
+		self.assertIn("| mariadb -h benchpress-mariadb -P 3306", command)
+		self.assertIn("_bpgolden_verify_crm", command)
+
+	def test_the_apps_are_read_from_the_column_that_holds_them(self):
+		"""`tabInstalled Application.name` is a row hash; the app's name is `app_name`."""
+		self.assertIn(
+			"SELECT app_name FROM `tabInstalled Application`",
+			golden._restored_command(_db_server(), "_bpgolden_verify_crm"),
+		)
+
+
+class TestGoldenVerificationCleanup(IntegrationTestCase):
+	def test_the_scratch_database_and_its_user_go_even_when_the_restore_fails(self):
+		with (
+			patch.object(golden, "create_mariadb_user", return_value=("db", "db_limited", "pw")),
+			patch.object(golden, "execute_sql", return_value=(0, "")),
+			patch.object(golden.docker_manager, "exec_in_container", return_value=(1, "gzip: bad")),
+			patch.object(golden, "drop_site_database") as drop_database,
+			patch.object(golden, "drop_mariadb_user") as drop_user,
+		):
+			with self.assertRaises(Exception):
+				golden._verify_dump("cid", _db_server(), _lab(), None)
+
+		drop_database.assert_called_once_with(
+			"benchpress-mariadb", "bpgolden-verify-crm", "_bpgolden_verify_crm"
+		)
+		drop_user.assert_called_once_with("benchpress-mariadb", "bpgolden-verify-crm", "_bpgolden_verify_crm")
+
+	def test_a_dump_that_does_not_verify_is_never_appended(self):
+		container = MagicMock()
+		with (
+			patch.object(golden, "ensure_infrastructure", return_value="benchpress-mariadb"),
+			patch.object(frappe, "get_doc", return_value=_db_server()),
+			patch.object(golden, "_start_scratch_container", return_value=container),
+			patch.object(golden, "_create_site"),
+			patch.object(golden, "_dump_site", return_value=dict(MANIFEST)),
+			patch.object(golden, "_verify_dump", side_effect=Exception("restored no tables")),
+			patch.object(golden, "_append_layer") as append,
+			patch.object(golden, "drop_site_database"),
+		):
+			with self.assertRaises(Exception):
+				build_golden(_lab())
+
+		append.assert_not_called()
+
+	def test_what_the_restore_proved_travels_in_the_manifest(self):
+		container = MagicMock()
+		verified = {"tables": 281, "installed_apps": ["crm", "frappe"], "restore_seconds": 6.6}
+		with (
+			patch.object(golden, "ensure_infrastructure", return_value="benchpress-mariadb"),
+			patch.object(frappe, "get_doc", return_value=_db_server()),
+			patch.object(golden, "_start_scratch_container", return_value=container),
+			patch.object(golden, "_create_site"),
+			patch.object(golden, "_dump_site", return_value=dict(MANIFEST)),
+			patch.object(golden, "_verify_dump", return_value=verified),
+			patch.object(golden, "_append_layer"),
+			patch.object(golden, "drop_site_database"),
+		):
+			manifest = build_golden(_lab())
+
+		self.assertEqual(manifest["tables"], 281)
+		self.assertEqual(manifest["installed_apps"], ["crm", "frappe"])
+		self.assertEqual(manifest["restore_seconds"], 6.6)
+
+
+class TestGoldenVersionGate(unittest.TestCase):
+	"""The one check that cannot be made inside the image: the server it is restored into."""
+
+	def _decide(self, dump: str, server: str, enabled: bool = True):
+		with (
+			patch.object(golden, "restore_enabled", return_value=enabled),
+			patch.object(golden, "golden_mariadb_version", return_value=dump),
+			patch.object(deploy_manager, "server_version", return_value=server),
+		):
+			return deploy_manager._golden_matches_server("benchpress/crm:lab", _db_server())
+
+	def test_the_same_major_restores(self):
+		self.assertEqual(self._decide("10.6.28-MariaDB-ubu2204", "10.6.28-MariaDB-ubu2204"), (True, ""))
+
+	def test_a_patch_bump_is_not_a_mismatch(self):
+		"""Refusing on one would take every golden on the host out of service on a server update."""
+		use_golden, refusal = self._decide("10.6.31-MariaDB", "10.6.28-MariaDB-ubu2204")
+
+		self.assertTrue(use_golden)
+		self.assertEqual(refusal, "")
+
+	def test_a_different_major_takes_the_cold_path_and_says_why(self):
+		use_golden, refusal = self._decide("11.4.5-MariaDB", "10.6.28-MariaDB-ubu2204")
+
+		self.assertFalse(use_golden)
+		self.assertIn("11.4", refusal)
+		self.assertIn("10.6", refusal)
+
+	def test_a_server_that_will_not_name_itself_takes_the_cold_path(self):
+		use_golden, refusal = self._decide("10.6.28-MariaDB", "")
+
+		self.assertFalse(use_golden)
+		self.assertIn("Could not compare", refusal)
+
+	def test_an_image_with_no_golden_is_already_reported_by_the_image_step(self):
+		self.assertEqual(self._decide("", "10.6.28-MariaDB"), (False, ""))
+
+	def test_the_switch_off_creates_the_site_even_where_a_golden_exists(self):
+		use_golden, refusal = self._decide("10.6.28-MariaDB", "10.6.28-MariaDB", enabled=False)
+
+		self.assertFalse(use_golden)
+		self.assertIn("turned off", refusal)
+
+
+class TestGoldenDrillMeasure(IntegrationTestCase):
+	"""The drill reads a run out of its own Deploy Log, through the pipeline's own parser."""
+
+	LOG = (
+		"=== Deploy started ===\n"
+		"=== Step 7/11: Creating the site [site @1.9s] ===\n"
+		"Site golddrill-crm.benchpress.cloud restored from the image's golden dump\n"
+		"=== Step 8/11: Preparing assets [assets @11.6s] ===\n"
+		"=== Step 11/11: Deploy complete [complete @12.4s] ===\n"
+	)
+
+	def _measure(self, message: str) -> dict:
+		with patch.object(frappe, "get_all", return_value=[frappe._dict(name="dl", message=message)]):
+			return golden_drill.measure("bench")
+
+	def test_the_site_step_is_the_gap_to_the_next_marker(self):
+		measured = self._measure(self.LOG)
+
+		self.assertEqual(measured["site_seconds"], 9.7)
+		self.assertEqual(measured["total_seconds"], 12.4)
+		self.assertTrue(measured["restored"])
+
+	def test_a_cold_run_reports_itself_as_one(self):
+		cold = self.LOG.replace("restored from the image's golden dump", "created successfully")
+
+		self.assertFalse(self._measure(cold)["restored"])
+
+	def test_a_run_that_never_reached_the_site_step_measures_nothing(self):
+		measured = self._measure("=== Step 2/11: Preparing the lab image [image @0.4s] ===\n")
+
+		self.assertIsNone(measured["site_seconds"])
+		self.assertIsNone(measured["total_seconds"])
+
+
+class TestGoldenSwitchDefaults(IntegrationTestCase):
+	"""A `Check` default only reaches a Single when something writes it."""
+
+	def test_the_patch_turns_both_switches_on_where_nothing_has_set_them(self):
+		from benchpress.patches.default_golden_switches import FIELDS, execute
+
+		with (
+			patch.object(frappe.db, "get_singles_dict", return_value={}),
+			patch.object(frappe.db, "set_single_value") as write,
+		):
+			execute()
+
+		self.assertEqual([call.args[1] for call in write.call_args_list], list(FIELDS))
+
+	def test_a_switch_an_admin_turned_off_is_left_off(self):
+		from benchpress.patches.default_golden_switches import execute
+
+		with (
+			patch.object(frappe.db, "get_singles_dict", return_value={"restore_from_golden": 0}),
+			patch.object(frappe.db, "set_single_value") as write,
+		):
+			execute()
+
+		self.assertEqual([call.args[1] for call in write.call_args_list], ["enable_golden_images"])

--- a/benchpress/tests/test_image_cache.py
+++ b/benchpress/tests/test_image_cache.py
@@ -365,16 +365,32 @@ class TestPrewarmCatalog(IntegrationTestCase):
 		for call in enqueue.call_args_list:
 			self.assertEqual(call.kwargs["queue"], "long")
 
+	def _prewarm_one(self, template_key="crm"):
+		from benchpress import golden
+
+		client = _client_with_tags()
+		with (
+			patch("benchpress.docker_manager.get_client", return_value=client),
+			patch.object(golden, "add_golden") as add_golden,
+		):
+			return image_cache.build_template_image(template_key), client, add_golden
+
 	def test_a_template_build_tags_by_the_template_s_own_key(self):
 		from benchpress import lab_templates
 
-		client = _client_with_tags()
-		with patch("benchpress.docker_manager.get_client", return_value=client):
-			tag = image_cache.build_template_image("crm")
+		tag, client, _add_golden = self._prewarm_one()
 
 		expected = image_cache.cache_tag(image_cache.template_spec(lab_templates.get_template("crm")))
 		self.assertEqual(tag, expected)
 		self.assertEqual(client.api.build.call_args.kwargs["tag"], expected)
+
+	def test_a_prewarmed_image_comes_out_golden_in_the_same_job(self):
+		"""Otherwise a fresh host's whole catalog needs a second pass someone has to remember."""
+		tag, _client, add_golden = self._prewarm_one()
+
+		spec = add_golden.call_args.args[0]
+		self.assertEqual(spec.image_tag, tag)
+		self.assertEqual(spec.memory_limit, "1g")
 
 
 class TestSweepCachedImages(IntegrationTestCase):

--- a/benchpress/tests/test_mariadb_manager.py
+++ b/benchpress/tests/test_mariadb_manager.py
@@ -63,34 +63,26 @@ class TestMariadbManager(IntegrationTestCase):
 
 		execute_sql("db-server-name", "SELECT 1")
 
-		# First exec_run call should base64-decode the SQL into a temp file
-		first_call_args = mock_container.exec_run.call_args_list[0]
-		cmd = first_call_args[1].get("cmd") or first_call_args[0][0]
-		cmd_str = " ".join(cmd)
+		call = mock_container.exec_run.call_args_list[0]
+		cmd_str = " ".join(call.kwargs.get("cmd") or call.args[0])
 		self.assertIn("base64 -d", cmd_str)
+		self.assertNotIn("SELECT 1", cmd_str)
 
 	@patch("benchpress.mariadb_manager.get_client")
 	@patch("benchpress.mariadb_manager.frappe.get_doc")
-	def test_execute_sql_cleans_up_tmp_file_on_error(self, mock_get_doc, mock_get_client):
+	def test_execute_sql_is_one_round_trip_and_leaves_no_temp_file(self, mock_get_doc, mock_get_client):
 		from benchpress.mariadb_manager import execute_sql
 
 		mock_get_doc.return_value = self._make_mock_db_server()
 		mock_container = MagicMock()
-		# Second exec_run (the actual SQL) raises an error
-		mock_container.exec_run.side_effect = [
-			(0, b""),  # write temp file
-			RuntimeError("DB exploded"),  # run SQL
-			(0, b""),  # rm -f in finally
-		]
+		mock_container.exec_run.return_value = (0, b"ok")
 		mock_get_client.return_value.containers.get.return_value = mock_container
 
-		with self.assertRaises(RuntimeError):
-			execute_sql("db-server-name", "DROP TABLE important")
+		execute_sql("db-server-name", "DROP TABLE important")
 
-		# rm -f should still be called (finally block)
-		last_call = mock_container.exec_run.call_args_list[-1]
-		cmd = last_call[1].get("cmd") or last_call[0][0]
-		self.assertIn("rm", cmd)
+		self.assertEqual(mock_container.exec_run.call_count, 1)
+		call = mock_container.exec_run.call_args_list[0]
+		self.assertNotIn("/tmp/", " ".join(call.kwargs.get("cmd") or call.args[0]))
 
 	@patch("benchpress.mariadb_manager.get_client")
 	@patch("benchpress.mariadb_manager.frappe.get_doc")
@@ -107,7 +99,7 @@ class TestMariadbManager(IntegrationTestCase):
 
 		execute_sql("db-server-name", "SELECT 1")
 
-		sql_call = mock_container.exec_run.call_args_list[1]
+		sql_call = mock_container.exec_run.call_args_list[0]
 		self.assertEqual(sql_call.kwargs.get("environment"), {"MYSQL_PWD": sentinel})
 		for call in mock_container.exec_run.call_args_list:
 			cmd = call.kwargs.get("cmd") or call.args[0]

--- a/scripts/golden_drill.py
+++ b/scripts/golden_drill.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Deploy the same lab with its golden and without it, and print what each arm cost.
+
+The harness for `specs/.../golden-bench-images`. It never reimplements the claim: every deploy
+goes over HTTP to the shipped `create_bench` endpoint, and every duration is read back out of
+the run's own Deploy Log, which is where the numbers in the spec came from.
+
+Three properties make it safe to run against a host that is serving real tenants:
+
+- **It goes to the host's own nginx, not through the CDN.** The public name is behind
+  Cloudflare, which answers a machine client with `1010` rather than with the endpoint.
+  `BENCHPRESS_URL` overrides it.
+- **It refuses to run against the wrong site.** `--i-know-this-is` must match the site's own
+  `base_domain`, and the drill token must authenticate as the user the setup step just made.
+- **It only ever touches what it created.** Every bench belongs to `golden-drill@example.com`,
+  a user only `benchpress.golden_drill` mints, and cleanup runs in a `finally` — never on
+  status, never on a lab it did not drill.
+
+`--cold` is the control, and it is the same image: it turns `restore_from_golden` off for the
+run and puts it back afterwards, so both arms deploy the same lab, the same apps and the same
+container on the same host, differing only in whether the site is restored or created.
+
+Runs are sequential and re-deploy one bench, because `get_instance_id` is `md5(email + lab)`
+and one user against one lab is one bench however many times it is asked for. A redeploy drops
+the site database and recreates the container first, so each run's site step is a fresh one.
+
+    python3 scripts/golden_drill.py --lab crm --runs 3 --i-know-this-is benchpress.cloud
+    python3 scripts/golden_drill.py --lab crm --runs 3 --cold --i-know-this-is benchpress.cloud
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+SITE = os.environ.get("BENCHPRESS_SITE", "frontend")
+COMPOSE_DIR = os.environ.get("BENCHPRESS_COMPOSE_DIR", "/home/ubuntu/benchpress_devops")
+BASE_URL = os.environ.get("BENCHPRESS_URL", "http://127.0.0.1:8080")
+# nginx routes by `FRAPPE_SITE_NAME_HEADER`, not by this, but a request that names the site it
+# means is the one worth measuring.
+HOST_HEADER = os.environ.get("BENCHPRESS_HOST", "staging.benchpress.cloud")
+
+CREATE_BENCH = "/api/method/benchpress.api.create_bench"
+GET_BENCHES = "/api/method/benchpress.api.get_benches"
+LOGGED_USER = "/api/method/frappe.auth.get_logged_user"
+
+REQUEST_TIMEOUT = 120
+BENCH_TIMEOUT = 900
+DEPLOY_TIMEOUT = 900
+POLL_SECONDS = 5
+
+TERMINAL = ("Running", "Failed", "Stopped")
+
+
+def main() -> int:
+	args = _parse_args()
+	if args.mode == "cleanup":
+		print("cleanup:", json.dumps(_bench_execute("cleanup")))
+		return 0
+
+	setup = _bench_execute("setup", lab=args.lab, cold=1 if args.cold else 0)
+	# Inside the try: setup has already moved the site's golden switch, so every way out of here
+	# has to put it back, including the refusal below.
+	try:
+		_assert_right_site(args.i_know_this_is, setup)
+		return _report(args, setup, _run(args, setup))
+	finally:
+		print("restore:", json.dumps(_bench_execute("restore", restore_before=setup["restore_before"])))
+		print("cleanup:", json.dumps(_bench_execute("cleanup")))
+
+
+def _run(args, setup) -> list[dict]:
+	"""One deploy per run, each waited out and measured before the next one starts."""
+	results = []
+	for index in range(1, args.runs + 1):
+		started = time.monotonic()
+		bench = _deploy(setup)
+		if not bench:
+			results.append({"run": index, "error": "create_bench was refused"})
+			continue
+		status = _wait_for_deploy(setup, bench)
+		measured = _bench_execute("measure", bench=bench)
+		results.append(
+			{
+				"run": index,
+				"bench": bench,
+				"status": status,
+				"waited": round(time.monotonic() - started, 1),
+				**measured,
+			}
+		)
+		print(
+			f"  run {index}: {status} · site {measured.get('site_seconds')}s"
+			f" · restored {measured.get('restored')}"
+		)
+	return results
+
+
+def _deploy(setup) -> str | None:
+	payload = {"lab": setup["lab"], "site_name": setup["site_label"]}
+	body = _post(CREATE_BENCH, payload, setup)
+	return (body or {}).get("message", {}).get("name")
+
+
+def _wait_for_deploy(setup, bench: str) -> str:
+	"""Poll the shipped bench list until this bench stops deploying."""
+	deadline = time.monotonic() + DEPLOY_TIMEOUT
+	status = "Deploying"
+	while time.monotonic() < deadline:
+		time.sleep(POLL_SECONDS)
+		rows = (_get(GET_BENCHES, setup) or {}).get("message") or []
+		status = next((row.get("status") for row in rows if row.get("name") == bench), status)
+		if status in TERMINAL:
+			return status
+	return f"still {status} after {DEPLOY_TIMEOUT}s"
+
+
+def _report(args, setup, results: list[dict]) -> int:
+	"""One table, and every run this drill could not use printed rather than dropped."""
+	mode = "golden" if setup["restoring"] else "cold"
+	usable = [r for r in results if r.get("site_seconds") is not None and r.get("status") == "Running"]
+	measured_runs = {r["run"] for r in usable}
+	dropped = [r for r in results if r["run"] not in measured_runs]
+
+	print(f"\n{'lab':<16} {'mode':<8} {'n':>3} {'p50':>8} {'p95':>8} {'total p50':>10}")
+	if usable:
+		site = sorted(r["site_seconds"] for r in usable)
+		total = sorted(r["total_seconds"] or 0.0 for r in usable)
+		print(
+			f"{args.lab:<16} {mode:<8} {len(usable):>3} {_percentile(site, 50):>8.1f} "
+			f"{_percentile(site, 95):>8.1f} {_percentile(total, 50):>10.1f}"
+		)
+	else:
+		print(f"{args.lab:<16} {mode:<8} {0:>3} {'-':>8} {'-':>8} {'-':>10}")
+
+	restored = {r.get("restored") for r in usable}
+	if usable and restored != {setup["restoring"]}:
+		print(f"note: this run asked for {mode} and the logs report restored={restored}", file=sys.stderr)
+	for run in dropped:
+		print(f"dropped run {run['run']}: {json.dumps(run)}", file=sys.stderr)
+	return 1 if not usable else 0
+
+
+def _percentile(ordered: list[float], percent: int) -> float:
+	"""Nearest-rank, because a drill of three runs has no business interpolating."""
+	rank = max(1, -(-len(ordered) * percent // 100))
+	return ordered[rank - 1]
+
+
+def _assert_right_site(claimed: str, setup: dict) -> None:
+	if claimed != setup["base_domain"]:
+		_refuse(f"this site is {setup['base_domain']!r}, not {claimed!r}")
+	logged_in = (_get(LOGGED_USER, setup) or {}).get("message")
+	if logged_in != setup["user"]:
+		_refuse(f"{BASE_URL} authenticated the drill token as {logged_in!r}, not {setup['user']!r}")
+
+
+def _auth(setup: dict) -> dict:
+	return {
+		"Authorization": f"token {setup['api_key']}:{setup['api_secret']}",
+		"Host": HOST_HEADER,
+	}
+
+
+def _get(path: str, setup: dict) -> dict | None:
+	return _send(urllib.request.Request(BASE_URL + path, headers=_auth(setup)))
+
+
+def _post(path: str, payload: dict, setup: dict) -> dict | None:
+	return _send(
+		urllib.request.Request(
+			BASE_URL + path,
+			data=json.dumps({"data": json.dumps(payload)}).encode(),
+			headers={**_auth(setup), "Content-Type": "application/json"},
+			method="POST",
+		)
+	)
+
+
+def _send(request) -> dict | None:
+	try:
+		with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT) as response:
+			return json.loads(response.read())
+	except urllib.error.HTTPError as refusal:
+		detail = refusal.read().decode(errors="replace")[:300]
+		print(f"{request.full_url} -> {refusal.code}: {detail}", file=sys.stderr)
+	except Exception as failure:
+		print(f"{request.full_url} -> {failure!r}", file=sys.stderr)
+	return None
+
+
+def _refuse(reason: str) -> None:
+	print(f"refusing to run: {reason}", file=sys.stderr)
+	raise SystemExit(2)
+
+
+def _bench_execute(function: str, **kwargs) -> dict:
+	"""Call one `benchpress.golden_drill` function inside the backend container.
+
+	`stdin` is closed deliberately: `docker compose exec` under a timeout hangs forever if it
+	inherits a terminal it can read from.
+	"""
+	command = [
+		"docker",
+		"compose",
+		"exec",
+		"-T",
+		"backend",
+		"bench",
+		"--site",
+		SITE,
+		"execute",
+		f"benchpress.golden_drill.{function}",
+	]
+	if kwargs:
+		command += ["--kwargs", json.dumps(kwargs)]
+	finished = subprocess.run(
+		command,
+		cwd=COMPOSE_DIR,
+		capture_output=True,
+		text=True,
+		stdin=subprocess.DEVNULL,
+		timeout=BENCH_TIMEOUT,
+	)
+	if finished.returncode:
+		_refuse(f"golden_drill.{function} failed:\n{finished.stdout}\n{finished.stderr}")
+	return _last_json(finished.stdout, function)
+
+
+def _last_json(output: str, function: str) -> dict:
+	for line in reversed(output.splitlines()):
+		try:
+			parsed = json.loads(line)
+		except ValueError:
+			continue
+		if isinstance(parsed, dict):
+			return parsed
+	_refuse(f"golden_drill.{function} printed nothing that parses:\n{output}")
+
+
+def _parse_args():
+	parser = argparse.ArgumentParser(description=__doc__)
+	parser.add_argument("--mode", choices=("drill", "cleanup"), default="drill")
+	parser.add_argument("--lab", default="crm", help="the lab to drill, which must already be built")
+	parser.add_argument("--runs", type=int, default=3)
+	parser.add_argument("--cold", action="store_true", help="the control: same image, no golden")
+	parser.add_argument("--i-know-this-is", required=True, help="the site's base_domain")
+	return parser.parse_args()
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())


### PR DESCRIPTION
Phase 1 of the golden-bench-images spec: a lab image carries its finished
site's database, and a spawn restores it instead of installing it.

## What is here

- `benchpress/golden.py` — `build_golden` starts a throwaway container from the
  lab's existing image, creates the site once with the same `setup-site.sh` a
  deploy runs (`USE_GOLDEN=0`), dumps the database through gzip, and appends one
  layer over the same tag carrying `/opt/benchpress/golden/{site.sql.gz,manifest.json}`
  and the script that reads them. The image is never rebuilt. The golden
  database and the container are dropped in a `finally`.
- `benchpress/api.py` — `build_lab_golden`, System-Manager-only, queues it on
  `queue-long` with a `Build Log`.
- `setup-site.sh` — a third branch between adopt and create: `bench new-site
  --source-sql` plus `set-admin-password`, because every tenant of a lab
  restores the same bytes.
- `deploy_manager.py` — `GOLDEN_MARKER`, and step 7 now reports which of the
  three branches ran.

## Measured on staging (CRM lab, `benchpress/crm:lab`)

| | before | after |
|---|---|---|
| site step | 40.4 s | **9.0 s** |
| whole deploy | 44.0 s | **14.1 s** |
| image growth | — | 266 KB over 9.1 GB |

Three changes were needed to get the site step under the spec's ten seconds,
all inside its own budget and all measured:

- the dump skips per-table `DROP TABLE`, `LOCK TABLES` and `DISABLE KEYS`. The
  restore is DDL-bound — a schema-only dump of the same site restores in the
  same time as the full one — so those statements are pure overhead against the
  empty database `bench new-site` has just created. 8 s to 6 s.
- `execute_sql` is one `docker exec` instead of three, and a sequence of
  statements is one call instead of one per statement. Twelve calls became
  three, ~2 s.
- `developer_mode` and `default_site` come from `common_site_config.json`, which
  the control plane already writes at step 6. `bench use` was writing the same
  `default_site` key. Two `bench` invocations, ~1 s.

The previous site's database is dropped beside the previous container now,
in the container step, where the rest of a redeploy's teardown already happens.

## How to verify

```bash
# 1. Build the golden for a lab whose image exists.
docker compose exec -T backend bench --site frontend execute \
  benchpress.api.build_lab_golden --kwargs '{"lab_name":"crm"}'

# 2. The artefact is in the image, not on a host path.
docker run --rm --entrypoint bash benchpress/crm:lab -c \
  'ls -l /opt/benchpress/golden/ && zcat /opt/benchpress/golden/site.sql.gz | head -3'

# 3. Nothing leaked.
docker ps -a --filter name=bpgolden- --format '{{.Names}}'
docker exec -e MYSQL_PWD=$ROOT_PW benchpress-mariadb \
  mariadb -u root -N -B -e "SHOW DATABASES LIKE '\_bpgolden%'"

# 4. Deploy a bench of that lab; step 7 says "restored from the image's golden
#    dump" and the gap to step 8 is under ten seconds.
# 5. Inside the container: `bench --site <site> list-apps` lists frappe and crm,
#    and the lab page's password logs in over HTTPS.
# 6. A lab with no golden still deploys and its log says the site was created.
```

All six were run against staging. 5: `frappe 15.118.0` + `crm 1.81.2`, 281
tables, `POST /api/method/login` returns `Logged In` and `/crm` returns 200.
6: the `erpnext` lab deployed in 91.1 s with an 88.6 s site step and
"Site created successfully".

`vpn-management-16` is not usable as the negative control the spec names: its
app's `install-app` needs the control plane's `wg-agent` socket, which no lab
container has, so a bench of it has never deployed on this host. That is
pre-existing and unrelated to this branch.

## Known gaps, left to later phases

The golden is produced by hand for one lab (phase 2), nothing records which labs
have one (phase 2), the dump is appended without being restored anywhere first
(phase 3), and a golden taken from a different MariaDB major version would still
be restored (phase 3).