### PR TITLE
docs(architecture): record the no-inbound-access rule

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -334,3 +334,11 @@ static markup of a session that is not running anywhere.
   it is a prerequisite to fix before [#129](https://github.com/Venkateshvenki404224/benchpress/issues/129)
   puts a public hostname in front of it.
 - **Container volumes**: `benchpress-{bench_name}-data` → `/home/frappe`
+- **No component may assume a port can be opened inward to a bench host.** Control flows
+  outward. Every bench-running process connects out to Redis and MariaDB, `lease.stop_queue_for`
+  ([lease.py:325](benchpress/credits/lease.py#L325)) addresses a node by queue name and never by
+  host, and `lease.assert_local` ([lease.py:336](benchpress/credits/lease.py#L336)) refuses a
+  command that reached the wrong daemon. `BenchPress Settings.docker_socket` holds a **local**
+  socket path (`unix:///var/run/docker.sock`), read at
+  [docker_manager.py:132](benchpress/docker_manager.py#L132). Pointing it at a `tcp://` address on
+  another host is the one edit that breaks the rule.


### PR DESCRIPTION
Resolves [Record the no-inbound-access rule in ARCHITECTURE.md](https://github.com/Venkateshvenki404224/benchpress/issues/187), a child of [Map: scaling BenchPress for the agent-runtime load profile](https://github.com/Venkateshvenki404224/benchpress/issues/166).

## What this adds

One bullet at the end of `## Networking`. No code changes.

> No component may assume a port can be opened inward to a bench host.

The rule is already true of every line in the repository. This makes it checkable rather than incidental, and names the three mechanisms a reviewer can look at: workers connect outward to Redis and MariaDB, `lease.stop_queue_for` addresses a node by queue name and never by host, and `lease.assert_local` refuses a command that reached the wrong daemon.

It also names the single edit that breaks it. `BenchPress Settings.docker_socket` defaults to `unix:///var/run/docker.sock` and is read at `docker_manager.py:132`. A `tcp://` value pointing at another host is the whole failure.

## Line numbers verified against the tracked file

The ticket cites `lease.assert_local` at `lease.py:338`. It is at **336**. `local_node` (320), `stop_queue_for` (325) and `docker_manager.py:132` are as cited.

## Known drift, deliberately not fixed here

`ARCHITECTURE.md:82` claims `deploy_manager.py` is 302 lines. The tracked file is 1,260. The ticket flags this and scopes it out, and the new bullet sits in `## Networking`, well clear of that paragraph. Worth its own pass.