### PR TITLE
chore(skills): gate Ralph loops on the host steps a spec declares

### DIFF
--- a/.claude/skills/issue-to-phases/assets/prompt.md.template
+++ b/.claude/skills/issue-to-phases/assets/prompt.md.template
@@ -142,6 +142,22 @@ shipped feature filed under "not started".
 
 {{SAFETY_RULES}}
 
+### Never touch the host
+
+These are the README's `## Host steps` Never list, restated here because this is
+the text you actually read. Each one carries its reason, because a rule without a
+reason invites a clever exception.
+
+{{HOST_NEVER_RULES}}
+
+The loop snapshots exactly these surfaces at preflight and diffs them at every
+phase. A change is **fatal**: the loop stops and waits for a human, rather than
+retracting your marker and trying again. Nothing the next iteration does can undo
+a host change.
+
+A host step that must happen is somebody else's job. Say so in your notes and
+write the blocked marker. Do not run it.
+
 ## Rollback
 
 {{ROLLBACK}}

--- a/.claude/skills/issue-to-phases/assets/ralph.sh.template
+++ b/.claude/skills/issue-to-phases/assets/ralph.sh.template
@@ -46,6 +46,13 @@ CI_WAIT_SECONDS=1800
 # The running UI, for the browser checks. Leave empty on a spec with no UI surface.
 APP_URL="{{APP_URL}}"
 
+# This spec's host precondition, from the README's `## Host steps` section.
+# Read-only, no root, and SCOPED TO THIS SPEC — a whole-host readiness check
+# refuses to start every later loop until unrelated debt is paid.
+# Leave both empty on a spec with no precondition.
+PRECONDITION_CMD='{{PRECONDITION_CMD}}'
+PRECONDITION_FIX='{{PRECONDITION_FIX}}'
+
 PROMOTE="$APP_DIR/.claude/skills/issue-to-phases/scripts/promote_spec.py"
 
 PHASE_FILES=(
@@ -95,6 +102,18 @@ assets_stale() {
 browser_ready() {
   [ -n "$APP_URL" ] || return 0          # no UI surface on this spec
   command -v agent-browser >/dev/null 2>&1
+}
+
+# ADAPT: exactly the surfaces the README's Never list names, and nothing else.
+# Every source must read without root, or the gate becomes a permission error at
+# every phase. Deliberately not a check for the artifact a host step produces:
+# that conflates "the loop did this" with "this is done", and fails forever once
+# a human legitimately runs the step.
+host_snapshot() {
+  cat /etc/docker/daemon.json 2>/dev/null || true
+  ls /etc/sysctl.d 2>/dev/null || true
+  systemctl show docker --property=ActiveEnterTimestamp 2>/dev/null || true
+  return 0
 }
 
 # The PR's checks as one word: green | red | pending | none.
@@ -147,6 +166,13 @@ ci_green() {
 preflight() {
   [ -f "$SNAP_DIR/.taken" ] && return 0
   echo "[ralph] preflight: snapshotting state before anything changes"
+  # A human's legitimate run of the fix belongs before this point, so it lands
+  # inside the host baseline below and never trips the host-diff gate.
+  if [ -n "$PRECONDITION_CMD" ] && ! eval "$PRECONDITION_CMD"; then
+    echo "[ralph] ERROR: host precondition unmet. Run this, then re-run me:"
+    echo "[ralph]   $PRECONDITION_FIX"
+    exit 1
+  fi
   if ! browser_ready; then
     echo "[ralph] ERROR: APP_URL is set but agent-browser is not installed."
     echo "[ralph] Install it before starting: npm i -g agent-browser && agent-browser install"
@@ -157,6 +183,7 @@ preflight() {
   # against. Rollback should be a file copy, not an act of memory.
 {{PREFLIGHT}}
   ( cd "$APP_DIR" && git rev-parse HEAD ) > "$SNAP_DIR/head.before" 2>/dev/null || true
+  host_snapshot > "$SNAP_DIR/host.before"
   touch "$SNAP_DIR/.taken"
 }
 
@@ -167,6 +194,20 @@ preflight() {
 # feature exists — a gate that passes on an unmodified tree is testing nothing.
 smoke_check() {
   local phase="$1" failed=0
+
+  # The host gate, before every other gate, and FATAL rather than
+  # retract-and-retry. A host change is not something the next iteration can
+  # undo, so retracting would burn every remaining iteration against an
+  # unfixable condition and keep an unattended agent working on a host it has
+  # already changed. Exit 2 is the blocked-marker path.
+  host_snapshot > "$SNAP_DIR/host.now"
+  if ! diff -q "$SNAP_DIR/host.before" "$SNAP_DIR/host.now" >/dev/null 2>&1; then
+    echo "[ralph] the host changed under the loop — STOPPING:"
+    diff "$SNAP_DIR/host.before" "$SNAP_DIR/host.now" | sed 's/^/[ralph]        /' || true
+    echo "[ralph] review the diff, undo it by hand, then re-run."
+    exit 2
+  fi
+  echo "[ralph]   ok   the host is unchanged since preflight"
 
   # ADAPT: the feature's own correctness gates.
 {{SMOKE_CHECKS}}

--- a/.claude/skills/issue-to-phases/references/ralph-loop.md
+++ b/.claude/skills/issue-to-phases/references/ralph-loop.md
@@ -12,6 +12,7 @@ block.
 - [Proving the UI](#proving-the-ui)
 - [Why a loop stalls](#why-a-loop-stalls)
 - [Preflight and rollback](#preflight-and-rollback)
+- [The two host gates](#the-two-host-gates)
 - [The phase prompt](#the-phase-prompt)
 - [Filling in the template](#filling-in-the-template)
 - [Before you hand it over](#before-you-hand-it-over)
@@ -191,6 +192,121 @@ composing it.
 State the order plainly: **restore first, diagnose after.** A rolled-back
 iteration that leaves the system working is a good iteration.
 
+## The two host gates
+
+A spec's `## Host steps` section names three lists — Precondition, Leftover,
+Never. See
+[references/spec-templates.md](spec-templates.md#the--host-steps-section) for how
+to write them. The loop turns two of those lists into gates. Prose alone was the
+old convention, and prose does not stop a loop.
+
+### Gate 1 — the precondition gate
+
+In `preflight`, before anything changes. The command is read-only, needs no root,
+and is **scoped to this spec**, never to the whole host.
+
+```bash
+# Exits non-zero when this spec's host precondition is unmet. Read-only, no root.
+PRECONDITION_CMD='...'
+PRECONDITION_FIX='sudo benchpress_devops/scripts/<script>.sh'
+
+preflight() {
+  if ! eval "$PRECONDITION_CMD"; then
+    echo "[ralph] host precondition unmet. Run this, then re-run me:"
+    echo "[ralph]   $PRECONDITION_FIX"
+    exit 1
+  fi
+  ...
+}
+```
+
+The scoping rule has teeth. `entry.py --check-host` exits 1 on this host right
+now: six of twelve knobs are low and `/etc/sysctl.d` holds no
+`99-benchpress-density.conf`, because item 5's leftover has never been run. A
+whole-host gate would refuse to start every later loop until unrelated debt was
+paid.
+
+A spec with no precondition leaves `PRECONDITION_CMD` empty and deletes the
+refusal.
+
+### Gate 2 — the host-diff gate
+
+In `smoke_check`, at every phase, and **fatal**. It snapshots exactly the surfaces
+the Never list names, and nothing else.
+
+```bash
+# Exactly the surfaces the Never list names, and nothing else.
+host_snapshot() {
+  cat /etc/docker/daemon.json 2>/dev/null || true
+  ls /etc/sysctl.d 2>/dev/null || true
+  systemctl show docker --property=ActiveEnterTimestamp 2>/dev/null || true
+  return 0
+}
+
+# inside smoke_check, before every other gate:
+host_snapshot > "$SNAP_DIR/host.now"
+if ! diff -q "$SNAP_DIR/host.before" "$SNAP_DIR/host.now" >/dev/null; then
+  echo "[ralph] the host changed under the loop — STOPPING:"
+  diff "$SNAP_DIR/host.before" "$SNAP_DIR/host.now" || true
+  echo "[ralph] review the diff, undo it by hand, then re-run."
+  exit 2
+fi
+```
+
+**Fatal, not retract-and-retry.** Every other gate deletes the done marker and
+lets the next iteration try again. This one exits 2, the blocked-marker path. A
+host change is not something the next iteration can undo, so retracting would burn
+every remaining iteration against an unfixable condition — and would keep an
+unattended agent working on a host it has already changed.
+
+`preflight` writes the `host.before` baseline. A human's legitimate run of a
+precondition script **before** the loop starts is therefore inside the baseline,
+so it never fires falsely.
+
+### Why the named-artifact gate rots
+
+The obvious gate is to check for the artifact the host step produces. It is wrong,
+and the density loop is the worked example:
+
+```bash
+host_sysctl_applied() { [ -f /etc/sysctl.d/99-benchpress-density.conf ]; }
+```
+
+That fails when the file **exists**, which conflates "the loop did this" with
+"this is done". The same spec tells a human to run `sudo tune-host.sh`, and that
+script creates the file. From the moment the human obeys the spec, the loop fails
+its smoke check at every phase on a correctly tuned host. The gate also catches
+only the one step its author thought of.
+
+A snapshot diff has neither fault. It has no opinion about who made a change or
+which change it was, and an unforeseen host change is caught along with the
+foreseen one.
+
+The snapshots are close to free. The density loop's `preflight` already writes
+eight `.before` files — `networks`, `legacy-members`, `containers`, `links`,
+`sysctl`, `sysctl.d`, `daemon.json` and `head` — and no `.before` file is read
+anywhere in that script. They are a human's rollback aid. This gate turns them
+into a gate.
+
+### Gate 3 is prose, and it is still needed
+
+`prompt.md` restates the Never list in its Safety section, each entry with its
+reason, because that is the text the agent actually reads. A rule without a reason
+invites a clever exception.
+
+### A leftover's durable home is tracked code, never a spec folder
+
+`specs/` is gitignored in full and a completed spec is deleted, so a spec is
+disposable scaffolding. A leftover is per-host state that outlives it: a second
+host owes every leftover, not the ones this host happened to skip.
+
+So the phase that creates the debt also ships a **read-only, non-root checker in
+tracked code** and a line in the **operations runbook**. Item 5 shipped both —
+`entry.py --check-host` and `benchpress_devops/PRODUCTION.md` §5.18. A spec whose
+leftover no tracked command can detect is not finished, and no `promote_spec.py`
+change is involved: `specs/STATUS.md`'s `⚠ by hand:` prefix is a working-tree
+convenience, not the record.
+
 ## The phase prompt
 
 **The prompt is not in ralph.sh.** It lives in `prompt.md` beside it, copied from
@@ -226,6 +342,9 @@ contract, escape hatch. What you write per spec:
   reasons. "Never X" alone invites a clever exception; "Never X, because Y" does
   not. Cover: what must never be deleted, what must never be restarted, which
   commands are out of bounds and why, and anything with a rate limit or a cost.
+- **`{{HOST_NEVER_RULES}}`** — the README's Never list, verbatim, each with its
+  reason. This is the prose half of the host-diff gate. The two must name the same
+  surfaces, or the loop stops on something the prompt never warned about.
 - **`{{EXTRA_RULES}}`** — repo-specific traps. Which lint command is wrong to run.
   Which services hold a stale module until restarted. Anything that has bitten
   someone.
@@ -259,6 +378,8 @@ In **`ralph.sh`** — the wiring:
 | `{{APP_URL}}` | the running UI, for the browser checks — empty on a spec with no UI |
 | `{{SRC_GLOB}}` / `{{BUILT_MARKER}}` | frontend source tree and one built asset, for `assets_stale` |
 | `{{RISK_LINE}}` | one line telling the user what this loop will change |
+| `PRECONDITION_CMD` / `PRECONDITION_FIX` | the spec's host precondition and the command that fixes it — empty on a spec with none |
+| `host_snapshot` | the surfaces the Never list names, and nothing else |
 | `{{HELPERS}}`, `{{PREFLIGHT}}`, `{{SMOKE_CHECKS}}` | bash, per above |
 
 In **`prompt.md`** — the words:
@@ -270,6 +391,7 @@ In **`prompt.md`** — the words:
 | `{{TEST_CMD}}` / `{{LINT_CMD}}` | the repo's real commands |
 | `{{EXTRA_RULES}}` | repo-specific traps |
 | `{{SAFETY_RULES}}` | the irreversible things, each with its reason |
+| `{{HOST_NEVER_RULES}}` | the README's Never list, each with its reason |
 | `{{ROLLBACK}}` | the exact restore command, with paths |
 | `<!-- PHASE n -->` blocks | per-phase warnings |
 
@@ -286,7 +408,7 @@ the first one's notes.
 
 ## Before you hand it over
 
-Five checks, all cheap, and each has caught a real bug:
+Six checks, all cheap, and each has caught a real bug:
 
 ```bash
 bash -n ralph.sh                      # 1. syntax
@@ -316,7 +438,11 @@ bash /tmp/harness.sh
    tree, naming the specific things the phase will fix. That pair is the
    calibration. Paste the output when you hand the loop over.
 
-4. **`chmod +x ralph.sh`.**
+4. **Run `host_snapshot` by hand** and confirm every source reads without root.
+   A source that needs root turns the gate into a permission error at every phase.
+   Run `PRECONDITION_CMD` too, and confirm its exit code matches reality.
+
+5. **`chmod +x ralph.sh`.**
 
 Then tell the user how to watch it and how to stop it, and say plainly what it
 will change.

--- a/.claude/skills/issue-to-phases/references/spec-templates.md
+++ b/.claude/skills/issue-to-phases/references/spec-templates.md
@@ -7,6 +7,7 @@ Read this when writing or revising a spec folder (Job 1).
 - [The folder](#the-folder)
 - [README.md template](#readmemd-template)
 - [phase-N.md template](#phase-nmd-template)
+- [The `## Host steps` section](#the--host-steps-section) — every spec writes it, even an empty one
 - [The code-snippet style contract](#the-code-snippet-style-contract) — read this one even if you skim the rest
 - [Verification sections that are worth writing](#verification-sections-that-are-worth-writing)
 
@@ -72,6 +73,11 @@ shippable and verified before the next.>
 - <concrete files, functions, fields each phase touches, so a phase doc can point
   here instead of repeating it>
 
+## Host steps
+
+<Three labelled lists — Precondition, Leftover, Never — all three written even
+when one is empty. See [The `## Host steps` section](#the--host-steps-section).>
+
 ## Conventions (from CLAUDE.md — apply to all phases)
 
 - <the repo conventions the implementer must follow>
@@ -111,6 +117,11 @@ boundary as an oversight.>
 
 1. <concrete, runnable steps — commands, and what the output must say>
 
+<Where a step depends on human-only host work, link it rather than restating it:>
+
+> **Host step (precondition):** <what must be true>. See
+> [Host steps](README.md#host-steps). The loop refuses to start otherwise.
+
 **Rollback**, if step <n> fails: <the exact command. Restore first, diagnose after.>
 
 ## Done when
@@ -119,6 +130,101 @@ boundary as an oversight.>
 (still works / no-ops cleanly when unconfigured), and a sentence naming the known
 gaps this phase deliberately leaves for later phases.>
 ```
+
+## The `## Host steps` section
+
+Every spec README carries this section, and it is the single source for the
+human-only work around the loop. Phase specs link to it. They never restate a
+step, because two copies drift and the loop reads neither.
+
+Three kinds of step, and they are not interchangeable:
+
+| | **Precondition** | **Leftover** | **Never** |
+|---|---|---|---|
+| When | before phase 1 is attempted | after the last phase lands | at any time |
+| Who runs it | a human, before the loop starts | a human, after the loop finishes | nobody |
+| What the loop does | `preflight` refuses to start | finishes, then reports it | `smoke_check` stops the loop |
+| Example | `sudo scripts/enable-sysbox.sh` | `sudo scripts/tune-host.sh` | write to `/etc/sysctl.d` |
+
+A Leftover and a Never are one action seen from two sides. "A human runs
+`tune-host.sh`" and "the loop must never run `tune-host.sh`" are the same entry,
+so every Leftover generates a Never. The Never list is never written on its own.
+
+**Write all three lists, even when one is empty.** An omitted list reads as "not
+considered". Write `— none` and the reason it is none.
+
+```markdown
+## Host steps
+
+### Precondition — true before phase 1 is attempted
+
+| Step | Verify (read-only, no root) | Why |
+|---|---|---|
+| <the command a human runs> | <a command that exits non-zero while the step is undone> | <what breaks without it> |
+
+### Leftover — a human runs this after the last phase
+
+| Step | Verify (read-only, no root) | Why |
+|---|---|---|
+| <the command a human runs> | <a command that exits non-zero while the step is undone> | <why no loop may run it> |
+
+### Never — the loop is gated on these
+
+| Never | Why |
+|---|---|
+| <the action> | <the damage, stated concretely> |
+```
+
+An empty list keeps its heading and gets a reason:
+
+```markdown
+### Leftover — a human runs this after the last phase
+
+— none. Nothing in this spec writes outside the checkout, so it adds no host
+debt and needs no new checker.
+```
+
+### The verify command is the load-bearing part
+
+Prose cannot gate a loop. Every Precondition and every Leftover names a command
+that is **read-only, needs no root, and exits non-zero while the step is undone**.
+Writing that checker is part of the work, not a note for later.
+
+**Scope the check to this spec, never to the whole host.** A whole-host readiness
+gate refuses to start every later loop until unrelated debt is paid. On this repo
+`entry.py --check-host` exits 1 today, because item 5's leftover has never been
+run. A spec about Docker events that gated on it would never start.
+
+### A leftover outlives the spec, so its record is tracked code
+
+`specs/` is gitignored in full, and a completed spec is deleted once its code
+lands. Nothing durable may be recorded only inside one.
+
+A leftover is per-host state, not a repo TODO. A second host owes every leftover,
+not the ones this host happened to skip. So the record is two tracked halves, and
+the phase that creates the debt ships both:
+
+| Half | Job |
+|---|---|
+| A read-only, non-root **checker** in tracked code | the host answers for itself, with no document to keep in step |
+| A line in the **operations runbook** | a human provisioning a fresh host reads it |
+
+Item 5 is the worked instance: `entry.py --check-host` and
+`benchpress_devops/PRODUCTION.md` §5.18. A spec whose leftover no tracked command
+can detect is not finished.
+
+`specs/STATUS.md` keeps a `⚠ by hand:` prefix in its Notes cell while the spec
+exists, so `grep '⚠ by hand:' specs/STATUS.md` lists what is outstanding on this
+host. That is a working-tree convenience, not the record of truth.
+
+### What the loop does with the section
+
+`ralph.sh` builds two gates from these lists, and `prompt.md` restates the Never
+list in its Safety section. See
+[references/ralph-loop.md](ralph-loop.md#the-two-host-gates) for both gates.
+
+A spec with no host steps at all deletes the section, the way a repo with no CI
+deletes the `ci_status` gate.
 
 ## The code-snippet style contract
 


### PR DESCRIPTION
Applies the convention resolved in [How does a spec express a step no Ralph loop may run?](https://github.com/Venkateshvenki404224/benchpress/issues/171), for wayfinder ticket [Apply the host-steps convention to issue-to-phases and docker-events-listener](https://github.com/Venkateshvenki404224/benchpress/issues/183).

## The problem

A spec states its human-only host work as prose, and prose does not stop a loop. The one mechanical gate that exists checks for a **named artifact** — `[ -f /etc/sysctl.d/99-benchpress-density.conf ]`, failing when the file exists. That conflates "the loop did this" with "this is done". The same spec tells a human to run `sudo tune-host.sh`, which creates that file, so from the moment the human obeys the spec the loop fails its smoke check at every phase on a correctly tuned host.

## What changes

Four tracked files in `.claude/skills/issue-to-phases/`. Disposable specs inherit the convention instead of copying it.

| File | Gains |
|---|---|
| `references/spec-templates.md` | the `## Host steps` section template, the rule that all three lists are written, and where a leftover's durable record lives |
| `references/ralph-loop.md` | both gates, why the named-artifact gate rots, and one more hand-over check |
| `assets/ralph.sh.template` | `PRECONDITION_CMD` / `PRECONDITION_FIX`, `host_snapshot`, the `preflight` refusal, the fatal `smoke_check` diff |
| `assets/prompt.md.template` | a `{{HOST_NEVER_RULES}}` slot in the Safety section |

**The section.** Three labelled lists — Precondition, Leftover, Never — all three written even when one is empty, because an omitted list reads as "not considered". Every Precondition and Leftover names a command that is read-only, needs no root, and exits non-zero while the step is undone. That check is **spec-scoped, never whole-host**: `entry.py --check-host` exits 1 on this host today, so a whole-host gate would refuse to start every later loop until unrelated debt was paid.

**Gate 1**, in `preflight`: refuse to start on an unmet precondition, naming the command that fixes it.

**Gate 2**, in `smoke_check`, at every phase and **fatal**: diff a snapshot of exactly the surfaces the Never list names. Exit 2, the blocked-marker path, not retract-and-retry — a host change is not something the next iteration can undo, so retracting would burn every remaining iteration against an unfixable condition and keep an unattended agent working on a host it has already changed. A snapshot diff also has no opinion about who made a change, so a human's legitimate run before the loop starts lands inside the baseline and never fires falsely.

**Leftovers.** `specs/` is gitignored in full and a completed spec is deleted, so nothing durable may be recorded only inside one. A leftover is per-host state that outlives the spec: the phase that creates the debt ships a read-only checker in tracked code plus a runbook line. Item 5 is the worked instance.

## Verified

The `docker-events-listener` retrofit lives in `specs/`, which is gitignored, so it is not in this diff. It was applied and both gates were exercised against the live host:

| Check | Result |
|---|---|
| `bash -n` on template and spec script | pass |
| `smoke_check 0` baseline on an unmodified tree | **BASELINE PASS**, with `ok the host is unchanged since preflight` |
| Precondition gate, against a `.env` claiming `DOCKER_GID=988` | refuses, **exit 1**, prints the fix command |
| Host gate, against an edited `daemon.json` line | **exit 2**, prints the exact diff |
| All three snapshot sources read as `ubuntu` | `daemon.json`, `ls /etc/sysctl.d`, `systemctl show docker` — no root needed |
| `uvx pre-commit@4.3.0 run --all-files` | pass |

The real precondition is met on this host: socket group `986`, `.env` `DOCKER_GID=986`.