### PR TITLE
chore(skills): order a string-named move as migrate before restart

### DIFF
--- a/.claude/skills/issue-to-phases/SKILL.md
+++ b/.claude/skills/issue-to-phases/SKILL.md
@@ -203,6 +203,15 @@ completed.
   test: **the built assets are older than the source**, **a feature flag hides
   it**, and **no row exercises it** (the feature reads a column every existing row
   has as `NULL`). Check those three before concluding the code is wrong.
+- **A move that changes a dotted path ends with `migrate`, then the restart.**
+  Frappe resolves scheduled and enqueued jobs from strings at run time, so moving
+  a function they name breaks them while every import still works. Rewrite every
+  string in the same commit, run
+  `docker compose exec backend bench --site frontend migrate`, and restart the
+  workers **after** — the other order leaves a `Scheduled Job Type` row pointing
+  at nothing, and that fails in complete silence. Job ids never change during a
+  move, and a re-export shim is not a fallback: see
+  [Moving code that a string names](references/ralph-loop.md#moving-code-that-a-string-names).
 - One subfolder per feature, always inside a status bucket — never loose in
   `specs/` or in a bucket root.
 - One branch and one PR per feature. Never a second PR for a later phase.

--- a/.claude/skills/issue-to-phases/assets/prompt.md.template
+++ b/.claude/skills/issue-to-phases/assets/prompt.md.template
@@ -214,6 +214,38 @@ them fails a test, and all three have cost a real iteration:
 Check the page the feature actually lives on. A dashboard or overview page that
 was never in scope will look untouched no matter how correct the work is.
 
+## If this phase moves a function that a string names
+
+Frappe resolves a scheduled job and an enqueued job from a **dotted string** at
+run time. Your imports can all be correct and those strings still point at
+nothing. Ending the phase in the wrong order is silent — the `Scheduled Job Type`
+row raises no exception, writes no log row, and still advances `last_execution`,
+so the desk list shows a job that ran a moment ago while nothing has run at all.
+
+End the phase in this order, and do not reorder it:
+
+1. Rewrite **every** string in the same commit as the move: call sites,
+   `hooks.py`, docstrings, tracked `.md`, and the test assertions naming the path.
+   `git grep '<old.dotted.path>'` must come back empty.
+2. `docker compose exec backend bench --site frontend migrate`
+3. `docker compose restart backend queue-long queue-short scheduler websocket`
+
+Before step 3, poll `queue-long` for at most 120 seconds, then go ahead anyway and
+write the depth you gave up at into your notes. Do not block until it is empty:
+the restart kills an in-flight deploy in any case, and waiting can hang this
+iteration behind a two-minute one.
+
+Two things you must not do:
+
+- **Do not add a re-export shim** to the module you moved the code out of. It
+  makes a cycle, and the form that looks safest — the shim at the bottom of the
+  old module — works when the old module is imported first and raises
+  `ImportError` when the new one is. That is the path an RQ worker takes, so the
+  shim is green in CI and broken in every worker.
+- **Do not rename any RQ `job_id`.** It is a dedup key, not an import path, so the
+  move cannot break it. Renaming it lets a job queued under the old id run beside
+  a new one.
+
 ## How an iteration ends
 
 **Never end your turn waiting for something.** This is a headless session: there

--- a/.claude/skills/issue-to-phases/references/ralph-loop.md
+++ b/.claude/skills/issue-to-phases/references/ralph-loop.md
@@ -10,6 +10,7 @@ block.
 - [The one idea that makes it work](#the-one-idea-that-makes-it-work)
 - [Designing smoke_check](#designing-smoke_check)
 - [Tests: scoped, fenced, exit code](#tests-scoped-fenced-exit-code)
+- [Moving code that a string names](#moving-code-that-a-string-names)
 - [Proving the UI](#proving-the-ui)
 - [Why a loop stalls](#why-a-loop-stalls)
 - [Preflight and rollback](#preflight-and-rollback)
@@ -125,6 +126,11 @@ On a repo with **no** workflows, delete the gate and both helpers. `gh pr checks
 reports nothing there, so the gate would wait out its entire budget and fail every
 phase for the absence of a thing that does not exist.
 
+**A phase that moves code gets a grep gate.** A moved function that a dotted
+string names is broken in a way no import error and no test catches, so
+`smoke_check` greps for the old path. See
+[Moving code that a string names](#moving-code-that-a-string-names).
+
 **Include the status-lockstep gate.** The template ships it: phases before the
 last must leave the spec in `in-progress/`, the final phase in `completed/`, and
 `promote_spec.py --check` must pass. Keep it. Spec bookkeeping is what an agent
@@ -170,6 +176,111 @@ OK
 A scoped command splits the same way — `--module benchpress.tests.test_deploy_manager`
 is 86 tests then 30 — so the rule holds everywhere. No `tail`, no `grep -q OK`.
 Only `$?` is honest.
+
+**A phase that moves a string-named function names one more module.** The static
+job-path tests are the gate that outlives the refactor, so every later phase of
+the move runs them too. See
+[Moving code that a string names](#moving-code-that-a-string-names).
+
+## Moving code that a string names
+
+A refactor phase that moves a function is not finished when the imports are
+right. Frappe resolves a scheduled job and an enqueued job from a **dotted
+string** at run time, through `frappe.get_attr`, so a name that moved leaves those
+strings pointing at nothing. The two carriers fail in opposite ways, and the
+persisted one is the silent one:
+
+| Carrier | What a stale string does | The only trace |
+|---|---|---|
+| a `Scheduled Job Type` row, from `hooks.scheduler_events` | the job stops running, indefinitely | one `INFO` line in `logs/scheduler.log` |
+| a `frappe.enqueue("…")` call site | the job fails once, at the moment it is queued | `ModuleNotFoundError` in `FailedJobRegistry` |
+
+The scheduler row is the dangerous one because it goes on looking healthy.
+`ScheduledJobType.execute()` catches the exception and `run_scheduled_job` catches
+again, so nothing raises. No `Scheduled Job Log` row is written when the row has
+`create_log = 0`, and no `Error Log` row appears either. `last_execution` still
+advances, because `log_status("Start")` stamps it before the call — so the desk
+list shows a job that ran a moment ago while a `*/5` reconcile has quietly
+stopped.
+
+### End the phase in this order
+
+1. **Move the code and rewrite every string in the same commit** — call sites,
+   `hooks.py`, docstrings, tracked `.md`, and the test assertions that name the
+   path. A forgotten test assertion fails loudly, which is the cheapest gate here.
+2. **`docker compose exec backend bench --site frontend migrate`.**
+3. **`docker compose restart backend queue-long queue-short scheduler websocket`.**
+
+Step 2 before step 3 is a rule, not a preference. `migrate` calls `sync_jobs()`
+(`frappe/migrate.py:162`), which inserts the new `Scheduled Job Type` row and then
+deletes the one whose method is no longer in `scheduler_events`. So the stale row
+never outlives the commit, and a scheduler string never needs a `patches.txt`
+entry. `migrate` runs inside `backend`, a fresh process reading the bind-mounted
+new code, so it sees the new hooks while the un-restarted workers resolve the new
+path straight from disk. Between steps 2 and 3 both paths work. **Migrating after
+the restart is the order that opens the silent window.**
+
+Before step 3, wait for `queue-long` — **bounded, and not a gate.** Poll for at
+most 120 seconds, then go ahead anyway and log the depth it gave up at. A restart
+already kills an in-flight deploy, so blocking until the queue is empty buys
+nothing and can hang the loop behind a two-minute deploy.
+
+### Never add a re-export shim
+
+The reflex fix for a moved name is to re-export it from the old module. Do not.
+A move that leaves any back-reference into the old module — and a partial extract
+usually leaves one — makes the re-export a cycle, and the cycle breaks on the path
+the workers take:
+
+| Where the shim goes | Entered via the old module | Entered via the new module |
+|---|---|---|
+| top of the old module | `ImportError` | `ImportError` |
+| bottom of the old module | works | **`ImportError`** |
+| lazy import inside the new module | works | works |
+
+The middle row is the trap. It is the form a reviewer asks for, it passes every
+test that imports the old module first, and it fails on
+`frappe.get_attr("<new module>.<name>")` — which is exactly what an RQ worker
+calls. A shim that is green in CI and broken in every worker is worse than no
+shim. Rewriting the strings costs one `git grep` and needs none of this.
+
+### Job ids are frozen
+
+An RQ `job_id` is a dedup key, not an import path, so moving the function cannot
+break it. Renaming it during the move is what breaks: a job queued under the old
+id is invisible to `is_job_enqueued` on the new one
+(`frappe/utils/background_jobs.py:664`), so two runs of a job that exists to be
+unique can overlap. `bench_instance.py:174`'s `deploy_bench:{self.name}` is the
+live example — one id shared by deploy and redeploy on purpose, so that "a deploy
+is already in progress" is true for both. Leave every job id exactly as it is,
+across every phase of the move.
+
+### The three gates
+
+Two are static and one is a runtime check, and none needs a human.
+
+**a. A repo-wide grep, in `smoke_check`.** After the phase, no moved name may
+survive as `<old dotted module>.<name>` anywhere. Use `git grep`, not a
+Python-only search: a docstring, a `.md` file or a JSON fixture holds these too.
+Write the pattern with the module prefix and the trailing dot so it cannot match a
+bare job id like `deploy_bench:`.
+
+**b. Two static tests, added once in the first phase that moves anything.** They
+generalize `benchpress/tests/test_scheduler_entries.py`, which already AST-walks
+`scheduler_events` and proves the shape works:
+
+- every string in `hooks.scheduler_events` resolves under `frappe.get_attr`;
+- every `enqueue` target resolves — AST-walk each non-test `.py` under the app,
+  take the first positional or `method=` `Constant` of each `enqueue` call, and
+  resolve it.
+
+This is the gate that outlives the refactor. Any later move of a job target then
+fails a test instead of going quiet.
+
+**c. One runtime assertion, after step 2.** Resolve every
+`Scheduled Job Type.method` on the live site with `frappe.get_attr` and fail on
+any that raises. Gate **b** proves the source is right. This one proves the
+**database** is, which is the half no static check can see.
 
 ## Proving the UI
 
@@ -396,7 +507,11 @@ contract, escape hatch. What you write per spec:
   Which services hold a stale module until restarted. Anything that has bitten
   someone.
 - **the `<!-- PHASE n -->` blocks** — per-phase warnings. Put the destructive
-  phase's order of operations here, phrased as "do not reorder them".
+  phase's order of operations here, phrased as "do not reorder them". A phase that
+  moves a function named by a string is exactly this case: write out
+  rewrite → `migrate` → restart, with the reason, because the wrong order fails
+  silently. See
+  [Moving code that a string names](#moving-code-that-a-string-names).
 
 Write prohibitions where the agent will be when it needs them, and give the
 reason. An agent that understands why a rule exists will not route around it.
@@ -436,6 +551,7 @@ In **`prompt.md`** — the words:
 | `{{FEATURE_SUMMARY}}` | two or three sentences of orientation |
 | `{{CONTEXT_DOCS}}` | the CLAUDE.md / design docs worth reading |
 | `{{TEST_CMD}}` | one scoped `--module` line per test file the phase touches — see [Tests](#tests-scoped-fenced-exit-code) |
+| `<!-- PHASE n -->` order of operations | any sequence the phase must not reorder, including a [string-named move](#moving-code-that-a-string-names) |
 | `{{LINT_CMD}}` | the repo's real lint command |
 | `{{EXTRA_RULES}}` | repo-specific traps |
 | `{{SAFETY_RULES}}` | the irreversible things, each with its reason |

--- a/.claude/skills/issue-to-phases/references/spec-templates.md
+++ b/.claude/skills/issue-to-phases/references/spec-templates.md
@@ -128,6 +128,14 @@ boundary as an oversight.>
 > site, so it fails on any bench with real rows. This phase gates on CI for it.
 > See [Tests](ralph-loop.md#tests-scoped-fenced-exit-code).
 
+<Where the phase moves a function that a scheduler entry or an `enqueue` call
+names by string, spell the closing order out — it is the step a phase drops:>
+
+> **String-named move:** this phase ends with rewrite every string → `migrate` →
+> restart the workers, in that order. Migrating after the restart leaves a
+> `Scheduled Job Type` row pointing at nothing, and that failure is silent. See
+> [Moving code that a string names](ralph-loop.md#moving-code-that-a-string-names).
+
 **Rollback**, if step <n> fails: <the exact command. Restore first, diagnose after.>
 
 ## Done when
@@ -323,6 +331,13 @@ phase runs the scoped test modules it touches — see
 none of them. The agent edits the suite, so the suite cannot be the independent
 word on the agent's work. Verification observes the running system, and CI runs
 the suite against a site the agent never touched.
+
+**A phase that moves code verifies the strings, not just the imports.** Frappe
+resolves scheduled and enqueued jobs from dotted strings at run time, so a green
+import proves nothing about them. The three gates that do — a `git grep` for the
+old path, two static tests that resolve every scheduler and `enqueue` target, and
+one runtime pass over `Scheduled Job Type.method` — are in
+[Moving code that a string names](ralph-loop.md#moving-code-that-a-string-names).
 
 Include a negative control wherever one is cheap: a name that should *not*
 resolve, a user who should *not* have access, a file that should *not* be


### PR DESCRIPTION
Closes #198. Applies the two conventions settled in #190 to the tracked `issue-to-phases` skill, the way #183 and #195 put theirs there. `specs/` is gitignored, so the skill is the only durable home.

## The gap

The skill mentioned `migrate` in **none** of its six files. So a generated loop moves a function and restarts the workers without migrating — the order that leaves a stale `Scheduled Job Type` row, which raises nothing, writes no `Scheduled Job Log` and no `Error Log` row, and still advances `last_execution`. The desk list shows a job that ran a moment ago while a `*/5` reconcile has stopped.

## What changed

`references/ralph-loop.md` gains **Moving code that a string names**:

- **The order** — rewrite every string in the same commit, `bench --site frontend migrate`, then `docker compose restart backend queue-long queue-short scheduler websocket`. `migrate` calls `sync_jobs()`, which deletes the stale row and inserts the new one, so no `patches.txt` entry is ever needed.
- **The bounded wait** — poll `queue-long` for at most 120 s before the restart, then proceed anyway and log the depth. A wait, not a gate: the restart kills an in-flight deploy in any case.
- **No re-export shim**, with the table that shows why. The form a reviewer asks for — shim at the bottom of the old module — works when the old module is imported first and raises `ImportError` when the new one is, which is the path an RQ worker takes.
- **Job ids are frozen.** An RQ `job_id` is a dedup key, not an import path.
- **The three gates** — a repo-wide `git grep` for the old dotted path in `smoke_check`, two static tests that resolve every `scheduler_events` string and every AST-found `enqueue` target, and one runtime pass over `Scheduled Job Type.method` after the migrate.

The three places a spec author already reads point at it: `Designing smoke_check`, `Tests: scoped, fenced, exit code`, and the `<!-- PHASE n -->` guidance. `spec-templates.md` gains the phase-spec callout beside the fenced-test one, and a line in `Verification sections that are worth writing`. `SKILL.md` gains one guardrail, so a phase implemented by hand under Job 2 gets the rule too. `assets/prompt.md.template` gains **If this phase moves a function that a string names**, so the ordering reaches the agent even when the spec author forgets the phase block.

`test_job_paths.py` itself is not written here — item 15's spec writes it in pass 1. This PR only puts the conventions in the skill.

## Verification

- Docs only. `uvx pre-commit@4.3.0` runs clean (every hook skips: markdown is outside `prettier`'s `types_or` and outside the `benchpress.*` file filter).
- Line references checked against this tree: `sync_jobs()` at `frappe/migrate.py:162`, `is_job_enqueued` at `frappe/utils/background_jobs.py:664`, `deploy_bench:{self.name}` at `bench_instance.py:174`.
- The static-test shape named in gate **b** generalizes `benchpress/tests/test_scheduler_entries.py`, which is tracked and passing.