### PR TITLE
Implemented phase two

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -342,3 +342,13 @@ static markup of a session that is not running anywhere.
   socket path (`unix:///var/run/docker.sock`), read at
   [docker_manager.py:132](benchpress/docker_manager.py#L132). Pointing it at a `tcp://` address on
   another host is the one edit that breaks the rule.
+- **No secret may reach a `docker exec` command line, a healthcheck command line, or a file
+  written through an exec.** Pass it as `environment=`, send a hash the server accepts, or upload
+  it with `put_archive`. Docker publishes every exec command into its event stream in full and
+  untruncated, and publishes no environment at all, so anything on that line is readable by
+  anything holding the socket. A sentinel test guards each site
+  ([test_docker_manager.py](benchpress/tests/test_docker_manager.py),
+  [test_vpn_adapter.py](benchpress/tests/test_vpn_adapter.py),
+  [test_mariadb_manager.py](benchpress/tests/test_mariadb_manager.py),
+  [test_deploy_manager.py](benchpress/tests/test_deploy_manager.py)). Base64 is not a defence:
+  `mariadb_manager.execute_sql` encodes its script and the encoding is on the line too.

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -876,9 +876,9 @@ def _start_code_server(bench, container_id: str, pipeline, settings) -> None:
 	"""Configure code-server, launch it, and only then claim it is up.
 
 	Every exec is checked. The config write decides whether code-server can authenticate at
-	all, the `chown`/`chmod` decides whether it reads that file or leaks the password to every
-	account in the container, and `restart.sh` is what actually launches it — a deploy that
-	reports a `code_server_url` answering nothing is worse than one that fails here.
+	all, the `chown` decides whether it reads that file, and `restart.sh` is what actually
+	launches it — a deploy that reports a `code_server_url` answering nothing is worse than
+	one that fails here.
 
 	The address is cleared before the attempt and stored after it, so a failed launch leaves
 	the field empty and `LabHeader.showCodeServer` hides the button instead of offering a
@@ -891,10 +891,12 @@ def _start_code_server(bench, container_id: str, pipeline, settings) -> None:
 	config_yaml = f"bind-addr: 0.0.0.0:8080\nauth: password\npassword: {code_server_password}\ncert: false\n"
 	config_path = f"{cs_home}/.config/code-server/config.yaml"
 
-	write_file_to_container(container_id, config_yaml, config_path)
+	write_file_to_container(container_id, config_yaml, config_path, mode=0o600)
+	# The tar header set the mode, but `linkuser.sh` minted the tenant account and this
+	# caller does not know its id, so the ownership fix still runs as its own exec.
 	_checked_exec(
 		container_id,
-		f"chown -R {cs_user}:{cs_user} {cs_home}/.config && chmod 600 {config_path}",
+		f"chown -R {cs_user}:{cs_user} {cs_home}/.config",
 		"Securing the code-server config",
 	)
 	_checked_exec(container_id, "bash /opt/benchpress/scripts/restart.sh", "restart.sh")

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -505,18 +505,20 @@ def _cleanup_failed_deploy(bench, container_id, append_log) -> None:
 	bench.wg_ip = None
 
 
-def build_linkuser_args(bench, lab, settings, ssh_password: str) -> list[str]:
+def build_linkuser_args(bench, lab, settings) -> list[str]:
 	"""Positional arguments for linkuser.sh, in the order the script reads them.
 
 	Order must match scripts/linkuser.sh:
-	USERNAME EMAIL LAB_NAME WG_IP SSH_PASSWORD BENCH_NAME BASE_DOMAIN LOGIN_SHELL
+	USERNAME EMAIL LAB_NAME WG_IP BENCH_NAME BASE_DOMAIN LOGIN_SHELL
+
+	The SSH password is not among them. It travels in the exec environment, which Docker
+	does not publish, while it publishes every command line in full.
 	"""
 	return [
 		bench.ssh_username,
 		bench.owner,
 		lab.title,
 		bench.wg_ip or "0.0.0.0",
-		ssh_password,
 		bench.bench_name,
 		settings.base_domain or "localhost",
 		lab.shell or "/bin/bash",
@@ -789,7 +791,7 @@ def _deploy_bench(bench_name: str) -> None:
 			bench.ssh_username = bench._derive_username(bench.owner)
 
 		ssh_password = secrets.token_urlsafe(12)
-		linkuser_args = build_linkuser_args(bench, lab, settings, ssh_password)
+		linkuser_args = build_linkuser_args(bench, lab, settings)
 		pipeline.step("ssh_user")
 		pipeline.log(f"linkuser.sh {bench.ssh_username}")
 		# The app's copy of linkuser.sh is authoritative over the one baked into the image.
@@ -800,7 +802,9 @@ def _deploy_bench(bench_name: str) -> None:
 			container_id, linkuser_script.read_text(), "/opt/benchpress/scripts/linkuser.sh"
 		)
 		linkuser_cmd = linkuser_command(linkuser_args)
-		exit_code, output = exec_in_container(container_id, linkuser_cmd, user="root")
+		exit_code, output = exec_in_container(
+			container_id, linkuser_cmd, user="root", environment={"SSH_PASSWORD": ssh_password}
+		)
 		if output:
 			pipeline.log(output.strip())
 		if exit_code != 0:

--- a/benchpress/docker_manager.py
+++ b/benchpress/docker_manager.py
@@ -6,6 +6,7 @@ import os
 import re
 import subprocess
 import time
+from pathlib import PurePosixPath
 
 import docker
 import frappe
@@ -526,21 +527,32 @@ def exec_in_container(
 	return exit_code, _decoded(output)
 
 
-def write_file_to_container(container_id: str, content: str, path: str) -> None:
-	"""Write a file into a running container using docker exec, raising when it did not land.
+# The exec environment, not its command line: Docker publishes every exec command into its
+# event stream in full and untruncated, and does not publish the environment at all.
+FILE_CONTENT_VAR = "BENCHPRESS_FILE_CONTENT"
 
-	The exec result used to be discarded, which made a failed write invisible: every caller
-	writes a file something later depends on — `common_site_config.json`, `wg0.conf`, the
-	code-server config — so a silent failure surfaced as a site that cannot find redis, a
-	tunnel serving the wrong key, or an IDE that never starts, long after the deploy said
-	it was fine.
+
+def write_file_to_container(container_id: str, content: str, path: str, *, mode: int | None = None) -> None:
+	"""Write a file into a running container, raising when it did not land.
+
+	The content travels in the exec environment. As a heredoc it was part of the command
+	line, so every file this ever wrote was published to anything reading Docker events —
+	a bench's WireGuard private key and its code-server password among them.
+
+	`mode` is applied only when given, so a file that already exists keeps the mode it had.
+
+	Not `put_archive`, which emits no event at all: sysbox re-mounts the container root over
+	Docker's own snapshot, so an upload lands in the snapshot and stays invisible inside.
 	"""
-	client = get_client()
-	container = client.containers.get(container_id)
-	escaped = content.replace("'", "'\\''")
+	container = get_client().containers.get(container_id)
+	directory = PurePosixPath(path).parent
+	command = f'mkdir -p {directory} && printf %s "${FILE_CONTENT_VAR}" > {path}'
+	if mode is not None:
+		command += f" && chmod {mode:o} {path}"
 	exit_code, output = container.exec_run(
-		cmd=["bash", "-c", f"mkdir -p $(dirname {path}) && cat > {path} << 'WGEOF'\n{escaped}\nWGEOF"],
+		cmd=["bash", "-c", command],
 		user="root",
+		environment={FILE_CONTENT_VAR: content},
 	)
 	if exit_code != 0:
 		raise Exception(f"Writing {path} failed (exit {exit_code}): {_decoded(output)}")

--- a/benchpress/lab-templates/scripts/linkuser.sh
+++ b/benchpress/lab-templates/scripts/linkuser.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 # linkuser.sh — User provisioning for BenchPress containers
 # Renames the 'frappe' user to the dynamic username instead of creating a new one.
-# Args: USERNAME EMAIL LAB_NAME WG_IP SSH_PASSWORD BENCH_NAME BASE_DOMAIN LOGIN_SHELL
+# Args: USERNAME EMAIL LAB_NAME WG_IP BENCH_NAME BASE_DOMAIN LOGIN_SHELL
+# SSH_PASSWORD comes from the environment, not from argv: Docker publishes an exec's
+# command line into its event stream and does not publish its environment.
 
 set -e
 
@@ -9,10 +11,9 @@ USERNAME="$1"
 EMAIL="$2"
 LAB_NAME="$3"
 WG_IP="$4"
-SSH_PASSWORD="$5"
-BENCH_NAME="$6"
-BASE_DOMAIN="$7"
-LOGIN_SHELL="${8:-/bin/bash}"
+BENCH_NAME="$5"
+BASE_DOMAIN="$6"
+LOGIN_SHELL="${7:-/bin/bash}"
 
 if [ -z "$USERNAME" ] || [ -z "$SSH_PASSWORD" ]; then
     echo "[error] USERNAME and SSH_PASSWORD are required"

--- a/benchpress/mariadb_manager.py
+++ b/benchpress/mariadb_manager.py
@@ -78,6 +78,15 @@ def _script(*statements: str) -> str:
 	return ";\n".join(statements) + ";\n"
 
 
+def _native_password_hash(password: str) -> str:
+	"""MariaDB's own `mysql_native_password` hash: `*` and SHA1(SHA1(password)) in upper hex.
+
+	Safe to publish, which is the whole point of using it. The server hashes what a client
+	sends once more before comparing, so a client presenting this value is refused.
+	"""
+	return "*" + hashlib.sha1(hashlib.sha1(password.encode()).digest()).hexdigest().upper()
+
+
 def _write_env_file(root_password: str, version: str = "10.6", mem_limit: str = "1g") -> None:
 	"""Write .env file for docker compose in the config directory."""
 	env_path = os.path.join(_get_config_dir(), ".env")
@@ -225,7 +234,10 @@ def create_mariadb_user(
 	exit_code, output = execute_sql(
 		db_server_name,
 		_script(
-			f"CREATE OR REPLACE USER '{user}'@'%' IDENTIFIED BY '{password}'",
+			# The hash, not the plaintext: `execute_sql` puts this script on a `docker exec`
+			# command line, and Docker publishes every one of those into its event stream.
+			f"CREATE OR REPLACE USER '{user}'@'%' "
+			f"IDENTIFIED VIA mysql_native_password USING '{_native_password_hash(password)}'",
 			f"CREATE OR REPLACE DATABASE `{user}`",
 			f"GRANT ALL ON `{user}`.* TO '{user}'@'%'",
 			f"GRANT RELOAD, CREATE USER ON *.* TO '{user}'@'%'",

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -7,6 +7,7 @@ import tempfile
 import unittest
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import docker
@@ -16,6 +17,7 @@ from frappe.tests import IntegrationTestCase
 
 from benchpress import docker_manager
 from benchpress.benchpress.doctype.bench_instance import get_instance_id
+from benchpress.tests.test_docker_manager import exec_commands, exec_environments
 
 # Any dotted quad, anywhere in the rendered file. The property routes must hold is that no
 # address of any kind appears — asserting one known IP is absent would pass for the next one.
@@ -837,12 +839,34 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		bench = self._bench()
 		self._enable_code_server()
 
-		self._run_deploy(bench, exec_failures={"chmod 600": (1, "Operation not permitted")})
+		self._run_deploy(bench, exec_failures={"chown -R": (1, "Operation not permitted")})
 
 		log = self._log(bench.name)
 		self.assertIn("Securing the code-server config failed (exit 1)", log)
 		self.assertNotIn("code-server ready at", log)
 		self.assertFalse(self._bench_field(bench, "code_server_url"))
+
+	@patch("benchpress.deploy_manager.secrets.token_urlsafe")
+	@patch("benchpress.docker_manager.get_client")
+	def test_the_code_server_password_goes_into_the_environment_and_into_no_command(self, get_client, token):
+		"""Docker publishes every exec command line, and the IDE password was in one."""
+		from benchpress import deploy_manager
+
+		sentinel = "cS1XnOtAr3alPassw0rd"
+		token.return_value = sentinel
+		container = get_client.return_value.containers.get.return_value
+		container.exec_run.return_value = (0, b"")
+		bench = self._bench()
+		bench.ssh_username = "tenant"
+
+		deploy_manager._start_code_server(
+			bench, "cid-cs", MagicMock(), SimpleNamespace(base_domain="localhost")
+		)
+
+		written = [env for env in exec_environments(container) if sentinel in str(env)]
+		self.assertEqual(len(written), 1)
+		for command in exec_commands(container):
+			self.assertNotIn(sentinel, command)
 
 	def test_a_working_step_ten_stores_the_tunnel_address_on_localhost(self):
 		bench = self._bench()

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -511,12 +511,11 @@ class TestDeployManager(IntegrationTestCase):
 		self.lab.shell = "/bin/zsh"
 		settings = frappe.get_single("BenchPress Settings")
 
-		args = build_linkuser_args(bench, self.lab, settings, "secret-pw")
+		args = build_linkuser_args(bench, self.lab, settings)
 
-		# 8 args: mount_target was removed, so LOGIN_SHELL immediately follows BASE_DOMAIN.
-		self.assertEqual(len(args), 8)
-		self.assertEqual(args[4], "secret-pw")  # SSH_PASSWORD position
-		self.assertEqual(args[6], settings.base_domain or "localhost")  # BASE_DOMAIN position
+		# 7 args: mount_target was removed, and SSH_PASSWORD now travels in the environment.
+		self.assertEqual(len(args), 7)
+		self.assertEqual(args[5], settings.base_domain or "localhost")  # BASE_DOMAIN position
 		self.assertEqual(args[-1], "/bin/zsh")  # LOGIN_SHELL position (right after BASE_DOMAIN)
 
 	def test_build_linkuser_args_defaults_shell_to_bash(self):
@@ -527,7 +526,7 @@ class TestDeployManager(IntegrationTestCase):
 		self.lab.shell = None
 		settings = frappe.get_single("BenchPress Settings")
 
-		args = build_linkuser_args(bench, self.lab, settings, "pw")
+		args = build_linkuser_args(bench, self.lab, settings)
 
 		self.assertEqual(args[-1], "/bin/bash")
 
@@ -645,6 +644,7 @@ class TestDeployStepMarkers(IntegrationTestCase):
 			patch("benchpress.vpn_adapter.create_container_peer", autospec=True) as mock_peer,
 		):
 			self.cert_check = mock_cert
+			self.execs = mock_exec
 			mock_infra.return_value = self.db_server_name
 			mock_runtimes.return_value = {"names": set(registered_runtimes), "default": "runc"}
 			mock_runtime_of.return_value = "sysbox-runc"
@@ -845,6 +845,21 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		self.assertIn("Securing the code-server config failed (exit 1)", log)
 		self.assertNotIn("code-server ready at", log)
 		self.assertFalse(self._bench_field(bench, "code_server_url"))
+
+	@patch("benchpress.deploy_manager.secrets.token_urlsafe")
+	def test_the_ssh_password_goes_into_the_environment_and_into_no_command(self, token):
+		"""Docker publishes every exec command line, and linkuser.sh read the password from argv."""
+		sentinel = "sS1XnOtAr3alPassw0rd"
+		token.return_value = sentinel
+		bench = self._bench()
+
+		self._run_deploy(bench)
+
+		linkuser = [call for call in self.execs.call_args_list if "linkuser.sh" in call.args[1]]
+		self.assertEqual(len(linkuser), 1)
+		self.assertEqual(linkuser[0].kwargs.get("environment"), {"SSH_PASSWORD": sentinel})
+		for call in self.execs.call_args_list:
+			self.assertNotIn(sentinel, call.args[1])
 
 	@patch("benchpress.deploy_manager.secrets.token_urlsafe")
 	@patch("benchpress.docker_manager.get_client")

--- a/benchpress/tests/test_docker_manager.py
+++ b/benchpress/tests/test_docker_manager.py
@@ -65,23 +65,69 @@ IP_ATTRS = {"NetworkSettings": {"Networks": {"benchpress": {"IPAddress": "172.30
 NO_IP_ATTRS = {"NetworkSettings": {"Networks": {"benchpress": {"IPAddress": ""}}}}
 
 
-class TestWriteFileToContainer(unittest.TestCase):
-	"""The exec result used to be discarded, so a file that never landed looked written."""
+def exec_commands(container):
+	"""Every command a mocked container was asked to exec, as text."""
+	return [" ".join(call.kwargs["cmd"]) for call in container.exec_run.call_args_list]
 
-	def _client_exec_returning(self, result):
+
+def exec_environments(container):
+	"""Every environment a mocked container's execs carried."""
+	return [call.kwargs.get("environment") or {} for call in container.exec_run.call_args_list]
+
+
+class TestWriteFileToContainer(unittest.TestCase):
+	"""Docker publishes an exec's command line and not its environment, so the file rides in the environment."""
+
+	def _container(self, result=(0, b"")):
 		client = MagicMock()
-		client.containers.get.return_value.exec_run.return_value = result
-		return client
+		container = client.containers.get.return_value
+		container.exec_run.return_value = result
+		return client, container
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_the_content_goes_into_the_environment_and_into_no_command(self, get_client):
+		sentinel = "sB1XnOtAr3alPr1vat3K3y="
+		client, container = self._container()
+		get_client.return_value = client
+
+		docker_manager.write_file_to_container("cid", f"PrivateKey = {sentinel}\n", "/etc/wireguard/wg0.conf")
+
+		environment = exec_environments(container)[0]
+		self.assertIn(sentinel, environment[docker_manager.FILE_CONTENT_VAR])
+		for command in exec_commands(container):
+			self.assertNotIn(sentinel, command)
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_a_mode_is_applied_in_the_same_exec(self, get_client):
+		"""The caller's second exec to repair the mode is what this replaces."""
+		client, container = self._container()
+		get_client.return_value = client
+
+		docker_manager.write_file_to_container("cid", "conf", "/etc/wireguard/wg0.conf", mode=0o600)
+
+		self.assertIn("chmod 600 /etc/wireguard/wg0.conf", exec_commands(container)[0])
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_no_mode_leaves_an_existing_file_the_mode_it_had(self, get_client):
+		"""`common_site_config.json` and `linkuser.sh` ship in the image already; a
+		default here would silently restate their modes."""
+		client, container = self._container()
+		get_client.return_value = client
+
+		docker_manager.write_file_to_container("cid", "{}", "/home/frappe/x.json")
+
+		self.assertNotIn("chmod", exec_commands(container)[0])
 
 	@patch("benchpress.docker_manager.get_client")
 	def test_a_zero_exit_returns_without_complaint(self, get_client):
-		get_client.return_value = self._client_exec_returning((0, b""))
+		get_client.return_value = self._container()[0]
 
 		docker_manager.write_file_to_container("cid", "hello", "/etc/wireguard/wg0.conf")
 
 	@patch("benchpress.docker_manager.get_client")
 	def test_a_non_zero_exit_raises_naming_the_path_and_the_output(self, get_client):
-		get_client.return_value = self._client_exec_returning((1, b"Read-only file system"))
+		"""A bench whose wg0.conf did not land has no tunnel, and nothing else would say so."""
+		get_client.return_value = self._container((1, b"Read-only file system"))[0]
 
 		with self.assertRaises(Exception) as caught:
 			docker_manager.write_file_to_container("cid", "hello", "/etc/wireguard/wg0.conf")

--- a/benchpress/tests/test_mariadb_manager.py
+++ b/benchpress/tests/test_mariadb_manager.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026, Venkatesh and Contributors
 # See license.txt
 
+import base64
 import hashlib
 import io
 import os
@@ -10,6 +11,12 @@ from unittest.mock import MagicMock, patch
 
 import frappe
 from frappe.tests import IntegrationTestCase
+
+
+def _sql_sent(container):
+	"""The SQL a mocked `execute_sql` piped in, decoded back out of the base64 on its command line."""
+	command = " ".join(container.exec_run.call_args_list[0].kwargs["cmd"])
+	return base64.b64decode(command.split("'")[1]).decode()
 
 
 class TestMariadbManager(IntegrationTestCase):
@@ -129,6 +136,40 @@ class TestMariadbManager(IntegrationTestCase):
 		for call in mock_container.exec_run.call_args_list:
 			cmd = call.kwargs.get("cmd") or call.args[0]
 			self.assertNotIn(sentinel, " ".join(cmd))
+
+	@patch("benchpress.mariadb_manager._random_string")
+	@patch("benchpress.mariadb_manager.get_client")
+	@patch("benchpress.mariadb_manager.frappe.get_doc")
+	def test_create_user_sends_the_hash_and_never_the_plaintext(
+		self, mock_get_doc, mock_get_client, mock_random
+	):
+		"""`execute_sql` puts its script on an exec command line, so the plaintext cannot be in it."""
+		from benchpress.mariadb_manager import _native_password_hash, create_mariadb_user
+
+		sentinel = "nOtAr3alUs3rPassw0rd"
+		mock_random.return_value = sentinel
+		mock_get_doc.return_value = self._make_mock_db_server()
+		mock_container = MagicMock()
+		mock_container.exec_run.return_value = (0, b"")
+		mock_get_client.return_value.containers.get.return_value = mock_container
+
+		_, _, password = create_mariadb_user("db-server-name", "mysite.localhost")
+
+		self.assertEqual(password, sentinel)
+		sql = _sql_sent(mock_container)
+		self.assertIn(_native_password_hash(sentinel), sql)
+		self.assertNotIn(sentinel, sql)
+
+	def test_the_native_hash_is_not_the_password(self):
+		"""The control: a hash that carried the plaintext would pass the test above."""
+		from benchpress.mariadb_manager import _native_password_hash
+
+		sentinel = "nOtAr3alUs3rPassw0rd"
+
+		native = _native_password_hash(sentinel)
+
+		self.assertNotIn(sentinel, native)
+		self.assertRegex(native, r"^\*[0-9A-F]{40}$")
 
 	def _make_backup_tar(self, name, data):
 		buffer = io.BytesIO()

--- a/benchpress/tests/test_vpn_adapter.py
+++ b/benchpress/tests/test_vpn_adapter.py
@@ -8,6 +8,7 @@ from frappe.tests import IntegrationTestCase
 
 from benchpress import vpn_adapter
 from benchpress.deploy_pipeline import DeployPipeline
+from benchpress.tests.test_docker_manager import exec_commands, exec_environments
 from benchpress.vpn_adapter import (
 	configure_container,
 	create_container_peer,
@@ -201,11 +202,26 @@ class TestConfigureContainer(IntegrationTestCase):
 	def test_writes_conf_and_brings_tunnel_up(self, mock_write, mock_exec, _render):
 		configure_container("cid123", "PRIV==", "172.27.0.5")
 
-		mock_write.assert_called_once_with("cid123", "CONF", "/etc/wireguard/wg0.conf")
+		mock_write.assert_called_once_with("cid123", "CONF", "/etc/wireguard/wg0.conf", mode=0o600)
 		commands = [call.args[1] for call in mock_exec.call_args_list]
-		self.assertIn("chmod 600 /etc/wireguard/wg0.conf", commands)
 		self.assertIn("wg-quick up wg0", commands)
 		self.assertLess(commands.index("wg-quick down wg0 || true"), commands.index("wg-quick up wg0"))
+
+	@patch("benchpress.vpn_adapter.render_container_config")
+	@patch("benchpress.docker_manager.get_client")
+	def test_the_private_key_goes_into_the_environment_and_into_no_command(self, get_client, render):
+		"""Docker publishes every exec command line, and a bench's tunnel key was in one."""
+		sentinel = "sB1XnOtAr3alPr1vat3K3y="
+		render.side_effect = lambda key, ip, network=None: f"[Interface]\nPrivateKey = {key}\n"
+		container = get_client.return_value.containers.get.return_value
+		container.exec_run.return_value = (0, b"")
+
+		configure_container("cid123", sentinel, "172.27.0.5")
+
+		written = [env for env in exec_environments(container) if sentinel in str(env)]
+		self.assertEqual(len(written), 1)
+		for command in exec_commands(container):
+			self.assertNotIn(sentinel, command)
 
 	@patch("benchpress.vpn_adapter.render_container_config", return_value="CONF")
 	@patch("benchpress.docker_manager.exec_in_container")
@@ -216,29 +232,17 @@ class TestConfigureContainer(IntegrationTestCase):
 		The interface is legitimately absent on a first deploy, and `|| true` is what makes
 		that tolerance visible rather than a discarded exit code.
 		"""
-		# chmod, a down that reports the interface was never there, then a good up.
-		mock_exec.side_effect = [(0, ""), (1, "wg-quick: `wg0' is not a WireGuard interface"), (0, "")]
+		# A down that reports the interface was never there, then a good up.
+		mock_exec.side_effect = [(1, "wg-quick: `wg0' is not a WireGuard interface"), (0, "")]
 
 		configure_container("cid123", "PRIV==", "172.27.0.5")
 
 	@patch("benchpress.vpn_adapter.render_container_config", return_value="CONF")
 	@patch("benchpress.docker_manager.exec_in_container")
 	@patch("benchpress.docker_manager.write_file_to_container")
-	def test_raises_when_the_conf_cannot_be_secured(self, _write, mock_exec, _render):
-		"""A world-readable wg0.conf hands the tunnel's private key to every account in the box."""
-		mock_exec.side_effect = [(1, "chmod: Operation not permitted")]
-
-		with self.assertRaises(Exception) as caught:
-			configure_container("cid123", "PRIV==", "172.27.0.5")
-
-		self.assertIn("Securing wg0.conf failed", str(caught.exception))
-
-	@patch("benchpress.vpn_adapter.render_container_config", return_value="CONF")
-	@patch("benchpress.docker_manager.exec_in_container")
-	@patch("benchpress.docker_manager.write_file_to_container")
 	def test_raises_when_wg_quick_fails(self, _write, mock_exec, _render):
-		# chmod, the tolerated down, then the up that decides the outcome.
-		mock_exec.side_effect = [(0, ""), (0, ""), (1, "wg-quick: boom")]
+		# The tolerated down, then the up that decides the outcome.
+		mock_exec.side_effect = [(0, ""), (1, "wg-quick: boom")]
 
 		with self.assertRaises(Exception) as caught:
 			configure_container("cid123", "PRIV==", "172.27.0.5")

--- a/benchpress/vpn_adapter.py
+++ b/benchpress/vpn_adapter.py
@@ -99,10 +99,7 @@ def configure_container(
 	from benchpress.docker_manager import exec_in_container, write_file_to_container
 
 	config = render_container_config(private_key, assigned_ip, network)
-	write_file_to_container(container_id, config, "/etc/wireguard/wg0.conf")
-	exit_code, output = exec_in_container(container_id, "chmod 600 /etc/wireguard/wg0.conf", user="root")
-	if exit_code != 0:
-		raise Exception(f"Securing wg0.conf failed inside container: {output}")
+	write_file_to_container(container_id, config, "/etc/wireguard/wg0.conf", mode=0o600)
 	# The one tolerated exec here: the interface may legitimately be down already, and
 	# `|| true` is what makes that tolerance visible rather than a discarded exit code.
 	exec_in_container(container_id, "wg-quick down wg0 || true", user="root")

--- a/setup.sh
+++ b/setup.sh
@@ -136,9 +136,10 @@ fi
 # Generate .env if it doesn't exist
 if [ ! -f "$ENV_FILE" ]; then
     info "Generating .env file for shared infrastructure..."
-    MARIADB_ROOT_PASSWORD=$(openssl rand -hex 16)
+    # Straight into the file, never through a shell variable: a variable holding it
+    # can be exported into a child process or echoed by a later edit.
     cat > "$ENV_FILE" <<EOF
-MARIADB_ROOT_PASSWORD=$MARIADB_ROOT_PASSWORD
+MARIADB_ROOT_PASSWORD=$(openssl rand -hex 16)
 MARIADB_VERSION=10.6
 MARIADB_MEM_LIMIT=1g
 EOF

--- a/setup.sh
+++ b/setup.sh
@@ -145,7 +145,6 @@ EOF
     success "Generated .env with random root password"
 else
     success ".env file already exists"
-    MARIADB_ROOT_PASSWORD=$(grep MARIADB_ROOT_PASSWORD "$ENV_FILE" | cut -d= -f2)
 fi
 
 # Ensure benchpress Docker network exists
@@ -174,7 +173,10 @@ success "Shared infrastructure is running"
 # Wait for MariaDB to be ready
 info "Waiting for MariaDB to accept connections..."
 for i in $(seq 1 30); do
-    if docker exec benchpress-mariadb mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "SELECT 1" &>/dev/null; then
+    # The image's own probe, which reads its credentials from a root-owned file inside the
+    # container. Passing the root password with -p published it on every attempt, because
+    # Docker puts an exec's command line into its event stream.
+    if docker exec benchpress-mariadb healthcheck.sh --connect --innodb_initialized &>/dev/null; then
         success "MariaDB is ready"
         break
     fi


### PR DESCRIPTION
Phase 1 of `secrets-off-the-exec-stream`.

`docker_manager.write_file_to_container` no longer builds a heredoc. The file
content travels in the exec environment, which the Docker daemon does not
publish; the command line carries the path and the mode only. Two `chmod` execs
go with it, because the write now applies the mode itself.

**`put_archive` — the planned transport — does not work on this host.** Bench
containers run `sysbox-runc`, which re-mounts the container root as its own
overlay over the snapshot Docker uploads into. Measured on a fresh container per
runtime, same image:

| Extraction | sysbox-runc | runc |
|---|---|---|
| `put_archive('/', 'etc/wireguard/wg0.conf')` | returns `True`, file absent inside | lands |
| `put_archive('/etc/wireguard', 'direct.conf')` | returns `True`, file absent inside | lands |
| `put_archive('/tmp', ...)` | lands | lands |

The first deploy on that design failed with ``wg-quick: `/etc/wireguard/wg0.conf'
does not exist``. `mariadb_manager.py` keeps its `put_archive` because
`benchpress-mariadb` is a runc container.

## How to verify

Captured `docker events` across a live deploy of bench
`01a5ba367a13e367fe64b5e5befc07c4`, which reached Running:

| Check | Result |
|---|---|
| `exec_create` events (control — the capture was live) | 46 |
| The exact WireGuard private key that landed in the container | 0 hits |
| The exact code-server password that landed in the container | 0 hits |
| `PrivateKey` / `WGEOF` anywhere in the stream | 0 |
| The bench SSH password (phase 2 owns it) | 2 hits, as expected |

What the daemon did publish:

```
exec_create: bash -c mkdir -p /etc/wireguard && printf %s "$BENCHPRESS_FILE_CONTENT" > /etc/wireguard/wg0.conf && chmod 600 /etc/wireguard/wg0.conf
```

Files landed with the modes and owners they had before, and the two the phase
tightens:

```
600 root:root                           /etc/wireguard/wg0.conf
600 administrator:administrator         /home/administrator/.config/code-server/config.yaml
644 administrator:administrator         .../sites/common_site_config.json
775 root:root                           /opt/benchpress/scripts/linkuser.sh
```

`wg show` reports the tunnel up. The IDE returns 302 with a session cookie for
its password and 200 for a wrong one.

Tests: `test_docker_manager`, `test_mariadb_manager`, `test_vpn_adapter`,
`test_deploy_manager` all exit 0. `uvx pre-commit@4.3.0 run --all-files` clean.