### PR TITLE
fix(scheduler): enqueue Docker work onto a socket-mounted queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -908,9 +908,13 @@ Device management is backed by the **VPN Peer** DocType in the vpn_management ap
 
 | Schedule | Function | Description |
 |----------|----------|-------------|
-| Every 1 minute | `benchpress.stats_collector.collect_bench_stats` | Polls Docker CPU/memory/health for running containers (VPN transfer counters are updated by vpn_management's own `poll_status` job) |
-| Every 5 minutes | `benchpress.mariadb_manager.scheduled_health_check` | Checks shared MariaDB health, attempts restart if down |
-| Daily at 2 AM | `benchpress.mariadb_manager.scheduled_backup` | Full MariaDB backup with 7-day retention |
+| Every 1 minute | `benchpress.stats_collector.enqueue_stats_sweep` | Enqueues `collect_bench_stats`, which polls Docker CPU/memory/health for running containers (VPN transfer counters are updated by vpn_management's own `poll_status` job) |
+| Every 5 minutes | `benchpress.mariadb_manager.enqueue_health_check` | Enqueues `scheduled_health_check`: shared MariaDB health, restart if down |
+| Daily at 2 AM | `benchpress.mariadb_manager.enqueue_backup` | Enqueues `scheduled_backup`: full MariaDB backup with 7-day retention |
+
+Every entry here is an enqueuer, not the work itself. Scheduled jobs land on the `default` queue,
+which `queue-short` consumes without a Docker socket — see the rule above `scheduler_events` in
+`benchpress/hooks.py`.
 
 ---
 

--- a/benchpress/hooks.py
+++ b/benchpress/hooks.py
@@ -200,6 +200,20 @@ website_route_rules = [
 # Scheduled Tasks
 # ---------------
 
+# A scheduled entry that touches Docker must name an enqueuer, never the work itself.
+#
+# `ScheduledJobType.get_queue_name()` returns `long` only for a frequency string containing `Long`
+# or `Maintenance`, so every entry below lands on `default` — which `queue-long` (Docker socket
+# mounted) and `queue-short` (no socket, no `group_add`) both consume. The two workers race the
+# same pop and the idle one usually wins, so the busier the platform, the more reliably the job
+# lands on the worker that cannot do it. It fails as a socket `FileNotFoundError`, which names
+# neither the queue nor the scheduler.
+#
+# The socket-mounted services are `queue-long` and `queue-stops`. So the entry is a small function
+# that calls `frappe.enqueue(..., queue="long")`, and the Docker call lives on the other side of
+# it. `enqueue_stats_sweep`, `enqueue_route_reconcile`, `enqueue_health_check`, `enqueue_backup`
+# and the two in `image_cache` are all that shape.
+
 scheduler_events = {
 	# "all": [
 	# 	"benchpress.tasks.all"
@@ -210,8 +224,6 @@ scheduler_events = {
 	# "hourly": [
 	# 	"benchpress.tasks.hourly"
 	# ],
-	# Both hand the real work to `queue-long`: the scheduler's own worker is
-	# `queue-short`, which has no Docker socket mounted.
 	"weekly": [
 		"benchpress.image_cache.enqueue_prewarm_catalog",
 		"benchpress.image_cache.enqueue_sweep",
@@ -220,18 +232,19 @@ scheduler_events = {
 	# 	"benchpress.tasks.monthly"
 	# ],
 	"cron": {
+		# `DEFAULT_SCHEDULER_TICK` is four minutes here, so this fires every four, not every one.
+		# The format stays `*/1` so shortening the tick needs no edit.
 		"*/1 * * * *": [
-			"benchpress.stats_collector.collect_bench_stats",
+			"benchpress.stats_collector.enqueue_stats_sweep",
 		],
 		"*/5 * * * *": [
-			"benchpress.mariadb_manager.scheduled_health_check",
+			"benchpress.mariadb_manager.enqueue_health_check",
 			# Never on the `*/1` stats cron: that job spends ~2s per container on the Docker
 			# socket, and a decision queued behind Docker I/O arrives late. The clock is not
 			# this job's business — `drain` owns expiry; this one checks balances.
 			"benchpress.credits.sweep.enforce_limits",
-			# The enqueuer, never `reconcile_instance_routes` itself: scheduled jobs land on
-			# `default`, which `queue-short` also consumes, and that container has no route
-			# mount. Lifecycle triggers already converge in seconds — this is the net under them.
+			# `queue-short` has no route mount either. Lifecycle triggers already converge in
+			# seconds — this is the net under them.
 			"benchpress.deploy_manager.enqueue_route_reconcile",
 			# The net under the lease warden, not the primary path: `DEFAULT_SCHEDULER_TICK` is
 			# four minutes here, so no cron entry can promise better than that. The warden claims
@@ -244,7 +257,7 @@ scheduler_events = {
 			"benchpress.credits.admission_repair.reconcile_admissions",
 		],
 		"0 2 * * *": [
-			"benchpress.mariadb_manager.scheduled_backup",
+			"benchpress.mariadb_manager.enqueue_backup",
 		],
 	},
 }

--- a/benchpress/mariadb_manager.py
+++ b/benchpress/mariadb_manager.py
@@ -16,6 +16,8 @@ from frappe import _
 
 from benchpress.docker_manager import ensure_network, get_client
 
+BACKUP_TIMEOUT = 3600
+
 DEFAULT_MARIADB_CONFIG = """[mysqld]
 character-set-server=utf8mb4
 collation-server=utf8mb4_unicode_ci
@@ -353,6 +355,18 @@ def get_container_logs(db_server_name: str, tail: int = 100) -> str:
 	return container.logs(tail=tail).decode("utf-8", errors="replace")
 
 
+def enqueue_health_check() -> None:
+	"""Convergence cron: hand the health check to `queue-long`."""
+	# The enqueuer, never `scheduled_health_check` itself — see the rule above `scheduler_events`
+	# in `hooks.py`.
+	frappe.enqueue(
+		"benchpress.mariadb_manager.scheduled_health_check",
+		queue="long",
+		job_id="mariadb_health_check",
+		deduplicate=True,
+	)
+
+
 def scheduled_health_check():
 	"""Cron job — check all active DB servers, attempt restart if down."""
 	servers = frappe.get_all(
@@ -475,6 +489,20 @@ def restore_database_server(db_server_name: str, backup_file: str) -> None:
 		container.exec_run(cmd=["rm", "-f", f"/tmp/{dump_name}"])
 	if exit_code != 0:
 		frappe.throw(_("Restore failed: {0}").format(output.decode()))
+
+
+def enqueue_backup() -> None:
+	"""Nightly cron: hand the dump to `queue-long`."""
+	# The enqueuer, never `scheduled_backup` itself — see the rule above `scheduler_events` in
+	# `hooks.py`. The dump is buffered in worker memory, so it gets its own timeout rather than
+	# the queue default: this is every tenant's site database in one file.
+	frappe.enqueue(
+		"benchpress.mariadb_manager.scheduled_backup",
+		queue="long",
+		timeout=BACKUP_TIMEOUT,
+		job_id="mariadb_backup",
+		deduplicate=True,
+	)
 
 
 def scheduled_backup():

--- a/benchpress/stats_collector.py
+++ b/benchpress/stats_collector.py
@@ -8,6 +8,18 @@ from frappe.utils import now_datetime
 from benchpress.docker_manager import container_is_gone, get_container_health, get_container_stats
 
 
+def enqueue_stats_sweep() -> None:
+	"""Sampling cron: hand the Docker polling to `queue-long`."""
+	# The enqueuer, never `collect_bench_stats` itself — see the rule above `scheduler_events`
+	# in `hooks.py`. Deduplicated: a sweep still running when the next tick fires keeps the slot.
+	frappe.enqueue(
+		"benchpress.stats_collector.collect_bench_stats",
+		queue="long",
+		job_id="bench_stats_sweep",
+		deduplicate=True,
+	)
+
+
 def collect_bench_stats() -> None:
 	"""Poll Docker for every Running bench: resource usage, health, and reconciliation.
 

--- a/benchpress/tests/test_scheduler_entries.py
+++ b/benchpress/tests/test_scheduler_entries.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+"""Every scheduled entry that can reach Docker must hand its work to a socket-mounted queue.
+
+`ScheduledJobType.get_queue_name()` returns `long` only for a frequency string containing `Long`
+or `Maintenance`, so every entry in `scheduler_events` is enqueued on `default` — which
+`queue-long` (Docker socket mounted) and `queue-short` (no socket) both consume, and the idle
+worker usually wins the race. Three entries sat broken for weeks because the only symptom is a
+socket `FileNotFoundError` in an error log nobody reads. This is the guard; the rule it enforces
+is written above `scheduler_events` in `hooks.py`.
+
+Reachability follows module-level imports only, so a module that imports Docker inside a function
+body is invisible here. That is the whole blind spot, and nothing under `scheduler_events` does it
+today — `credits.reaper` is the one that imports `deploy_manager` lazily, and it enqueues anyway.
+"""
+
+import ast
+import unittest
+from importlib.util import find_spec
+from pathlib import Path
+
+from benchpress.hooks import scheduler_events
+
+DOCKER_MODULE = "benchpress.docker_manager"
+SOCKET_QUEUES = {"long", "stops"}
+
+
+class TestSchedulerEntries(unittest.TestCase):
+	def test_every_docker_reaching_entry_is_an_enqueuer(self):
+		for method in _scheduled_methods():
+			module, _, function = method.rpartition(".")
+			if not _reaches_docker(module):
+				continue
+			with self.subTest(method=method):
+				self.assertTrue(
+					_enqueues_onto_socket_queue(module, function),
+					f"{method} is scheduled from a module that reaches Docker, so it must call "
+					f"frappe.enqueue(queue=…) onto one of {sorted(SOCKET_QUEUES)} instead of "
+					"doing the work itself. See the rule above `scheduler_events` in hooks.py.",
+				)
+
+	def test_the_guard_can_fail(self):
+		"""A check that cannot fail is not a guard: the two halves must each reject something."""
+		self.assertTrue(_reaches_docker("benchpress.stats_collector"))
+		self.assertFalse(_reaches_docker("benchpress.credits.admission_repair"))
+		self.assertFalse(_enqueues_onto_socket_queue("benchpress.stats_collector", "collect_bench_stats"))
+
+
+def _scheduled_methods() -> list[str]:
+	"""Flatten `scheduler_events` — frequency lists, plus the cron dict of lists."""
+	methods = []
+	for frequency in scheduler_events.values():
+		entries = frequency.values() if isinstance(frequency, dict) else [frequency]
+		for entry in entries:
+			methods.extend(entry)
+	return methods
+
+
+def _reaches_docker(module: str, seen: set[str] | None = None) -> bool:
+	seen = set() if seen is None else seen
+	if module in seen:
+		return False
+	seen.add(module)
+	if module == DOCKER_MODULE:
+		return True
+	return any(_reaches_docker(imported, seen) for imported in _benchpress_imports(module))
+
+
+def _benchpress_imports(module: str) -> list[str]:
+	"""Module-level `benchpress` imports, both `from x import y` and `import x`.
+
+	A `from benchpress import docker_manager` names the submodule in its aliases, not its module,
+	so both are collected. Aliases that turn out to be functions simply resolve to nothing.
+	"""
+	imported = []
+	for node in _parse(module).body:
+		if isinstance(node, ast.ImportFrom) and (node.module or "").startswith("benchpress"):
+			imported.append(node.module)
+			imported.extend(f"{node.module}.{alias.name}" for alias in node.names)
+		elif isinstance(node, ast.Import):
+			imported.extend(a.name for a in node.names if a.name.startswith("benchpress"))
+	return imported
+
+
+def _enqueues_onto_socket_queue(module: str, function: str) -> bool:
+	definition = next(
+		(node for node in _parse(module).body if isinstance(node, ast.FunctionDef) and node.name == function),
+		None,
+	)
+	return bool(definition) and any(_is_socket_enqueue(node) for node in ast.walk(definition))
+
+
+def _is_socket_enqueue(node: ast.AST) -> bool:
+	if not isinstance(node, ast.Call) or getattr(node.func, "attr", None) != "enqueue":
+		return False
+	queue = next((kw.value for kw in node.keywords if kw.arg == "queue"), None)
+	return isinstance(queue, ast.Constant) and queue.value in SOCKET_QUEUES
+
+
+def _parse(module: str) -> ast.Module:
+	"""Source of `module`, or an empty tree when the name is not an importable .py module."""
+	try:
+		spec = find_spec(module)
+	except (ImportError, AttributeError, ValueError):
+		return ast.parse("")
+	if not spec or not spec.origin or not spec.origin.endswith(".py"):
+		return ast.parse("")
+	return ast.parse(Path(spec.origin).read_text())


### PR DESCRIPTION
Closes #191.

## The fault

`ScheduledJobType.get_queue_name()` returns `long` only for a frequency string containing `Long` or `Maintenance`. Every `Cron`, `Daily` and `Weekly` entry therefore lands on the `default` queue, which `queue-long` (Docker socket mounted) and `queue-short` (no socket, no `group_add`) both consume. The two workers race the same pop and the idle one usually wins, so the busier the platform, the more reliably the job lands on the worker that cannot do it.

`hooks.py` documented this for one entry. Three entries did not follow it.

Measured on the live site before the fix:

| entry | state |
|---|---|
| `stats_collector.collect_bench_stats` (`*/1`) | 167 `Stats collection failed` rows today, last successful write 16:34 |
| `mariadb_manager.scheduled_health_check` (`*/5`) | 165 failures, every one a Docker socket `FileNotFoundError` |
| `mariadb_manager.scheduled_backup` (`0 2 * * *`) | one backup file on disk, dated 2026-08-21 |

The backup holds every tenant's site database, and its newest copy was five days old.

## The change

- `stats_collector.enqueue_stats_sweep`, `mariadb_manager.enqueue_health_check` and `mariadb_manager.enqueue_backup` are the cron entries now. Each hands its target to `queue="long"`, deduplicated by `job_id`, the shape `deploy_manager.enqueue_route_reconcile` already had.
- The backup gets an explicit `BACKUP_TIMEOUT` rather than the queue default. The dump is buffered in worker memory.
- `hooks.py` carries the rule over `scheduler_events` instead of a comment on one entry, and names the socket-mounted services so the next author does not have to read the compose file.
- `tests/test_scheduler_entries.py` enforces it. Any scheduled entry in a module that reaches `benchpress.docker_manager` through module-level imports must call `frappe.enqueue` onto `long` or `stops`. The docstring names the one blind spot: a lazy in-function import is invisible to the check.
- The README scheduler table named the three old methods. It names the enqueuers now.

## Verification, on the live site

After `bench migrate`:

- `tabScheduled Job Type` holds the three enqueuers and no longer holds the direct methods.
- `queue-short` ran only enqueuers and non-Docker work. `queue-long` ran `collect_bench_stats`, `scheduled_health_check`, `scheduled_backup` and `reconcile_instance_routes`.
- The backup wrote `all_databases_2026-08-26_17-53-41.sql.gz`, 6.9 MB.
- The stats sweep wrote `last_health_check`, `cpu_usage` and `memory_usage` for all five running benches at 17:58.
- Zero `Stats collection failed` or `MariaDB health check failed` rows since the deploy.

Scoped tests pass by exit code, not by the last line: `test_scheduler_entries`, `test_stats_collector` and `test_mariadb_manager` all exit 0.