### PR TITLE
test(scope): narrow the whole-site test modules to their own fixtures

### DIFF
--- a/.claude/skills/issue-to-phases/references/ralph-loop.md
+++ b/.claude/skills/issue-to-phases/references/ralph-loop.md
@@ -148,18 +148,33 @@ docker compose exec backend bench --site frontend run-tests --module benchpress.
 Three rules, and each one has cost a real run.
 
 **Never `--app benchpress`.** The whole suite is CI's job. It takes 60 seconds
-against the live site, and eight of its tests fail on any developer site with
-real rows, for a reason no phase can fix — the fence list below.
+against the live site, one of its tests fails there for good (the fence list
+below), and the rest of the run does not repeat. Three runs of the same tree gave
+one failure, then four, then one: `test_api` blew a 600 ms budget at 1,473 ms
+under whole-suite load, and `test_credit_guard` got a Docker 404 that it does not
+get on its own. Scoped `--module` runs of the same tests were stable every time.
+A red whole-suite run here tells a loop nothing it can act on.
 
-**Never name a fenced module.** `test_credit_sweep`, `test_demo_data`,
-`test_lease` and `test_signup` call a production function that scans the whole
-site, then assert on the whole result. `enforce_limits()["stopped"] == [my bench]`
-is true on an empty site and false as soon as one real bench exists. Cardinality
-is the property under test, so the assertions are correct and only unrunnable
-here. CI stays green because `ci.yml` builds a fresh `test_site` first. A phase
-that must touch one of these gates on CI alone, and its phase spec says so.
-Tracked as [#196](https://github.com/Venkateshvenki404224/benchpress/issues/196):
-delete a module from this list when that issue fixes it, not before.
+**Never name a fenced module.** `test_lease` is the only one left.
+`test_a_restarted_bench_gets_a_fresh_deadline_and_is_not_reclaimed` errors here
+because `guard._enforce` holds credits against the caller instead of the bench
+owner, so an admin restarting a bench they do not own is priced against the wrong
+account. That is a production bug, not a test one, and no phase spec works around
+it. CI stays green only because a fresh `Administrator` on `test_site` collects
+the signup grant. Tracked as
+[#202](https://github.com/Venkateshvenki404224/benchpress/issues/202) — item 9's
+spec fixes it and deletes this entry. A phase that must touch `test_lease` gates
+on CI alone, and its phase spec says so.
+
+`test_credit_sweep`, `test_demo_data` and `test_signup` were fenced here until
+[#203](https://github.com/Venkateshvenki404224/benchpress/issues/203) fixed them,
+and the fix is the pattern to copy. They called a production function that scans
+the whole site, then asserted on the whole result. That was never "correct but
+unrunnable here": on CI's empty site `enforce_limits()["stopped"] == [my bench]`
+passes for a sweep that stopped every bench on it too. Narrow every assertion to
+a fixture universe the test owns, and give each discrimination test a control row
+that must survive. `enforce_limits` decides per **owner**, so the control there is
+a second funded owner, never a second bench under the same one.
 
 **Read the exit code, never the output.** `run-tests` prints one summary per test
 category, so any target holding both integration and unit tests prints two. The

--- a/.claude/skills/issue-to-phases/references/spec-templates.md
+++ b/.claude/skills/issue-to-phases/references/spec-templates.md
@@ -124,9 +124,9 @@ boundary as an oversight.>
 
 <Where the phase touches a test module fenced for live-site coupling, say so:>
 
-> **Fenced test module:** `benchpress.tests.<module>` asserts against the whole
-> site, so it fails on any bench with real rows. This phase gates on CI for it.
-> See [Tests](ralph-loop.md#tests-scoped-fenced-exit-code).
+> **Fenced test module:** `benchpress.tests.<module>` cannot pass on a developer
+> site. This phase gates on CI for it. See
+> [Tests](ralph-loop.md#tests-scoped-fenced-exit-code) for the reason.
 
 <Where the phase moves a function that a scheduler entry or an `enqueue` call
 names by string, spell the closing order out — it is the step a phase drops:>

--- a/benchpress/tests/test_credit_sweep.py
+++ b/benchpress/tests/test_credit_sweep.py
@@ -12,6 +12,11 @@ Warnings are asserted for their *cardinality*, not just their content. "At most 
 is the property that decides whether these notices get read or muted, and it is the one a refactor
 loses silently.
 
+Both sweeps scan the whole site, so every assertion here narrows to the two owners this class
+creates before it counts. A second **funded** owner is the control: `enforce_limits` decides per
+owner, so a sweep that stopped everything would still satisfy an assertion about one bench under
+one owner, and only a neighbour that must survive catches it.
+
 As in `test_credit_guard`, nothing in this module commits: `IntegrationTestCase` rolls back once per
 class, so a single commit would make every retuned price durable on the site.
 """
@@ -34,6 +39,7 @@ LEDGER = "Credit Ledger Entry"
 GRANT = 40.0
 REAP_AFTER_DAYS = 7
 USER = "sweep-user@example.com"
+NEIGHBOUR = "sweep-neighbour@example.com"
 
 TUNED_SETTINGS = ("reap_after_days", "low_balance_warn_percent")
 
@@ -122,6 +128,10 @@ class TestCreditSweep(IntegrationTestCase):
 		cls.user = _ensure_user(USER)
 		cls.lab = _ensure_lab("sweep-lab", cls.user)
 		cls.bench = _ensure_bench(cls.lab, cls.user)
+		cls.neighbour = _ensure_user(NEIGHBOUR)
+		cls.neighbour_lab = _ensure_lab("sweep-neighbour-lab", cls.neighbour)
+		cls.neighbour_bench = _ensure_bench(cls.neighbour_lab, cls.neighbour)
+		cls.owned = {cls.bench.name, cls.neighbour_bench.name}
 		# Not committed: the class rollback takes these with it, and one commit here would make
 		# every retuned cap and price durable on the site.
 
@@ -129,7 +139,8 @@ class TestCreditSweep(IntegrationTestCase):
 		frappe.set_user("Administrator")
 		self.restore_economics()
 		self.wipe_credits()
-		self.reset_bench()
+		self.reset_benches()
+		self.fund(GRANT, self.neighbour)  # before the spies: funding an account enqueues nothing
 		self.enqueued = self.spy("frappe.enqueue")
 		self.alerts = self.spy("benchpress.notifications.notify_owner")
 		self.emails = self.spy("benchpress.notifications.email_owner")
@@ -153,19 +164,19 @@ class TestCreditSweep(IntegrationTestCase):
 	def test_a_spent_balance_stops_a_running_instance(self):
 		self.enable_credits()
 		self.fund(0)
-		self.assertEqual(sweep.enforce_limits()["stopped"], [self.bench.name])
+		self.assertEqual(self.ours(sweep.enforce_limits()["stopped"]), [self.bench.name])
 		self.assert_enqueued("benchpress.deploy_manager.stop_bench")
 
 	def test_a_funded_owner_keeps_running(self):
 		self.enable_credits()
 		self.fund(GRANT)
-		self.assertEqual(sweep.enforce_limits()["stopped"], [])
+		self.assertEqual(self.ours(sweep.enforce_limits()["stopped"]), [])
 
 	def test_an_owner_with_no_account_row_is_not_stopped(self):
 		"""Credits were only just switched on; there is no balance to be out of yet."""
 		self.enable_credits()
 		self.assertFalse(frappe.db.exists(ACCOUNT, self.user))
-		self.assertEqual(sweep.enforce_limits()["stopped"], [])
+		self.assertEqual(self.ours(sweep.enforce_limits()["stopped"]), [])
 
 	# --- The two rules the sweep must never break ----------------------------
 
@@ -180,13 +191,14 @@ class TestCreditSweep(IntegrationTestCase):
 		self.enable_credits()
 		self.fund(0)
 		sweep.enforce_limits()
-		self.assertEqual(self.enqueued.call_args.kwargs["queue"], "long")
-		self.assertTrue(self.enqueued.call_args.kwargs["deduplicate"])
+		stop = self.enqueue_for(self.bench.name)
+		self.assertEqual(stop.kwargs["queue"], "long")
+		self.assertTrue(stop.kwargs["deduplicate"])
 
 	def test_the_stop_cannot_start_before_the_decision_commits(self):
 		"""`stop_bench` re-reads the row, so a job that runs first acts on a decision that may roll back."""
 		sweep._enqueue_stop(self.bench.name)
-		self.assertTrue(self.enqueued.call_args.kwargs["enqueue_after_commit"])
+		self.assertTrue(self.enqueue_for(self.bench.name).kwargs["enqueue_after_commit"])
 
 	def test_the_sweep_does_not_scale_in_query_count(self):
 		"""One query per load, whatever the fleet size — never a `get_doc` per instance."""
@@ -211,8 +223,10 @@ class TestCreditSweep(IntegrationTestCase):
 
 		sweep.enforce_limits()
 		sweep.enforce_limits()
-		self.assertEqual(self.alerts.call_count, 1)
-		self.assertIn("Credits running low", self.alerts.call_args.args[1])
+		warnings = self.alerts_for(self.user)
+		self.assertEqual(len(warnings), 1)
+		self.assertIn("Credits running low", warnings[0].args[1])
+		self.assertEqual(self.alerts_for(self.neighbour), [], "the funded owner is the control")
 
 	def test_the_low_balance_warning_re_arms_when_the_balance_recovers(self):
 		self.enable_credits()
@@ -228,7 +242,7 @@ class TestCreditSweep(IntegrationTestCase):
 		self.enable_credits()
 		self.fund(GRANT)
 		sweep.enforce_limits()
-		self.alerts.assert_not_called()
+		self.assertEqual(self.alerts_for(self.user), [])
 
 	# --- The reaper -----------------------------------------------------------
 
@@ -236,34 +250,37 @@ class TestCreditSweep(IntegrationTestCase):
 		self.enable_credits()
 		self.stopped_for_days(REAP_AFTER_DAYS + 1)
 		result = reaper.reap_stopped_instances()
-		self.assertEqual(result["reaped"], [self.bench.name])
+		self.assertEqual(self.ours(result["reaped"]), [self.bench.name])
 		self.assert_enqueued("benchpress.credits.reaper.reap_bench")
 
 	def test_a_recently_stopped_instance_is_left_alone(self):
 		self.enable_credits()
 		self.stopped_for_days(1)
-		self.assertEqual(reaper.reap_stopped_instances(), {"reaped": [], "warned": []})
+		result = reaper.reap_stopped_instances()
+		self.assertEqual(self.ours(result["reaped"]), [])
+		self.assertEqual(self.ours(result["warned"]), [])
 
 	def test_a_running_instance_is_never_reaped(self):
 		self.enable_credits()
 		self.stopped_for_days(REAP_AFTER_DAYS + 1)
 		frappe.db.set_value(BENCH, self.bench.name, "status", "Running", update_modified=False)
-		self.assertEqual(reaper.reap_stopped_instances()["reaped"], [])
+		self.assertEqual(self.ours(reaper.reap_stopped_instances()["reaped"]), [])
 
 	def test_the_reaper_emails_two_days_out_exactly_once(self):
 		self.enable_credits()
 		self.stopped_for_days(REAP_AFTER_DAYS - 1)
 
-		self.assertEqual(reaper.reap_stopped_instances()["warned"], [self.bench.name])
-		self.assertEqual(reaper.reap_stopped_instances()["warned"], [])
-		self.assertEqual(self.emails.call_count, 1, "an email a day about the same deletion is spam")
-		self.assertIn("will be deleted", self.emails.call_args.args[1])
+		self.assertEqual(self.ours(reaper.reap_stopped_instances()["warned"]), [self.bench.name])
+		self.assertEqual(self.ours(reaper.reap_stopped_instances()["warned"]), [])
+		notices = self.emails_for(self.user)
+		self.assertEqual(len(notices), 1, "an email a day about the same deletion is spam")
+		self.assertIn("will be deleted", notices[0].args[1])
 
 	def test_the_reaper_does_not_warn_before_the_window(self):
 		self.enable_credits()
 		self.stopped_for_days(REAP_AFTER_DAYS - 4)
-		self.assertEqual(reaper.reap_stopped_instances()["warned"], [])
-		self.emails.assert_not_called()
+		self.assertEqual(self.ours(reaper.reap_stopped_instances()["warned"]), [])
+		self.assertEqual(self.emails_for(self.user), [])
 
 	def test_a_zero_reap_window_never_reaps(self):
 		self.enable_credits()
@@ -320,14 +337,35 @@ class TestCreditSweep(IntegrationTestCase):
 		frappe.db.set_single_value(CREDIT_SETTINGS, field, value)
 		frappe.clear_cache(doctype=CREDIT_SETTINGS)
 
-	def fund(self, credits) -> None:
-		account.ensure_account(self.user)
+	def fund(self, credits, user: str | None = None) -> None:
+		user = user or self.user
+		account.ensure_account(user)
 		frappe.db.set_value(
 			ACCOUNT,
-			self.user,
+			user,
 			{"balance": credits, "low_balance_warned": 0},
 			update_modified=False,
 		)
+
+	# --- The fixture universe -------------------------------------------------
+	#
+	# Both sweeps return every bench on the site, and both notify every owner on it. Narrowing to
+	# the rows this class owns keeps the cardinality assertions meaningful instead of vacuous.
+
+	def ours(self, bench_names: list) -> list:
+		return [name for name in bench_names if name in self.owned]
+
+	def alerts_for(self, user: str) -> list:
+		return [call for call in self.alerts.call_args_list if call.args[0] == user]
+
+	def emails_for(self, user: str) -> list:
+		return [call for call in self.emails.call_args_list if call.args[0] == user]
+
+	def enqueue_for(self, bench_name: str):
+		"""This bench's own enqueue call. On a site with real rows it is never the last one."""
+		calls = [call for call in self.enqueued.call_args_list if call.kwargs.get("bench_name") == bench_name]
+		self.assertEqual(len(calls), 1, f"expected exactly one enqueue for {bench_name}")
+		return calls[0]
 
 	def warn_threshold(self) -> float:
 		percent = config.settings().low_balance_warn_percent
@@ -340,22 +378,24 @@ class TestCreditSweep(IntegrationTestCase):
 			BENCH, self.bench.name, "modified", add_days(now_datetime(), -days), update_modified=False
 		)
 
-	def reset_bench(self) -> None:
-		frappe.db.set_value(
-			BENCH,
-			self.bench.name,
-			{
-				"status": "Running",
-				"started_at": now_datetime(),
-				"reap_warned_at": None,
-				"database_server": None,
-			},
-			update_modified=True,
-		)
+	def reset_benches(self) -> None:
+		for name in self.owned:
+			frappe.db.set_value(
+				BENCH,
+				name,
+				{
+					"status": "Running",
+					"started_at": now_datetime(),
+					"reap_warned_at": None,
+					"database_server": None,
+				},
+				update_modified=True,
+			)
 
 	def assert_enqueued(self, method: str) -> None:
-		self.assertEqual(self.enqueued.call_args.args[0], method)
-		self.assertEqual(self.enqueued.call_args.kwargs["queue"], "long")
+		call = self.enqueue_for(self.bench.name)
+		self.assertEqual(call.args[0], method)
+		self.assertEqual(call.kwargs["queue"], "long")
 
 	def count_queries(self, action) -> int:
 		count = 0
@@ -380,5 +420,5 @@ class TestCreditSweep(IntegrationTestCase):
 				frappe.delete_doc(doctype, name, force=True, ignore_permissions=True)
 
 	def wipe_credits(self) -> None:
-		frappe.db.delete(LEDGER, {"account": USER})
-		frappe.db.delete(ACCOUNT, {"user": USER})
+		frappe.db.delete(LEDGER, {"account": ("in", [USER, NEIGHBOUR])})
+		frappe.db.delete(ACCOUNT, {"user": ("in", [USER, NEIGHBOUR])})

--- a/benchpress/tests/test_demo_data.py
+++ b/benchpress/tests/test_demo_data.py
@@ -14,6 +14,32 @@ def demo_lab_ids():
 	return [spec["lab_id"] for spec in demo_data.LAB_SPECS]
 
 
+def demo_universe():
+	"""The rows this module owns, per seeded doctype: the field to filter on, and its values.
+
+	A dev site carries real labs, benches and logs, and the seeder is run by hand against it. Every
+	count and every scan below narrows to these rows, or it reads whatever else is on the site.
+	`Lab` is named after its `lab_id`, so the seeded ids are their own filter.
+	"""
+	labs = demo_lab_ids()
+	benches = frappe.get_all("Bench Instance", filters={"lab": ["in", labs]}, pluck="name")
+	return {
+		"Lab": ("lab_id", labs),
+		"Bench Instance": ("lab", labs),
+		"Bench Site": ("bench", benches),
+		"Deploy Log": ("bench", benches),
+		"Build Log": ("lab", labs),
+	}
+
+
+def demo_rows(doctype, fields):
+	"""Seeded rows only. An empty universe is asked for nothing — `in ()` is not a query."""
+	field, values = demo_universe()[doctype]
+	if not values:
+		return []
+	return frappe.get_all(doctype, filters={field: ["in", values]}, fields=fields)
+
+
 def delete_all(doctype, filters):
 	for name in frappe.get_all(doctype, filters=filters, pluck="name"):
 		frappe.delete_doc(doctype, name, force=True, ignore_permissions=True)
@@ -36,7 +62,8 @@ def purge_demo_data():
 
 
 def record_counts():
-	return {doctype: frappe.db.count(doctype) for doctype in SEEDED_DOCTYPES}
+	"""Delta-compared, so it tolerates old rows — but not a concurrent deploy writing its own."""
+	return {doctype: len(demo_rows(doctype, ["name"])) for doctype in SEEDED_DOCTYPES}
 
 
 class TestDemoData(IntegrationTestCase):
@@ -44,6 +71,9 @@ class TestDemoData(IntegrationTestCase):
 
 	def setUp(self):
 		purge_demo_data()
+
+	def seeded_statuses(self, doctype) -> set:
+		return {row.status for row in demo_rows(doctype, ["status"])}
 
 	def test_seeding_is_idempotent(self):
 		before = record_counts()
@@ -62,22 +92,22 @@ class TestDemoData(IntegrationTestCase):
 
 	def test_every_widget_status_is_represented(self):
 		demo_data.create_demo_data()
-		self.assertTrue(frappe.db.count("Lab", {"status": "Ready"}))
-		self.assertTrue(frappe.db.count("Bench Instance", {"status": "Running"}))
-		self.assertTrue(frappe.db.count("Bench Instance", {"status": "Error"}))
-		self.assertTrue(frappe.db.count("Bench Site", {"status": "Active"}))
+		self.assertIn("Ready", self.seeded_statuses("Lab"))
+		self.assertIn("Running", self.seeded_statuses("Bench Instance"))
+		self.assertIn("Error", self.seeded_statuses("Bench Instance"))
+		self.assertIn("Active", self.seeded_statuses("Bench Site"))
 
 	def test_deploy_logs_span_the_chart_timespan(self):
 		"""A single-day pile of logs would draw one spike instead of a curve."""
 		demo_data.create_demo_data()
-		days = frappe.get_all("Deploy Log", fields=["timestamp"], pluck="timestamp")
-		self.assertGreater(len({day.date() for day in days}), 1)
+		days = {row.timestamp.date() for row in demo_rows("Deploy Log", ["timestamp"])}
+		self.assertGreater(len(days), 1)
 
 	def test_a_seeded_run_lasts_minutes_not_weeks(self):
 		"""Duration is `modified - timestamp`, so a backdated log must settle its own `modified`."""
 		demo_data.create_demo_data()
 		for doctype in ("Deploy Log", "Build Log"):
-			for log in frappe.get_all(doctype, fields=["name", "timestamp", "modified"]):
+			for log in demo_rows(doctype, ["name", "timestamp", "modified"]):
 				seconds = time_diff_in_seconds(log.modified, log.timestamp)
 				self.assertGreater(seconds, 0, f"{doctype} {log.name} settled before it started")
 				self.assertLess(seconds, 3600, f"{doctype} {log.name} claims a {seconds / 3600:.0f}h run")

--- a/benchpress/tests/test_signup.py
+++ b/benchpress/tests/test_signup.py
@@ -27,6 +27,7 @@ from unittest.mock import MagicMock, patch
 
 import frappe
 from frappe.tests import IntegrationTestCase
+from frappe.utils import now_datetime
 
 from benchpress import signup, waitlist
 from benchpress.credits import account, admission, guard, onboarding
@@ -42,9 +43,10 @@ WEBSITE_SETTINGS = "Website Settings"
 EMAIL = "signup-test@example.com"
 OAUTH_EMAIL = "signup-oauth@example.com"
 DESK_EMAIL = "signup-desk@example.com"
+NOTIFIED_EMAIL = "signup-notified@example.com"
 BLOCKED_DOMAIN = "signup-throwaway.example"
 BLOCKED_EMAIL = f"nobody@{BLOCKED_DOMAIN}"
-EVERY_EMAIL = (EMAIL, OAUTH_EMAIL, DESK_EMAIL, BLOCKED_EMAIL)
+EVERY_EMAIL = (EMAIL, OAUTH_EMAIL, DESK_EMAIL, NOTIFIED_EMAIL, BLOCKED_EMAIL)
 
 GRANT_CREDITS = 40.0
 FREE_CEILING = 2
@@ -121,7 +123,7 @@ class TestSelfServeSignup(IntegrationTestCase):
 		`.message` off what this returns when there is a document.
 		"""
 		mailer = patch("frappe.sendmail", return_value=None)
-		mailer.start()
+		self.mailer = mailer.start()
 		self.addCleanup(mailer.stop)
 		self.addCleanup(setattr, frappe.flags, "mute_emails", frappe.flags.mute_emails)
 		frappe.flags.mute_emails = True
@@ -168,6 +170,10 @@ class TestSelfServeSignup(IntegrationTestCase):
 					frappe.delete_doc(doctype, email, force=True, ignore_permissions=True)
 
 	# --- Assertions the whole module shares -----------------------------------
+
+	def mails_to(self, email: str) -> int:
+		"""Sends to one address. The waitlist notice goes out to the whole list at once."""
+		return len([call for call in self.mailer.call_args_list if call.kwargs["recipients"] == [email]])
 
 	def assert_granted_once(self, email: str) -> None:
 		grants = frappe.get_all(
@@ -383,16 +389,26 @@ class TestSelfServeSignup(IntegrationTestCase):
 		self.assertTrue(waitlist.join(EMAIL)["joined"])
 
 	def test_a_retirement_notice_goes_out_once_per_entry(self):
+		"""Once per *entry*, so the count that matters is per address, not the site-wide total.
+
+		`notify_of_signup` mails every un-invited row on the waitlist, and a dev site holds real
+		ones. The already-invited entry is the control: it proves the one-shot is stored on the row
+		rather than inferred from the run.
+		"""
 		self.set_setting("waitlist_open", 1)
 		waitlist.join(EMAIL)
+		waitlist.join(NOTIFIED_EMAIL)
+		invited_on = now_datetime()
+		frappe.db.set_value(WAITLIST, NOTIFIED_EMAIL, "invite_sent_on", invited_on, update_modified=False)
 		self.set_setting("waitlist_open", 0)
 
-		first = waitlist.notify_of_signup()
-		second = waitlist.notify_of_signup()
+		waitlist.notify_of_signup()
+		waitlist.notify_of_signup()
 
-		self.assertEqual(first["notified"], 1)
-		self.assertEqual(second["notified"], 0, "an operator re-running this must not mail anybody twice")
+		self.assertEqual(self.mails_to(EMAIL), 1, "an operator re-running this must not mail anybody twice")
+		self.assertEqual(self.mails_to(NOTIFIED_EMAIL), 0, "an invited entry is never mailed again")
 		self.assertIsNotNone(frappe.db.get_value(WAITLIST, EMAIL, "invite_sent_on"))
+		self.assertEqual(frappe.db.get_value(WAITLIST, NOTIFIED_EMAIL, "invite_sent_on"), invited_on)
 
 	def test_the_retirement_notice_is_denied_to_a_non_admin(self):
 		frappe.set_user("Guest")


### PR DESCRIPTION
Applies the rule settled in
[#196](https://github.com/Venkateshvenki404224/benchpress/issues/196) and closes
[#203](https://github.com/Venkateshvenki404224/benchpress/issues/203).

Three modules called a production function that scans the whole site, then
asserted on the whole result. They failed on any developer site with real rows.
The global equality was not "correct but unrunnable here" either: on CI's empty
site `enforce_limits()["stopped"] == [my bench]` also passes for a sweep that
stopped every bench on it.

**Every assertion narrows to a fixture universe the test owns, and each
discrimination test owns a control row that must survive.** No production code
moves.

### `test_credit_sweep`

`enforce_limits` decides per **owner**, so the control is a second funded owner
— `sweep-neighbour@example.com` with its own lab and running bench — not a
second bench under the fixture owner. Three helpers carry it: `ours()` filters a
bench-name list to the class's own rows, `alerts_for()` and `emails_for()` count
notices per recipient.

The reaper half read the whole site too, and passed only because no bench on
this host has sat stopped past the window. It is scoped the same way rather than
left to fail later, so the module has no whole-site read left except the two
assertions on `_nothing_to_do()`, which are deterministic.

### `test_signup`

The property is once per **entry**, so the fixture gets two waitlist rows, one
already carrying `invite_sent_on`. The test asserts on the rows and on the
`frappe.sendmail` spy per recipient, over two runs of `notify_of_signup`.

### `test_demo_data`

`demo_universe()` names the field and values that bound each seeded doctype, and
`demo_rows()` reads only those. Beyond the two the issue named, this also scopes
`test_every_widget_status_is_represented` and
`test_deploy_logs_span_the_chart_timespan`: both were `assertTrue` over
site-wide counts, so they passed here even if the seeder did nothing.

### The skill

`references/ralph-loop.md` drops the three modules from the fence list and
rewrites the two claims that went with them. `test_lease` stays, now with the
real reason — `guard._enforce` prices a restart against the caller instead of
the bench owner
([#202](https://github.com/Venkateshvenki404224/benchpress/issues/202)), a
production bug that no phase spec can work around.

## Verification

| Module | Before | After |
| --- | --- | --- |
| `test_credit_sweep` | 5 failures, exit 1 | 19 tests, exit 0 |
| `test_signup` | 1 failure, exit 1 | 25 tests, exit 0 |
| `test_demo_data` | 1 failure, exit 1 | 5 tests, exit 0 |

Exit codes read from `$?`, never from the last output line.

**The check the old assertion could not make.** With `_out_of_credits` forced to
return `True` for every owner, `test_a_spent_balance_stops_a_running_instance`
fails, naming the neighbour's bench in the diff. The control row is what buys
that.

**`--app benchpress` against this live site does not repeat.** Three runs of the
same tree gave one failure, then four, then one. The stable one is `test_lease`.
The other three were `test_api` blowing a 600 ms budget at 1,473 ms under
whole-suite load, `test_credit_guard` taking a Docker 404 on `guard-container`,
and a second `test_lease` error — all three pass when their module is run alone.
That instability is now recorded in the skill beside the "never `--app`" rule.
