### PR TITLE
Implemented phase two

### DIFF
--- a/benchpress/tests/fakes.py
+++ b/benchpress/tests/fakes.py
@@ -1,0 +1,283 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+"""One stateful in-memory Docker, installed at `docker_manager.get_client`.
+
+Tests read state (`self.docker.created[-1]`) rather than mock call records.
+"""
+
+from unittest.mock import patch
+
+import docker
+
+from benchpress import diagnostics, docker_manager, mariadb_manager
+
+# The modules that bind `get_client` at import instead of reaching it through
+# `docker_manager`, so `patch.object(docker_manager, ...)` alone misses them.
+# `test_fakes.TestGetClientImporters` re-derives this from source: a new
+# module-level import fails a test rather than reaching a real daemon.
+GET_CLIENT_MODULES = (docker_manager, mariadb_manager, diagnostics)
+
+DEFAULT_BLOCK_DEVICES = ["/dev/sda"]
+DEFAULT_INFO = {"Runtimes": {"runc": {}, "sysbox-runc": {}}, "DefaultRuntime": "runc"}
+DEFAULT_STATS = {
+	"cpu_stats": {
+		"cpu_usage": {"total_usage": 200_000_000},
+		"system_cpu_usage": 4_000_000_000,
+		"online_cpus": 2,
+	},
+	"precpu_stats": {"cpu_usage": {"total_usage": 100_000_000}, "system_cpu_usage": 2_000_000_000},
+	"memory_stats": {"usage": 128 * 1024 * 1024, "limit": 512 * 1024 * 1024},
+}
+
+
+class UnscriptedExec(AssertionError):
+	"""A strict FakeDocker was asked to run a command no test registered."""
+
+
+class FakeContainer:
+	def __init__(self, client, container_id, name, labels, network, runtime, ip, status="created"):
+		self.client = client
+		self.id = container_id
+		self.name = name
+		self.labels = labels or {}
+		self.status = status
+		self.health = ""
+		self.stats_response = dict(DEFAULT_STATS)
+		self.archives: dict[str, bytes] = {}
+		self.attrs = {
+			"HostConfig": {"Runtime": runtime or "runc", "NetworkMode": network},
+			"NetworkSettings": {"Networks": {network: {"IPAddress": ip}}, "IPAddress": ip},
+			"State": {"Health": {"Status": self.health}},
+		}
+
+	def exec_run(self, cmd=None, **kwargs):
+		return self.client._run_exec(cmd)
+
+	def start(self, **kwargs):
+		self.status = "running"
+
+	def stop(self, **kwargs):
+		self.status = "exited"
+
+	def restart(self, **kwargs):
+		self.status = "running"
+
+	def remove(self, **kwargs):
+		self.client._store.pop(self.id, None)
+
+	def reload(self):
+		self.attrs["State"]["Health"]["Status"] = self.health
+
+	def logs(self, **kwargs):
+		return b""
+
+	def stats(self, stream=False, **kwargs):
+		return self.stats_response
+
+	def get_archive(self, path, **kwargs):
+		data = self.archives.get(path, b"")
+		return iter([data]), {"name": path, "size": len(data)}
+
+	def put_archive(self, path, data):
+		self.client.archives_put.append((path, data))
+		return True
+
+
+class FakeNetwork:
+	def __init__(self, client, name, **kwargs):
+		self.client = client
+		self.name = name
+		self.kwargs = kwargs
+		self.attrs = {"Name": name, "Containers": {}}
+
+	def connect(self, container, **kwargs):
+		name = getattr(container, "name", container)
+		if name not in self.client._by_name:
+			raise docker.errors.NotFound(f"no such container: {name}")
+		found = self.client._by_name[name]
+		self.attrs["Containers"][found.id] = {"Name": name}
+
+
+class FakeVolume:
+	def __init__(self, name):
+		self.name = name
+		self.attrs = {"Name": name}
+
+
+class _Containers:
+	def __init__(self, client):
+		self.client = client
+
+	def get(self, key):
+		container = self.client._store.get(key) or self.client._by_name.get(key)
+		if container is None:
+			raise docker.errors.NotFound(f"no such container: {key}")
+		return container
+
+	def create(self, **kwargs):
+		self.client.created.append(kwargs)
+		return self.client._add(kwargs)
+
+	def run(self, image=None, command=None, **kwargs):
+		container = self.create(image=image, command=command, **kwargs)
+		container.start()
+		if kwargs.get("remove"):
+			container.remove()
+		return container
+
+	def list(self, all=False, filters=None):
+		found = list(self.client._store.values())
+		if not all:
+			found = [c for c in found if c.status == "running"]
+		for key, value in (filters or {}).items():
+			found = [c for c in found if _matches(c, key, value)]
+		return found
+
+
+class _Networks:
+	def __init__(self, client):
+		self.client = client
+
+	def get(self, name):
+		network = self.client._networks.get(name)
+		if network is None:
+			raise docker.errors.NotFound(f"no such network: {name}")
+		return network
+
+	def create(self, name, **kwargs):
+		network = FakeNetwork(self.client, name, **kwargs)
+		self.client._networks[name] = network
+		return network
+
+
+class _Volumes:
+	def __init__(self, client):
+		self.client = client
+
+	def get(self, name):
+		self.client.volume_gets.append(name)
+		volume = self.client._volumes.get(name)
+		if volume is None:
+			raise docker.errors.NotFound(f"no such volume: {name}")
+		return volume
+
+	def create(self, name=None, **kwargs):
+		volume = FakeVolume(name)
+		self.client._volumes[name] = volume
+		return volume
+
+
+class _Images:
+	def __init__(self, client):
+		self.client = client
+
+	def remove(self, tag, **kwargs):
+		self.client.images_removed.append(tag)
+
+
+def _matches(container, key, value) -> bool:
+	if key == "label":
+		wanted = value if isinstance(value, list) else [value]
+		return all(_has_label(container, term) for term in wanted)
+	if key == "status":
+		return container.status == value
+	if key == "name":
+		return value in container.name
+	raise AssertionError(f"FakeDocker does not filter on {key!r}")
+
+
+def _has_label(container, term: str) -> bool:
+	name, _, value = term.partition("=")
+	if not value:
+		return name in container.labels
+	return container.labels.get(name) == value
+
+
+class FakeDocker:
+	def __init__(self, *, strict: bool = False):
+		self.strict = strict
+		self.containers = _Containers(self)
+		self.networks = _Networks(self)
+		self.volumes = _Volumes(self)
+		self.images = _Images(self)
+		self.created: list[dict] = []
+		self.execs: list[str] = []
+		self.volume_gets: list[str] = []
+		self.images_removed: list[str] = []
+		self.archives_put: list[tuple[str, bytes]] = []
+		self.info_response = dict(DEFAULT_INFO)
+		self._scripted: list[tuple[str, tuple[int, bytes]]] = []
+		self._store: dict[str, FakeContainer] = {}
+		self._networks: dict[str, FakeNetwork] = {}
+		self._volumes: dict[str, FakeVolume] = {}
+		self._next_id = 0
+
+	def info(self):
+		return self.info_response
+
+	def script_exec(self, substring: str, result: tuple[int, bytes]) -> None:
+		"""Answer any exec whose command contains `substring` with `result`."""
+		self._scripted.append((substring, result))
+
+	def add_container(self, name, *, labels=None, status="running", health="", network="benchpress"):
+		"""Seed a container the app did not create, for `containers.get` and `list`."""
+		return self._add(
+			{"name": name, "labels": labels, "network": network},
+			status=status,
+			health=health,
+		)
+
+	def _add(self, kwargs, status="created", health=""):
+		self._next_id += 1
+		container_id = f"fake{self._next_id:04d}"
+		network = kwargs.get("network") or docker_manager.LEGACY_NETWORK
+		container = FakeContainer(
+			self,
+			container_id,
+			kwargs.get("name") or container_id,
+			kwargs.get("labels"),
+			network,
+			kwargs.get("runtime"),
+			f"172.30.0.{self._next_id % 250 + 2}",
+			status=status,
+		)
+		container.health = health
+		self._store[container_id] = container
+		return container
+
+	@property
+	def _by_name(self) -> dict[str, FakeContainer]:
+		return {c.name: c for c in self._store.values()}
+
+	def _run_exec(self, cmd) -> tuple[int, bytes]:
+		command = " ".join(cmd) if isinstance(cmd, list | tuple) else str(cmd)
+		self.execs.append(command)
+		for substring, result in self._scripted:
+			if substring in command:
+				return result
+		if self.strict:
+			raise UnscriptedExec(f"unscripted exec: {command}")
+		return 0, b""
+
+
+class FakeDockerMixin:
+	"""Installs a `FakeDocker` at every `get_client` binding, plus the two host reads."""
+
+	docker_strict = False
+
+	def setUp(self):
+		super().setUp()
+		self.docker = FakeDocker(strict=self.docker_strict)
+		for module in GET_CLIENT_MODULES:
+			self._install(module, "get_client", self.docker)
+		self.host_block_devices = self._install(
+			docker_manager, "_get_host_block_devices", list(DEFAULT_BLOCK_DEVICES)
+		)
+		self.compose_cmd = self._install(mariadb_manager, "_compose_cmd", (0, ""))
+
+	def _install(self, module, attribute, return_value):
+		patcher = patch.object(module, attribute, return_value=return_value)
+		mock = patcher.start()
+		self.addCleanup(patcher.stop)
+		return mock

--- a/benchpress/tests/fakes.py
+++ b/benchpress/tests/fakes.py
@@ -6,11 +6,13 @@
 Tests read state (`self.docker.created[-1]`) rather than mock call records.
 """
 
+import base64
 from unittest.mock import patch
 
 import docker
 
 from benchpress import diagnostics, docker_manager, mariadb_manager
+from benchpress.request_cache import clear_local_cache
 
 # The modules that bind `get_client` at import instead of reaching it through
 # `docker_manager`, so `patch.object(docker_manager, ...)` alone misses them.
@@ -35,6 +37,15 @@ class UnscriptedExec(AssertionError):
 	"""A strict FakeDocker was asked to run a command no test registered."""
 
 
+def _command_text(cmd) -> str:
+	return " ".join(cmd) if isinstance(cmd, list | tuple) else str(cmd)
+
+
+def sql_of(exec_command: str) -> str:
+	"""The SQL inside an `execute_sql` exec, which travels base64 so nothing is shell-interpolated."""
+	return base64.b64decode(exec_command.split("'")[1]).decode()
+
+
 class FakeContainer:
 	def __init__(self, client, container_id, name, labels, network, runtime, ip, status="created"):
 		self.client = client
@@ -44,6 +55,8 @@ class FakeContainer:
 		self.status = status
 		self.health = ""
 		self.stats_response = dict(DEFAULT_STATS)
+		self.execs: list[str] = []
+		self.start_refusal = ""
 		self.archives: dict[str, bytes] = {}
 		self.attrs = {
 			"HostConfig": {"Runtime": runtime or "runc", "NetworkMode": network},
@@ -52,18 +65,23 @@ class FakeContainer:
 		}
 
 	def exec_run(self, cmd=None, **kwargs):
+		self.execs.append(_command_text(cmd))
 		return self.client._run_exec(cmd)
 
 	def start(self, **kwargs):
+		if self.start_refusal:
+			raise docker.errors.APIError(self.start_refusal)
 		self.status = "running"
 
 	def stop(self, **kwargs):
+		self.client.stopped.append(self.name)
 		self.status = "exited"
 
 	def restart(self, **kwargs):
 		self.status = "running"
 
 	def remove(self, **kwargs):
+		self.client.removed.append(self.name)
 		self.client._store.pop(self.id, None)
 
 	def reload(self):
@@ -203,11 +221,14 @@ class FakeDocker:
 		self.images = _Images(self)
 		self.created: list[dict] = []
 		self.execs: list[str] = []
+		self.stopped: list[str] = []
+		self.removed: list[str] = []
 		self.volume_gets: list[str] = []
 		self.images_removed: list[str] = []
 		self.archives_put: list[tuple[str, bytes]] = []
 		self.info_response = dict(DEFAULT_INFO)
 		self._scripted: list[tuple[str, tuple[int, bytes]]] = []
+		self._start_refusals: dict[str, str] = {}
 		self._store: dict[str, FakeContainer] = {}
 		self._networks: dict[str, FakeNetwork] = {}
 		self._volumes: dict[str, FakeVolume] = {}
@@ -219,6 +240,10 @@ class FakeDocker:
 	def script_exec(self, substring: str, result: tuple[int, bytes]) -> None:
 		"""Answer any exec whose command contains `substring` with `result`."""
 		self._scripted.append((substring, result))
+
+	def refuse_start(self, name: str, message: str) -> None:
+		"""Make this container's `start()` raise `APIError`, the way a daemon refusing one does."""
+		self._start_refusals[name] = message
 
 	def add_container(self, name, *, labels=None, status="running", health="", network="benchpress"):
 		"""Seed a container the app did not create, for `containers.get` and `list`."""
@@ -243,6 +268,7 @@ class FakeDocker:
 			status=status,
 		)
 		container.health = health
+		container.start_refusal = self._start_refusals.get(container.name, "")
 		self._store[container_id] = container
 		return container
 
@@ -251,7 +277,7 @@ class FakeDocker:
 		return {c.name: c for c in self._store.values()}
 
 	def _run_exec(self, cmd) -> tuple[int, bytes]:
-		command = " ".join(cmd) if isinstance(cmd, list | tuple) else str(cmd)
+		command = _command_text(cmd)
 		self.execs.append(command)
 		for substring, result in self._scripted:
 			if substring in command:
@@ -271,6 +297,10 @@ class FakeDockerMixin:
 		self.docker = FakeDocker(strict=self.docker_strict)
 		for module in GET_CLIENT_MODULES:
 			self._install(module, "get_client", self.docker)
+		# `host_runtimes` memoises on `frappe.local`, which outlives a test, so a real daemon
+		# read taken earlier in the run would otherwise survive the fake.
+		clear_local_cache(docker_manager.HOST_RUNTIMES_ATTRIBUTE)
+		self.addCleanup(clear_local_cache, docker_manager.HOST_RUNTIMES_ATTRIBUTE)
 		self.host_block_devices = self._install(
 			docker_manager, "_get_host_block_devices", list(DEFAULT_BLOCK_DEVICES)
 		)

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -16,7 +16,7 @@ from frappe.tests import IntegrationTestCase
 
 from benchpress import ingress
 from benchpress.benchpress.doctype.bench_instance import get_instance_id
-from benchpress.tests.fakes import FakeDockerMixin
+from benchpress.tests.fakes import FakeDockerMixin, sql_of
 from benchpress.tests.test_docker_manager import exec_commands, exec_environments
 
 # Any dotted quad, anywhere in the rendered file. The property routes must hold is that no
@@ -154,6 +154,8 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 					"doctype": "Database Server",
 					"container_name": "test-db-server",
 					"mariadb_version": "10.6",
+					"status": "Active",
+					"mariadb_root_password": "test-root-password",
 				}
 			).insert(ignore_permissions=True)
 		cls.db_server_name = frappe.db.get_value(
@@ -175,13 +177,18 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 	def _fresh_bench(self):
 		return _fresh_bench(self, self.lab.name)
 
+	def _shared_mariadb_up(self):
+		"""A live container for every `Database Server` row, since a deploy resolves the oldest."""
+		for container_name in frappe.get_all("Database Server", pluck="container_name"):
+			self.docker.add_container(container_name)
+
 	# --- stop_bench ---
 
-	@patch("benchpress.deploy_manager.stop_container")
-	def test_stop_bench_sets_status_stopped(self, mock_stop):
+	def test_stop_bench_sets_status_stopped(self):
 		from benchpress.deploy_manager import stop_bench
 
 		bench = self._fresh_bench()
+		self.docker.add_container("container-xyz")
 		bench.container_id = "container-xyz"
 		bench.status = "Running"
 		bench.save(ignore_permissions=True)
@@ -191,20 +198,19 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 		bench.reload()
 		self.assertEqual(bench.status, "Stopped")
 
-	@patch("benchpress.deploy_manager.stop_container")
-	def test_stop_bench_calls_stop_container(self, mock_stop):
+	def test_stop_bench_calls_stop_container(self):
 		from benchpress.deploy_manager import stop_bench
 
 		bench = self._fresh_bench()
+		self.docker.add_container("container-stop-test")
 		bench.container_id = "container-stop-test"
 		bench.save(ignore_permissions=True)
 		frappe.db.commit()
 
 		stop_bench(bench.name)
-		mock_stop.assert_called_once_with("container-stop-test")
+		self.assertEqual(self.docker.stopped, ["container-stop-test"])
 
-	@patch("benchpress.deploy_manager.stop_container")
-	def test_stop_bench_skips_container_stop_when_no_container_id(self, mock_stop):
+	def test_stop_bench_skips_container_stop_when_no_container_id(self):
 		from benchpress.deploy_manager import stop_bench
 
 		bench = self._fresh_bench()
@@ -213,16 +219,16 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 		frappe.db.commit()
 
 		stop_bench(bench.name)
-		mock_stop.assert_not_called()
+		self.assertEqual(self.docker.stopped, [])
 		bench.reload()
 		self.assertEqual(bench.status, "Stopped")
 
-	@patch("benchpress.deploy_manager.stop_container")
-	def test_stop_bench_deactivates_every_site_on_the_bench(self, mock_stop):
+	def test_stop_bench_deactivates_every_site_on_the_bench(self):
 		"""Nothing answers inside a stopped container, so no row may stay Active."""
 		from benchpress.deploy_manager import stop_bench
 
 		bench = self._fresh_bench()
+		self.docker.add_container("container-stop-sites")
 		bench.container_id = "container-stop-sites"
 		bench.status = "Running"
 		bench.save(ignore_permissions=True)
@@ -237,12 +243,11 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 		self.assertEqual(statuses, ["Inactive", "Inactive"])
 
 	@patch("benchpress.deploy_manager._deploy_bench")
-	@patch("benchpress.deploy_manager.remove_container")
-	@patch("benchpress.deploy_manager.stop_container")
-	def test_redeploy_bench_resets_status_to_draft_before_deploy(self, mock_stop, mock_remove, mock_deploy):
+	def test_redeploy_bench_resets_status_to_draft_before_deploy(self, mock_deploy):
 		from benchpress.deploy_manager import redeploy_bench
 
 		bench = self._fresh_bench()
+		self.docker.add_container("old-container")
 		bench.container_id = "old-container"
 		bench.status = "Running"
 		bench.save(ignore_permissions=True)
@@ -261,12 +266,11 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 		self.assertEqual(status_at_deploy["status"], "Draft")
 
 	@patch("benchpress.deploy_manager._deploy_bench")
-	@patch("benchpress.deploy_manager.remove_container")
-	@patch("benchpress.deploy_manager.stop_container")
-	def test_redeploy_bench_never_touches_volumes(self, mock_stop, mock_remove, mock_deploy):
+	def test_redeploy_bench_never_touches_volumes(self, mock_deploy):
 		from benchpress.deploy_manager import redeploy_bench
 
 		bench = self._fresh_bench()
+		self.docker.add_container("old-container")
 		bench.container_id = "old-container"
 		bench.save(ignore_permissions=True)
 		frappe.db.commit()
@@ -276,20 +280,25 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 		self.assertEqual(self.docker.volume_gets, [])
 
 	@patch("benchpress.deploy_manager._deploy_bench")
-	@patch("benchpress.deploy_manager.remove_container")
-	@patch("benchpress.deploy_manager.stop_container")
-	@patch("benchpress.mariadb_manager.drop_site_database")
-	def test_redeploy_bench_drops_site_database(self, mock_drop_db, mock_stop, mock_remove, mock_deploy):
+	def test_redeploy_bench_drops_site_database(self, mock_deploy):
 		from benchpress.deploy_manager import redeploy_bench
+		from benchpress.mariadb_manager import get_database_name
 
 		bench = self._fresh_bench()
+		self.docker.add_container("old-container")
+		self._shared_mariadb_up()
 		frappe.db.set_value("Bench Instance", bench.name, "container_id", "old-container")
 		frappe.db.set_value("Bench Instance", bench.name, "database_server", self.db_server_name)
 		frappe.db.commit()
 		bench.reload()
 
 		redeploy_bench(bench.name)
-		mock_drop_db.assert_called_once_with(self.db_server_name, bench.site_name)
+
+		db_container = self.docker.containers.get("test-db-server")
+		self.assertIn(
+			f"DROP DATABASE IF EXISTS `{get_database_name(bench.site_name)}`",
+			sql_of(db_container.execs[-1]),
+		)
 
 	# --- deploy concurrency lock (issue #92) ---
 
@@ -334,8 +343,7 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 		self.assertEqual(mock_deploy.call_count, 2)
 
 	@patch("benchpress.deploy_manager._deploy_bench")
-	@patch("benchpress.deploy_manager.remove_container")
-	def test_redeploy_skipped_when_lock_held(self, mock_remove, mock_deploy):
+	def test_redeploy_skipped_when_lock_held(self, mock_deploy):
 		from benchpress.deploy_manager import redeploy_bench
 
 		bench = self._fresh_bench()
@@ -344,7 +352,7 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 		with self._held_deploy_lock(bench.name):
 			redeploy_bench(bench.name)
 
-		mock_remove.assert_not_called()
+		self.assertEqual(self.docker.removed, [])
 		mock_deploy.assert_not_called()
 
 	def _deploy_log(self, bench_name):
@@ -362,41 +370,25 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 
 		bench = self._fresh_bench()
 		self._cleanup_deploy_logs(bench.name)
+		self._shared_mariadb_up()
 		frappe.db.set_value(
 			"Bench Instance",
 			bench.name,
-			{"container_ip": "172.30.0.50", "wg_ip": "10.8.0.20"},
+			{"container_id": "old-container", "container_ip": "172.30.0.50", "wg_ip": "10.8.0.20"},
 		)
 		frappe.db.commit()
+		# The daemon takes the create and refuses the start, so the run fails owning a container.
+		self.docker.refuse_start(bench.bench_name, "cannot join network: operation not permitted")
 
 		with (
 			_cached_image(self.lab.name),
-			patch.object(deploy_manager, "ensure_infrastructure", autospec=True) as mock_infra,
-			patch.object(deploy_manager, "wait_for_mariadb", autospec=True),
 			patch.object(ingress, "ensure_anchor", autospec=True),
-			patch.object(deploy_manager, "_remove_stale_container", autospec=True),
-			patch.object(deploy_manager, "host_runtimes", autospec=True) as mock_runtimes,
-			patch.object(deploy_manager, "container_runtime", autospec=True) as mock_runtime_of,
-			patch.object(deploy_manager, "create_bench_container", autospec=True) as mock_create,
-			# The deploy starts through the roll wrapper, so the bridge it lands on is a
-			# read-back rather than the id that went in.
-			patch.object(deploy_manager, "start_bench_container", new=lambda cid, bench, lab: cid),
-			patch.object(deploy_manager, "container_network", new=lambda cid: "benchpress-0"),
-			patch.object(deploy_manager, "wait_for_container_running", autospec=True) as mock_wait,
-			patch.object(deploy_manager, "remove_container", autospec=True) as mock_remove_container,
 			patch.object(deploy_manager, "_notify_owner", autospec=True),
-			patch("benchpress.vpn_adapter.remove_bench_peer", autospec=True) as mock_remove_peer,
 		):
-			mock_infra.return_value = self.db_server_name
-			mock_runtimes.return_value = {"names": {"runc", "sysbox-runc"}, "default": "runc"}
-			mock_runtime_of.return_value = "sysbox-runc"
-			mock_create.return_value = "cid-cleanup"
-			mock_wait.side_effect = Exception("container did not report running")
-
 			deploy_manager.deploy_bench(bench.name)
 
-		mock_remove_container.assert_called_once_with("cid-cleanup")
-		mock_remove_peer.assert_called_once()
+		self.assertEqual(self.docker.removed, [bench.bench_name])
+		self.assertIn("Cleanup: VPN peer removed", self._deploy_log(bench.name))
 		bench.reload()
 		self.assertEqual(bench.status, "Error")
 		self.assertIsNone(bench.container_id)
@@ -421,19 +413,17 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 		)
 		frappe.db.commit()
 
+		# Shared Redis never comes up, so the run fails on its first step, owning nothing.
+		self.compose_cmd.return_value = (1, "no such service: redis")
+
 		with (
 			_cached_image(self.lab.name),
-			patch.object(deploy_manager, "ensure_infrastructure", autospec=True) as mock_infra,
-			patch.object(deploy_manager, "remove_container", autospec=True) as mock_remove_container,
 			patch.object(deploy_manager, "_notify_owner", autospec=True),
-			patch("benchpress.vpn_adapter.remove_bench_peer", autospec=True) as mock_remove_peer,
 		):
-			mock_infra.side_effect = Exception("infrastructure unavailable")
-
 			deploy_manager.deploy_bench(bench.name)
 
-		mock_remove_container.assert_not_called()
-		mock_remove_peer.assert_not_called()
+		self.assertEqual(self.docker.removed, [])
+		self.assertNotIn("Cleanup: VPN peer removed", self._deploy_log(bench.name))
 		self.assertIn(deploy_manager.NOTHING_TO_ROLL_BACK, self._deploy_log(bench.name))
 		bench.reload()
 		self.assertEqual(bench.status, "Error")

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -16,6 +16,7 @@ from frappe.tests import IntegrationTestCase
 
 from benchpress import ingress
 from benchpress.benchpress.doctype.bench_instance import get_instance_id
+from benchpress.tests.fakes import FakeDockerMixin
 from benchpress.tests.test_docker_manager import exec_commands, exec_environments
 
 # Any dotted quad, anywhere in the rendered file. The property routes must hold is that no
@@ -141,7 +142,7 @@ def _exec_results(failures: dict | None):
 	return run
 
 
-class TestDeployManager(IntegrationTestCase):
+class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
@@ -238,10 +239,7 @@ class TestDeployManager(IntegrationTestCase):
 	@patch("benchpress.deploy_manager._deploy_bench")
 	@patch("benchpress.deploy_manager.remove_container")
 	@patch("benchpress.deploy_manager.stop_container")
-	@patch("benchpress.docker_manager.get_client")
-	def test_redeploy_bench_resets_status_to_draft_before_deploy(
-		self, mock_client, mock_stop, mock_remove, mock_deploy
-	):
+	def test_redeploy_bench_resets_status_to_draft_before_deploy(self, mock_stop, mock_remove, mock_deploy):
 		from benchpress.deploy_manager import redeploy_bench
 
 		bench = self._fresh_bench()
@@ -265,8 +263,7 @@ class TestDeployManager(IntegrationTestCase):
 	@patch("benchpress.deploy_manager._deploy_bench")
 	@patch("benchpress.deploy_manager.remove_container")
 	@patch("benchpress.deploy_manager.stop_container")
-	@patch("benchpress.docker_manager.get_client")
-	def test_redeploy_bench_never_touches_volumes(self, mock_client, mock_stop, mock_remove, mock_deploy):
+	def test_redeploy_bench_never_touches_volumes(self, mock_stop, mock_remove, mock_deploy):
 		from benchpress.deploy_manager import redeploy_bench
 
 		bench = self._fresh_bench()
@@ -276,16 +273,13 @@ class TestDeployManager(IntegrationTestCase):
 
 		redeploy_bench(bench.name)
 
-		mock_client.return_value.volumes.get.assert_not_called()
+		self.assertEqual(self.docker.volume_gets, [])
 
 	@patch("benchpress.deploy_manager._deploy_bench")
 	@patch("benchpress.deploy_manager.remove_container")
 	@patch("benchpress.deploy_manager.stop_container")
-	@patch("benchpress.docker_manager.get_client")
 	@patch("benchpress.mariadb_manager.drop_site_database")
-	def test_redeploy_bench_drops_site_database(
-		self, mock_drop_db, mock_client, mock_stop, mock_remove, mock_deploy
-	):
+	def test_redeploy_bench_drops_site_database(self, mock_drop_db, mock_stop, mock_remove, mock_deploy):
 		from benchpress.deploy_manager import redeploy_bench
 
 		bench = self._fresh_bench()

--- a/benchpress/tests/test_docker_manager.py
+++ b/benchpress/tests/test_docker_manager.py
@@ -22,6 +22,7 @@ from benchpress.docker_manager import (
 	wait_for_container_running,
 )
 from benchpress.request_cache import clear_local_cache
+from benchpress.tests.fakes import FakeDockerMixin
 
 
 def _client_returning(status):
@@ -185,26 +186,19 @@ def _make_lab(lab_id, **extra):
 	return doc
 
 
-class TestDockerManagerBlockIO(IntegrationTestCase):
+class TestDockerManagerBlockIO(FakeDockerMixin, IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
 		frappe.set_user("Administrator")
 
 	def _container_create_kwargs(self, lab, runtime="runc", bridge_network="benchpress-0"):
-		"""Run create_bench_container with Docker mocked and return the
-		kwargs passed to client.containers.create."""
+		"""Run create_bench_container against the fake and return the create kwargs."""
 		bench = types.SimpleNamespace(
 			bench_name="blockio-test-bench", runtime=runtime, bridge_network=bridge_network
 		)
-		with (
-			patch("benchpress.docker_manager.get_client") as mock_client,
-			patch("benchpress.placement.ensure_bench_network_for"),
-			patch("benchpress.docker_manager._get_host_block_devices", return_value=["/dev/sda"]),
-		):
-			mock_client.return_value.containers.create.return_value = MagicMock(id="cid")
-			docker_manager.create_bench_container(bench, lab)
-			return mock_client.return_value.containers.create.call_args.kwargs
+		docker_manager.create_bench_container(bench, lab)
+		return self.docker.created[-1]
 
 	def test_no_volume_is_mounted_over_the_bench(self):
 		"""A named volume over /home/frappe forces a full bench copy on every create."""
@@ -214,6 +208,17 @@ class TestDockerManagerBlockIO(IntegrationTestCase):
 		kwargs = self._container_create_kwargs(lab)
 
 		self.assertNotIn("volumes", kwargs)
+
+	def test_the_container_is_stamped_with_the_managed_labels(self):
+		"""`containers.list` filtering and every reconcile pass key off these."""
+		lab = _make_lab("labels")
+		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
+
+		kwargs = self._container_create_kwargs(lab)
+
+		self.assertEqual(kwargs["labels"]["benchpress.managed"], "true")
+		self.assertEqual(kwargs["labels"]["benchpress.bench_name"], "blockio-test-bench")
+		self.assertEqual(kwargs["labels"]["benchpress.lab"], "labels")
 
 	def test_lab_block_io_limits_passed_to_container(self):
 		lab = _make_lab("blockio-custom", iops_limit=500, bps_limit=2 * 1024 * 1024)

--- a/benchpress/tests/test_fakes.py
+++ b/benchpress/tests/test_fakes.py
@@ -2,6 +2,7 @@
 # See license.txt
 
 import ast
+import base64
 import unittest
 from pathlib import Path
 
@@ -10,7 +11,13 @@ import frappe
 from frappe.tests import IntegrationTestCase
 
 from benchpress import docker_manager, mariadb_manager
-from benchpress.tests.fakes import GET_CLIENT_MODULES, FakeDocker, FakeDockerMixin, UnscriptedExec
+from benchpress.tests.fakes import (
+	GET_CLIENT_MODULES,
+	FakeDocker,
+	FakeDockerMixin,
+	UnscriptedExec,
+	sql_of,
+)
 
 
 class TestFakeDocker(unittest.TestCase):
@@ -68,6 +75,48 @@ class TestFakeDocker(unittest.TestCase):
 		fake.add_container("bench").exec_run(cmd=["bash", "-c", "whoami"])
 
 		self.assertEqual(fake.execs, ["bash -c whoami"])
+
+	def test_a_container_records_only_its_own_execs(self):
+		"""One client runs execs in several containers, and a test names the one it means."""
+		fake = FakeDocker()
+		bench = fake.add_container("bench")
+		db = fake.add_container("db")
+
+		bench.exec_run(cmd=["bash", "-c", "whoami"])
+		db.exec_run(cmd=["bash", "-c", "mariadb"])
+
+		self.assertEqual(bench.execs, ["bash -c whoami"])
+		self.assertEqual(db.execs, ["bash -c mariadb"])
+
+	def test_stops_and_removals_are_recorded_by_name(self):
+		fake = FakeDocker()
+		fake.add_container("bench-a")
+
+		fake.containers.get("bench-a").stop()
+		fake.containers.get("bench-a").remove()
+
+		self.assertEqual((fake.stopped, fake.removed), (["bench-a"], ["bench-a"]))
+		with self.assertRaises(docker.errors.NotFound):
+			fake.containers.get("bench-a")
+
+	def test_a_refused_start_raises_api_error(self):
+		"""`start_bench_container` has a branch for a daemon that refuses, so the fake must too."""
+		fake = FakeDocker()
+		fake.refuse_start("bench-a", "no available ipv4 addresses")
+		container = fake.add_container("bench-a", status="created")
+
+		with self.assertRaises(docker.errors.APIError):
+			container.start()
+		self.assertEqual(container.status, "created")
+
+	def test_sql_of_reads_back_the_base64_execute_sql_pipes_in(self):
+		fake = FakeDocker()
+		container = fake.add_container("db")
+		encoded = base64.b64encode(b"DROP DATABASE `_abc`;\n").decode()
+
+		container.exec_run(cmd=["bash", "-c", f"echo '{encoded}' | base64 -d | mariadb -u root"])
+
+		self.assertEqual(sql_of(container.execs[-1]), "DROP DATABASE `_abc`;\n")
 
 
 class TestFakeDockerMixinOnUnitTestCase(FakeDockerMixin, unittest.TestCase):

--- a/benchpress/tests/test_fakes.py
+++ b/benchpress/tests/test_fakes.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+import ast
+import unittest
+from pathlib import Path
+
+import docker
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from benchpress import docker_manager, mariadb_manager
+from benchpress.tests.fakes import GET_CLIENT_MODULES, FakeDocker, FakeDockerMixin, UnscriptedExec
+
+
+class TestFakeDocker(unittest.TestCase):
+	def test_get_on_an_unknown_id_raises_not_found(self):
+		with self.assertRaises(docker.errors.NotFound):
+			FakeDocker().containers.get("nope")
+
+	def test_list_returns_a_container_the_label_filter_matches(self):
+		fake = FakeDocker()
+		fake.add_container("bench-a", labels={"benchpress.managed": "true"})
+
+		found = fake.containers.list(filters={"label": "benchpress.managed=true"})
+
+		self.assertEqual([c.name for c in found], ["bench-a"])
+
+	def test_list_omits_a_container_the_label_filter_misses(self):
+		"""A list that returned everything would let a managed-only filter ship broken."""
+		fake = FakeDocker()
+		fake.add_container("bench-a", labels={"benchpress.managed": "true"})
+		fake.add_container("stranger", labels={"com.example.other": "true"})
+
+		found = fake.containers.list(filters={"label": "benchpress.managed=true"})
+
+		self.assertEqual([c.name for c in found], ["bench-a"])
+
+	def test_list_omits_a_stopped_container_unless_asked_for_all(self):
+		fake = FakeDocker()
+		fake.add_container("stopped", status="exited")
+
+		self.assertEqual(fake.containers.list(), [])
+		self.assertEqual([c.name for c in fake.containers.list(all=True)], ["stopped"])
+
+	def test_script_exec_matches_on_substring(self):
+		fake = FakeDocker()
+		fake.script_exec("SELECT VERSION", (0, b"10.6.16"))
+		container = fake.add_container("db")
+
+		self.assertEqual(
+			container.exec_run(cmd=["bash", "-c", "mariadb -e 'SELECT VERSION()'"]), (0, b"10.6.16")
+		)
+
+	def test_an_unmatched_exec_returns_zero_and_empty_output(self):
+		container = FakeDocker().add_container("bench")
+
+		self.assertEqual(container.exec_run(cmd=["bash", "-c", "true"]), (0, b""))
+
+	def test_strict_raises_on_an_unmatched_exec(self):
+		container = FakeDocker(strict=True).add_container("bench")
+
+		with self.assertRaises(UnscriptedExec):
+			container.exec_run(cmd=["bash", "-c", "true"])
+
+	def test_every_exec_is_recorded(self):
+		fake = FakeDocker()
+		fake.add_container("bench").exec_run(cmd=["bash", "-c", "whoami"])
+
+		self.assertEqual(fake.execs, ["bash -c whoami"])
+
+
+class TestFakeDockerMixinOnUnitTestCase(FakeDockerMixin, unittest.TestCase):
+	def test_every_get_client_binding_answers_with_the_fake(self):
+		for module in GET_CLIENT_MODULES:
+			self.assertIs(module.get_client(), self.docker)
+
+	def test_the_two_host_reads_are_stubbed(self):
+		self.assertEqual(docker_manager._get_host_block_devices(), ["/dev/sda"])
+		self.assertEqual(mariadb_manager._compose_cmd("ps"), (0, ""))
+
+
+class TestFakeDockerMixinOnIntegrationTestCase(FakeDockerMixin, IntegrationTestCase):
+	def test_the_fake_installs_alongside_the_frappe_fixtures(self):
+		self.assertIs(docker_manager.get_client(), self.docker)
+
+
+class TestGetClientImporters(unittest.TestCase):
+	def test_the_mixin_patches_every_module_that_binds_get_client(self):
+		"""A new module-level import would otherwise reach the real daemon in silence."""
+		patched = {module.__name__ for module in GET_CLIENT_MODULES}
+
+		self.assertEqual(_modules_binding_get_client() | {"benchpress.docker_manager"}, patched)
+
+
+def _modules_binding_get_client() -> set[str]:
+	root = Path(frappe.get_app_path("benchpress"))
+	found = set()
+	for path in root.rglob("*.py"):
+		if "tests" in path.parts:
+			continue
+		tree = ast.parse(path.read_text())
+		for node in tree.body:
+			if not isinstance(node, ast.ImportFrom) or node.module != "benchpress.docker_manager":
+				continue
+			if any(alias.name == "get_client" for alias in node.names):
+				found.add(_dotted_name(root, path))
+	return found
+
+
+def _dotted_name(root: Path, path: Path) -> str:
+	parts = path.relative_to(root).with_suffix("").parts
+	return ".".join((root.name, *parts))


### PR DESCRIPTION
Phase 1 of the `fake-docker-test-seam` spec: one stateful in-memory Docker client, installed at `docker_manager.get_client`, with the real modules running against it.

## What this adds

- `benchpress/tests/fakes.py` — `FakeDocker` (containers, networks, volumes, images, `info`, and the nine container methods) and `FakeDockerMixin`.
- `benchpress/tests/test_fakes.py` — the fake has its own tests, or a bug in it reads as a bug in the app. `containers.list` is tested in both directions.
- `TestDockerManagerBlockIO` and `TestDeployManager` take the mixin. `TestDeployManager` drops from 42 patch calls to 39; phase 2 takes it to 13.

No production file is touched.

## Two things worth knowing

`get_client` is bound at import in `mariadb_manager` and `diagnostics`, so patching `docker_manager` alone misses them. `TestGetClientImporters` re-derives that list from source with `ast`, so a new module-level import fails a test rather than silently reaching a real daemon.

`DOCKER_HOST` is not a kill switch for this app: `get_client` passes an explicit `base_url` from `BenchPress Settings` and never reads the environment. The conversion was verified by refusing `docker.DockerClient.__init__` for a whole run instead.

## How to verify

```bash
docker compose exec backend bench --site frontend run-tests --module benchpress.tests.test_fakes; echo "exit=$?"
docker compose exec backend bench --site frontend run-tests --module benchpress.tests.test_docker_manager; echo "exit=$?"
docker compose exec backend bench --site frontend run-tests --module benchpress.tests.test_deploy_manager; echo "exit=$?"
```

To prove the fake is installed rather than trusted, put a `sitecustomize.py` on the path that raises from `docker.DockerClient.__init__` and run the same three modules. All three stay green.

That run also surfaced a finding outside this phase's scope: 25 tests in `TestDeployStepMarkers` and `TestTerminalStateNotifications` do reach a real daemon today. They are not part of `TestDeployManager`, so the spec leaves them; the mixin is available whenever someone next touches them.