### PR TITLE
fix(mariadb): resolve the shared container by name, not a stored id

### DIFF
--- a/benchpress/mariadb_manager.py
+++ b/benchpress/mariadb_manager.py
@@ -51,6 +51,10 @@ def _compose_cmd(*args: str) -> tuple[int, str]:
 	return result.returncode, output
 
 
+def _get_container(db_server):
+	return get_client().containers.get(db_server.container_name)
+
+
 def get_database_name(site_name: str) -> str:
 	"""Generate DB name from site name using SHA1 hash.
 	Follows press agent/bench.py:256-258 pattern.
@@ -70,8 +74,7 @@ def execute_sql(db_server_name: str, sql: str) -> tuple[int, str]:
 	also leaves no temp file to clean up on the failure path.
 	"""
 	db_server = frappe.get_doc("Database Server", db_server_name)
-	client = get_client()
-	container = client.containers.get(db_server.container_id)
+	container = _get_container(db_server)
 
 	encoded = base64.b64encode(sql.encode()).decode()
 	exit_code, output = container.exec_run(
@@ -362,8 +365,7 @@ def wait_for_mariadb(
 def get_container_logs(db_server_name: str, tail: int = 100) -> str:
 	"""Return recent container logs."""
 	db_server = frappe.get_doc("Database Server", db_server_name)
-	client = get_client()
-	container = client.containers.get(db_server.container_id)
+	container = _get_container(db_server)
 	return container.logs(tail=tail).decode("utf-8", errors="replace")
 
 
@@ -531,8 +533,7 @@ def backup_database_server(db_server_name: str, output_path: str = "/var/lib/mys
 	Returns the host path; on pull failure returns the in-container path (dump kept as fallback).
 	"""
 	db_server = frappe.get_doc("Database Server", db_server_name)
-	client = get_client()
-	container = client.containers.get(db_server.container_id)
+	container = _get_container(db_server)
 	root_pw = db_server.get_root_password()
 
 	timestamp = frappe.utils.now().replace(" ", "_").replace(":", "-")
@@ -566,8 +567,7 @@ def cleanup_old_backups(
 ) -> None:
 	"""Retain only the last `keep` backups on host disk; container prune catches failed-pull leftovers."""
 	db_server = frappe.get_doc("Database Server", db_server_name)
-	client = get_client()
-	container = client.containers.get(db_server.container_id)
+	container = _get_container(db_server)
 	container.exec_run(
 		cmd=[
 			"bash",
@@ -588,7 +588,7 @@ def restore_database_server(db_server_name: str, backup_file: str) -> None:
 	See docs/database-backup-restore.md for the full runbook.
 	"""
 	db_server = frappe.get_doc("Database Server", db_server_name)
-	container = get_client().containers.get(db_server.container_id)
+	container = _get_container(db_server)
 	root_pw = db_server.get_root_password()
 
 	dump_name = os.path.basename(backup_file)

--- a/benchpress/tests/test_mariadb_manager.py
+++ b/benchpress/tests/test_mariadb_manager.py
@@ -52,11 +52,28 @@ class TestMariadbManager(IntegrationTestCase):
 			get_database_name("site-b.localhost"),
 		)
 
-	def _make_mock_db_server(self, container_id="ctr-abc"):
+	def _make_mock_db_server(self, container_id="ctr-abc", container_name="benchpress-mariadb"):
 		db_server = MagicMock()
 		db_server.container_id = container_id
+		db_server.container_name = container_name
 		db_server.get_root_password.return_value = "rootpw"
 		return db_server
+
+	@patch("benchpress.mariadb_manager.get_client")
+	@patch("benchpress.mariadb_manager.frappe.get_doc")
+	def test_execute_sql_resolves_the_container_by_name_not_id(self, mock_get_doc, mock_get_client):
+		from benchpress.mariadb_manager import execute_sql
+
+		mock_get_doc.return_value = self._make_mock_db_server(container_id="stale-id")
+		mock_container = MagicMock()
+		mock_container.exec_run.return_value = (0, b"ok")
+		mock_get_client.return_value.containers.get.return_value = mock_container
+
+		execute_sql("db-server-name", "SELECT 1")
+
+		looked_up = mock_get_client.return_value.containers.get.call_args.args[0]
+		self.assertEqual(looked_up, "benchpress-mariadb")
+		self.assertNotEqual(looked_up, "stale-id")
 
 	@patch("benchpress.mariadb_manager.get_client")
 	@patch("benchpress.mariadb_manager.frappe.get_doc")


### PR DESCRIPTION
## The bug

A Docker container id is regenerated on every recreate. `Database Server` stores one, and five functions in `mariadb_manager` looked the shared MariaDB up by it:

| Function | Effect when the id goes stale |
|---|---|
| `execute_sql` | **a new bench gets no database and no user — every deploy fails** |
| `get_container_logs` | no MariaDB logs |
| `backup_database_server` | no backups |
| `cleanup_old_backups` | no rotation |
| `restore_database_server` | no restores |

This is not hypothetical. Applying PR #208's `command:` flags requires `docker compose up -d` on the shared services — which replaces the container. It ran on 2026-08-27 and left `docker inspect <stored id>` returning `no such object`, with `execute_sql` raising until the stored id was refreshed by hand. Running benches were unaffected: they reach MariaDB over the network by hostname, not through the Docker API.

`specs/TODO.md` lists that recreate as a routine leftover step, so this recurs on schedule.

## The fix

One helper, `_get_container`, resolving by `container_name` — which does not move. `start_database_server` already did this, which is why it was able to repair the stored id afterwards; the other five now match it.

`container_id` is still written by `setup_database_server` and `start_database_server` and stays as a record. Nothing outside this module reads it — the `container_id` hits elsewhere are bench container ids passed as parameters.

## Verified

- `uvx pre-commit@4.3.0 run --all-files` exit 0.
- No orphaned `client` locals left behind by the removed `client = get_client()` lines; module compiles.
- New regression test asserts the lookup argument is the name and not a stale id.

Built in a git worktree off `origin/version-16` (0e42034) so it stayed clear of the Ralph loop running `bench-bridge-placement` in the main checkout. The scoped test suite was therefore **not** run locally — that would have meant pointing the container at the loop's in-progress tree. CI runs it here.