### PR TITLE
Implemented phase two

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,7 +907,7 @@ Device management is backed by the **VPN Peer** DocType in the vpn_management ap
 | Schedule | Function | Description |
 |----------|----------|-------------|
 | Every 1 minute | `benchpress.stats_collector.enqueue_stats_sweep` | Enqueues `collect_bench_stats`, which polls Docker CPU/memory/health for running containers (VPN transfer counters are updated by vpn_management's own `poll_status` job) |
-| Every 5 minutes | `benchpress.mariadb_manager.enqueue_health_check` | Enqueues `scheduled_health_check`: shared MariaDB health, restart if down |
+| Every 5 minutes | `benchpress.mariadb_manager.enqueue_health_check` | Enqueues `scheduled_health_check`: shared MariaDB health, restart if down, and logs any live setting that disagrees with the declared flags |
 | Daily at 2 AM | `benchpress.mariadb_manager.enqueue_backup` | Enqueues `scheduled_backup`: full MariaDB backup with 7-day retention |
 
 Every entry here is an enqueuer, not the work itself. Scheduled jobs land on the `default` queue,

--- a/README.md
+++ b/README.md
@@ -725,9 +725,7 @@ benchpress/
 |   +-- hooks.py                  # App config: routes, scheduler, ignore_links_on_delete
 |   +-- mariadb_manager.py        # Shared MariaDB + Redis lifecycle (docker compose)
 |   +-- config/
-|   |   +-- docker-compose.yml    # Shared infrastructure (MariaDB + Redis)
-|   |   +-- mariadb.cnf           # MariaDB custom configuration
-|   |   +-- redis.conf            # Redis custom configuration
+|   |   +-- docker-compose.yml    # Shared infrastructure (MariaDB + Redis), tuned by command flags
 |   |   +-- .env.example          # Environment variable template
 |   |   +-- benchpress-infra.service  # Systemd unit for auto-start on boot
 |   +-- lab-templates/

--- a/benchpress/benchpress/doctype/database_server/database_server.json
+++ b/benchpress/benchpress/doctype/database_server/database_server.json
@@ -21,8 +21,6 @@
   "memory_limit",
   "volume_name",
   "created_at",
-  "configuration_section",
-  "custom_config",
   "error_section",
   "error_message"
  ],
@@ -121,19 +119,6 @@
    "fieldtype": "Datetime",
    "label": "Created At",
    "read_only": 1
-  },
-  {
-   "collapsible": 1,
-   "fieldname": "configuration_section",
-   "fieldtype": "Section Break",
-   "label": "MariaDB Configuration"
-  },
-  {
-   "description": "Full MariaDB server config (INI). Seeded with sensible defaults on creation; edit to tune the server (e.g. max_connections, buffer pool). Re-run setup to apply.",
-   "fieldname": "custom_config",
-   "fieldtype": "Code",
-   "label": "Custom Config",
-   "options": "INI"
   },
   {
    "collapsible": 1,

--- a/benchpress/benchpress/doctype/database_server/database_server.py
+++ b/benchpress/benchpress/doctype/database_server/database_server.py
@@ -5,8 +5,6 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
-from benchpress.mariadb_manager import DEFAULT_MARIADB_CONFIG
-
 
 class DatabaseServer(Document):
 	def before_insert(self):
@@ -18,8 +16,6 @@ class DatabaseServer(Document):
 			self.image_tag = f"mariadb:{self.mariadb_version or '10.6'}"
 		if not self.volume_name:
 			self.volume_name = "benchpress-mariadb-data"
-		if not self.custom_config:
-			self.custom_config = DEFAULT_MARIADB_CONFIG
 
 	def get_root_password(self) -> str:
 		return self.get_password("mariadb_root_password")

--- a/benchpress/config/docker-compose.yml
+++ b/benchpress/config/docker-compose.yml
@@ -6,9 +6,16 @@ services:
     restart: always
     environment:
       MARIADB_ROOT_PASSWORD: ${MARIADB_ROOT_PASSWORD}
+    # Flags, not a mounted .cnf: this file is run from inside the backend container, so a
+    # relative bind reaches the host daemon as a path the host does not have. See
+    # tests/test_shared_compose.py.
+    command: >
+      mariadbd
+      --max-connections=500
+      --innodb-buffer-pool-size=128M
+      --key-buffer-size=16M
     volumes:
       - mariadb-data:/var/lib/mysql
-      - ./mariadb.cnf:/etc/mysql/conf.d/benchpress.cnf:ro
     mem_limit: ${MARIADB_MEM_LIMIT:-1g}
     networks:
       - benchpress
@@ -18,10 +25,13 @@ services:
     container_name: benchpress-redis
     hostname: benchpress-redis
     restart: always
-    command: redis-server /usr/local/etc/redis/redis.conf
+    command: >
+      redis-server
+      --maxmemory 256mb
+      --maxmemory-policy allkeys-lru
     volumes:
       - redis-data:/data
-      - ./redis.conf:/usr/local/etc/redis/redis.conf:ro
+    mem_limit: 512m
     networks:
       - benchpress
 

--- a/benchpress/config/mariadb.cnf
+++ b/benchpress/config/mariadb.cnf
@@ -1,6 +1,0 @@
-[mysqld]
-character-set-server=utf8mb4
-collation-server=utf8mb4_unicode_ci
-innodb_buffer_pool_size=536870912
-max_connections=500
-wait_timeout=28800

--- a/benchpress/config/redis.conf
+++ b/benchpress/config/redis.conf
@@ -1,3 +1,0 @@
-maxmemory 256mb
-maxmemory-policy allkeys-lru
-appendonly yes

--- a/benchpress/diagnostics.py
+++ b/benchpress/diagnostics.py
@@ -21,10 +21,15 @@ from benchpress.docker_manager import (
 	get_client,
 	host_runtimes,
 )
-from benchpress.mariadb_manager import check_mariadb_health
+from benchpress.mariadb_manager import (
+	REDIS_CONTAINER_NAME,
+	check_mariadb_health,
+	mariadb_drift,
+	redis_drift,
+)
 from benchpress.vpn_adapter import DEFAULT_INTERFACE
 
-REDIS_CONTAINER_NAME = "benchpress-redis"
+DRIFT_FIX = "Recreate the shared pair: docker compose up -d in benchpress/config"
 
 # Not an operator preference: past this, arithmetic on a stored deadline is wrong.
 # Two seconds absorbs MariaDB truncating NOW() to whole seconds; what it catches
@@ -179,13 +184,19 @@ def _check_mariadb() -> dict:
 				"No Database Server record — shared MariaDB is provisioned on first deploy",
 			)
 		server = servers[0]
-		if check_mariadb_health(server.name):
-			return check_row("mariadb", True, f"MariaDB responding at {server.container_name}")
-		return check_row(
-			"mariadb",
-			False,
-			f"MariaDB at {server.container_name} is not answering SELECT 1 (doc status: {server.status})",
-		)
+		if not check_mariadb_health(server.name):
+			return check_row(
+				"mariadb",
+				False,
+				f"MariaDB at {server.container_name} is not answering SELECT 1 (doc status: {server.status})",
+			)
+		drift, hit_rate = mariadb_drift(server.name)
+		summary = f"MariaDB responding at {server.container_name}, buffer pool hit rate {hit_rate}"
+		if drift:
+			return check_row(
+				"mariadb", False, f"{summary}, but {'; '.join(drift)}. {DRIFT_FIX}", severity="Warning"
+			)
+		return check_row("mariadb", True, f"{summary}, on the declared settings")
 	except Exception as e:
 		return check_row("mariadb", False, f"Could not check MariaDB: {e}")
 
@@ -213,11 +224,24 @@ def _check_clock_skew() -> dict:
 
 
 def _check_redis() -> dict:
+	"""Running is not enough — a stock Redis is unbounded and never evicts.
+
+	Drift is a Warning, never an Error: the cache still serves every bench, and it stays
+	drifted until a human recreates the pair.
+	"""
 	try:
 		container = get_client().containers.get(REDIS_CONTAINER_NAME)
-		if container.status == "running":
-			return check_row("redis", True, f"{REDIS_CONTAINER_NAME} is running")
-		return check_row("redis", False, f"{REDIS_CONTAINER_NAME} status is {container.status}")
+		if container.status != "running":
+			return check_row("redis", False, f"{REDIS_CONTAINER_NAME} status is {container.status}")
+		drift = redis_drift()
+		if drift:
+			return check_row(
+				"redis",
+				False,
+				f"{REDIS_CONTAINER_NAME} is running, but {'; '.join(drift)}. {DRIFT_FIX}",
+				severity="Warning",
+			)
+		return check_row("redis", True, f"{REDIS_CONTAINER_NAME} is running on the declared settings")
 	except docker.errors.NotFound:
 		return check_row(
 			"redis",

--- a/benchpress/mariadb_manager.py
+++ b/benchpress/mariadb_manager.py
@@ -18,14 +18,6 @@ from benchpress.docker_manager import ensure_network, get_client
 
 BACKUP_TIMEOUT = 3600
 
-DEFAULT_MARIADB_CONFIG = """[mysqld]
-character-set-server=utf8mb4
-collation-server=utf8mb4_unicode_ci
-innodb_buffer_pool_size=536870912
-max_connections=500
-wait_timeout=28800
-"""
-
 
 def _get_config_dir() -> str:
 	return os.path.join(frappe.get_app_path("benchpress"), "config")
@@ -96,15 +88,8 @@ def _write_env_file(root_password: str, version: str = "10.6", mem_limit: str = 
 		f.write(f"MARIADB_MEM_LIMIT={mem_limit}\n")
 
 
-def _write_mariadb_config(custom_config: str | None = None) -> None:
-	"""Write MariaDB config to persistent path (not /tmp/)."""
-	config_path = os.path.join(_get_config_dir(), "mariadb.cnf")
-	with open(config_path, "w") as f:  # nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal  # fmt: skip
-		f.write(custom_config or DEFAULT_MARIADB_CONFIG)
-
-
 def setup_database_server(db_server_name: str) -> None:
-	"""Full setup: write config, bring up MariaDB via docker compose, wait for ready."""
+	"""Full setup: write .env, bring up MariaDB via docker compose, wait for ready."""
 	db_server = frappe.get_doc("Database Server", db_server_name)
 
 	try:
@@ -112,7 +97,6 @@ def setup_database_server(db_server_name: str) -> None:
 		version = (db_server.mariadb_version or "10.6").strip()
 		mem_limit = db_server.memory_limit or "1g"
 
-		_write_mariadb_config(db_server.custom_config)
 		_write_env_file(root_password, version, mem_limit)
 		client = get_client()
 		ensure_network(client)

--- a/benchpress/mariadb_manager.py
+++ b/benchpress/mariadb_manager.py
@@ -18,6 +18,22 @@ from benchpress.docker_manager import ensure_network, get_client
 
 BACKUP_TIMEOUT = 3600
 
+REDIS_CONTAINER_NAME = "benchpress-redis"
+
+# What config/docker-compose.yml declares as command flags, in the units the servers report
+# back. A live value that disagrees means the container predates the flags, or the daemon
+# refused one, or somebody ran SET GLOBAL.
+DECLARED_MARIADB = {
+	"max_connections": "500",
+	"innodb_buffer_pool_size": "134217728",
+	"key_buffer_size": "16777216",
+}
+DECLARED_REDIS = {
+	"maxmemory": "268435456",
+	"maxmemory-policy": "allkeys-lru",
+}
+HIT_RATE_COUNTERS = ("Innodb_buffer_pool_read_requests", "Innodb_buffer_pool_reads")
+
 
 def _get_config_dir() -> str:
 	return os.path.join(frappe.get_app_path("benchpress"), "config")
@@ -363,8 +379,85 @@ def enqueue_health_check() -> None:
 	)
 
 
-def scheduled_health_check():
-	"""Cron job — check all active DB servers, attempt restart if down."""
+def _drift(declared: dict[str, str], live: dict[str, str]) -> list[str]:
+	"""Declared settings the live server disagrees with, phrased for an operator."""
+	return [
+		f"{name} is {live.get(name, 'unreadable')}, declared {value}"
+		for name, value in declared.items()
+		if live.get(name) != value
+	]
+
+
+def _mariadb_settings(db_server_name: str) -> dict[str, str]:
+	"""The declared variables and the buffer-pool counters, in one round trip."""
+	names = "', '".join([*DECLARED_MARIADB, *HIT_RATE_COUNTERS])
+	exit_code, output = execute_sql(
+		db_server_name,
+		_script(
+			f"SHOW GLOBAL VARIABLES WHERE Variable_name IN ('{names}')",
+			f"SHOW GLOBAL STATUS WHERE Variable_name IN ('{names}')",
+		),
+	)
+	if exit_code != 0:
+		raise Exception(f"could not read global settings: {output}")
+	rows = (line.split("\t", 1) for line in output.splitlines() if "\t" in line)
+	# Batch mode repeats a column header per result set.
+	return {name: value for name, value in rows if name != "Variable_name"}
+
+
+def _hit_rate(settings: dict[str, str]) -> str:
+	requests = int(settings.get("Innodb_buffer_pool_read_requests", "0"))
+	reads = int(settings.get("Innodb_buffer_pool_reads", "0"))
+	if not requests:
+		return "no reads yet"
+	return f"{100 * (requests - reads) / requests:.2f}%"
+
+
+def mariadb_drift(db_server_name: str) -> tuple[list[str], str]:
+	"""Declared settings the live server disagrees with, and its buffer-pool hit rate.
+
+	The hit rate is reported, never judged: the 128M pool rests on a single 99.94%
+	measurement, and the next person should revisit it on evidence rather than on the
+	assumption that put 512M there.
+	"""
+	settings = _mariadb_settings(db_server_name)
+	return _drift(DECLARED_MARIADB, settings), _hit_rate(settings)
+
+
+def redis_drift() -> list[str]:
+	"""Declared settings the live shared Redis disagrees with."""
+	container = get_client().containers.get(REDIS_CONTAINER_NAME)
+	exit_code, output = container.exec_run(cmd=["redis-cli", "config", "get", *DECLARED_REDIS])
+	if exit_code != 0:
+		raise Exception(f"redis-cli config get failed: {output}")
+	fields = output.decode("utf-8", errors="replace").split()
+	return _drift(DECLARED_REDIS, dict(zip(fields[::2], fields[1::2], strict=True)))
+
+
+def shared_setting_drift(db_server_name: str) -> tuple[list[str], str]:
+	"""Every declared setting the live shared pair disagrees with, and the buffer-pool hit rate.
+
+	Never raises: a service it cannot read becomes a line, because the scheduler is the
+	caller and a stack trace there is a log nobody reads.
+	"""
+	lines, hit_rate = [], "unreadable"
+	try:
+		drift, hit_rate = mariadb_drift(db_server_name)
+		lines += [f"MariaDB {line}" for line in drift]
+	except Exception as e:
+		lines.append(f"MariaDB settings unreadable: {e}")
+	try:
+		lines += [f"Redis {line}" for line in redis_drift()]
+	except Exception as e:
+		lines.append(f"Redis settings unreadable: {e}")
+	return lines, hit_rate
+
+
+def scheduled_health_check() -> list[str]:
+	"""Cron job — restart any DB server that is down, then report shared-setting drift.
+
+	Returns the drift lines it logged, so `bench execute` shows them too.
+	"""
 	servers = frappe.get_all(
 		"Database Server",
 		filters={"status": ["in", ["Active", "Error"]]},
@@ -383,6 +476,17 @@ def scheduled_health_check():
 				title=f"MariaDB health check failed: {s.name}",
 				message=frappe.get_traceback(),
 			)
+
+	if not servers:
+		return []
+
+	drift, hit_rate = shared_setting_drift(servers[0].name)
+	if drift:
+		frappe.log_error(
+			title="Shared service settings drift",
+			message="\n".join([*drift, f"InnoDB buffer pool hit rate {hit_rate}"]),
+		)
+	return drift
 
 
 def _host_backup_dir() -> str:

--- a/benchpress/mariadb_manager.py
+++ b/benchpress/mariadb_manager.py
@@ -453,10 +453,30 @@ def shared_setting_drift(db_server_name: str) -> tuple[list[str], str]:
 	return lines, hit_rate
 
 
+DRIFT_CACHE_KEY = "benchpress:shared_setting_drift"
+
+
+def _log_new_drift(lines: list[str], hit_rate: str) -> None:
+	"""Log a drift set only when it changes.
+
+	The check runs every five minutes and drift stays true until a human recreates the pair,
+	so logging unconditionally would bury the Error Log under 288 copies of one row a day.
+	"""
+	signature = "\n".join(lines)
+	if frappe.cache().get_value(DRIFT_CACHE_KEY) == signature:
+		return
+	frappe.cache().set_value(DRIFT_CACHE_KEY, signature)
+	if lines:
+		frappe.log_error(
+			title="Shared service settings drift",
+			message="\n".join([*lines, f"InnoDB buffer pool hit rate {hit_rate}"]),
+		)
+
+
 def scheduled_health_check() -> list[str]:
 	"""Cron job — restart any DB server that is down, then report shared-setting drift.
 
-	Returns the drift lines it logged, so `bench execute` shows them too.
+	Returns the current drift, so `bench execute` shows it even when the log row is a repeat.
 	"""
 	servers = frappe.get_all(
 		"Database Server",
@@ -481,11 +501,7 @@ def scheduled_health_check() -> list[str]:
 		return []
 
 	drift, hit_rate = shared_setting_drift(servers[0].name)
-	if drift:
-		frappe.log_error(
-			title="Shared service settings drift",
-			message="\n".join([*drift, f"InnoDB buffer pool hit rate {hit_rate}"]),
-		)
+	_log_new_drift(drift, hit_rate)
 	return drift
 
 

--- a/benchpress/tests/test_diagnostics.py
+++ b/benchpress/tests/test_diagnostics.py
@@ -39,6 +39,8 @@ HEALTHY_CEILINGS = {
 	"net.netfilter.nf_conntrack_max": 1048576,
 }
 DB_ROW = frappe._dict(name="db-server-1", status="Running", container_name="benchpress-mariadb")
+# (no drifted setting, buffer-pool hit rate) — what `mariadb_drift` answers on a healthy pair.
+NO_DRIFT = ([], "99.94%")
 
 # What this host really answers: MariaDB is UTC, Python is Asia/Calcutta.
 DB_CLOCK = datetime(2026, 8, 24, 23, 11, 53)
@@ -74,6 +76,8 @@ class TestDiagnostics(unittest.TestCase):
 		db_clock=None,
 		db_clock_error=None,
 		ceilings=None,
+		mariadb_drift=None,
+		redis_drift=None,
 	):
 		"""Run run_diagnostics with everything healthy unless overridden.
 
@@ -90,6 +94,8 @@ class TestDiagnostics(unittest.TestCase):
 				return_value=HOST_RUNTIMES if runtimes is None else runtimes,
 			),
 			patch("benchpress.diagnostics.check_mariadb_health", return_value=mariadb_healthy),
+			patch("benchpress.diagnostics.mariadb_drift", return_value=mariadb_drift or NO_DRIFT),
+			patch("benchpress.diagnostics.redis_drift", return_value=redis_drift or []),
 			# The capacity check reaches the daemon through docker_manager's own client rather
 			# than the one above, so the same client is injected there — and left unmocked
 			# beyond that, so `networks.create.assert_not_called()` really covers it.
@@ -276,3 +282,42 @@ class TestDiagnostics(unittest.TestCase):
 
 		self.assertEqual([row["check"] for row in DIAGNOSTICS_ROWS], CHECK_ORDER)
 		self.assertIn(COUNT_WORDS[len(CHECK_ORDER)], inspect.getdoc(_infrastructure))
+
+	def test_the_mariadb_row_always_reports_the_buffer_pool_hit_rate(self):
+		"""The 128M pool rests on one measurement, so the number stays in front of the operator."""
+		by_check, _rows = self._run()
+
+		self.assertEqual(by_check["mariadb"]["status"], "pass")
+		self.assertIn("99.94%", by_check["mariadb"]["hint"])
+
+	def test_a_drifted_mariadb_is_a_warning_that_names_the_setting(self):
+		by_check, _rows = self._run(mariadb_drift=(["max_connections is 151, declared 500"], "88.00%"))
+
+		row = by_check["mariadb"]
+		self.assertEqual(row["status"], "fail")
+		self.assertEqual(row["severity"], "Warning")
+		self.assertIn("max_connections is 151, declared 500", row["hint"])
+		self.assertIn("88.00%", row["hint"])
+		self.assertIn("docker compose up -d", row["hint"])
+
+	def test_a_redis_on_the_declared_settings_passes(self):
+		by_check, _rows = self._run()
+
+		self.assertEqual(by_check["redis"]["status"], "pass")
+		self.assertIn("declared settings", by_check["redis"]["hint"])
+
+	def test_a_running_but_unbounded_redis_is_a_warning_naming_both_settings(self):
+		"""Running was the whole old check, and a stock Redis passed it."""
+		by_check, _rows = self._run(
+			redis_drift=[
+				"maxmemory is 0, declared 268435456",
+				"maxmemory-policy is noeviction, declared allkeys-lru",
+			]
+		)
+
+		row = by_check["redis"]
+		self.assertEqual(row["status"], "fail")
+		self.assertEqual(row["severity"], "Warning")
+		self.assertIn("maxmemory is 0", row["hint"])
+		self.assertIn("noeviction", row["hint"])
+		self.assertIn("docker compose up -d", row["hint"])

--- a/benchpress/tests/test_mariadb_manager.py
+++ b/benchpress/tests/test_mariadb_manager.py
@@ -372,3 +372,123 @@ class TestMariadbManager(IntegrationTestCase):
 		self.assertIn(db_name, combined)
 		self.assertIn("DROP DATABASE", combined)
 		self.assertIn("DROP USER", combined)
+
+
+# What the server answers, batch mode's per-result-set header row included.
+LIVE_SETTINGS = "\n".join(
+	[
+		"Variable_name\tValue",
+		"innodb_buffer_pool_size\t134217728",
+		"key_buffer_size\t16777216",
+		"max_connections\t500",
+		"Variable_name\tValue",
+		"Innodb_buffer_pool_read_requests\t100000",
+		"Innodb_buffer_pool_reads\t60",
+	]
+)
+STOCK_SETTINGS = "\n".join(
+	[
+		"Variable_name\tValue",
+		"innodb_buffer_pool_size\t134217728",
+		"key_buffer_size\t134217728",
+		"max_connections\t151",
+		"Variable_name\tValue",
+		"Innodb_buffer_pool_read_requests\t0",
+		"Innodb_buffer_pool_reads\t0",
+	]
+)
+
+
+class TestSharedSettingDrift(IntegrationTestCase):
+	def _redis_answering(self, mock_get_client, payload: bytes):
+		container = MagicMock()
+		container.exec_run.return_value = (0, payload)
+		mock_get_client.return_value.containers.get.return_value = container
+		return container
+
+	@patch("benchpress.mariadb_manager.execute_sql")
+	def test_a_mariadb_on_the_declared_settings_reports_no_drift(self, mock_execute_sql):
+		from benchpress.mariadb_manager import mariadb_drift
+
+		mock_execute_sql.return_value = (0, LIVE_SETTINGS)
+
+		drift, hit_rate = mariadb_drift("db-1")
+
+		self.assertEqual(drift, [])
+		self.assertEqual(hit_rate, "99.94%")
+
+	@patch("benchpress.mariadb_manager.execute_sql")
+	def test_a_stock_mariadb_names_every_setting_that_disagrees(self, mock_execute_sql):
+		from benchpress.mariadb_manager import mariadb_drift
+
+		mock_execute_sql.return_value = (0, STOCK_SETTINGS)
+
+		drift, hit_rate = mariadb_drift("db-1")
+
+		self.assertEqual(
+			drift,
+			[
+				"max_connections is 151, declared 500",
+				"key_buffer_size is 134217728, declared 16777216",
+			],
+		)
+		self.assertEqual(hit_rate, "no reads yet")
+
+	@patch("benchpress.mariadb_manager.execute_sql")
+	def test_the_drift_read_costs_one_round_trip(self, mock_execute_sql):
+		"""It runs on the scheduler every five minutes, so both queries go in one exec."""
+		from benchpress.mariadb_manager import mariadb_drift
+
+		mock_execute_sql.return_value = (0, LIVE_SETTINGS)
+		mariadb_drift("db-1")
+
+		sql = mock_execute_sql.call_args.args[1]
+		self.assertEqual(mock_execute_sql.call_count, 1)
+		self.assertIn("SHOW GLOBAL VARIABLES", sql)
+		self.assertIn("SHOW GLOBAL STATUS", sql)
+
+	@patch("benchpress.mariadb_manager.get_client")
+	def test_a_redis_on_the_declared_settings_reports_no_drift(self, mock_get_client):
+		from benchpress.mariadb_manager import redis_drift
+
+		self._redis_answering(mock_get_client, b"maxmemory\n268435456\nmaxmemory-policy\nallkeys-lru\n")
+
+		self.assertEqual(redis_drift(), [])
+
+	@patch("benchpress.mariadb_manager.get_client")
+	def test_an_unbounded_redis_names_both_settings(self, mock_get_client):
+		"""The live fault this spec exists to end: no ceiling and nothing evictable."""
+		from benchpress.mariadb_manager import redis_drift
+
+		self._redis_answering(mock_get_client, b"maxmemory\n0\nmaxmemory-policy\nnoeviction\n")
+
+		self.assertEqual(
+			redis_drift(),
+			[
+				"maxmemory is 0, declared 268435456",
+				"maxmemory-policy is noeviction, declared allkeys-lru",
+			],
+		)
+
+	@patch("benchpress.mariadb_manager.redis_drift", side_effect=Exception("redis is gone"))
+	@patch("benchpress.mariadb_manager.mariadb_drift", side_effect=Exception("db is gone"))
+	def test_a_pair_it_cannot_read_is_a_line_and_not_an_exception(self, _mariadb, _redis):
+		from benchpress.mariadb_manager import shared_setting_drift
+
+		lines, hit_rate = shared_setting_drift("db-1")
+
+		self.assertEqual(
+			lines,
+			["MariaDB settings unreadable: db is gone", "Redis settings unreadable: redis is gone"],
+		)
+		self.assertEqual(hit_rate, "unreadable")
+
+	@patch("benchpress.mariadb_manager.redis_drift", return_value=["maxmemory is 0, declared 268435456"])
+	@patch("benchpress.mariadb_manager.mariadb_drift", return_value=([], "99.94%"))
+	def test_both_services_report_under_their_own_name(self, _mariadb, _redis):
+		from benchpress.mariadb_manager import shared_setting_drift
+
+		lines, hit_rate = shared_setting_drift("db-1")
+
+		self.assertEqual(lines, ["Redis maxmemory is 0, declared 268435456"])
+		self.assertEqual(hit_rate, "99.94%")

--- a/benchpress/tests/test_mariadb_manager.py
+++ b/benchpress/tests/test_mariadb_manager.py
@@ -492,3 +492,45 @@ class TestSharedSettingDrift(IntegrationTestCase):
 
 		self.assertEqual(lines, ["Redis maxmemory is 0, declared 268435456"])
 		self.assertEqual(hit_rate, "99.94%")
+
+	def _health_check_with(self, drift):
+		"""scheduled_health_check over one healthy server, with a cache that really remembers."""
+		cache = {}
+		with (
+			patch("benchpress.mariadb_manager.check_mariadb_health", return_value=True),
+			patch("benchpress.mariadb_manager.shared_setting_drift", side_effect=drift),
+			patch("benchpress.mariadb_manager.frappe") as mock_frappe,
+		):
+			mock_frappe.get_all.return_value = [frappe._dict(name="db-1")]
+			mock_frappe.cache.return_value.get_value.side_effect = cache.get
+			mock_frappe.cache.return_value.set_value.side_effect = cache.__setitem__
+			from benchpress.mariadb_manager import scheduled_health_check
+
+			returned = [scheduled_health_check() for _ in drift]
+		return returned, mock_frappe.log_error
+
+	def test_an_unchanged_drift_is_logged_once_and_not_every_five_minutes(self):
+		"""288 copies of one true row a day is the Error Log this check exists to be read in."""
+		drifted = (["Redis maxmemory is 0, declared 268435456"], "99.94%")
+
+		returned, log_error = self._health_check_with([drifted, drifted])
+
+		self.assertEqual(returned, [drifted[0], drifted[0]])
+		self.assertEqual(log_error.call_count, 1)
+		message = log_error.call_args.kwargs["message"]
+		self.assertIn("Redis maxmemory is 0, declared 268435456", message)
+		self.assertIn("InnoDB buffer pool hit rate 99.94%", message)
+
+	def test_a_drift_that_changes_is_logged_again(self):
+		redis_only = (["Redis maxmemory is 0, declared 268435456"], "99.94%")
+		both = (["MariaDB max_connections is 151, declared 500", *redis_only[0]], "99.94%")
+
+		_returned, log_error = self._health_check_with([redis_only, both])
+
+		self.assertEqual(log_error.call_count, 2)
+		self.assertIn("max_connections is 151", log_error.call_args.kwargs["message"])
+
+	def test_a_pair_that_agrees_logs_nothing(self):
+		_returned, log_error = self._health_check_with([([], "99.94%")])
+
+		log_error.assert_not_called()

--- a/benchpress/tests/test_mariadb_manager.py
+++ b/benchpress/tests/test_mariadb_manager.py
@@ -372,28 +372,3 @@ class TestMariadbManager(IntegrationTestCase):
 		self.assertIn(db_name, combined)
 		self.assertIn("DROP DATABASE", combined)
 		self.assertIn("DROP USER", combined)
-
-	@patch("benchpress.mariadb_manager._get_config_dir")
-	def test_write_mariadb_config_writes_custom_config_verbatim(self, mock_config_dir):
-		"""Database Server.custom_config flows verbatim into the mounted mariadb.cnf."""
-		from benchpress.mariadb_manager import _write_mariadb_config
-
-		with tempfile.TemporaryDirectory() as tmp:
-			mock_config_dir.return_value = tmp
-			custom = "[mysqld]\nmax_connections=1234\ninnodb_buffer_pool_size=1073741824\n"
-			_write_mariadb_config(custom)
-			with open(os.path.join(tmp, "mariadb.cnf")) as f:
-				written = f.read()
-		self.assertEqual(written, custom)
-
-	@patch("benchpress.mariadb_manager._get_config_dir")
-	def test_write_mariadb_config_falls_back_to_default(self, mock_config_dir):
-		"""An empty custom_config falls back to DEFAULT_MARIADB_CONFIG."""
-		from benchpress.mariadb_manager import DEFAULT_MARIADB_CONFIG, _write_mariadb_config
-
-		with tempfile.TemporaryDirectory() as tmp:
-			mock_config_dir.return_value = tmp
-			_write_mariadb_config(None)
-			with open(os.path.join(tmp, "mariadb.cnf")) as f:
-				written = f.read()
-		self.assertEqual(written, DEFAULT_MARIADB_CONFIG)

--- a/benchpress/tests/test_shared_compose.py
+++ b/benchpress/tests/test_shared_compose.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+"""The shared-infrastructure compose file may not declare a relative bind mount.
+
+`mariadb_manager._compose_cmd` runs `docker compose -f <this file>` from inside the backend
+container, so a relative source resolves against a container path and reaches the host daemon
+as an absolute path the host does not have. The daemon then creates a directory there and the
+service starts on stock defaults, silently. Both services sat like that for months: the fix is
+that every setting is now a `command:` flag, which a daemon that refuses one exits over.
+
+The guard is the fault class, not the instance — it rejects any relative source, in either the
+short `src:dst` form or the long `{type, source}` form.
+"""
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+import benchpress
+
+COMPOSE_PATH = Path(benchpress.__file__).parent / "config" / "docker-compose.yml"
+
+REASON = (
+	"docker compose runs this file from inside the backend container, so the relative source "
+	"{source!r} reaches the host daemon as a container path the host does not have. Pass the "
+	"setting as a command flag, or use a named volume."
+)
+
+
+class TestSharedCompose(unittest.TestCase):
+	def test_no_service_declares_a_relative_bind(self):
+		for service, source in _bind_sources(yaml.safe_load(COMPOSE_PATH.read_text())):
+			with self.subTest(service=service, source=source):
+				self.assertFalse(source.startswith("."), REASON.format(source=source))
+
+	def test_the_guard_can_fail(self):
+		"""A check that cannot fail is not a guard, and the real file can only ever pass now."""
+		offender = {
+			"services": {
+				"mariadb": {
+					"volumes": [
+						"mariadb-data:/var/lib/mysql",
+						"./mariadb.cnf:/etc/mysql/conf.d/benchpress.cnf:ro",
+					]
+				},
+				"redis": {
+					"volumes": [
+						{
+							"type": "bind",
+							"source": "../redis.conf",
+							"target": "/usr/local/etc/redis/redis.conf",
+						}
+					]
+				},
+			}
+		}
+		relative = [source for _, source in _bind_sources(offender) if source.startswith(".")]
+		self.assertEqual(relative, ["./mariadb.cnf", "../redis.conf"])
+
+
+def _bind_sources(compose: dict) -> list[tuple[str, str]]:
+	"""Every (service, source) pair, reading both the short `src:dst` and long `{source:}` forms."""
+	pairs = []
+	for service, definition in compose["services"].items():
+		for volume in definition.get("volumes", []):
+			source = volume["source"] if isinstance(volume, dict) else volume.split(":")[0]
+			pairs.append((service, source))
+	return pairs

--- a/docs/DESIGN_BRIEF.md
+++ b/docs/DESIGN_BRIEF.md
@@ -111,7 +111,7 @@ Fields: `site_name`, `full_domain`, `bench`, `admin_password`,
 
 Infrastructure, admin-only concern. Fields: `container_name`,
 `mariadb_version`, `port`, `container_ip`, `memory_limit`, `volume_name`,
-`custom_config`, `error_message`.
+`error_message`.
 
 **Status: `Pending` → `Active` → `Stopped` → `Error`**
 

--- a/docs/design_handoff_benchpress_ui/DESIGN_BRIEF.md
+++ b/docs/design_handoff_benchpress_ui/DESIGN_BRIEF.md
@@ -111,7 +111,7 @@ Fields: `site_name`, `full_domain`, `bench`, `admin_password`,
 
 Infrastructure, admin-only concern. Fields: `container_name`,
 `mariadb_version`, `port`, `container_ip`, `memory_limit`, `volume_name`,
-`custom_config`, `error_message`.
+`error_message`.
 
 **Status: `Pending` → `Active` → `Stopped` → `Error`**
 


### PR DESCRIPTION
## What this changes

`_compose_cmd` runs `benchpress/config/docker-compose.yml` from inside the backend container, so
both `./*.conf` binds reached the host daemon as container paths the host does not have. The
daemon created directories at those paths and both shared services have run on stock defaults
ever since — Redis on `maxmemory 0`, `noeviction` and no memory limit.

Both services now take their settings as `command:` flags:

```yaml
mariadb:  mariadbd --max-connections=500 --innodb-buffer-pool-size=128M --key-buffer-size=16M
redis:    redis-server --maxmemory 256mb --maxmemory-policy allkeys-lru
```

Redis also gains the `mem_limit: 512m` it never had. The buffer pool is pinned at the stock
128M, not the declared 512M: 512M does not fit under the 1g limit (a scratch container reached
779.6 MiB anon and went into swap) and buys nothing at a measured 99.94% hit rate.

Three dead surfaces go with the file nothing read: `DEFAULT_MARIADB_CONFIG`,
`_write_mariadb_config`, and `Database Server.custom_config`. The two config files themselves are
deleted, and `README.md` / `DESIGN_BRIEF.md` no longer name them.

`benchpress/tests/test_shared_compose.py` bans the fault class rather than the instance: no
service in that file may declare a relative bind, in either the short `src:dst` or the long
`{type, source}` form.

## How to verify

```bash
docker compose exec backend bench --site frontend run-tests --module benchpress.tests.test_shared_compose
docker compose exec backend bench --site frontend run-tests --module benchpress.tests.test_mariadb_manager
```

The flags themselves were proved on a scratch pair, which is what keeps this change off the live
containers:

```bash
docker run -d --name p1probe-db --memory 1g -e MARIADB_ROOT_PASSWORD=probe mariadb:10.6 \
  mariadbd --max-connections=500 --innodb-buffer-pool-size=128M --key-buffer-size=16M
docker exec p1probe-db mariadb -u root -pprobe -e \
  "SHOW GLOBAL VARIABLES WHERE Variable_name IN ('max_connections','innodb_buffer_pool_size','key_buffer_size')"
docker rm -f p1probe-db
```

Read back `max_connections 500`, `innodb_buffer_pool_size 134217728`, `key_buffer_size 16777216`,
and on the Redis probe `maxmemory 268435456` with `maxmemory-policy allkeys-lru`. A daemon that
refuses a flag exits rather than ignoring it, which is the loud failure the bind never had.

## Leftovers for a human

**The live pair still runs on stock defaults, deliberately.** A `command:` change applies only on
`docker compose up -d`, and that recreate briefly drops every running bench's database connection
and clears the shared Redis. Interrupting live tenants is a human's call:

```bash
cd benchpress/config && docker compose up -d
docker exec benchpress-redis redis-cli config get maxmemory-policy   # expect allkeys-lru
```

Two empty root-owned directories the daemon created remain on the host at
`/home/frappe/frappe-bench/apps/benchpress/benchpress/config/{mariadb.cnf,redis.conf}`. They are
outside this checkout, they are the live containers' current bind sources, and removing them
needs root — so they are part of the same recreate step, not of this branch:

```bash
sudo rmdir /home/frappe/frappe-bench/apps/benchpress/benchpress/config/{mariadb.cnf,redis.conf}
```

Phase 2 adds the drift check that tells an operator whether the recreate has happened. It will
report drift until it does, and that is correct.