### PR TITLE
chore(skills): scope the Ralph loop's test command to the phase

### DIFF
--- a/.claude/skills/issue-to-phases/assets/prompt.md.template
+++ b/.claude/skills/issue-to-phases/assets/prompt.md.template
@@ -49,6 +49,17 @@ instead.
 {{LINT_CMD}}
 ```
 
+Those are the only tests you run. Do not widen them to the whole app: the suite
+is CI's job, and running it here reports failures that predate your branch.
+
+**Read the exit code, never the last line.** `run-tests` prints one summary per
+test category, so most targets print two, and the last one can say `OK` while the
+command exits 1. No `tail`, no `grep -q OK`:
+
+```bash
+<the test command above>; echo "exit=$?"
+```
+
 {{EXTRA_RULES}}
 
 ## How to write the code

--- a/.claude/skills/issue-to-phases/assets/ralph.sh.template
+++ b/.claude/skills/issue-to-phases/assets/ralph.sh.template
@@ -209,7 +209,10 @@ smoke_check() {
   fi
   echo "[ralph]   ok   the host is unchanged since preflight"
 
-  # ADAPT: the feature's own correctness gates.
+  # ADAPT: the feature's own correctness gates. No test-suite invocation belongs
+  # here: the agent edits the suite, so it cannot be the independent word on the
+  # agent's work. The agent runs its scoped tests from the prompt, ci_green runs
+  # the suite again on the runner.
 {{SMOKE_CHECKS}}
 
   # Ships-but-invisible. A correct component behind a stale bundle passes every

--- a/.claude/skills/issue-to-phases/references/ralph-loop.md
+++ b/.claude/skills/issue-to-phases/references/ralph-loop.md
@@ -9,6 +9,7 @@ block.
 - [What a Ralph loop is](#what-a-ralph-loop-is)
 - [The one idea that makes it work](#the-one-idea-that-makes-it-work)
 - [Designing smoke_check](#designing-smoke_check)
+- [Tests: scoped, fenced, exit code](#tests-scoped-fenced-exit-code)
 - [Proving the UI](#proving-the-ui)
 - [Why a loop stalls](#why-a-loop-stalls)
 - [Preflight and rollback](#preflight-and-rollback)
@@ -103,6 +104,12 @@ the redirect would override the pipe and break the query. The signature when it
 happens: `ps -o pid,pgid,tpgid,stat` shows `T`/`Tl` with `PGID != TPGID`.
 SIGCONT does not help — the kernel re-stops it.
 
+**smoke_check invokes no tests.** The gate is worth having because the agent is
+not the only judge of its own work, and the suite is a thing the agent edits. A
+phase that adds a passing test to a suite it also changed proves nothing. Tests
+belong in `{{TEST_CMD}}`, where the agent runs them. The independent run comes
+from `ci_green`, against a site the agent never touched.
+
 **Gate on CI, and let the gate wait.** The template ships `ci_status` and
 `ci_green`: a phase is not done while the PR's checks are pending, and not done at
 all while any is failing. Two things make this worth its own helper rather than an
@@ -123,6 +130,46 @@ last must leave the spec in `in-progress/`, the final phase in `completed/`, and
 `promote_spec.py --check` must pass. Keep it. Spec bookkeeping is what an agent
 drops first when it is concentrating on code, and a shipped feature filed under
 "not started" is how a tracker stops being worth reading.
+
+## Tests: scoped, fenced, exit code
+
+`{{TEST_CMD}}` names the test modules the phase touches, one line each:
+
+```bash
+docker compose exec backend bench --site frontend run-tests --module benchpress.tests.test_deploy_manager
+```
+
+Three rules, and each one has cost a real run.
+
+**Never `--app benchpress`.** The whole suite is CI's job. It takes 60 seconds
+against the live site, and eight of its tests fail on any developer site with
+real rows, for a reason no phase can fix — the fence list below.
+
+**Never name a fenced module.** `test_credit_sweep`, `test_demo_data`,
+`test_lease` and `test_signup` call a production function that scans the whole
+site, then assert on the whole result. `enforce_limits()["stopped"] == [my bench]`
+is true on an empty site and false as soon as one real bench exists. Cardinality
+is the property under test, so the assertions are correct and only unrunnable
+here. CI stays green because `ci.yml` builds a fresh `test_site` first. A phase
+that must touch one of these gates on CI alone, and its phase spec says so.
+Tracked as [#196](https://github.com/Venkateshvenki404224/benchpress/issues/196):
+delete a module from this list when that issue fixes it, not before.
+
+**Read the exit code, never the output.** `run-tests` prints one summary per test
+category, so any target holding both integration and unit tests prints two. The
+last line is the second summary, and it says `OK` on a run that exits 1:
+
+```
+Ran 786 tests in 60.320s
+FAILED (failures=7, errors=1)
+
+Ran 153 tests in 0.282s
+OK
+```
+
+A scoped command splits the same way — `--module benchpress.tests.test_deploy_manager`
+is 86 tests then 30 — so the rule holds everywhere. No `tail`, no `grep -q OK`.
+Only `$?` is honest.
 
 ## Proving the UI
 
@@ -388,7 +435,8 @@ In **`prompt.md`** — the words:
 |---|---|
 | `{{FEATURE_SUMMARY}}` | two or three sentences of orientation |
 | `{{CONTEXT_DOCS}}` | the CLAUDE.md / design docs worth reading |
-| `{{TEST_CMD}}` / `{{LINT_CMD}}` | the repo's real commands |
+| `{{TEST_CMD}}` | one scoped `--module` line per test file the phase touches — see [Tests](#tests-scoped-fenced-exit-code) |
+| `{{LINT_CMD}}` | the repo's real lint command |
 | `{{EXTRA_RULES}}` | repo-specific traps |
 | `{{SAFETY_RULES}}` | the irreversible things, each with its reason |
 | `{{HOST_NEVER_RULES}}` | the README's Never list, each with its reason |

--- a/.claude/skills/issue-to-phases/references/spec-templates.md
+++ b/.claude/skills/issue-to-phases/references/spec-templates.md
@@ -122,6 +122,12 @@ boundary as an oversight.>
 > **Host step (precondition):** <what must be true>. See
 > [Host steps](README.md#host-steps). The loop refuses to start otherwise.
 
+<Where the phase touches a test module fenced for live-site coupling, say so:>
+
+> **Fenced test module:** `benchpress.tests.<module>` asserts against the whole
+> site, so it fails on any bench with real rows. This phase gates on CI for it.
+> See [Tests](ralph-loop.md#tests-scoped-fenced-exit-code).
+
 **Rollback**, if step <n> fails: <the exact command. Restore first, diagnose after.>
 
 ## Done when
@@ -310,6 +316,13 @@ Good verification steps share three properties:
 3. **They say what to do when the step fails**, when the step touches something
    live. Restore first, diagnose after — a rolled-back attempt that leaves the
    system working beats a forward-debugged outage.
+
+**Tests are not the phase's verification, and they are never the loop's gate.** A
+phase runs the scoped test modules it touches — see
+[Tests](ralph-loop.md#tests-scoped-fenced-exit-code) — but `smoke_check` invokes
+none of them. The agent edits the suite, so the suite cannot be the independent
+word on the agent's work. Verification observes the running system, and CI runs
+the suite against a site the agent never touched.
 
 Include a negative control wherever one is cheap: a name that should *not*
 resolve, a user who should *not* have access, a file that should *not* be


### PR DESCRIPTION
Applies the rule resolved in #184 to the tracked `issue-to-phases` skill. `specs/` is gitignored, so the skill is the only durable home for it — the same reason #183 put the host-steps convention there.

## The problem

`{{TEST_CMD}}` is free text. A spec author can write `--app benchpress` into it and nothing objects. That command runs the whole suite against the live site, where eight tests fail on rows no phase created, and its **last line reads `OK` on a run that exits 1**:

```
Ran 786 tests in 60.320s
FAILED (failures=7, errors=1)

Ran 153 tests in 0.282s
OK
```

## The four rules, and where each landed

| Rule | File |
|---|---|
| `{{TEST_CMD}}` names one `--module` line per test file the phase touches | `references/ralph-loop.md` (new **Tests** section), and the `{{TEST_CMD}}` row of the filling-in table |
| The fence list — `test_credit_sweep`, `test_demo_data`, `test_lease`, `test_signup` — with what couples them to live state | `references/ralph-loop.md`, plus a callout slot in the phase-N template so a phase says it gates on CI |
| Read `$?`, never the output. No `tail`, no `grep -q OK` | `assets/prompt.md.template` **Tests and lint**, and `references/ralph-loop.md` |
| `smoke_check` invokes no tests, and why | `references/spec-templates.md`, the `smoke_check` bullet list in `references/ralph-loop.md`, and the `{{SMOKE_CHECKS}}` ADAPT comment in `assets/ralph.sh.template` |

The fence list names #196 beside it, so it is deleted from the skill when that issue fixes the modules rather than becoming permanent.

## How to verify

A prompt generated by the real `phase_prompt()` out of `ralph.sh.template`, with `{{TEST_CMD}}` filled as an author would:

```
## Tests and lint

    docker compose exec backend bench --site frontend run-tests --module benchpress.tests.test_deploy_manager
    docker compose exec backend bench --site frontend run-tests --module benchpress.tests.test_docker_manager
    uvx pre-commit@4.3.0 run --all-files

Those are the only tests you run. Do not widen them to the whole app: the suite
is CI's job, and running it here reports failures that predate your branch.

**Read the exit code, never the last line.** ...
```

No placeholder is left unsubstituted, and `--app benchpress` appears nowhere in the generated prompt. `bash -n` passes on `ralph.sh.template`, and `uvx pre-commit@4.3.0 run --all-files` is clean.

Resolves #195.