### PR TITLE
Implemented phase three

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -20,7 +20,8 @@ apps/benchpress/
 ├── benchpress/
 │   ├── hooks.py               # App config, scheduler, routes
 │   ├── api.py                 # REST API (~20 endpoints)
-│   ├── deploy_manager.py      # Build & deploy orchestration
+│   ├── lifecycle.py           # Bench transitions: running, and the deploy that reaches it
+│   ├── deploy_manager.py      # Image building, site creation, stop and teardown
 │   ├── docker_manager.py      # Docker SDK wrapper
 │   ├── vpn_adapter.py         # Seam to the vpn_management VPN plane
 │   ├── stats_collector.py     # Container stats cron job
@@ -88,9 +89,9 @@ This is the **brain** of BenchPress. It coordinates builds and deployments.
 | Function | Called By | What It Does |
 |----------|-----------|--------------|
 | `build_lab(lab_name)` | Background job from `build_lab_image` API | Builds Docker image for a Lab. Creates Build Log doc, streams logs via WebSocket (`lab_build_log` event). Sets Lab status to Ready or Error. |
-| `deploy_bench(bench_name)` | Background job from `create_bench` API | **Main deploy pipeline**: check image → remove stale container → create container → start → register VPN Peer + configure container tunnel (via `vpn_adapter`) → set SSH password → mark Running |
+| `lifecycle.deploy_bench(bench_name)` | Background job from `create_bench` API | **Main deploy pipeline**: check image → remove stale container → create container → start → register VPN Peer + configure container tunnel (via `vpn_adapter`) → set SSH password → mark Running |
 | `stop_bench(bench_name)` | Background job from `bench_action` | Stop container |
-| `redeploy_bench(bench_name)` | Background job from `bench_action` | Stop + remove container, reset to Draft, call deploy_bench |
+| `lifecycle.redeploy_bench(bench_name)` | Background job from `bench_action` | Stop + remove container, reset to Draft, call deploy_bench |
 | `log_deploy(bench_name, msg, type)` | Internal helper | Saves Deploy Log + publishes `bench_deploy_log` WebSocket event |
 
 ### `docker_manager.py` (191 lines) — Docker SDK Wrapper
@@ -273,7 +274,7 @@ static markup of a session that is not running anywhere.
                        ▼
 ┌─────────────────────────────────────────────────────────────┐
 │ 3. DEPLOY BENCH                                             │
-│    api.create_bench() → enqueue deploy_manager.deploy_bench │
+│    api.create_bench() → enqueue lifecycle.deploy_bench      │
 │    Status: Deploying                                        │
 │    Pipeline:                                                │
 │      a. Check image exists (build if not)                   │

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -90,7 +90,7 @@ This is the **brain** of BenchPress. It coordinates builds and deployments.
 |----------|-----------|--------------|
 | `build_lab(lab_name)` | Background job from `build_lab_image` API | Builds Docker image for a Lab. Creates Build Log doc, streams logs via WebSocket (`lab_build_log` event). Sets Lab status to Ready or Error. |
 | `lifecycle.deploy_bench(bench_name)` | Background job from `create_bench` API | **Main deploy pipeline**: check image → remove stale container → create container → start → register VPN Peer + configure container tunnel (via `vpn_adapter`) → set SSH password → mark Running |
-| `stop_bench(bench_name)` | Background job from `bench_action` | Stop container |
+| `lifecycle.stopped(bench_name)` | Background job from `bench_action` | Stop container |
 | `lifecycle.redeploy_bench(bench_name)` | Background job from `bench_action` | Stop + remove container, reset to Draft, call deploy_bench |
 | `log_deploy(bench_name, msg, type)` | Internal helper | Saves Deploy Log + publishes `bench_deploy_log` WebSocket event |
 

--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -6,7 +6,7 @@ from frappe import _
 from frappe.query_builder import DocType
 from frappe.query_builder.functions import Count
 
-from benchpress import addressing, image_cache, lab_detail, lab_templates, labs, site_names
+from benchpress import addressing, image_cache, lab_detail, lab_templates, labs, lifecycle, site_names
 from benchpress.benchpress.doctype.bench_instance.bench_instance import DEPLOY_JOB_TIMEOUT
 
 # Every field the renew path decides from, read once under the row lock.
@@ -308,8 +308,6 @@ def _start_bench(bench, action: str) -> dict:
 	This is the start path the SPA uses, so it is where the cap and the hold have to be. Stopping
 	and deleting stay outside the gate: stopping is what a refused caller is being told to do.
 	"""
-	from benchpress import lifecycle
-
 	_require_container(bench)
 	lifecycle.running(bench, action=action)
 	return {"name": bench.name, "status": bench.status}
@@ -575,8 +573,6 @@ def _restart_in_grace(bench) -> None:
 	`bench` is the locked row read rather than a document, so the transition runs on a loaded
 	one and the status it wrote is reflected back for the caller's response.
 	"""
-	from benchpress import lifecycle
-
 	doc = frappe.get_doc("Bench Instance", bench.name)
 	lifecycle.running(doc)
 	bench.status = doc.status

--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -216,7 +216,7 @@ def create_bench(data: str) -> dict:
 	site_names.claim(doc)
 
 	frappe.enqueue(
-		"benchpress.deploy_manager.deploy_bench",
+		"benchpress.lifecycle.deploy_bench",
 		bench_name=doc.name,
 		queue="long",
 		timeout=DEPLOY_JOB_TIMEOUT,
@@ -308,26 +308,10 @@ def _start_bench(bench, action: str) -> dict:
 	This is the start path the SPA uses, so it is where the cap and the hold have to be. Stopping
 	and deleting stay outside the gate: stopping is what a refused caller is being told to do.
 	"""
-	from benchpress import ingress
-	from benchpress.docker_manager import restart_container, start_container
+	from benchpress import lifecycle
 
 	_require_container(bench)
-	if action == "start":
-		start_container(bench.container_id)
-		bench.started_at = frappe.utils.now_datetime()
-	else:
-		restart_container(bench.container_id)
-
-	bench.status = "Running"
-	# A restart does not interrupt the window the user already bought, so this only buys one
-	# for a bench that had none — and it runs before the save so the deadline and the status
-	# it belongs to are written together.
-	metering.on_bench_running(bench)
-	bench.save()
-	frappe.db.commit()
-	# A restart re-allocates the container address, and a start may be following a stop that
-	# removed the file — both need the route re-established.
-	ingress.enqueue_route_sync(bench.name)
+	lifecycle.running(bench, action=action)
 	return {"name": bench.name, "status": bench.status}
 
 
@@ -520,8 +504,6 @@ def renew_bench(bench_name: str, plan: str, request_id: str) -> dict:
 	the charge last. Raises `ValidationError` when the sweep already claimed the row, when the
 	plan would push the lease past the lab's ceiling, or when the grace window has closed.
 	"""
-	from benchpress import ingress
-
 	require_bench_access(bench_name)
 	if not config.credits_enabled():
 		frappe.throw(_("Credits are switched off on this site, so there is nothing to renew."))
@@ -557,8 +539,6 @@ def renew_bench(bench_name: str, plan: str, request_id: str) -> dict:
 		_restart_in_grace(bench)
 	lease.announce_renewed(bench)
 	frappe.db.commit()  # nosemgrep -- releases the row lock, and the push is hung off this commit
-	if stopped:
-		ingress.enqueue_route_sync(bench.name)
 	return _lease_state(bench, charged=charged)
 
 
@@ -590,17 +570,16 @@ def _assert_inside_grace(bench) -> None:
 
 
 def _restart_in_grace(bench) -> None:
-	"""Start the container the bench still has. Expiry only stopped it, so this is not a rebuild."""
-	from benchpress.docker_manager import start_container
+	"""Start the container the bench still has. Expiry only stopped it, so this is not a rebuild.
 
-	start_container(bench.container_id)
-	bench.status = "Running"
-	frappe.db.set_value(
-		"Bench Instance",
-		bench.name,
-		{"status": "Running", "started_at": frappe.utils.now_datetime()},
-		update_modified=False,
-	)
+	`bench` is the locked row read rather than a document, so the transition runs on a loaded
+	one and the status it wrote is reflected back for the caller's response.
+	"""
+	from benchpress import lifecycle
+
+	doc = frappe.get_doc("Bench Instance", bench.name)
+	lifecycle.running(doc)
+	bench.status = doc.status
 
 
 def _lease_state(bench, charged: float) -> dict:

--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -268,7 +268,7 @@ def _assert_site_name_changeable(doc) -> None:
 
 	`Draft` is the only status that guarantees no live site exists under `doc.site_name`:
 	either nothing was ever deployed, or `teardown_bench` ran and actually dropped the
-	database before resetting status. `stop_bench` marks the instance `Stopped` and
+	database before resetting status. `lifecycle.stopped` marks the instance `Stopped` and
 	deactivates its `Bench Site` rows WITHOUT dropping the database (only `teardown_bench`
 	does that) — so `Stopped` must still block a rename, or the old database would be
 	silently orphaned. The caller stops/deletes the instance first to rename it.
@@ -326,11 +326,9 @@ def _require_container(bench) -> None:
 
 
 def _stop_bench(bench) -> dict:
-	"""Stop through `deploy_manager.stop_bench`, the one path that also deactivates the sites."""
-	from benchpress.deploy_manager import stop_bench
-
+	"""Stop through `lifecycle.stopped`, the one path that also deactivates the sites."""
 	_require_container(bench)
-	stop_bench(bench.name)
+	lifecycle.stopped(bench.name)
 	return {"name": bench.name, "status": "Stopped"}
 
 

--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -267,9 +267,9 @@ def _assert_site_name_changeable(doc) -> None:
 	"""Refuse to rename a bench whose current name might still own a live database.
 
 	`Draft` is the only status that guarantees no live site exists under `doc.site_name`:
-	either nothing was ever deployed, or `teardown_bench` ran and actually dropped the
+	either nothing was ever deployed, or `lifecycle.torn_down` ran and actually dropped the
 	database before resetting status. `lifecycle.stopped` marks the instance `Stopped` and
-	deactivates its `Bench Site` rows WITHOUT dropping the database (only `teardown_bench`
+	deactivates its `Bench Site` rows WITHOUT dropping the database (only `torn_down`
 	does that) — so `Stopped` must still block a rename, or the old database would be
 	silently orphaned. The caller stops/deletes the instance first to rename it.
 	"""
@@ -335,14 +335,13 @@ def _stop_bench(bench) -> dict:
 def _delete_bench(bench) -> dict:
 	"""Remove an instance and everything it owns, then the row itself.
 
-	Container, volume, site database and metering session go through
-	`deploy_manager.teardown_bench`, the one teardown path, where every removal is
-	best-effort. Only what it does not cover is left here.
+	Container, volume, site database and metering session go through `lifecycle.torn_down`,
+	the one teardown path, where every removal is best-effort. Only what it does not cover is
+	left here.
 	"""
-	from benchpress.deploy_manager import teardown_bench
 	from benchpress.vpn_adapter import remove_bench_peer
 
-	teardown_bench(bench)
+	lifecycle.torn_down(bench)
 	# Before the instance: it reads the `Bench Site` rows, which `BenchInstance.on_trash` removes.
 	_drop_bench_site_databases(bench)
 	remove_bench_peer(bench)

--- a/benchpress/benchpress/doctype/bench_instance/bench_instance.py
+++ b/benchpress/benchpress/doctype/bench_instance/bench_instance.py
@@ -149,9 +149,7 @@ class BenchInstance(Document):
 
 	@frappe.whitelist()
 	def enqueue_stop(self):
-		from benchpress.deploy_manager import stop_bench
-
-		stop_bench(self.name)
+		lifecycle.stopped(self.name)
 		frappe.msgprint(_("Bench stopped."))
 
 	@frappe.whitelist()

--- a/benchpress/benchpress/doctype/bench_instance/bench_instance.py
+++ b/benchpress/benchpress/doctype/bench_instance/bench_instance.py
@@ -8,6 +8,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils.background_jobs import is_job_enqueued
 
+from benchpress import lifecycle
 from benchpress.benchpress.doctype.bench_instance import get_instance_id
 from benchpress.credits.guard import instance_lease_cost, requires_admission
 from benchpress.permissions import is_admin
@@ -176,8 +177,6 @@ class BenchInstance(Document):
 	@frappe.whitelist()
 	@requires_admission(cost=instance_lease_cost)
 	def enqueue_start(self):
-		from benchpress import lifecycle
-
 		if not self.container_id:
 			frappe.throw(_("No container to start."))
 		lifecycle.running(self)

--- a/benchpress/benchpress/doctype/bench_instance/bench_instance.py
+++ b/benchpress/benchpress/doctype/bench_instance/bench_instance.py
@@ -136,7 +136,7 @@ class BenchInstance(Document):
 			frappe.msgprint(_("A deploy is already in progress for this bench."))
 			return
 		frappe.enqueue(
-			"benchpress.deploy_manager.deploy_bench",
+			"benchpress.lifecycle.deploy_bench",
 			bench_name=self.name,
 			queue="long",
 			timeout=DEPLOY_JOB_TIMEOUT,
@@ -160,7 +160,7 @@ class BenchInstance(Document):
 			frappe.msgprint(_("A deploy is already in progress for this bench."))
 			return
 		frappe.enqueue(
-			"benchpress.deploy_manager.redeploy_bench",
+			"benchpress.lifecycle.redeploy_bench",
 			bench_name=self.name,
 			queue="long",
 			timeout=DEPLOY_JOB_TIMEOUT,
@@ -176,19 +176,9 @@ class BenchInstance(Document):
 	@frappe.whitelist()
 	@requires_admission(cost=instance_lease_cost)
 	def enqueue_start(self):
-		from benchpress import ingress
-		from benchpress.credits import metering
-		from benchpress.docker_manager import start_container
+		from benchpress import lifecycle
 
 		if not self.container_id:
 			frappe.throw(_("No container to start."))
-		start_container(self.container_id)
-		self.status = "Running"
-		self.started_at = frappe.utils.now_datetime()
-		# Buys a fresh window before the save writes `Running`. A start that left the old,
-		# passed deadline on the row would be claimed by the next sweep and stopped again.
-		metering.on_bench_running(self)
-		self.save()
-		frappe.db.commit()  # nosemgrep: intentional commit to persist status before response
-		ingress.enqueue_route_sync(self.name)
+		lifecycle.running(self)
 		frappe.msgprint(_("Bench started."))

--- a/benchpress/benchpress/doctype/bench_instance/test_bench_instance.py
+++ b/benchpress/benchpress/doctype/bench_instance/test_bench_instance.py
@@ -203,8 +203,8 @@ class IntegrationTestBenchInstance(IntegrationTestCase):
 		bench.reload()
 		self.assertEqual(bench.status, "Running")
 
-	@patch("benchpress.deploy_manager.stop_bench")
-	def test_enqueue_stop_calls_stop_bench(self, mock_stop):
+	@patch("benchpress.lifecycle.stopped")
+	def test_enqueue_stop_calls_stopped(self, mock_stop):
 		bench = self._insert_bench()
 		bench.enqueue_stop()
 		mock_stop.assert_called_once_with(bench.name)

--- a/benchpress/benchpress/doctype/bench_instance/test_bench_instance.py
+++ b/benchpress/benchpress/doctype/bench_instance/test_bench_instance.py
@@ -193,7 +193,7 @@ class IntegrationTestBenchInstance(IntegrationTestCase):
 		with self.assertRaises(frappe.ValidationError):
 			bench.enqueue_start()
 
-	@patch("benchpress.docker_manager.start_container")
+	@patch("benchpress.lifecycle.start_container")
 	def test_enqueue_start_starts_container_and_sets_running(self, mock_start):
 		bench = self._insert_bench()
 		bench.container_id = "test-container-abc"

--- a/benchpress/benchpress/doctype/database_server/database_server.py
+++ b/benchpress/benchpress/doctype/database_server/database_server.py
@@ -5,6 +5,8 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
+from benchpress.mariadb_manager import SERVER_ERROR
+
 
 class DatabaseServer(Document):
 	def before_insert(self):
@@ -28,7 +30,7 @@ class DatabaseServer(Document):
 		}
 
 	def set_error(self, message: str):
-		self.status = "Error"
+		self.status = SERVER_ERROR
 		self.error_message = message
 		self.save(ignore_permissions=True)
 		frappe.db.commit()

--- a/benchpress/benchpress/doctype/lab/lab.py
+++ b/benchpress/benchpress/doctype/lab/lab.py
@@ -11,6 +11,11 @@ from benchpress.image_cache import build_spec
 
 BASELINE_CPU_CORES = 1
 
+# A `Lab` spells its statuses the same way a `Bench Instance` does, and one grep cannot tell the
+# two doctypes apart. Named so the lifecycle's one-writer guard stays readable.
+LAB_DRAFT = "Draft"
+LAB_READY = "Ready"
+
 
 class Lab(Document):
 	def validate(self):
@@ -25,11 +30,11 @@ class Lab(Document):
 		hash), so an edit to what actually gets built no longer changes the tag by itself —
 		nothing else would catch a Ready lab quietly pointing at a stale image.
 		"""
-		if self.status != "Ready" or self.is_new():
+		if self.status != LAB_READY or self.is_new():
 			return
 		before = self.get_doc_before_save()
 		if before and build_spec(self) != build_spec(before):
-			self.status = "Draft"
+			self.status = LAB_DRAFT
 			# The golden in the old image was built from the old spec, so it no longer describes
 			# what this lab asks for.
 			self.golden_manifest = None

--- a/benchpress/credits/drill.py
+++ b/benchpress/credits/drill.py
@@ -21,6 +21,7 @@ site name. Each one has to be able to fail for its own reason and no other.
 import frappe
 from frappe.utils import cint, flt
 
+from benchpress import lifecycle
 from benchpress.credits import account, config
 
 ACCOUNT = "Credit Account"
@@ -211,13 +212,12 @@ def _drill_benches() -> list[str]:
 
 
 def _delete_bench(bench_name: str) -> None:
-	from benchpress.deploy_manager import teardown_bench
 	from benchpress.vpn_adapter import remove_bench_peer
 
 	bench = frappe.get_doc(BENCH, bench_name)
 	if bench.container_id:
 		try:
-			teardown_bench(bench)
+			lifecycle.torn_down(bench)
 			remove_bench_peer(bench)
 		except Exception:
 			# Best-effort, and named rather than swallowed: a drill container the harness cannot

--- a/benchpress/credits/lease.py
+++ b/benchpress/credits/lease.py
@@ -306,7 +306,7 @@ def _claim(bench_name: str, cutoff: int) -> bool:
 
 def enqueue_stop(bench_name: str, node: str | None = None) -> None:
 	frappe.enqueue(
-		"benchpress.deploy_manager.stop_bench",
+		"benchpress.lifecycle.stopped",
 		bench_name=bench_name,
 		queue=stop_queue_for(node),
 		timeout=STOP_TIMEOUT,

--- a/benchpress/credits/reaper.py
+++ b/benchpress/credits/reaper.py
@@ -20,7 +20,6 @@ sweep, the scheduler decides and `queue-long` acts: this worker has no Docker so
 import frappe
 from frappe.utils import add_days, cint, get_datetime, now_datetime, time_diff_in_hours
 
-from benchpress import lifecycle
 from benchpress.credits import config, notify
 
 BENCH = "Bench Instance"
@@ -45,6 +44,10 @@ def reap_bench(bench_name: str) -> None:
 	bench = frappe.get_doc(BENCH, bench_name)
 	if bench.status != "Stopped":
 		return  # started again between the decision and this job; it has earned another window
+	# Inside the function, not at module scope: the scheduler imports this module and has no
+	# Docker socket, and `test_scheduler_entries` holds that line.
+	from benchpress import lifecycle
+
 	lifecycle.torn_down(bench)
 	notify.announce_reap(bench)
 

--- a/benchpress/credits/reaper.py
+++ b/benchpress/credits/reaper.py
@@ -10,8 +10,8 @@ an email two days before so nobody loses work to a rule they had forgotten.
 
 **The `Lab` survives.** Its apps, branches, version and size are all intact, so "reaped" means one
 click to rebuild rather than lost work — which is exactly what lets us keep saying stopped is free.
-Teardown is `deploy_manager.teardown_bench`, the same path a redeploy takes; there is deliberately
-no second teardown in this app.
+Teardown is `lifecycle.torn_down`, the same path a redeploy takes; there is deliberately no
+second teardown in this app.
 
 Both queries filter on `status` and `modified`, so neither scans the table. As with the enforcement
 sweep, the scheduler decides and `queue-long` acts: this worker has no Docker socket.
@@ -20,6 +20,7 @@ sweep, the scheduler decides and `queue-long` acts: this worker has no Docker so
 import frappe
 from frappe.utils import add_days, cint, get_datetime, now_datetime, time_diff_in_hours
 
+from benchpress import lifecycle
 from benchpress.credits import config, notify
 
 BENCH = "Bench Instance"
@@ -44,9 +45,7 @@ def reap_bench(bench_name: str) -> None:
 	bench = frappe.get_doc(BENCH, bench_name)
 	if bench.status != "Stopped":
 		return  # started again between the decision and this job; it has earned another window
-	from benchpress import deploy_manager
-
-	deploy_manager.teardown_bench(bench)
+	lifecycle.torn_down(bench)
 	notify.announce_reap(bench)
 
 

--- a/benchpress/credits/sweep.py
+++ b/benchpress/credits/sweep.py
@@ -139,7 +139,7 @@ def _accounts(owners: set) -> dict:
 def _enqueue_stop(bench_name: str) -> None:
 	"""Deduplicated, so a sweep that overlaps the previous one cannot stop the same bench twice."""
 	frappe.enqueue(
-		"benchpress.deploy_manager.stop_bench",
+		"benchpress.lifecycle.stopped",
 		bench_name=bench_name,
 		queue="long",
 		timeout=STOP_TIMEOUT,

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -9,16 +9,14 @@ import shlex
 import frappe
 from frappe import _
 
-from benchpress import addressing, image_cache, ingress, lifecycle, site_names
-from benchpress.credits import admission, lease, metering
+from benchpress import addressing, image_cache, site_names
+from benchpress.credits import metering
 from benchpress.deploy_pipeline import DeployLogWriter
 from benchpress.docker_manager import (
 	build_lab_image,
 	exec_in_container,
 	host_runtimes,
-	remove_container,
 	resolve_runtime,
-	stop_container,
 	write_file_to_container,
 )
 from benchpress.mariadb_manager import (
@@ -65,42 +63,10 @@ def _remove_stale_container(bench) -> None:
 		pass  # best-effort
 
 
-NOTHING_TO_ROLL_BACK = "Cleanup: nothing to roll back — no container was created"
-
 ADOPTED_MARKER = "already exists — adopting it"
 GOLDEN_MARKER = "Restored from golden dump"
 # What the Deploy Log says when the golden branch ran. `golden_drill` reads runs back by it.
 GOLDEN_RESTORED = "restored from the image's golden dump"
-
-
-def _cleanup_failed_deploy(bench, container_id, append_log) -> None:
-	"""Best-effort teardown of resources created by this failed run.
-
-	Fires only when this run created a container — earlier failures leave the
-	previous deploy's container and peer untouched. Never raises: the except
-	block must still record Error state.
-
-	Either way the outcome is written to the log, so the screen reporting the
-	failure can state what was rolled back instead of inferring it from silence.
-	"""
-	if not container_id:
-		append_log(NOTHING_TO_ROLL_BACK)
-		return
-	try:
-		remove_container(container_id)
-		append_log("Cleanup: removed container created by this run")
-	except Exception:
-		pass  # best-effort
-	try:
-		from benchpress.vpn_adapter import remove_bench_peer
-
-		remove_bench_peer(bench)
-		append_log("Cleanup: VPN peer removed")
-	except Exception:
-		pass  # best-effort
-	bench.container_id = None
-	bench.container_ip = None
-	bench.wg_ip = None
 
 
 def build_linkuser_args(bench, lab, settings) -> list[str]:
@@ -338,67 +304,6 @@ def _setup_container_vpn(bench, container_id: str, pipeline) -> None:
 	pipeline.log(f"VPN peer {peer['peer']} registered, claimed IP {peer['assigned_ip']}")
 	configure_container(container_id, peer["private_key"], peer["assigned_ip"], bench.bridge_network)
 	pipeline.log(f"Container VPN: {peer['assigned_ip']}")
-
-
-def teardown_bench(bench, *, release_admission: bool = True) -> None:
-	"""Return an instance to `Draft`: container, volume and site database all gone.
-
-	The one teardown path in the app. A redeploy runs it before building the instance again, and
-	the reaper runs it and stops there — which is what makes a reaped instance one click from
-	running: the `Lab` it was built from, with its apps, branches, version and size, is untouched.
-
-	Every removal is best-effort. A volume that was already gone, or a database that never
-	existed, must not leave the instance stuck describing resources it no longer has.
-
-	`release_admission=False` keeps the concurrency slot, and only `_redeploy_bench` passes it:
-	a redeploy is this plus a deploy, and the caller must not lose their own slot in between.
-	"""
-	if bench.container_id:
-		try:
-			stop_container(bench.container_id)
-		except Exception:
-			pass  # best-effort
-		try:
-			remove_container(bench.container_id)
-		except Exception:
-			pass  # best-effort
-
-	try:
-		# Direct, not enqueued: teardown must not leave live routing behind if a job is lost.
-		ingress.withdraw(bench.name)
-	except Exception:
-		pass  # best-effort
-
-	_drop_site_database(bench)
-	# Marked, not deleted: a redeploy refreshes them, and the reaper leaves the instance
-	# one click from running.
-	lifecycle._deactivate_bench_sites(bench)
-
-	# The container this bench was burning for is gone, so the session ends here. Without
-	# this the burning flag would survive the teardown and the fresh container — which
-	# `_deploy_bench` bills through the same idempotence guard — would run unmetered.
-	metering.on_bench_stopped(bench)
-
-	if release_admission:
-		admission.release(bench.name)
-
-	bench.container_id = None
-	bench.container_image = None
-	bench.status = "Draft"
-	bench.started_at = None
-	bench.save(ignore_permissions=True)
-	frappe.db.commit()  # nosemgrep -- the caller may redeploy next, which must see Draft
-
-
-def _drop_site_database(bench) -> None:
-	if not (bench.database_server and bench.site_name):
-		return
-	from benchpress.mariadb_manager import drop_site_database
-
-	try:
-		drop_site_database(bench.database_server, bench.site_name)
-	except Exception:
-		pass  # best-effort
 
 
 def _prepare_lab_image(lab, pipeline, user: str) -> None:

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -9,7 +9,7 @@ import shlex
 import frappe
 from frappe import _
 
-from benchpress import addressing, image_cache, ingress, site_names
+from benchpress import addressing, image_cache, ingress, lifecycle, site_names
 from benchpress.credits import admission, lease, metering
 from benchpress.deploy_pipeline import DeployLogWriter
 from benchpress.docker_manager import (
@@ -372,7 +372,7 @@ def teardown_bench(bench, *, release_admission: bool = True) -> None:
 	_drop_site_database(bench)
 	# Marked, not deleted: a redeploy refreshes them, and the reaper leaves the instance
 	# one click from running.
-	_deactivate_bench_sites(bench)
+	lifecycle._deactivate_bench_sites(bench)
 
 	# The container this bench was burning for is gone, so the session ends here. Without
 	# this the burning flag would survive the teardown and the fresh container — which
@@ -388,14 +388,6 @@ def teardown_bench(bench, *, release_admission: bool = True) -> None:
 	bench.started_at = None
 	bench.save(ignore_permissions=True)
 	frappe.db.commit()  # nosemgrep -- the caller may redeploy next, which must see Draft
-
-
-def _deactivate_bench_sites(bench) -> None:
-	"""Mark every `Bench Site` on this instance Inactive, since its data is gone.
-
-	One UPDATE: `set_value` takes the filter itself, so the row names never have to be read.
-	"""
-	frappe.db.set_value("Bench Site", {"bench": bench.name}, "status", "Inactive", update_modified=False)
 
 
 def _drop_site_database(bench) -> None:
@@ -549,46 +541,3 @@ def build_lab(lab_name: str) -> None:
 		_notify_owner(lab.owner, f"Lab build failed: {lab.title}", "Lab", lab_name)
 		return
 	_notify_owner(lab.owner, f"Lab build complete: {lab.title} ({image_tag})", "Lab", lab_name)
-
-
-def stop_bench(bench_name: str, from_claim: bool = False) -> None:
-	"""Stop a bench container, and with it every site the container was serving.
-
-	VPN stops automatically with the container. The sites do not: nothing answers on a stopped
-	container, so a row left `Active` is the page telling the user to open an address that has
-	gone quiet. This is the one stop path — `api.bench_action("stop")` routes here too — so the
-	deactivation cannot be missed by a second caller.
-
-	It is also where an expired lease lands, which is why it starts by confirming the claim
-	under a row lock. `from_claim` marks that caller: a user pressing Stop carries no claim and
-	always goes ahead, while a queued expiry that has outlived its claim must not.
-	"""
-	if not lease.confirm_expiry(bench_name, from_claim=from_claim):
-		return
-
-	lease.record_stop_started(bench_name)
-	bench = frappe.get_doc("Bench Instance", bench_name)
-	lease.assert_local(bench)
-	expired = bench.lease_state == lease.STOPPING
-
-	try:
-		if bench.container_id:
-			stop_container(bench.container_id)
-	except Exception:
-		if expired:
-			lease.release(bench_name, failed=True)
-			frappe.db.commit()  # nosemgrep -- the retry has to survive the failure that caused it
-		raise
-
-	lease.record_stopped(bench, expired)
-	bench.status = "Stopped"
-	metering.on_bench_stopped(bench)
-	# Stopped is free, so it must stop holding a slot too: a caller at their cap who stops
-	# everything they own would otherwise never start anything again.
-	admission.release(bench.name)
-	bench.save(ignore_permissions=True)
-	_deactivate_bench_sites(bench)
-	if expired:
-		lease.announce_expired(bench)
-	frappe.db.commit()  # nosemgrep -- intentional commit to persist status before response
-	ingress.enqueue_route_sync(bench.name)

--- a/benchpress/deploy_manager.py
+++ b/benchpress/deploy_manager.py
@@ -5,36 +5,26 @@ import json
 import re
 import secrets
 import shlex
-from pathlib import Path
 
 import frappe
 from frappe import _
-from frappe.utils.file_lock import LockTimeoutError
-from frappe.utils.synchronization import filelock
 
-from benchpress import addressing, image_cache, ingress, placement, site_names
+from benchpress import addressing, image_cache, ingress, site_names
 from benchpress.credits import admission, lease, metering
-from benchpress.deploy_pipeline import DeployLogWriter, DeployPipeline
+from benchpress.deploy_pipeline import DeployLogWriter
 from benchpress.docker_manager import (
 	build_lab_image,
-	container_network,
-	container_runtime,
-	create_bench_container,
 	exec_in_container,
 	host_runtimes,
 	remove_container,
 	resolve_runtime,
-	start_bench_container,
 	stop_container,
-	wait_for_container_running,
 	write_file_to_container,
 )
 from benchpress.mariadb_manager import (
 	create_mariadb_user,
 	drop_mariadb_user,
-	ensure_infrastructure,
 	server_version,
-	wait_for_mariadb,
 )
 from benchpress.notifications import notify_owner
 
@@ -247,243 +237,6 @@ def _log_deploy_skipped(bench_name: str) -> None:
 	# no manual commit: the job ends right after this, and the worker commits on return
 
 
-def deploy_bench(bench_name: str) -> None:
-	"""Deploy a bench, refusing to run concurrently with another deploy of the same bench."""
-	try:
-		with filelock(f"bench_deploy_{bench_name}", timeout=1):
-			_deploy_bench(bench_name)
-	except LockTimeoutError:
-		_log_deploy_skipped(bench_name)
-
-
-def _deploy_bench(bench_name: str) -> None:
-	"""Deploy pipeline — shared MariaDB, site created at runtime via press agent pattern."""
-	bench = frappe.get_doc("Bench Instance", bench_name)
-	lab = frappe.get_doc("Lab", bench.lab)
-
-	deploy_log = frappe.get_doc(
-		{
-			"doctype": "Deploy Log",
-			"bench": bench_name,
-			"message": "=== Deploy started ===\n",
-			"log_type": "info",
-			"timestamp": frappe.utils.now_datetime(),
-		}
-	)
-	deploy_log.insert(ignore_permissions=True)
-	frappe.db.commit()
-	deploy_log_name = deploy_log.name
-
-	# Scoped to the bench's owner: a deploy log is that user's, and nobody
-	# else's socket has any business receiving it.
-	append_log = DeployLogWriter(
-		"Deploy Log",
-		deploy_log_name,
-		"bench_deploy_log",
-		{"bench": bench_name, "deploy_log": deploy_log_name},
-		bench.owner,
-	)
-	pipeline = DeployPipeline(append_log)
-
-	created_container_id = None
-	try:
-		if bench.status == "Draft":
-			# Not the value `validate` defaulted: a bench can sit in Draft for days, and the
-			# bridge with room then is not the bridge with room now.
-			placement.record_bridge_network(bench, placement.pick_network())
-		bench.status = "Deploying"
-		bench.save(ignore_permissions=True)
-		frappe.db.commit()
-
-		admin_password = secrets.token_urlsafe(10)
-		bench.admin_password = admin_password
-
-		pipeline.step("infrastructure")
-		db_server_name = ensure_infrastructure()
-		db_server = frappe.get_doc("Database Server", db_server_name)
-		wait_for_mariadb(db_server_name, timeout=60)
-		pipeline.log(f"MariaDB reachable at {db_server.container_name}:{db_server.port or 3306}")
-
-		# First step of the deploy, so this runs minutes ahead of the image build —
-		# headroom a fresh install needs, because DNS-01 has to finish issuing before
-		# the bench route goes live.
-		settings = frappe.get_cached_doc("BenchPress Settings")
-		if ingress.ensure_anchor(settings.base_domain):
-			pipeline.log(f"Traefik wildcard anchor written for *.{settings.base_domain}")
-
-		bench.database_server = db_server_name
-		bench.save(ignore_permissions=True)
-		frappe.db.commit()
-
-		# Ahead of the image step on purpose: the build is where the minutes go,
-		# and a bench the host cannot isolate has no business paying for one.
-		_assert_runtime_registered(bench)
-
-		# One step whichever way it goes: the run either builds the image or
-		# adopts a cached one, and the detail line says which.
-		pipeline.step("image")
-		_prepare_lab_image(lab, pipeline, bench.owner)
-
-		# Both halves of the previous deploy go together, and before the new container
-		# exists: the site database is the other thing a redeploy replaces, and dropping a
-		# few hundred tables is teardown, not part of creating the site that follows.
-		_remove_stale_container(bench)
-		_drop_site_database(bench)
-		pipeline.step("container")
-		container_id = create_bench_container(bench, lab)
-		created_container_id = container_id
-		# Read back rather than assumed: the stored log answers what a bench was
-		# isolated by long after the run.
-		pipeline.log(f"container runtime {container_runtime(container_id)}")
-
-		container_id = created_container_id = start_bench_container(container_id, bench, lab)
-		placement.record_bridge_network(bench, container_network(container_id))
-		pipeline.log(f"bench bridge {bench.bridge_network}")
-
-		bench.container_id = container_id
-		bench.node = lease.local_node()
-		bench.container_image = lab.image_tag
-		bench.save(ignore_permissions=True)
-		frappe.db.commit()
-
-		pipeline.step("container_ip")
-		container_ip = wait_for_container_running(container_id, bench.bridge_network, timeout=60)
-		bench.container_ip = container_ip
-		pipeline.log(f"container_ip {container_ip}")
-		bench.save(ignore_permissions=True)
-		frappe.db.commit()
-
-		bench.public_url = addressing.public_site_url(bench.name, settings.base_domain)
-		ingress.publish(bench.name, settings.base_domain)
-		ingress.log_certificate_state(bench.name, settings.base_domain, pipeline)
-
-		_setup_container_vpn(bench, container_id, pipeline)
-
-		bench_dir = "/home/frappe/frappe-bench"
-		site_name = bench.site_name
-		config = {
-			**db_server.get_connection_config(),
-			"redis_cache": "redis://benchpress-redis:6379/0",
-			"redis_queue": "redis://benchpress-redis:6379/1",
-			"redis_socketio": "redis://benchpress-redis:6379/2",
-			"socketio_port": 9000,
-			"webserver_port": addressing.SITE_HTTP_PORT,
-			"default_site": site_name,
-			"developer_mode": 1,
-		}
-		pipeline.step("site_config")
-		write_file_to_container(
-			container_id, json.dumps(config, indent=2), f"{bench_dir}/sites/common_site_config.json"
-		)
-		pipeline.log(f"{bench_dir}/sites/common_site_config.json written")
-
-		pipeline.step("site")
-		apps_csv = ",".join(a.app_name for a in lab.apps if a.app_name.lower() != "frappe")
-		pipeline.log(f"Site {site_name} with {apps_csv or 'frappe'}")
-		use_golden, refusal = _golden_matches_server(lab.image_tag, db_server)
-		if refusal:
-			pipeline.log(refusal)
-		exit_code, output = create_site_in_container(
-			container_id, db_server, site_name, admin_password, apps_csv, use_golden=use_golden
-		)
-		if exit_code != 0:
-			raise Exception(f"Site setup failed (exit {exit_code}): {output}")
-		pipeline.log(_site_outcome(output, site_name))
-		_record_primary_site(bench, lab, admin_password)
-
-		pipeline.step("assets")
-		# Deploy never builds; rebuilding the lab image is how a stale bundle is refreshed.
-		pipeline.log("Assets ship in the image — bundled at build time")
-
-		if not bench.ssh_username:
-			bench.ssh_username = bench._derive_username(bench.owner)
-
-		ssh_password = secrets.token_urlsafe(12)
-		linkuser_args = build_linkuser_args(bench, lab, settings)
-		pipeline.step("ssh_user")
-		pipeline.log(f"linkuser.sh {bench.ssh_username}")
-		# The app's copy of linkuser.sh is authoritative over the one baked into the image.
-		linkuser_script = (
-			Path(frappe.get_app_path("benchpress")) / "lab-templates" / "scripts" / "linkuser.sh"
-		)
-		write_file_to_container(
-			container_id, linkuser_script.read_text(), "/opt/benchpress/scripts/linkuser.sh"
-		)
-		linkuser_cmd = linkuser_command(linkuser_args)
-		exit_code, output = exec_in_container(
-			container_id, linkuser_cmd, user="root", environment={"SSH_PASSWORD": ssh_password}
-		)
-		if output:
-			pipeline.log(output.strip())
-		if exit_code != 0:
-			raise Exception(f"linkuser.sh failed (exit {exit_code}): {output}")
-
-		bench.ssh_password = ssh_password
-
-		# Emitted even when the lab has code-server off: a step the run decided
-		# to skip is information, and a stepper missing its tenth row is not.
-		pipeline.step("code_server")
-
-		# After linkuser.sh, not after site creation: that renames the bench user, and
-		# `usermod --login` refuses to rename a user owning a running process. The account is
-		# named here rather than derived inside the container from a path the tenant owns.
-		exit_code, output = exec_in_container(
-			container_id,
-			f"bash /opt/benchpress/scripts/serve.sh {shlex.quote(bench.ssh_username)}",
-			user="root",
-		)
-		if exit_code != 0:
-			raise Exception(f"serve.sh failed (exit {exit_code}): {output}")
-		pipeline.log(f"Site served on port {addressing.SITE_HTTP_PORT}")
-
-		if getattr(lab, "enable_code_server", 0):
-			_start_code_server(bench, container_id, pipeline, settings)
-		else:
-			pipeline.log("Code server is disabled for this lab — skipped")
-
-		bench.status = "Running"
-		bench.started_at = frappe.utils.now_datetime()
-		# Before the save, not after: the lease charge and the deadline it writes belong in the
-		# same transaction as the status they pay for. Everything above this line is free
-		# however long it took, because a deploy that never gets here never reaches `Running`.
-		metering.on_bench_running(bench)
-		bench.save(ignore_permissions=True)
-		frappe.db.commit()
-		# The eleventh step and the run's success line are one line: it carries
-		# the total elapsed time, and "Deploy complete" is still in its text for
-		# everything that reads the marker rather than the metadata.
-		pipeline.step("complete", "success")
-		frappe.db.set_value("Deploy Log", deploy_log_name, "log_type", "success")
-		frappe.db.commit()
-		_notify_owner(
-			bench.owner,
-			f"Bench deployed: {bench.bench_name} ({bench.site_name})",
-			"Bench Instance",
-			bench.name,
-		)
-
-	except Exception as e:
-		bench.reload()
-		_cleanup_failed_deploy(bench, created_container_id, append_log)
-		bench.status = "Error"
-		bench.save(ignore_permissions=True)
-		# Settle whatever did run and charge nothing further: a failed deploy is free, and a
-		# failed *re*deploy of an instance that was already burning must not keep burning.
-		metering.on_bench_stopped(bench)
-		# Beside the settle, not behind it: `on_bench_stopped` is free on a bench that never
-		# held a lease, which is every deploy that fails before Running.
-		admission.release(bench.name)
-		frappe.db.commit()
-		append_log(f"=== Deploy failed: {e!s} ===", "error")
-		frappe.db.set_value("Deploy Log", deploy_log_name, "log_type", "error")
-		frappe.db.commit()
-		frappe.log_error(
-			title=f"BenchPress deploy failed: {bench_name}",
-			message=frappe.get_traceback(),
-		)
-		_notify_owner(bench.owner, f"Bench deploy failed: {bench.bench_name}", "Bench Instance", bench.name)
-
-
 def _start_code_server(bench, container_id: str, pipeline, settings) -> None:
 	"""Configure code-server, launch it, and only then claim it is up.
 
@@ -585,21 +338,6 @@ def _setup_container_vpn(bench, container_id: str, pipeline) -> None:
 	pipeline.log(f"VPN peer {peer['peer']} registered, claimed IP {peer['assigned_ip']}")
 	configure_container(container_id, peer["private_key"], peer["assigned_ip"], bench.bridge_network)
 	pipeline.log(f"Container VPN: {peer['assigned_ip']}")
-
-
-def redeploy_bench(bench_name: str) -> None:
-	try:
-		with filelock(f"bench_deploy_{bench_name}", timeout=1):
-			_redeploy_bench(bench_name)
-	except LockTimeoutError:
-		_log_deploy_skipped(bench_name)
-
-
-def _redeploy_bench(bench_name: str) -> None:
-	# The slot is held across the whole redeploy: releasing between the two halves would hand it
-	# to somebody else and leave this caller one over their limit when their own deploy lands.
-	teardown_bench(frappe.get_doc("Bench Instance", bench_name), release_admission=False)
-	_deploy_bench(bench_name)
 
 
 def teardown_bench(bench, *, release_admission: bool = True) -> None:

--- a/benchpress/deploy_pipeline.py
+++ b/benchpress/deploy_pipeline.py
@@ -33,7 +33,7 @@ class DeployStep:
 	label: str
 
 
-# The order below is `deploy_manager._deploy_bench`'s own order. DESIGN_BRIEF §4
+# The order below is `lifecycle._deploy_bench`'s own order. DESIGN_BRIEF §4
 # lists the WireGuard peer at position 10; `_setup_container_vpn` actually runs
 # it at 5, right after the container reports an IP. The stepper is a report of
 # the run, not of the plan, so the code wins — do not "correct" this to the

--- a/benchpress/lifecycle.py
+++ b/benchpress/lifecycle.py
@@ -1,0 +1,324 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""The bench lifecycle transitions, and the side effects each one must not forget."""
+
+import json
+import secrets
+import shlex
+from pathlib import Path
+
+import frappe
+from frappe.utils.file_lock import LockTimeoutError
+from frappe.utils.synchronization import filelock
+
+from benchpress import addressing, ingress, placement
+from benchpress.credits import admission, lease, metering
+from benchpress.deploy_pipeline import DeployLogWriter, DeployPipeline
+from benchpress.docker_manager import (
+	container_network,
+	container_runtime,
+	create_bench_container,
+	exec_in_container,
+	restart_container,
+	start_bench_container,
+	start_container,
+	wait_for_container_running,
+	write_file_to_container,
+)
+from benchpress.mariadb_manager import ensure_infrastructure, wait_for_mariadb
+from benchpress.notifications import notify_owner
+
+
+def running(bench, *, action: str = "start") -> None:
+	"""Bring a bench to Running, with the four side effects a start must not forget.
+
+	`action` is "start" or "restart"; a restart keeps the `started_at` it already has.
+	"""
+	if action == "restart":
+		restart_container(bench.container_id)
+	else:
+		start_container(bench.container_id)
+		bench.started_at = frappe.utils.now_datetime()
+
+	bench.status = "Running"
+	# Before the save, so the deadline and the status it belongs to are written together. A
+	# restart does not interrupt the window the user already bought: this only buys one for a
+	# bench that had none.
+	metering.on_bench_running(bench)
+	bench.save(ignore_permissions=True)
+	frappe.db.commit()  # nosemgrep: the route job below re-reads `status`
+	# After the commit, because the job re-reads `status`.
+	ingress.enqueue_route_sync(bench.name)
+
+
+def deploy_bench(bench_name: str) -> None:
+	"""Deploy a bench, refusing to run concurrently with another deploy of the same bench."""
+	from benchpress.deploy_manager import _log_deploy_skipped
+
+	try:
+		with filelock(f"bench_deploy_{bench_name}", timeout=1):
+			_deploy_bench(bench_name)
+	except LockTimeoutError:
+		_log_deploy_skipped(bench_name)
+
+
+def _deploy_bench(bench_name: str) -> None:
+	"""Deploy pipeline — shared MariaDB, site created at runtime via press agent pattern."""
+	# Permanent, not a step on the way to a module-scope import: image building and site
+	# creation are the remainder `deploy_manager` keeps, and importing them at module scope
+	# would make a cycle the moment anything there needs a transition.
+	from benchpress.deploy_manager import (
+		_assert_runtime_registered,
+		_cleanup_failed_deploy,
+		_drop_site_database,
+		_golden_matches_server,
+		_prepare_lab_image,
+		_record_primary_site,
+		_remove_stale_container,
+		_setup_container_vpn,
+		_site_outcome,
+		_start_code_server,
+		build_linkuser_args,
+		create_site_in_container,
+		linkuser_command,
+	)
+
+	bench = frappe.get_doc("Bench Instance", bench_name)
+	lab = frappe.get_doc("Lab", bench.lab)
+
+	deploy_log = frappe.get_doc(
+		{
+			"doctype": "Deploy Log",
+			"bench": bench_name,
+			"message": "=== Deploy started ===\n",
+			"log_type": "info",
+			"timestamp": frappe.utils.now_datetime(),
+		}
+	)
+	deploy_log.insert(ignore_permissions=True)
+	frappe.db.commit()
+	deploy_log_name = deploy_log.name
+
+	# Scoped to the bench's owner: a deploy log is that user's, and nobody
+	# else's socket has any business receiving it.
+	append_log = DeployLogWriter(
+		"Deploy Log",
+		deploy_log_name,
+		"bench_deploy_log",
+		{"bench": bench_name, "deploy_log": deploy_log_name},
+		bench.owner,
+	)
+	pipeline = DeployPipeline(append_log)
+
+	created_container_id = None
+	try:
+		if bench.status == "Draft":
+			# Not the value `validate` defaulted: a bench can sit in Draft for days, and the
+			# bridge with room then is not the bridge with room now.
+			placement.record_bridge_network(bench, placement.pick_network())
+		bench.status = "Deploying"
+		bench.save(ignore_permissions=True)
+		frappe.db.commit()
+
+		admin_password = secrets.token_urlsafe(10)
+		bench.admin_password = admin_password
+
+		pipeline.step("infrastructure")
+		db_server_name = ensure_infrastructure()
+		db_server = frappe.get_doc("Database Server", db_server_name)
+		wait_for_mariadb(db_server_name, timeout=60)
+		pipeline.log(f"MariaDB reachable at {db_server.container_name}:{db_server.port or 3306}")
+
+		# First step of the deploy, so this runs minutes ahead of the image build —
+		# headroom a fresh install needs, because DNS-01 has to finish issuing before
+		# the bench route goes live.
+		settings = frappe.get_cached_doc("BenchPress Settings")
+		if ingress.ensure_anchor(settings.base_domain):
+			pipeline.log(f"Traefik wildcard anchor written for *.{settings.base_domain}")
+
+		bench.database_server = db_server_name
+		bench.save(ignore_permissions=True)
+		frappe.db.commit()
+
+		# Ahead of the image step on purpose: the build is where the minutes go,
+		# and a bench the host cannot isolate has no business paying for one.
+		_assert_runtime_registered(bench)
+
+		# One step whichever way it goes: the run either builds the image or
+		# adopts a cached one, and the detail line says which.
+		pipeline.step("image")
+		_prepare_lab_image(lab, pipeline, bench.owner)
+
+		# Both halves of the previous deploy go together, and before the new container
+		# exists: the site database is the other thing a redeploy replaces, and dropping a
+		# few hundred tables is teardown, not part of creating the site that follows.
+		_remove_stale_container(bench)
+		_drop_site_database(bench)
+		pipeline.step("container")
+		container_id = create_bench_container(bench, lab)
+		created_container_id = container_id
+		# Read back rather than assumed: the stored log answers what a bench was
+		# isolated by long after the run.
+		pipeline.log(f"container runtime {container_runtime(container_id)}")
+
+		container_id = created_container_id = start_bench_container(container_id, bench, lab)
+		placement.record_bridge_network(bench, container_network(container_id))
+		pipeline.log(f"bench bridge {bench.bridge_network}")
+
+		bench.container_id = container_id
+		bench.node = lease.local_node()
+		bench.container_image = lab.image_tag
+		bench.save(ignore_permissions=True)
+		frappe.db.commit()
+
+		pipeline.step("container_ip")
+		container_ip = wait_for_container_running(container_id, bench.bridge_network, timeout=60)
+		bench.container_ip = container_ip
+		pipeline.log(f"container_ip {container_ip}")
+		bench.save(ignore_permissions=True)
+		frappe.db.commit()
+
+		bench.public_url = addressing.public_site_url(bench.name, settings.base_domain)
+		ingress.publish(bench.name, settings.base_domain)
+		ingress.log_certificate_state(bench.name, settings.base_domain, pipeline)
+
+		_setup_container_vpn(bench, container_id, pipeline)
+
+		bench_dir = "/home/frappe/frappe-bench"
+		site_name = bench.site_name
+		config = {
+			**db_server.get_connection_config(),
+			"redis_cache": "redis://benchpress-redis:6379/0",
+			"redis_queue": "redis://benchpress-redis:6379/1",
+			"redis_socketio": "redis://benchpress-redis:6379/2",
+			"socketio_port": 9000,
+			"webserver_port": addressing.SITE_HTTP_PORT,
+			"default_site": site_name,
+			"developer_mode": 1,
+		}
+		pipeline.step("site_config")
+		write_file_to_container(
+			container_id, json.dumps(config, indent=2), f"{bench_dir}/sites/common_site_config.json"
+		)
+		pipeline.log(f"{bench_dir}/sites/common_site_config.json written")
+
+		pipeline.step("site")
+		apps_csv = ",".join(a.app_name for a in lab.apps if a.app_name.lower() != "frappe")
+		pipeline.log(f"Site {site_name} with {apps_csv or 'frappe'}")
+		use_golden, refusal = _golden_matches_server(lab.image_tag, db_server)
+		if refusal:
+			pipeline.log(refusal)
+		exit_code, output = create_site_in_container(
+			container_id, db_server, site_name, admin_password, apps_csv, use_golden=use_golden
+		)
+		if exit_code != 0:
+			raise Exception(f"Site setup failed (exit {exit_code}): {output}")
+		pipeline.log(_site_outcome(output, site_name))
+		_record_primary_site(bench, lab, admin_password)
+
+		pipeline.step("assets")
+		# Deploy never builds; rebuilding the lab image is how a stale bundle is refreshed.
+		pipeline.log("Assets ship in the image — bundled at build time")
+
+		if not bench.ssh_username:
+			bench.ssh_username = bench._derive_username(bench.owner)
+
+		ssh_password = secrets.token_urlsafe(12)
+		linkuser_args = build_linkuser_args(bench, lab, settings)
+		pipeline.step("ssh_user")
+		pipeline.log(f"linkuser.sh {bench.ssh_username}")
+		# The app's copy of linkuser.sh is authoritative over the one baked into the image.
+		linkuser_script = (
+			Path(frappe.get_app_path("benchpress")) / "lab-templates" / "scripts" / "linkuser.sh"
+		)
+		write_file_to_container(
+			container_id, linkuser_script.read_text(), "/opt/benchpress/scripts/linkuser.sh"
+		)
+		linkuser_cmd = linkuser_command(linkuser_args)
+		exit_code, output = exec_in_container(
+			container_id, linkuser_cmd, user="root", environment={"SSH_PASSWORD": ssh_password}
+		)
+		if output:
+			pipeline.log(output.strip())
+		if exit_code != 0:
+			raise Exception(f"linkuser.sh failed (exit {exit_code}): {output}")
+
+		bench.ssh_password = ssh_password
+
+		# Emitted even when the lab has code-server off: a step the run decided
+		# to skip is information, and a stepper missing its tenth row is not.
+		pipeline.step("code_server")
+
+		# After linkuser.sh, not after site creation: that renames the bench user, and
+		# `usermod --login` refuses to rename a user owning a running process. The account is
+		# named here rather than derived inside the container from a path the tenant owns.
+		exit_code, output = exec_in_container(
+			container_id,
+			f"bash /opt/benchpress/scripts/serve.sh {shlex.quote(bench.ssh_username)}",
+			user="root",
+		)
+		if exit_code != 0:
+			raise Exception(f"serve.sh failed (exit {exit_code}): {output}")
+		pipeline.log(f"Site served on port {addressing.SITE_HTTP_PORT}")
+
+		if getattr(lab, "enable_code_server", 0):
+			_start_code_server(bench, container_id, pipeline, settings)
+		else:
+			pipeline.log("Code server is disabled for this lab — skipped")
+
+		# Everything above this line is free however long it took, because a deploy that never
+		# gets here never reaches `Running`.
+		running(bench)
+		# The eleventh step and the run's success line are one line: it carries
+		# the total elapsed time, and "Deploy complete" is still in its text for
+		# everything that reads the marker rather than the metadata.
+		pipeline.step("complete", "success")
+		frappe.db.set_value("Deploy Log", deploy_log_name, "log_type", "success")
+		frappe.db.commit()
+		notify_owner(
+			bench.owner,
+			f"Bench deployed: {bench.bench_name} ({bench.site_name})",
+			"Bench Instance",
+			bench.name,
+		)
+
+	except Exception as e:
+		bench.reload()
+		_cleanup_failed_deploy(bench, created_container_id, append_log)
+		bench.status = "Error"
+		bench.save(ignore_permissions=True)
+		# Settle whatever did run and charge nothing further: a failed deploy is free, and a
+		# failed *re*deploy of an instance that was already burning must not keep burning.
+		metering.on_bench_stopped(bench)
+		# Beside the settle, not behind it: `on_bench_stopped` is free on a bench that never
+		# held a lease, which is every deploy that fails before Running.
+		admission.release(bench.name)
+		frappe.db.commit()
+		append_log(f"=== Deploy failed: {e!s} ===", "error")
+		frappe.db.set_value("Deploy Log", deploy_log_name, "log_type", "error")
+		frappe.db.commit()
+		frappe.log_error(
+			title=f"BenchPress deploy failed: {bench_name}",
+			message=frappe.get_traceback(),
+		)
+		notify_owner(bench.owner, f"Bench deploy failed: {bench.bench_name}", "Bench Instance", bench.name)
+
+
+def redeploy_bench(bench_name: str) -> None:
+	from benchpress.deploy_manager import _log_deploy_skipped
+
+	try:
+		with filelock(f"bench_deploy_{bench_name}", timeout=1):
+			_redeploy_bench(bench_name)
+	except LockTimeoutError:
+		_log_deploy_skipped(bench_name)
+
+
+def _redeploy_bench(bench_name: str) -> None:
+	from benchpress.deploy_manager import teardown_bench
+
+	# The slot is held across the whole redeploy: releasing between the two halves would hand it
+	# to somebody else and leave this caller one over their limit when their own deploy lands.
+	teardown_bench(frappe.get_doc("Bench Instance", bench_name), release_admission=False)
+	_deploy_bench(bench_name)

--- a/benchpress/lifecycle.py
+++ b/benchpress/lifecycle.py
@@ -47,7 +47,7 @@ def running(bench, *, action: str = "start") -> None:
 	# bench that had none.
 	metering.on_bench_running(bench)
 	bench.save(ignore_permissions=True)
-	frappe.db.commit()  # nosemgrep: the route job below re-reads `status`
+	frappe.db.commit()  # nosemgrep -- the route job re-reads `status`, so it must not start before this
 	# After the commit, because the job re-reads `status`.
 	ingress.enqueue_route_sync(bench.name)
 
@@ -97,7 +97,7 @@ def _deploy_bench(bench_name: str) -> None:
 		}
 	)
 	deploy_log.insert(ignore_permissions=True)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep -- the SPA opens the log by name, so the row has to exist before the run continues
 	deploy_log_name = deploy_log.name
 
 	# Scoped to the bench's owner: a deploy log is that user's, and nobody
@@ -119,7 +119,7 @@ def _deploy_bench(bench_name: str) -> None:
 			placement.record_bridge_network(bench, placement.pick_network())
 		bench.status = "Deploying"
 		bench.save(ignore_permissions=True)
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep -- `Deploying` has to be visible while the minutes below run
 
 		admin_password = secrets.token_urlsafe(10)
 		bench.admin_password = admin_password
@@ -139,7 +139,7 @@ def _deploy_bench(bench_name: str) -> None:
 
 		bench.database_server = db_server_name
 		bench.save(ignore_permissions=True)
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep -- the server the rest of the run uses, published before it is used
 
 		# Ahead of the image step on purpose: the build is where the minutes go,
 		# and a bench the host cannot isolate has no business paying for one.
@@ -170,14 +170,14 @@ def _deploy_bench(bench_name: str) -> None:
 		bench.node = lease.local_node()
 		bench.container_image = lab.image_tag
 		bench.save(ignore_permissions=True)
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep -- the container id, so a crash after this point leaves something to clean up
 
 		pipeline.step("container_ip")
 		container_ip = wait_for_container_running(container_id, bench.bridge_network, timeout=60)
 		bench.container_ip = container_ip
 		pipeline.log(f"container_ip {container_ip}")
 		bench.save(ignore_permissions=True)
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep -- the address the route file is written from
 
 		bench.public_url = addressing.public_site_url(bench.name, settings.base_domain)
 		ingress.publish(bench.name, settings.base_domain)
@@ -275,7 +275,7 @@ def _deploy_bench(bench_name: str) -> None:
 		# everything that reads the marker rather than the metadata.
 		pipeline.step("complete", "success")
 		frappe.db.set_value("Deploy Log", deploy_log_name, "log_type", "success")
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep -- the success marker, read by everything watching the run
 		notify_owner(
 			bench.owner,
 			f"Bench deployed: {bench.bench_name} ({bench.site_name})",
@@ -294,10 +294,10 @@ def _deploy_bench(bench_name: str) -> None:
 		# Beside the settle, not behind it: `on_bench_stopped` is free on a bench that never
 		# held a lease, which is every deploy that fails before Running.
 		admission.release(bench.name)
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep -- the failure state, before the log lines that explain it
 		append_log(f"=== Deploy failed: {e!s} ===", "error")
 		frappe.db.set_value("Deploy Log", deploy_log_name, "log_type", "error")
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep -- the log's own outcome, so a watcher sees why the run stopped
 		frappe.log_error(
 			title=f"BenchPress deploy failed: {bench_name}",
 			message=frappe.get_traceback(),

--- a/benchpress/lifecycle.py
+++ b/benchpress/lifecycle.py
@@ -20,6 +20,7 @@ from benchpress.docker_manager import (
 	container_runtime,
 	create_bench_container,
 	exec_in_container,
+	remove_container,
 	restart_container,
 	start_bench_container,
 	start_container,
@@ -29,6 +30,8 @@ from benchpress.docker_manager import (
 )
 from benchpress.mariadb_manager import ensure_infrastructure, wait_for_mariadb
 from benchpress.notifications import notify_owner
+
+NOTHING_TO_ROLL_BACK = "Cleanup: nothing to roll back — no container was created"
 
 
 def running(bench, *, action: str = "start") -> None:
@@ -97,6 +100,103 @@ def _deactivate_bench_sites(bench) -> None:
 	frappe.db.set_value("Bench Site", {"bench": bench.name}, "status", "Inactive", update_modified=False)
 
 
+def torn_down(bench, *, release_admission: bool = True) -> None:
+	"""Return an instance to `Draft`: container, volume and site database all gone.
+
+	`release_admission=False` keeps the slot for `_redeploy_bench`, which is this plus a deploy.
+	"""
+	if bench.container_id:
+		try:
+			stop_container(bench.container_id)
+		except Exception:
+			pass  # best-effort
+		_remove_container(bench.container_id)
+
+	_drop_site_database(bench)
+	bench.container_id = None
+	bench.container_image = None
+	bench.started_at = None
+	_ended(bench, "Draft", release_admission=release_admission)
+
+
+def errored(bench, container_id: str | None, append_log) -> None:
+	"""Roll back a deploy that failed, keeping the site name so a retry still owns it.
+
+	`container_id` is this run's; `bench.container_id` may still name the previous deploy's.
+	"""
+	if not container_id:
+		append_log(NOTHING_TO_ROLL_BACK)
+	else:
+		_remove_container(container_id)
+		append_log("Cleanup: removed container created by this run")
+		if _remove_bench_peer(bench):
+			append_log("Cleanup: VPN peer removed")
+		# Only this run's addresses are cleared: a failure before the container leaves the
+		# previous deploy's, and that container is still running.
+		bench.container_id = None
+		bench.container_ip = None
+		bench.wg_ip = None
+
+	# No `_drop_site_database` here: the `Bench Site` row is the name claim, and the retry drops
+	# the database itself before it recreates the site.
+	_ended(bench, "Error", release_admission=True)
+
+
+def _ended(bench, status: str, *, release_admission: bool) -> None:
+	"""Write the end of a bench's life, with the side effects both endings share.
+
+	`status` is the only difference: `Draft` discards the instance, `Error` leaves it for a retry.
+	"""
+	try:
+		# Direct, not enqueued: a lost job would leave a public hostname answering for a bench
+		# that no longer runs.
+		ingress.withdraw(bench.name)
+	except Exception:
+		pass  # best-effort
+
+	# Marked, not deleted: the row is the site-name claim, and a redeploy refreshes it.
+	_deactivate_bench_sites(bench)
+	# The container this bench was burning for is gone, so the session ends here. Without this
+	# the burning flag would survive into the next container, which `_deploy_bench` bills
+	# through the same idempotence guard, and it would run unmetered.
+	metering.on_bench_stopped(bench)
+	if release_admission:
+		admission.release(bench.name)
+
+	bench.status = status
+	bench.save(ignore_permissions=True)
+	frappe.db.commit()  # nosemgrep -- the caller may redeploy next, which must see this status
+
+
+def _remove_container(container_id: str) -> None:
+	try:
+		remove_container(container_id)
+	except Exception:
+		pass  # best-effort
+
+
+def _remove_bench_peer(bench) -> bool:
+	"""Drop the WireGuard peer, reporting whether it went, since the caller logs the outcome."""
+	from benchpress.vpn_adapter import remove_bench_peer
+
+	try:
+		remove_bench_peer(bench)
+		return True
+	except Exception:
+		return False
+
+
+def _drop_site_database(bench) -> None:
+	if not (bench.database_server and bench.site_name):
+		return
+	from benchpress.mariadb_manager import drop_site_database
+
+	try:
+		drop_site_database(bench.database_server, bench.site_name)
+	except Exception:
+		pass  # best-effort
+
+
 def deploy_bench(bench_name: str) -> None:
 	"""Deploy a bench, refusing to run concurrently with another deploy of the same bench."""
 	from benchpress.deploy_manager import _log_deploy_skipped
@@ -115,8 +215,6 @@ def _deploy_bench(bench_name: str) -> None:
 	# would make a cycle the moment anything there needs a transition.
 	from benchpress.deploy_manager import (
 		_assert_runtime_registered,
-		_cleanup_failed_deploy,
-		_drop_site_database,
 		_golden_matches_server,
 		_prepare_lab_image,
 		_record_primary_site,
@@ -330,16 +428,9 @@ def _deploy_bench(bench_name: str) -> None:
 
 	except Exception as e:
 		bench.reload()
-		_cleanup_failed_deploy(bench, created_container_id, append_log)
-		bench.status = "Error"
-		bench.save(ignore_permissions=True)
-		# Settle whatever did run and charge nothing further: a failed deploy is free, and a
+		# Settles metering and releases the slot on the way past: a failed deploy is free, and a
 		# failed *re*deploy of an instance that was already burning must not keep burning.
-		metering.on_bench_stopped(bench)
-		# Beside the settle, not behind it: `on_bench_stopped` is free on a bench that never
-		# held a lease, which is every deploy that fails before Running.
-		admission.release(bench.name)
-		frappe.db.commit()  # nosemgrep -- the failure state, before the log lines that explain it
+		errored(bench, created_container_id, append_log)
 		append_log(f"=== Deploy failed: {e!s} ===", "error")
 		frappe.db.set_value("Deploy Log", deploy_log_name, "log_type", "error")
 		frappe.db.commit()  # nosemgrep -- the log's own outcome, so a watcher sees why the run stopped
@@ -361,9 +452,7 @@ def redeploy_bench(bench_name: str) -> None:
 
 
 def _redeploy_bench(bench_name: str) -> None:
-	from benchpress.deploy_manager import teardown_bench
-
 	# The slot is held across the whole redeploy: releasing between the two halves would hand it
 	# to somebody else and leave this caller one over their limit when their own deploy lands.
-	teardown_bench(frappe.get_doc("Bench Instance", bench_name), release_admission=False)
+	torn_down(frappe.get_doc("Bench Instance", bench_name), release_admission=False)
 	_deploy_bench(bench_name)

--- a/benchpress/lifecycle.py
+++ b/benchpress/lifecycle.py
@@ -23,6 +23,7 @@ from benchpress.docker_manager import (
 	restart_container,
 	start_bench_container,
 	start_container,
+	stop_container,
 	wait_for_container_running,
 	write_file_to_container,
 )
@@ -50,6 +51,50 @@ def running(bench, *, action: str = "start") -> None:
 	frappe.db.commit()  # nosemgrep -- the route job re-reads `status`, so it must not start before this
 	# After the commit, because the job re-reads `status`.
 	ingress.enqueue_route_sync(bench.name)
+
+
+def stopped(bench_name: str, from_claim: bool = False) -> None:
+	"""Stop a bench container, and with it every site the container was serving.
+
+	`from_claim` marks a queued expiry, which must not go ahead once it has outlived its claim.
+	"""
+	if not lease.confirm_expiry(bench_name, from_claim=from_claim):
+		return
+
+	lease.record_stop_started(bench_name)
+	bench = frappe.get_doc("Bench Instance", bench_name)
+	lease.assert_local(bench)
+	expired = bench.lease_state == lease.STOPPING
+
+	try:
+		if bench.container_id:
+			stop_container(bench.container_id)
+	except Exception:
+		if expired:
+			lease.release(bench_name, failed=True)
+			frappe.db.commit()  # nosemgrep -- the retry has to survive the failure that caused it
+		raise
+
+	lease.record_stopped(bench, expired)
+	bench.status = "Stopped"
+	metering.on_bench_stopped(bench)
+	# Stopped is free, so it must stop holding a slot too: a caller at their cap who stops
+	# everything they own would otherwise never start anything again.
+	admission.release(bench.name)
+	bench.save(ignore_permissions=True)
+	_deactivate_bench_sites(bench)
+	if expired:
+		lease.announce_expired(bench)
+	frappe.db.commit()  # nosemgrep -- intentional commit to persist status before response
+	ingress.enqueue_route_sync(bench.name)
+
+
+def _deactivate_bench_sites(bench) -> None:
+	"""Mark every `Bench Site` on this instance Inactive, since its data is gone.
+
+	One UPDATE: `set_value` takes the filter itself, so the row names never have to be read.
+	"""
+	frappe.db.set_value("Bench Site", {"bench": bench.name}, "status", "Inactive", update_modified=False)
 
 
 def deploy_bench(bench_name: str) -> None:

--- a/benchpress/mariadb_manager.py
+++ b/benchpress/mariadb_manager.py
@@ -20,6 +20,13 @@ BACKUP_TIMEOUT = 3600
 
 REDIS_CONTAINER_NAME = "benchpress-redis"
 
+# `Database Server` statuses. A bench carries its own, spelled the same and meaning
+# something else, and only `lifecycle` writes that one.
+SERVER_PENDING = "Pending"
+SERVER_ACTIVE = "Active"
+SERVER_STOPPED = "Stopped"
+SERVER_ERROR = "Error"
+
 # What config/docker-compose.yml declares as command flags, in the units the servers report
 # back. A live value that disagrees means the container predates the flags, or the daemon
 # refused one, or somebody ran SET GLOBAL.
@@ -147,7 +154,7 @@ def setup_database_server(db_server_name: str) -> None:
 		db_server.reload()
 		db_server.container_id = container.id
 		db_server.container_ip = container_ip
-		db_server.status = "Active"
+		db_server.status = SERVER_ACTIVE
 		db_server.created_at = frappe.utils.now()
 		db_server.save(ignore_permissions=True)
 		frappe.db.commit()
@@ -173,7 +180,7 @@ def start_database_server(db_server_name: str) -> None:
 	client = get_client()
 	container = client.containers.get(db_server.container_name)
 	db_server.container_id = container.id
-	db_server.status = "Active"
+	db_server.status = SERVER_ACTIVE
 	db_server.save(ignore_permissions=True)
 	frappe.db.commit()
 
@@ -183,7 +190,7 @@ def stop_database_server(db_server_name: str) -> None:
 	_compose_cmd("stop", "mariadb")
 
 	db_server = frappe.get_doc("Database Server", db_server_name)
-	db_server.status = "Stopped"
+	db_server.status = SERVER_STOPPED
 	db_server.save(ignore_permissions=True)
 	frappe.db.commit()
 
@@ -194,7 +201,7 @@ def ensure_database_server() -> str:
 	"""
 	servers = frappe.get_all(
 		"Database Server",
-		filters={"status": ["in", ["Active", "Pending", "Stopped"]]},
+		filters={"status": ["in", [SERVER_ACTIVE, SERVER_PENDING, SERVER_STOPPED]]},
 		fields=["name", "status"],
 		order_by="creation asc",
 		limit=1,
@@ -202,9 +209,9 @@ def ensure_database_server() -> str:
 
 	if servers:
 		server = servers[0]
-		if server.status == "Stopped":
+		if server.status == SERVER_STOPPED:
 			start_database_server(server.name)
-		elif server.status == "Pending":
+		elif server.status == SERVER_PENDING:
 			setup_database_server(server.name)
 		return server.name
 
@@ -482,7 +489,7 @@ def scheduled_health_check() -> list[str]:
 	"""
 	servers = frappe.get_all(
 		"Database Server",
-		filters={"status": ["in", ["Active", "Error"]]},
+		filters={"status": ["in", [SERVER_ACTIVE, SERVER_ERROR]]},
 		fields=["name"],
 	)
 	for s in servers:
@@ -623,7 +630,7 @@ def enqueue_backup() -> None:
 
 def scheduled_backup():
 	"""Cron job — nightly backup with 7-day retention."""
-	servers = frappe.get_all("Database Server", filters={"status": "Active"}, fields=["name"])
+	servers = frappe.get_all("Database Server", filters={"status": SERVER_ACTIVE}, fields=["name"])
 	for s in servers:
 		try:
 			backup_database_server(s.name)

--- a/benchpress/patches/name_bench_sites_by_site_name.py
+++ b/benchpress/patches/name_bench_sites_by_site_name.py
@@ -10,7 +10,7 @@ first tenant's data. `autoname: field:site_name` closes that, and existing rows 
 moved onto their names before the constraint can hold.
 
 A duplicate loser is suffixed and deactivated, never deleted. An `Inactive` row can still own a
-live database - `stop_bench` deactivates without dropping - and `api._drop_bench_site_databases`
+live database - `lifecycle.stopped` deactivates without dropping - and `api._drop_bench_site_databases`
 reads `site_name` to find what to drop, so a row deleted here is a database nothing will ever
 clean up. The suffixed loser is the record that the collision happened.
 """

--- a/benchpress/site_names.py
+++ b/benchpress/site_names.py
@@ -90,9 +90,9 @@ def claimed(bench):
 	return site
 
 
-# The name is held for exactly as long as the row. `teardown_bench` keeps it so a redeploy still
-# owns its own name; only a deleted instance frees it, which is once `api._delete_bench` has
-# dropped the database the name keyed.
+# The name is held for exactly as long as the row. `lifecycle.torn_down` keeps it so a redeploy
+# still owns its own name; only a deleted instance frees it, which is once `api._delete_bench`
+# has dropped the database the name keyed.
 def release(bench_name: str) -> None:
 	"""Free every name this bench holds, by deleting the rows that are the claim."""
 	for site in frappe.get_all("Bench Site", filters={"bench": bench_name}, pluck="name"):

--- a/benchpress/stats_collector.py
+++ b/benchpress/stats_collector.py
@@ -5,6 +5,7 @@ import frappe
 from frappe import _
 from frappe.utils import now_datetime
 
+from benchpress import lifecycle
 from benchpress.docker_manager import container_is_gone, get_container_health, get_container_stats
 
 
@@ -88,10 +89,9 @@ def _stop_if_dead(bench: dict, health: str) -> None:
 	if health == "Unknown" and not container_is_gone(bench["container_id"]):
 		return
 
-	from benchpress.deploy_manager import stop_bench
 	from benchpress.notifications import notify_owner
 
-	stop_bench(bench["name"])
+	lifecycle.stopped(bench["name"])
 	notify_owner(
 		bench["owner"],
 		_("Bench {0} was stopped: its container is no longer running.").format(bench["name"]),

--- a/benchpress/tests/test_admission.py
+++ b/benchpress/tests/test_admission.py
@@ -215,16 +215,16 @@ class TestAdmission(IntegrationTestCase):
 	# --- The lifecycle paths that must give it back ---------------------------
 
 	def test_stopping_a_bench_frees_its_slot(self):
-		from benchpress.deploy_manager import stop_bench
+		from benchpress.lifecycle import stopped
 
 		bench = self.running_bench(self.benches[0])
 		admission.claim(USER, bench.name, 1)
 		with (
-			patch("benchpress.deploy_manager.stop_container"),
+			patch("benchpress.lifecycle.stop_container"),
 			patch("frappe.enqueue"),
 			patch("frappe.db.commit"),
 		):
-			stop_bench(bench.name)
+			stopped(bench.name)
 		self.assertEqual(self.counter(), 0)
 
 	def test_tearing_a_bench_down_frees_its_slot(self):

--- a/benchpress/tests/test_admission.py
+++ b/benchpress/tests/test_admission.py
@@ -438,7 +438,7 @@ class TestAdmission(IntegrationTestCase):
 		self.running_bench(self.benches[1])
 		frappe.set_user(USER)
 		with (
-			patch("benchpress.docker_manager.start_container"),
+			patch("benchpress.lifecycle.start_container"),
 			patch("benchpress.ingress.enqueue_route_sync"),
 			patch("frappe.db.commit"),
 		):

--- a/benchpress/tests/test_admission.py
+++ b/benchpress/tests/test_admission.py
@@ -455,7 +455,7 @@ class TestAdmission(IntegrationTestCase):
 		admission.claim(USER, bench.name, 0)
 		frappe.set_user(USER)
 		with (
-			patch("benchpress.deploy_manager.stop_container"),
+			patch("benchpress.lifecycle.stop_container"),
 			patch("frappe.enqueue"),
 			patch("frappe.db.commit"),
 		):
@@ -549,16 +549,16 @@ class TestAdmission(IntegrationTestCase):
 		)
 
 	def teardown(self, bench, **kwargs) -> None:
-		from benchpress.deploy_manager import teardown_bench
+		from benchpress import lifecycle
 
 		with (
-			patch("benchpress.deploy_manager.stop_container"),
-			patch("benchpress.deploy_manager.remove_container"),
-			patch("benchpress.deploy_manager._drop_site_database"),
+			patch("benchpress.lifecycle.stop_container"),
+			patch("benchpress.lifecycle.remove_container"),
+			patch("benchpress.lifecycle._drop_site_database"),
 			patch("benchpress.ingress.withdraw"),
 			patch("frappe.db.commit"),
 		):
-			teardown_bench(frappe.get_doc(BENCH, bench.name), **kwargs)
+			lifecycle.torn_down(frappe.get_doc(BENCH, bench.name), **kwargs)
 
 	def running_bench(self, bench):
 		frappe.db.set_value(

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -749,7 +749,7 @@ class TestApi(IntegrationTestCase):
 		self.addCleanup(frappe.delete_doc, "Bench Site", site.name, force=True, ignore_permissions=True)
 		self.addCleanup(frappe.db.commit)
 
-		with patch("benchpress.deploy_manager.stop_container"):
+		with patch("benchpress.lifecycle.stop_container"):
 			api.bench_action(self.action_bench.name, "stop")
 
 		self.assertEqual(frappe.db.get_value("Bench Site", site.name, "status"), "Inactive")
@@ -766,7 +766,7 @@ class TestApi(IntegrationTestCase):
 			with (
 				self.subTest(action=action),
 				patch("benchpress.lifecycle.start_container") as start,
-				patch("benchpress.deploy_manager.stop_container") as stop,
+				patch("benchpress.lifecycle.stop_container") as stop,
 				patch("benchpress.lifecycle.restart_container") as restart,
 			):
 				with self.assertRaises(frappe.ValidationError) as caught:

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -660,7 +660,7 @@ class TestApi(IntegrationTestCase):
 		)
 
 	def test_create_bench_refuses_to_rename_a_stopped_instance(self):
-		"""`stop_bench` never drops the database, so a `Stopped` instance's site is still live."""
+		"""`lifecycle.stopped` never drops the database, so a `Stopped` instance's site is still live."""
 		self._set_base_domain("benchpress.cloud")
 		lab = _ensure_lab("api-timing-rename-stopped-lab", apps=[_lab_app()])
 		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
@@ -726,9 +726,7 @@ class TestApi(IntegrationTestCase):
 	def test_bench_action_start_stop_restart_and_timing(self):
 		with (
 			patch("benchpress.lifecycle.start_container"),
-			# Stop routes through `deploy_manager.stop_bench`, which bound its Docker call at
-			# import — so the patch has to land on that module, not on `docker_manager`.
-			patch("benchpress.deploy_manager.stop_container"),
+			patch("benchpress.lifecycle.stop_container"),
 			patch("benchpress.lifecycle.restart_container"),
 			patch("benchpress.docker_manager.remove_container"),
 		):
@@ -826,11 +824,11 @@ class TestApi(IntegrationTestCase):
 		self.assertEqual(enqueue.call_args.args[0], "benchpress.lifecycle.redeploy_bench")
 		self.assert_within_budget("enqueue_redeploy", elapsed_ms)
 
-	def test_enqueue_stop_calls_stop_bench_and_timing(self):
+	def test_enqueue_stop_calls_stopped_and_timing(self):
 		bench = frappe.get_doc("Bench Instance", self.bench.name)
-		with patch("benchpress.deploy_manager.stop_bench") as stop_bench:
+		with patch("benchpress.lifecycle.stopped") as stopped:
 			_, elapsed_ms = _timed(bench.enqueue_stop)
-		stop_bench.assert_called_once_with(bench.name)
+		stopped.assert_called_once_with(bench.name)
 		self.assert_within_budget("enqueue_stop", elapsed_ms)
 
 	def test_enqueue_start_starts_container_and_timing(self):

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -815,7 +815,7 @@ class TestApi(IntegrationTestCase):
 		with patch("frappe.enqueue") as enqueue:
 			_, elapsed_ms = _timed(bench.enqueue_deploy)
 		enqueue.assert_called_once()
-		self.assertEqual(enqueue.call_args.args[0], "benchpress.deploy_manager.deploy_bench")
+		self.assertEqual(enqueue.call_args.args[0], "benchpress.lifecycle.deploy_bench")
 		self.assert_within_budget("enqueue_deploy", elapsed_ms)
 
 	def test_enqueue_redeploy_calls_job_and_timing(self):
@@ -823,7 +823,7 @@ class TestApi(IntegrationTestCase):
 		with patch("frappe.enqueue") as enqueue:
 			_, elapsed_ms = _timed(bench.enqueue_redeploy)
 		enqueue.assert_called_once()
-		self.assertEqual(enqueue.call_args.args[0], "benchpress.deploy_manager.redeploy_bench")
+		self.assertEqual(enqueue.call_args.args[0], "benchpress.lifecycle.redeploy_bench")
 		self.assert_within_budget("enqueue_redeploy", elapsed_ms)
 
 	def test_enqueue_stop_calls_stop_bench_and_timing(self):
@@ -835,7 +835,7 @@ class TestApi(IntegrationTestCase):
 
 	def test_enqueue_start_starts_container_and_timing(self):
 		bench = frappe.get_doc("Bench Instance", self.bench.name)
-		with patch("benchpress.docker_manager.start_container") as start_container:
+		with patch("benchpress.lifecycle.start_container") as start_container:
 			_, elapsed_ms = _timed(bench.enqueue_start)
 		start_container.assert_called_once_with(bench.container_id)
 		self.assertEqual(bench.status, "Running")

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -725,11 +725,11 @@ class TestApi(IntegrationTestCase):
 
 	def test_bench_action_start_stop_restart_and_timing(self):
 		with (
-			patch("benchpress.docker_manager.start_container"),
+			patch("benchpress.lifecycle.start_container"),
 			# Stop routes through `deploy_manager.stop_bench`, which bound its Docker call at
 			# import — so the patch has to land on that module, not on `docker_manager`.
 			patch("benchpress.deploy_manager.stop_container"),
-			patch("benchpress.docker_manager.restart_container"),
+			patch("benchpress.lifecycle.restart_container"),
 			patch("benchpress.docker_manager.remove_container"),
 		):
 			for action, expected in (("start", "Running"), ("stop", "Stopped"), ("restart", "Running")):
@@ -767,9 +767,9 @@ class TestApi(IntegrationTestCase):
 		for action in ("start", "stop", "restart"):
 			with (
 				self.subTest(action=action),
-				patch("benchpress.docker_manager.start_container") as start,
+				patch("benchpress.lifecycle.start_container") as start,
 				patch("benchpress.deploy_manager.stop_container") as stop,
-				patch("benchpress.docker_manager.restart_container") as restart,
+				patch("benchpress.lifecycle.restart_container") as restart,
 			):
 				with self.assertRaises(frappe.ValidationError) as caught:
 					api.bench_action(bench.name, action)

--- a/benchpress/tests/test_credit_sweep.py
+++ b/benchpress/tests/test_credit_sweep.py
@@ -297,8 +297,8 @@ class TestCreditSweep(IntegrationTestCase):
 
 		with (
 			patch("frappe.db.commit"),
-			patch("benchpress.deploy_manager.stop_container") as stop,
-			patch("benchpress.deploy_manager.remove_container") as remove,
+			patch("benchpress.lifecycle.stop_container") as stop,
+			patch("benchpress.lifecycle.remove_container") as remove,
 			patch("benchpress.docker_manager.get_client") as client,
 			patch("benchpress.mariadb_manager.drop_site_database") as drop,
 		):
@@ -315,7 +315,7 @@ class TestCreditSweep(IntegrationTestCase):
 		"""Between the decision and the job, one click can make the decision wrong."""
 		self.enable_credits()
 		frappe.db.set_value(BENCH, self.bench.name, "status", "Running", update_modified=False)
-		with patch("benchpress.deploy_manager.teardown_bench") as teardown:
+		with patch("benchpress.lifecycle.torn_down") as teardown:
 			reaper.reap_bench(self.bench.name)
 		teardown.assert_not_called()
 

--- a/benchpress/tests/test_credit_sweep.py
+++ b/benchpress/tests/test_credit_sweep.py
@@ -165,7 +165,7 @@ class TestCreditSweep(IntegrationTestCase):
 		self.enable_credits()
 		self.fund(0)
 		self.assertEqual(self.ours(sweep.enforce_limits()["stopped"]), [self.bench.name])
-		self.assert_enqueued("benchpress.deploy_manager.stop_bench")
+		self.assert_enqueued("benchpress.lifecycle.stopped")
 
 	def test_a_funded_owner_keeps_running(self):
 		self.enable_credits()
@@ -196,7 +196,7 @@ class TestCreditSweep(IntegrationTestCase):
 		self.assertTrue(stop.kwargs["deduplicate"])
 
 	def test_the_stop_cannot_start_before_the_decision_commits(self):
-		"""`stop_bench` re-reads the row, so a job that runs first acts on a decision that may roll back."""
+		"""`lifecycle.stopped` re-reads the row, so a job that runs first acts on a decision that may roll back."""
 		sweep._enqueue_stop(self.bench.name)
 		self.assertTrue(self.enqueue_for(self.bench.name).kwargs["enqueue_after_commit"])
 

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -182,66 +182,6 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 		for container_name in frappe.get_all("Database Server", pluck="container_name"):
 			self.docker.add_container(container_name)
 
-	# --- stop_bench ---
-
-	def test_stop_bench_sets_status_stopped(self):
-		from benchpress.deploy_manager import stop_bench
-
-		bench = self._fresh_bench()
-		self.docker.add_container("container-xyz")
-		bench.container_id = "container-xyz"
-		bench.status = "Running"
-		bench.save(ignore_permissions=True)
-		frappe.db.commit()
-
-		stop_bench(bench.name)
-		bench.reload()
-		self.assertEqual(bench.status, "Stopped")
-
-	def test_stop_bench_calls_stop_container(self):
-		from benchpress.deploy_manager import stop_bench
-
-		bench = self._fresh_bench()
-		self.docker.add_container("container-stop-test")
-		bench.container_id = "container-stop-test"
-		bench.save(ignore_permissions=True)
-		frappe.db.commit()
-
-		stop_bench(bench.name)
-		self.assertEqual(self.docker.stopped, ["container-stop-test"])
-
-	def test_stop_bench_skips_container_stop_when_no_container_id(self):
-		from benchpress.deploy_manager import stop_bench
-
-		bench = self._fresh_bench()
-		bench.container_id = None
-		bench.save(ignore_permissions=True)
-		frappe.db.commit()
-
-		stop_bench(bench.name)
-		self.assertEqual(self.docker.stopped, [])
-		bench.reload()
-		self.assertEqual(bench.status, "Stopped")
-
-	def test_stop_bench_deactivates_every_site_on_the_bench(self):
-		"""Nothing answers inside a stopped container, so no row may stay Active."""
-		from benchpress.deploy_manager import stop_bench
-
-		bench = self._fresh_bench()
-		self.docker.add_container("container-stop-sites")
-		bench.container_id = "container-stop-sites"
-		bench.status = "Running"
-		bench.save(ignore_permissions=True)
-		_make_bench_site(bench.name, "one.localhost")
-		_make_bench_site(bench.name, "two.localhost")
-		frappe.db.commit()
-
-		stop_bench(bench.name)
-		stop_bench(bench.name)  # a second stop is a no-op, not an error
-
-		statuses = frappe.get_all("Bench Site", filters={"bench": bench.name}, pluck="status")
-		self.assertEqual(statuses, ["Inactive", "Inactive"])
-
 	@patch("benchpress.lifecycle._deploy_bench")
 	def test_redeploy_bench_resets_status_to_draft_before_deploy(self, mock_deploy):
 		from benchpress.lifecycle import redeploy_bench
@@ -1293,7 +1233,8 @@ class TestRecordPrimarySite(IntegrationTestCase):
 		self.assertEqual(frappe.db.count("Bench Site", {"bench": bench.name}), 1)
 
 	def test_teardown_marks_the_site_inactive(self):
-		from benchpress.deploy_manager import _deactivate_bench_sites, _record_primary_site
+		from benchpress.deploy_manager import _record_primary_site
+		from benchpress.lifecycle import _deactivate_bench_sites
 
 		bench = self._bench()
 		_record_primary_site(bench, self.lab, "secret-one")
@@ -1302,11 +1243,12 @@ class TestRecordPrimarySite(IntegrationTestCase):
 
 		self.assertEqual(frappe.db.get_value("Bench Site", {"bench": bench.name}, "status"), "Inactive")
 
-	@patch("benchpress.deploy_manager.stop_container")
+	@patch("benchpress.lifecycle.stop_container")
 	def test_a_deploy_returns_a_stopped_site_to_active(self, mock_stop):
 		"""The round trip, which needs no code of its own: `_record_primary_site` already writes
 		`Active`, so a stop followed by a deploy must land back where it started."""
-		from benchpress.deploy_manager import _record_primary_site, stop_bench
+		from benchpress.deploy_manager import _record_primary_site
+		from benchpress.lifecycle import stopped
 
 		bench = self._bench()
 		bench.container_id = "container-round-trip"
@@ -1314,7 +1256,7 @@ class TestRecordPrimarySite(IntegrationTestCase):
 		_record_primary_site(bench, self.lab, "secret-one")
 		frappe.db.commit()
 
-		stop_bench(bench.name)
+		stopped(bench.name)
 		self.assertEqual(frappe.db.get_value("Bench Site", {"bench": bench.name}, "status"), "Inactive")
 
 		bench.reload()

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -14,7 +14,7 @@ import frappe
 import yaml
 from frappe.tests import IntegrationTestCase
 
-from benchpress import ingress
+from benchpress import deploy_manager, ingress, lifecycle
 from benchpress.benchpress.doctype.bench_instance import get_instance_id
 from benchpress.tests.fakes import FakeDockerMixin, sql_of
 from benchpress.tests.test_docker_manager import exec_commands, exec_environments
@@ -242,9 +242,9 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 		statuses = frappe.get_all("Bench Site", filters={"bench": bench.name}, pluck="status")
 		self.assertEqual(statuses, ["Inactive", "Inactive"])
 
-	@patch("benchpress.deploy_manager._deploy_bench")
+	@patch("benchpress.lifecycle._deploy_bench")
 	def test_redeploy_bench_resets_status_to_draft_before_deploy(self, mock_deploy):
-		from benchpress.deploy_manager import redeploy_bench
+		from benchpress.lifecycle import redeploy_bench
 
 		bench = self._fresh_bench()
 		self.docker.add_container("old-container")
@@ -265,9 +265,9 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 		mock_deploy.assert_called_once_with(bench.name)
 		self.assertEqual(status_at_deploy["status"], "Draft")
 
-	@patch("benchpress.deploy_manager._deploy_bench")
+	@patch("benchpress.lifecycle._deploy_bench")
 	def test_redeploy_bench_never_touches_volumes(self, mock_deploy):
-		from benchpress.deploy_manager import redeploy_bench
+		from benchpress.lifecycle import redeploy_bench
 
 		bench = self._fresh_bench()
 		self.docker.add_container("old-container")
@@ -279,9 +279,9 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 
 		self.assertEqual(self.docker.volume_gets, [])
 
-	@patch("benchpress.deploy_manager._deploy_bench")
+	@patch("benchpress.lifecycle._deploy_bench")
 	def test_redeploy_bench_drops_site_database(self, mock_deploy):
-		from benchpress.deploy_manager import redeploy_bench
+		from benchpress.lifecycle import redeploy_bench
 		from benchpress.mariadb_manager import get_database_name
 
 		bench = self._fresh_bench()
@@ -314,9 +314,9 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 
 		self.addCleanup(_purge)
 
-	@patch("benchpress.deploy_manager._deploy_bench")
+	@patch("benchpress.lifecycle._deploy_bench")
 	def test_deploy_skipped_when_lock_held(self, mock_deploy):
-		from benchpress.deploy_manager import deploy_bench
+		from benchpress.lifecycle import deploy_bench
 
 		bench = self._fresh_bench()
 		self._cleanup_deploy_logs(bench.name)
@@ -332,9 +332,9 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 		)
 		self.assertIn("skipped", skip_message)
 
-	@patch("benchpress.deploy_manager._deploy_bench")
+	@patch("benchpress.lifecycle._deploy_bench")
 	def test_deploy_lock_released_after_run(self, mock_deploy):
-		from benchpress.deploy_manager import deploy_bench
+		from benchpress.lifecycle import deploy_bench
 
 		bench = self._fresh_bench()
 		deploy_bench(bench.name)
@@ -342,9 +342,9 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 
 		self.assertEqual(mock_deploy.call_count, 2)
 
-	@patch("benchpress.deploy_manager._deploy_bench")
+	@patch("benchpress.lifecycle._deploy_bench")
 	def test_redeploy_skipped_when_lock_held(self, mock_deploy):
-		from benchpress.deploy_manager import redeploy_bench
+		from benchpress.lifecycle import redeploy_bench
 
 		bench = self._fresh_bench()
 		self._cleanup_deploy_logs(bench.name)
@@ -366,8 +366,6 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 		return logs[0].message if logs else ""
 
 	def test_deploy_failure_after_container_creation_cleans_up(self):
-		from benchpress import deploy_manager
-
 		bench = self._fresh_bench()
 		self._cleanup_deploy_logs(bench.name)
 		self._shared_mariadb_up()
@@ -383,9 +381,9 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 		with (
 			_cached_image(self.lab.name),
 			patch.object(ingress, "ensure_anchor", autospec=True),
-			patch.object(deploy_manager, "_notify_owner", autospec=True),
+			patch.object(lifecycle, "notify_owner", autospec=True),
 		):
-			deploy_manager.deploy_bench(bench.name)
+			lifecycle.deploy_bench(bench.name)
 
 		self.assertEqual(self.docker.removed, [bench.bench_name])
 		self.assertIn("Cleanup: VPN peer removed", self._deploy_log(bench.name))
@@ -418,9 +416,9 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 
 		with (
 			_cached_image(self.lab.name),
-			patch.object(deploy_manager, "_notify_owner", autospec=True),
+			patch.object(lifecycle, "notify_owner", autospec=True),
 		):
-			deploy_manager.deploy_bench(bench.name)
+			lifecycle.deploy_bench(bench.name)
 
 		self.assertEqual(self.docker.removed, [])
 		self.assertNotIn("Cleanup: VPN peer removed", self._deploy_log(bench.name))
@@ -507,6 +505,20 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 		self.assertEqual(parsed[2:], args)
 
 
+def _install_on_both(case, name, mock=None):
+	"""Install one mock at both bindings of a `docker_manager` wrapper, and return it.
+
+	Started outside the `with` block rather than in it: CPython allows twenty nested blocks and
+	the deploy's mock list is already at that ceiling.
+	"""
+	mock = mock or MagicMock(name=name)
+	for module in (lifecycle, deploy_manager):
+		patcher = patch.object(module, name, new=mock)
+		patcher.start()
+		case.addCleanup(patcher.stop)
+	return mock
+
+
 class TestDeployStepMarkers(IntegrationTestCase):
 	"""Phase 4: the run reports its eleven steps, in the order the code runs them."""
 
@@ -579,28 +591,35 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		self.route_dir = Path(route_dir.name) / "dynamic"
 		self.route_dir.mkdir()
 
+		# The deploy runs in `lifecycle`; the code-server step it calls stayed in
+		# `deploy_manager`, and both modules imported these wrappers by name.
+		mock_write = _install_on_both(self, "write_file_to_container")
+		mock_exec = _install_on_both(self, "exec_in_container")
+
 		with (
 			_cached_image(self.lab.name) if cache_hit else nullcontext(),
 			patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", self.route_dir),
-			patch.object(deploy_manager, "ensure_infrastructure", autospec=True) as mock_infra,
-			patch.object(deploy_manager, "wait_for_mariadb", autospec=True),
+			patch.object(lifecycle, "ensure_infrastructure", autospec=True) as mock_infra,
+			patch.object(lifecycle, "wait_for_mariadb", autospec=True),
 			patch.object(deploy_manager, "_remove_stale_container", autospec=True),
 			patch.object(deploy_manager, "host_runtimes", autospec=True) as mock_runtimes,
-			patch.object(deploy_manager, "container_runtime", autospec=True) as mock_runtime_of,
-			patch.object(deploy_manager, "create_bench_container", autospec=True) as mock_create,
+			patch.object(lifecycle, "container_runtime", autospec=True) as mock_runtime_of,
+			patch.object(lifecycle, "create_bench_container", autospec=True) as mock_create,
 			# The deploy starts through the roll wrapper, so the bridge it lands on is a
 			# read-back rather than the id that went in.
-			patch.object(deploy_manager, "start_bench_container", new=lambda cid, bench, lab: cid),
-			patch.object(deploy_manager, "container_network", new=lambda cid: "benchpress-0"),
-			patch.object(deploy_manager, "wait_for_container_running", autospec=True) as mock_wait,
+			patch.object(lifecycle, "start_bench_container", new=lambda cid, bench, lab: cid),
+			patch.object(lifecycle, "container_network", new=lambda cid: "benchpress-0"),
+			patch.object(lifecycle, "wait_for_container_running", autospec=True) as mock_wait,
 			# Only the socket is mocked, not the reporting around it: a unit test must not
 			# depend on a running Traefik, but the log line must still be the real one.
 			patch.object(ingress, "_certificate_error", autospec=True, return_value=cert_error) as mock_cert,
-			patch.object(deploy_manager, "write_file_to_container", autospec=True) as mock_write,
-			patch.object(deploy_manager, "exec_in_container", autospec=True) as mock_exec,
+			# One mock, two bindings: the deploy runs in `lifecycle` and the code-server step it
+			# calls stayed in `deploy_manager`, and both imported the wrapper by name.
 			patch.object(deploy_manager, "create_site_in_container", autospec=True) as mock_site,
 			patch.object(deploy_manager, "remove_container", autospec=True),
-			patch.object(deploy_manager, "_notify_owner", autospec=True),
+			# The transition reissues `start` on the container the deploy already brought up.
+			patch.object(lifecycle, "start_container", autospec=True),
+			patch.object(lifecycle, "notify_owner", autospec=True),
 			patch("benchpress.vpn_adapter.remove_bench_peer", autospec=True),
 			patch("benchpress.vpn_adapter.configure_container", autospec=True),
 			patch("benchpress.vpn_adapter.create_container_peer", autospec=True) as mock_peer,
@@ -625,7 +644,7 @@ class TestDeployStepMarkers(IntegrationTestCase):
 			else:
 				mock_site.return_value = site_result
 
-			deploy_manager.deploy_bench(bench.name)
+			lifecycle.deploy_bench(bench.name)
 
 	def _log(self, bench_name):
 		logs = frappe.get_all(
@@ -808,7 +827,7 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		self.assertNotIn("code-server ready at", log)
 		self.assertFalse(self._bench_field(bench, "code_server_url"))
 
-	@patch("benchpress.deploy_manager.secrets.token_urlsafe")
+	@patch("benchpress.lifecycle.secrets.token_urlsafe")
 	def test_the_ssh_password_goes_into_the_environment_and_into_no_command(self, token):
 		"""Docker publishes every exec command line, and linkuser.sh read the password from argv."""
 		sentinel = "sS1XnOtAr3alPassw0rd"
@@ -823,7 +842,7 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		for call in self.execs.call_args_list:
 			self.assertNotIn(sentinel, call.args[1])
 
-	@patch("benchpress.deploy_manager.secrets.token_urlsafe")
+	@patch("benchpress.lifecycle.secrets.token_urlsafe")
 	@patch("benchpress.docker_manager.get_client")
 	def test_the_code_server_password_goes_into_the_environment_and_into_no_command(self, get_client, token):
 		"""Docker publishes every exec command line, and the IDE password was in one."""
@@ -1096,9 +1115,9 @@ class TestTerminalStateNotifications(IntegrationTestCase):
 			as_dict=True,
 		)
 
-	@patch("benchpress.deploy_manager.ensure_infrastructure", autospec=True)
+	@patch("benchpress.lifecycle.ensure_infrastructure", autospec=True)
 	def test_deploy_failure_notifies_owner(self, mock_infra):
-		from benchpress.deploy_manager import deploy_bench
+		from benchpress.lifecycle import deploy_bench
 
 		bench = self._owned_bench()
 		mock_infra.side_effect = Exception("mariadb container refused to start")
@@ -1112,41 +1131,40 @@ class TestTerminalStateNotifications(IntegrationTestCase):
 		self.assertIn("failed", notification.subject)
 
 	def test_deploy_success_notifies_owner(self):
-		from benchpress import deploy_manager
-
 		bench = self._owned_bench()
+		_install_on_both(self, "write_file_to_container")
+		_install_on_both(self, "exec_in_container", MagicMock(return_value=(0, "")))
 		frappe.db.commit()
 
 		with (
 			_cached_image(self.lab.name),
-			patch.object(deploy_manager, "ensure_infrastructure", autospec=True) as mock_infra,
-			patch.object(deploy_manager, "wait_for_mariadb", autospec=True),
+			patch.object(lifecycle, "ensure_infrastructure", autospec=True) as mock_infra,
+			patch.object(lifecycle, "wait_for_mariadb", autospec=True),
 			patch.object(deploy_manager, "_remove_stale_container", autospec=True),
 			patch.object(deploy_manager, "host_runtimes", autospec=True) as mock_runtimes,
-			patch.object(deploy_manager, "container_runtime", autospec=True) as mock_runtime_of,
-			patch.object(deploy_manager, "create_bench_container", autospec=True) as mock_create,
+			patch.object(lifecycle, "container_runtime", autospec=True) as mock_runtime_of,
+			patch.object(lifecycle, "create_bench_container", autospec=True) as mock_create,
 			# The deploy starts through the roll wrapper, so the bridge it lands on is a
 			# read-back rather than the id that went in.
-			patch.object(deploy_manager, "start_bench_container", new=lambda cid, bench, lab: cid),
-			patch.object(deploy_manager, "container_network", new=lambda cid: "benchpress-0"),
-			patch.object(deploy_manager, "wait_for_container_running", autospec=True) as mock_wait,
+			patch.object(lifecycle, "start_bench_container", new=lambda cid, bench, lab: cid),
+			patch.object(lifecycle, "container_network", new=lambda cid: "benchpress-0"),
+			patch.object(lifecycle, "wait_for_container_running", autospec=True) as mock_wait,
 			patch.object(ingress, "publish", autospec=True),
 			patch.object(ingress, "ensure_anchor", autospec=True),
 			patch.object(ingress, "_certificate_error", autospec=True, return_value=None),
 			patch.object(deploy_manager, "_setup_container_vpn", autospec=True),
-			patch.object(deploy_manager, "write_file_to_container", autospec=True),
-			patch.object(deploy_manager, "exec_in_container", autospec=True) as mock_exec,
 			patch.object(deploy_manager, "create_site_in_container", autospec=True) as mock_site,
+			# The transition reissues `start` on the container the deploy already brought up.
+			patch.object(lifecycle, "start_container", autospec=True),
 		):
 			mock_infra.return_value = self.db_server_name
 			mock_runtimes.return_value = {"names": {"runc", "sysbox-runc"}, "default": "runc"}
 			mock_runtime_of.return_value = "sysbox-runc"
 			mock_create.return_value = "cid-notify"
 			mock_wait.return_value = "172.30.0.9"
-			mock_exec.return_value = (0, "")
 			mock_site.return_value = (0, "site created")
 
-			deploy_manager.deploy_bench(bench.name)
+			lifecycle.deploy_bench(bench.name)
 
 		self.assertEqual(frappe.db.get_value("Bench Instance", bench.name, "status"), "Running")
 		notification = self._owner_notification("Bench Instance", bench.name)
@@ -1189,9 +1207,9 @@ class TestTerminalStateNotifications(IntegrationTestCase):
 		"frappe.desk.doctype.notification_log.notification_log.enqueue_create_notification",
 		autospec=True,
 	)
-	@patch("benchpress.deploy_manager.ensure_infrastructure", autospec=True)
+	@patch("benchpress.lifecycle.ensure_infrastructure", autospec=True)
 	def test_notification_failure_does_not_break_deploy(self, mock_infra, mock_notify):
-		from benchpress.deploy_manager import deploy_bench
+		from benchpress.lifecycle import deploy_bench
 
 		bench = self._owned_bench()
 		mock_infra.side_effect = Exception("infrastructure down")

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -205,34 +205,28 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 		mock_deploy.assert_called_once_with(bench.name)
 		self.assertEqual(status_at_deploy["status"], "Draft")
 
-	@patch("benchpress.lifecycle._deploy_bench")
-	def test_redeploy_bench_never_touches_volumes(self, mock_deploy):
-		from benchpress.lifecycle import redeploy_bench
-
+	def test_redeploy_bench_never_touches_volumes(self):
 		bench = self._fresh_bench()
-		self.docker.add_container("old-container")
-		bench.container_id = "old-container"
+		bench.container_id = self.docker.add_container("old-container").id
 		bench.save(ignore_permissions=True)
 		frappe.db.commit()
 
-		redeploy_bench(bench.name)
+		lifecycle.torn_down(bench, release_admission=False)
 
 		self.assertEqual(self.docker.volume_gets, [])
 
-	@patch("benchpress.lifecycle._deploy_bench")
-	def test_redeploy_bench_drops_site_database(self, mock_deploy):
-		from benchpress.lifecycle import redeploy_bench
+	def test_redeploy_bench_drops_site_database(self):
 		from benchpress.mariadb_manager import get_database_name
 
 		bench = self._fresh_bench()
-		self.docker.add_container("old-container")
+		container = self.docker.add_container("old-container")
 		self._shared_mariadb_up()
-		frappe.db.set_value("Bench Instance", bench.name, "container_id", "old-container")
+		frappe.db.set_value("Bench Instance", bench.name, "container_id", container.id)
 		frappe.db.set_value("Bench Instance", bench.name, "database_server", self.db_server_name)
 		frappe.db.commit()
 		bench.reload()
 
-		redeploy_bench(bench.name)
+		lifecycle.torn_down(bench, release_admission=False)
 
 		db_container = self.docker.containers.get("test-db-server")
 		self.assertIn(
@@ -336,8 +330,6 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 		self.assertIn("Cleanup: removed container created by this run", self._deploy_log(bench.name))
 
 	def test_deploy_failure_before_container_skips_cleanup(self):
-		from benchpress import deploy_manager
-
 		bench = self._fresh_bench()
 		self._cleanup_deploy_logs(bench.name)
 		frappe.db.set_value(
@@ -362,7 +354,7 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 
 		self.assertEqual(self.docker.removed, [])
 		self.assertNotIn("Cleanup: VPN peer removed", self._deploy_log(bench.name))
-		self.assertIn(deploy_manager.NOTHING_TO_ROLL_BACK, self._deploy_log(bench.name))
+		self.assertIn(lifecycle.NOTHING_TO_ROLL_BACK, self._deploy_log(bench.name))
 		bench.reload()
 		self.assertEqual(bench.status, "Error")
 		self.assertEqual(bench.container_id, "old-container")
@@ -541,7 +533,6 @@ class TestDeployStepMarkers(IntegrationTestCase):
 			patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", self.route_dir),
 			patch.object(lifecycle, "ensure_infrastructure", autospec=True) as mock_infra,
 			patch.object(lifecycle, "wait_for_mariadb", autospec=True),
-			patch.object(deploy_manager, "_remove_stale_container", autospec=True),
 			patch.object(deploy_manager, "host_runtimes", autospec=True) as mock_runtimes,
 			patch.object(lifecycle, "container_runtime", autospec=True) as mock_runtime_of,
 			patch.object(lifecycle, "create_bench_container", autospec=True) as mock_create,
@@ -556,7 +547,7 @@ class TestDeployStepMarkers(IntegrationTestCase):
 			# One mock, two bindings: the deploy runs in `lifecycle` and the code-server step it
 			# calls stayed in `deploy_manager`, and both imported the wrapper by name.
 			patch.object(deploy_manager, "create_site_in_container", autospec=True) as mock_site,
-			patch.object(deploy_manager, "remove_container", autospec=True),
+			patch.object(lifecycle, "remove_container", autospec=True),
 			# The transition reissues `start` on the container the deploy already brought up.
 			patch.object(lifecycle, "start_container", autospec=True),
 			patch.object(lifecycle, "notify_owner", autospec=True),
@@ -881,6 +872,42 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		self.assertIn("Traefik wildcard anchor written for *.benchpress.cloud", self._log(bench.name))
 		self.assertNotIn("certResolver", (self.route_dir / f"{bench.name}.yml").read_text())
 
+	# --- what a failed deploy must not leave behind (issue #190) ---
+
+	def _failed_after_the_route(self, bench):
+		"""A deploy that dies at the SSH step, which is past both the route and the site row."""
+		self._set_base_domain("benchpress.cloud")
+		self._run_deploy(bench, exec_failures={"linkuser.sh": (1, "linkuser exploded")})
+		self.assertEqual(self._bench_field(bench, "status"), "Error")
+
+	def test_a_failed_deploy_leaves_no_route_file_answering(self):
+		"""The leak: the route file outlived the deploy that wrote it, so a public hostname kept
+		answering for a bench with no container."""
+		bench = self._bench()
+
+		self._failed_after_the_route(bench)
+
+		written = sorted(p.name for p in self.route_dir.iterdir())
+		self.assertEqual(written, ["wildcard-anchor.yml"])
+
+	def test_a_failed_deploy_leaves_no_site_row_reading_active(self):
+		"""`_record_primary_site` writes `Active` before the steps that can still fail."""
+		bench = self._bench()
+
+		self._failed_after_the_route(bench)
+
+		status = frappe.db.get_value("Bench Site", {"bench": bench.name}, "status")
+		self.assertEqual(status, "Inactive")
+
+	def test_a_failed_deploy_keeps_the_site_name_for_the_retry(self):
+		"""Deactivated, not deleted: the row is the claim, so the retry still owns its own name."""
+		bench = self._bench()
+
+		self._failed_after_the_route(bench)
+
+		site = frappe.get_doc("Bench Site", {"bench": bench.name})
+		self.assertEqual(site.site_name, self._bench_field(bench, "site_name"))
+
 	def test_a_public_deploy_states_which_certificate_serves_the_url(self):
 		"""Phase 2: the routers name no resolver, so the deploy has to say the store held a
 		certificate — otherwise the first evidence it did not is a user meeting a 526."""
@@ -1080,7 +1107,6 @@ class TestTerminalStateNotifications(IntegrationTestCase):
 			_cached_image(self.lab.name),
 			patch.object(lifecycle, "ensure_infrastructure", autospec=True) as mock_infra,
 			patch.object(lifecycle, "wait_for_mariadb", autospec=True),
-			patch.object(deploy_manager, "_remove_stale_container", autospec=True),
 			patch.object(deploy_manager, "host_runtimes", autospec=True) as mock_runtimes,
 			patch.object(lifecycle, "container_runtime", autospec=True) as mock_runtime_of,
 			patch.object(lifecycle, "create_bench_container", autospec=True) as mock_create,
@@ -1161,7 +1187,7 @@ class TestTerminalStateNotifications(IntegrationTestCase):
 		self.assertFalse(frappe.db.exists("Notification Log", {"for_user": self.owner}))
 
 
-class TestRecordPrimarySite(IntegrationTestCase):
+class TestRecordPrimarySite(FakeDockerMixin, IntegrationTestCase):
 	"""The site a deploy makes must be visible, and pressing Deploy twice must not duplicate it."""
 
 	@classmethod
@@ -1243,15 +1269,14 @@ class TestRecordPrimarySite(IntegrationTestCase):
 
 		self.assertEqual(frappe.db.get_value("Bench Site", {"bench": bench.name}, "status"), "Inactive")
 
-	@patch("benchpress.lifecycle.stop_container")
-	def test_a_deploy_returns_a_stopped_site_to_active(self, mock_stop):
+	def test_a_deploy_returns_a_stopped_site_to_active(self):
 		"""The round trip, which needs no code of its own: `_record_primary_site` already writes
 		`Active`, so a stop followed by a deploy must land back where it started."""
 		from benchpress.deploy_manager import _record_primary_site
 		from benchpress.lifecycle import stopped
 
 		bench = self._bench()
-		bench.container_id = "container-round-trip"
+		bench.container_id = self.docker.add_container(bench.bench_name).id
 		bench.save(ignore_permissions=True)
 		_record_primary_site(bench, self.lab, "secret-one")
 		frappe.db.commit()
@@ -1281,53 +1306,3 @@ class TestRecordPrimarySite(IntegrationTestCase):
 		dropped = {call.args[1] for call in mock_drop.call_args_list}
 		self.assertEqual(dropped, {bench.site_name})
 		self.assertNotIn(f"{bench.site_name}.example.com", dropped)
-
-	def test_teardown_removes_the_instance_route_file(self):
-		"""Freed container IPs get reused by Docker — a stale route file left after teardown
-		would keep pointing the old public hostname at whoever gets that IP next. See
-		phase-3-teardown-cleanup.md."""
-		from benchpress import deploy_manager
-		from benchpress.deploy_manager import teardown_bench
-
-		bench = self._bench()
-
-		with tempfile.TemporaryDirectory() as tmp:
-			with patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", _mounted(tmp)):
-				ingress.publish(bench.name, "benchpress.cloud")
-				route_file = Path(tmp) / "instances" / f"{bench.name}.yml"
-				self.assertTrue(route_file.exists())
-
-				teardown_bench(bench)
-
-				self.assertFalse(route_file.exists())
-
-	def test_teardown_keeps_the_wildcard_anchor(self):
-		"""The anchor outlives every bench — it is what keeps the certificate renewing,
-		so a reaper that tidies it away would silently stop renewal."""
-		from benchpress import deploy_manager
-		from benchpress.deploy_manager import teardown_bench
-
-		bench = self._bench()
-
-		with tempfile.TemporaryDirectory() as tmp:
-			with patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", _mounted(tmp)):
-				ingress.ensure_anchor("benchpress.cloud")
-				ingress.publish(bench.name, "benchpress.cloud")
-				anchor = Path(tmp) / "instances" / "wildcard-anchor.yml"
-
-				teardown_bench(bench)
-
-				self.assertFalse((Path(tmp) / "instances" / f"{bench.name}.yml").exists())
-				self.assertTrue(anchor.exists())
-
-	def test_teardown_does_not_raise_when_no_route_file_exists(self):
-		"""The `base_domain = localhost` case: phase 1 never wrote a route file, so teardown
-		must no-op cleanly rather than raising on a missing path."""
-		from benchpress import deploy_manager
-		from benchpress.deploy_manager import teardown_bench
-
-		bench = self._bench()
-
-		with tempfile.TemporaryDirectory() as tmp:
-			with patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", _mounted(tmp)):
-				teardown_bench(bench)

--- a/benchpress/tests/test_image_cache.py
+++ b/benchpress/tests/test_image_cache.py
@@ -216,25 +216,25 @@ class TestDeployReusesTheSharedImage(IntegrationTestCase):
 
 	def _run_deploy(self, bench, cached_tags=()):
 		"""A whole deploy with every side effect mocked but the log and the Docker client."""
-		from benchpress import deploy_manager
+		from benchpress import deploy_manager, lifecycle
 
 		client = _client_with_tags(*cached_tags)
 		with (
 			patch("benchpress.docker_manager.get_client", return_value=client),
-			patch.object(deploy_manager, "ensure_infrastructure", autospec=True) as mock_infra,
-			patch.object(deploy_manager, "wait_for_mariadb", autospec=True),
+			patch.object(lifecycle, "ensure_infrastructure", autospec=True) as mock_infra,
+			patch.object(lifecycle, "wait_for_mariadb", autospec=True),
 			patch.object(deploy_manager, "_remove_stale_container", autospec=True),
-			patch.object(deploy_manager, "create_bench_container", autospec=True) as mock_create,
+			patch.object(lifecycle, "create_bench_container", autospec=True) as mock_create,
 			# The deploy starts through the roll wrapper, so the bridge it lands on is a
 			# read-back rather than the id that went in.
-			patch.object(deploy_manager, "start_bench_container", new=lambda cid, bench, lab: cid),
-			patch.object(deploy_manager, "container_network", new=lambda cid: "benchpress-0"),
-			patch.object(deploy_manager, "wait_for_container_running", autospec=True) as mock_wait,
+			patch.object(lifecycle, "start_bench_container", new=lambda cid, bench, lab: cid),
+			patch.object(lifecycle, "container_network", new=lambda cid: "benchpress-0"),
+			patch.object(lifecycle, "wait_for_container_running", autospec=True) as mock_wait,
 			patch.object(deploy_manager, "_setup_container_vpn", autospec=True),
-			patch.object(deploy_manager, "write_file_to_container", autospec=True),
-			patch.object(deploy_manager, "exec_in_container", autospec=True) as mock_exec,
+			patch.object(lifecycle, "write_file_to_container", autospec=True),
+			patch.object(lifecycle, "exec_in_container", autospec=True) as mock_exec,
 			patch.object(deploy_manager, "create_site_in_container", autospec=True) as mock_site,
-			patch.object(deploy_manager, "_notify_owner", autospec=True),
+			patch.object(lifecycle, "notify_owner", autospec=True),
 			# Traefik's route directory is mounted into queue-long, not into the container
 			# these tests run in, so both writers have to be mocked for the deploy to reach
 			# its end — as the docstring above says it does.
@@ -249,7 +249,7 @@ class TestDeployReusesTheSharedImage(IntegrationTestCase):
 			mock_wait.return_value = "172.30.0.21"
 			mock_exec.return_value = (0, "")
 			mock_site.return_value = (0, "site created")
-			deploy_manager.deploy_bench(bench.name)
+			lifecycle.deploy_bench(bench.name)
 		return client
 
 	def _log(self, bench_name):

--- a/benchpress/tests/test_image_cache.py
+++ b/benchpress/tests/test_image_cache.py
@@ -223,7 +223,6 @@ class TestDeployReusesTheSharedImage(IntegrationTestCase):
 			patch("benchpress.docker_manager.get_client", return_value=client),
 			patch.object(lifecycle, "ensure_infrastructure", autospec=True) as mock_infra,
 			patch.object(lifecycle, "wait_for_mariadb", autospec=True),
-			patch.object(deploy_manager, "_remove_stale_container", autospec=True),
 			patch.object(lifecycle, "create_bench_container", autospec=True) as mock_create,
 			# The deploy starts through the roll wrapper, so the bridge it lands on is a
 			# read-back rather than the id that went in.

--- a/benchpress/tests/test_ingress.py
+++ b/benchpress/tests/test_ingress.py
@@ -883,7 +883,7 @@ class TestRouteSyncTriggers(IntegrationTestCase):
 	def test_teardown_deletes_directly_and_enqueues_nothing(self):
 		"""Teardown already runs on `queue-long`, and it must not depend on a second job
 		surviving to remove live routing state."""
-		from benchpress.deploy_manager import teardown_bench
+		from benchpress import lifecycle
 
 		bench = self._bench()
 		bench.container_id = None
@@ -894,7 +894,7 @@ class TestRouteSyncTriggers(IntegrationTestCase):
 			route_file = target_dir / f"{bench.name}.yml"
 
 			with patch("frappe.enqueue") as enqueue:
-				teardown_bench(bench)
+				lifecycle.torn_down(bench)
 
 			self.assertFalse(route_file.exists())
 			enqueue.assert_not_called()

--- a/benchpress/tests/test_ingress.py
+++ b/benchpress/tests/test_ingress.py
@@ -838,7 +838,7 @@ class TestRouteSyncTriggers(IntegrationTestCase):
 
 		bench = self._bench("Stopped")
 
-		with patch("benchpress.docker_manager.start_container"), patch("frappe.enqueue") as enqueue:
+		with patch("benchpress.lifecycle.start_container"), patch("frappe.enqueue") as enqueue:
 			bench_action(bench.name, "start")
 
 		self._assert_synced_on_long(enqueue, bench.name)
@@ -850,7 +850,7 @@ class TestRouteSyncTriggers(IntegrationTestCase):
 
 		bench = self._bench()
 
-		with patch("benchpress.docker_manager.restart_container"), patch("frappe.enqueue") as enqueue:
+		with patch("benchpress.lifecycle.restart_container"), patch("frappe.enqueue") as enqueue:
 			bench_action(bench.name, "restart")
 
 		self._assert_synced_on_long(enqueue, bench.name)
@@ -859,7 +859,7 @@ class TestRouteSyncTriggers(IntegrationTestCase):
 		bench = self._bench("Stopped")
 
 		with (
-			patch("benchpress.docker_manager.start_container"),
+			patch("benchpress.lifecycle.start_container"),
 			patch("frappe.msgprint"),
 			patch("frappe.enqueue") as enqueue,
 		):

--- a/benchpress/tests/test_ingress.py
+++ b/benchpress/tests/test_ingress.py
@@ -822,14 +822,14 @@ class TestRouteSyncTriggers(IntegrationTestCase):
 		# The job re-reads `status`, so it must not start before the new value is committed.
 		self.assertTrue(kwargs["enqueue_after_commit"])
 
-	@patch("benchpress.deploy_manager.stop_container")
+	@patch("benchpress.lifecycle.stop_container")
 	def test_stop_enqueues_the_sync_on_the_long_queue(self, mock_stop):
-		from benchpress.deploy_manager import stop_bench
+		from benchpress.lifecycle import stopped
 
 		bench = self._bench()
 
 		with patch("frappe.enqueue") as enqueue:
-			stop_bench(bench.name)
+			stopped(bench.name)
 
 		self._assert_synced_on_long(enqueue, bench.name)
 

--- a/benchpress/tests/test_lease.py
+++ b/benchpress/tests/test_lease.py
@@ -282,7 +282,7 @@ class TestLease(IntegrationTestCase):
 	def renewing(self):
 		"""Renew with Docker, the route job and the commit stood down, so the rollback still holds."""
 		with (
-			patch("benchpress.docker_manager.start_container") as start,
+			patch("benchpress.lifecycle.start_container") as start,
 			patch("benchpress.ingress.enqueue_route_sync") as route,
 			patch("frappe.publish_realtime") as publish,
 			patch.object(frappe.db, "commit"),
@@ -512,7 +512,7 @@ class TestLease(IntegrationTestCase):
 		self.assertEqual(self.deadline(), 0)
 
 		with (
-			patch("benchpress.docker_manager.start_container"),
+			patch("benchpress.lifecycle.start_container"),
 			patch.object(ingress, "enqueue_route_sync"),
 			patch.object(frappe.db, "commit"),
 		):

--- a/benchpress/tests/test_lease.py
+++ b/benchpress/tests/test_lease.py
@@ -31,7 +31,7 @@ import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, flt, now_datetime
 
-from benchpress import api, deploy_manager, ingress, lab_detail
+from benchpress import api, deploy_manager, ingress, lab_detail, lifecycle
 from benchpress.benchpress.doctype.bench_instance import get_instance_id
 from benchpress.credits import account, config, drain, lease, metering
 from benchpress.credits.seed import ensure_ledger_index, seed_default_lease_plan, seed_defaults
@@ -298,11 +298,11 @@ class TestLease(IntegrationTestCase):
 
 	def stop_the_bench(self) -> None:
 		with (
-			patch.object(deploy_manager, "stop_container"),
+			patch.object(lifecycle, "stop_container"),
 			patch.object(frappe.db, "commit"),
 			patch("frappe.publish_realtime"),
 		):
-			deploy_manager.stop_bench(self.bench.name)
+			lifecycle.stopped(self.bench.name)
 
 	def age_the_bench(self, days: int) -> None:
 		"""Backdate `modified`, which is what the reaper measures a stopped bench against."""
@@ -504,11 +504,11 @@ class TestLease(IntegrationTestCase):
 		metering.on_bench_running(self.running_bench())
 		self.expire()
 		with (
-			patch.object(deploy_manager, "stop_container"),
+			patch.object(lifecycle, "stop_container"),
 			patch.object(frappe.db, "commit"),
 			patch("frappe.publish_realtime"),
 		):
-			deploy_manager.stop_bench(self.bench.name)
+			lifecycle.stopped(self.bench.name)
 		self.assertEqual(self.deadline(), 0)
 
 		with (
@@ -622,8 +622,8 @@ class TestLease(IntegrationTestCase):
 			lease.claim_due(50)
 		frappe.db.set_value(BENCH, self.bench.name, "expires_at_ts", lease.now_ts() + 1800)
 
-		with patch.object(deploy_manager, "stop_container") as stop, patch.object(frappe.db, "commit"):
-			deploy_manager.stop_bench(self.bench.name)
+		with patch.object(lifecycle, "stop_container") as stop, patch.object(frappe.db, "commit"):
+			lifecycle.stopped(self.bench.name)
 
 		stop.assert_not_called()
 		self.assertEqual(frappe.db.get_value(BENCH, self.bench.name, "status"), "Running")
@@ -636,9 +636,9 @@ class TestLease(IntegrationTestCase):
 		with patch.object(frappe.db, "commit"), patch("frappe.enqueue"):
 			lease.claim_due(50)
 
-		with patch.object(deploy_manager, "stop_container", side_effect=RuntimeError("docker is down")):
+		with patch.object(lifecycle, "stop_container", side_effect=RuntimeError("docker is down")):
 			with patch.object(frappe.db, "commit"):
-				self.assertRaises(RuntimeError, deploy_manager.stop_bench, self.bench.name)
+				self.assertRaises(RuntimeError, lifecycle.stopped, self.bench.name)
 
 		self.assertEqual(self.lease_state(), lease.ACTIVE)
 		self.assertEqual(frappe.db.get_value(BENCH, self.bench.name, "expiry_attempts"), 1)
@@ -655,8 +655,8 @@ class TestLease(IntegrationTestCase):
 	def test_a_plain_stop_is_untouched_by_the_lease(self):
 		"""A bench with no lease stops exactly the way it does on a dev checkout."""
 		self.set_credits_enabled(0)
-		with patch.object(deploy_manager, "stop_container") as stop, patch.object(frappe.db, "commit"):
-			deploy_manager.stop_bench(self.bench.name)
+		with patch.object(lifecycle, "stop_container") as stop, patch.object(frappe.db, "commit"):
+			lifecycle.stopped(self.bench.name)
 		stop.assert_called_once()
 		self.assertEqual(frappe.db.get_value(BENCH, self.bench.name, "status"), "Stopped")
 
@@ -676,11 +676,11 @@ class TestLease(IntegrationTestCase):
 			lease.claim_due(50)
 
 		with (
-			patch.object(deploy_manager, "stop_container"),
+			patch.object(lifecycle, "stop_container"),
 			patch.object(frappe.db, "commit"),
 			patch("frappe.publish_realtime") as publish,
 		):
-			deploy_manager.stop_bench(self.bench.name)
+			lifecycle.stopped(self.bench.name)
 
 		events = self.lease_events(publish)
 		self.assertEqual(len(events), 1)
@@ -705,11 +705,11 @@ class TestLease(IntegrationTestCase):
 			lease.claim_due(50)
 
 		with (
-			patch.object(deploy_manager, "stop_container"),
+			patch.object(lifecycle, "stop_container"),
 			patch.object(frappe.db, "commit"),
 			patch("frappe.publish_realtime") as publish,
 		):
-			deploy_manager.stop_bench(self.other_bench.name)
+			lifecycle.stopped(self.other_bench.name)
 
 		events = self.lease_events(publish)
 		self.assertEqual(len(events), 1)
@@ -719,11 +719,11 @@ class TestLease(IntegrationTestCase):
 		"""Only an expiry is news the tab did not ask for; a user pressing Stop already knows."""
 		self.enable_credits()
 		with (
-			patch.object(deploy_manager, "stop_container"),
+			patch.object(lifecycle, "stop_container"),
 			patch.object(frappe.db, "commit"),
 			patch("frappe.publish_realtime") as publish,
 		):
-			deploy_manager.stop_bench(self.bench.name)
+			lifecycle.stopped(self.bench.name)
 		self.assertEqual(self.lease_events(publish), [])
 
 	# --- The clock the browser anchors on --------------------------------------
@@ -898,8 +898,8 @@ class TestLease(IntegrationTestCase):
 		metering.on_bench_running(self.running_bench())
 		frappe.db.set_value(BENCH, self.bench.name, "status", "Running", update_modified=False)
 
-		with patch.object(deploy_manager, "stop_container") as stop, patch.object(frappe.db, "commit"):
-			deploy_manager.stop_bench(self.bench.name, from_claim=True)
+		with patch.object(lifecycle, "stop_container") as stop, patch.object(frappe.db, "commit"):
+			lifecycle.stopped(self.bench.name, from_claim=True)
 
 		stop.assert_not_called()
 		self.assertEqual(frappe.db.get_value(BENCH, self.bench.name, "status"), "Running")
@@ -910,8 +910,8 @@ class TestLease(IntegrationTestCase):
 		self.enable_credits()
 		metering.on_bench_running(self.running_bench())
 
-		with patch.object(deploy_manager, "stop_container") as stop, patch.object(frappe.db, "commit"):
-			deploy_manager.stop_bench(self.bench.name)
+		with patch.object(lifecycle, "stop_container") as stop, patch.object(frappe.db, "commit"):
+			lifecycle.stopped(self.bench.name)
 
 		stop.assert_called_once()
 		self.assertEqual(frappe.db.get_value(BENCH, self.bench.name, "status"), "Stopped")

--- a/benchpress/tests/test_lease.py
+++ b/benchpress/tests/test_lease.py
@@ -31,7 +31,7 @@ import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, flt, now_datetime
 
-from benchpress import api, deploy_manager, ingress, lab_detail, lifecycle
+from benchpress import api, ingress, lab_detail, lifecycle
 from benchpress.benchpress.doctype.bench_instance import get_instance_id
 from benchpress.credits import account, config, drain, lease, metering
 from benchpress.credits.seed import ensure_ledger_index, seed_default_lease_plan, seed_defaults
@@ -1123,13 +1123,13 @@ class TestLease(IntegrationTestCase):
 		metering.on_bench_running(self.running_bench())
 
 		with (
-			patch.object(deploy_manager, "stop_container"),
-			patch.object(deploy_manager, "remove_container"),
+			patch.object(lifecycle, "stop_container"),
+			patch.object(lifecycle, "remove_container"),
 			patch.object(ingress, "withdraw"),
-			patch.object(deploy_manager, "_drop_site_database"),
+			patch.object(lifecycle, "_drop_site_database"),
 			patch.object(frappe.db, "commit"),
 		):
-			deploy_manager.teardown_bench(frappe.get_doc(BENCH, self.bench.name))
+			lifecycle.torn_down(frappe.get_doc(BENCH, self.bench.name))
 		self.assertEqual(self.deadline(), 0)
 
 		frappe.db.set_value(BENCH, self.bench.name, "status", "Running", update_modified=False)

--- a/benchpress/tests/test_lease_drain.py
+++ b/benchpress/tests/test_lease_drain.py
@@ -31,7 +31,7 @@ import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import add_to_date, now_datetime
 
-from benchpress import deploy_manager, docker_manager, hooks
+from benchpress import deploy_manager, docker_manager, hooks, lifecycle
 from benchpress.credits import drain, lease, warden
 from benchpress.credits.seed import seed_defaults
 from benchpress.tests.test_lease import _ensure_bench, _ensure_lab, _ensure_plan, _ensure_user
@@ -421,7 +421,7 @@ class TestLeaseDrain(IntegrationTestCase):
 
 	def test_a_deploy_stamps_the_node_beside_the_container_id(self):
 		"""Backfilling this later means inspecting Docker across live hosts while benches run."""
-		source = inspect.getsource(deploy_manager._deploy_bench)
+		source = inspect.getsource(lifecycle._deploy_bench)
 		self.assertIn("bench.node = lease.local_node()", source)
 
 	# --- The warden -----------------------------------------------------------

--- a/benchpress/tests/test_lease_drain.py
+++ b/benchpress/tests/test_lease_drain.py
@@ -157,10 +157,10 @@ class TestLeaseDrain(IntegrationTestCase):
 
 	def failing_stop(self, bench_name: str) -> None:
 		with (
-			patch.object(deploy_manager, "stop_container", side_effect=RuntimeError("docker is down")),
+			patch.object(lifecycle, "stop_container", side_effect=RuntimeError("docker is down")),
 			patch.object(frappe.db, "commit"),
 		):
-			self.assertRaises(RuntimeError, deploy_manager.stop_bench, bench_name, from_claim=True)
+			self.assertRaises(RuntimeError, lifecycle.stopped, bench_name, from_claim=True)
 
 	# --- The backlog gauge ----------------------------------------------------
 
@@ -395,10 +395,10 @@ class TestLeaseDrain(IntegrationTestCase):
 		self.claim()
 
 		with (
-			patch.object(deploy_manager, "stop_container") as stop,
+			patch.object(lifecycle, "stop_container") as stop,
 			patch.object(frappe.db, "commit"),
 		):
-			self.assertRaises(frappe.ValidationError, deploy_manager.stop_bench, self.bench.name, True)
+			self.assertRaises(frappe.ValidationError, lifecycle.stopped, self.bench.name, True)
 
 		stop.assert_not_called()
 		self.assertEqual(self.row(self.bench.name, "status"), "Running")
@@ -410,11 +410,11 @@ class TestLeaseDrain(IntegrationTestCase):
 
 		with (
 			patch.object(lease, "local_node", return_value=OTHER_NODE),
-			patch.object(deploy_manager, "stop_container") as stop,
+			patch.object(lifecycle, "stop_container") as stop,
 			patch.object(frappe.db, "commit"),
 			patch("frappe.publish_realtime"),
 		):
-			deploy_manager.stop_bench(self.bench.name, from_claim=True)
+			lifecycle.stopped(self.bench.name, from_claim=True)
 
 		stop.assert_called_once()
 		self.assertEqual(self.row(self.bench.name, "status"), "Stopped")
@@ -506,11 +506,11 @@ class TestLeaseDrain(IntegrationTestCase):
 		self.claim()
 
 		with (
-			patch.object(deploy_manager, "stop_container"),
+			patch.object(lifecycle, "stop_container"),
 			patch.object(frappe.db, "commit"),
 			patch("frappe.publish_realtime"),
 		):
-			deploy_manager.stop_bench(self.bench.name, from_claim=True)
+			lifecycle.stopped(self.bench.name, from_claim=True)
 
 		lateness = self.row(self.bench.name, "expiry_lateness")
 		self.assertIsNotNone(lateness)
@@ -530,11 +530,11 @@ class TestLeaseDrain(IntegrationTestCase):
 	def test_a_user_pressed_stop_records_no_lateness(self):
 		"""It was not late — nothing was due. A zero here would flatter the histogram."""
 		with (
-			patch.object(deploy_manager, "stop_container"),
+			patch.object(lifecycle, "stop_container"),
 			patch.object(frappe.db, "commit"),
 			patch("frappe.publish_realtime"),
 		):
-			deploy_manager.stop_bench(self.bench.name)
+			lifecycle.stopped(self.bench.name)
 
 		self.assertIsNone(self.row(self.bench.name, "expiry_lateness"))
 		self.assertTrue(self.row(self.bench.name, "container_stopped_at"))
@@ -543,11 +543,11 @@ class TestLeaseDrain(IntegrationTestCase):
 		self.expire(self.bench.name, seconds_ago=90)
 		self.claim()
 		with (
-			patch.object(deploy_manager, "stop_container"),
+			patch.object(lifecycle, "stop_container"),
 			patch.object(frappe.db, "commit"),
 			patch("frappe.publish_realtime"),
 		):
-			deploy_manager.stop_bench(self.bench.name, from_claim=True)
+			lifecycle.stopped(self.bench.name, from_claim=True)
 
 		report = drain.stop_slo()
 		self.assertGreaterEqual(report["count"], 1)

--- a/benchpress/tests/test_lifecycle.py
+++ b/benchpress/tests/test_lifecycle.py
@@ -88,7 +88,7 @@ class TestRunning(FakeDockerMixin, IntegrationTestCase):
 		super().setUpClass()
 		frappe.set_user("Administrator")
 		cls.lab = _make_lab("test-lab-lifecycle")
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep -- the fixtures outlive the per-test rollback
 
 	@classmethod
 	def tearDownClass(cls):
@@ -98,7 +98,7 @@ class TestRunning(FakeDockerMixin, IntegrationTestCase):
 			_delete_bench_sites(name)
 			frappe.delete_doc(BENCH, name, force=True, ignore_permissions=True)
 		cls.lab.delete(ignore_permissions=True)
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep -- the teardown must outlive the per-test rollback too
 		super().tearDownClass()
 
 	def _stopped_bench(self):
@@ -107,7 +107,7 @@ class TestRunning(FakeDockerMixin, IntegrationTestCase):
 		bench.container_id = container.id
 		bench.status = "Stopped"
 		bench.save(ignore_permissions=True)
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep -- the transition under test commits, so its fixture has to be durable
 		self.addCleanup(frappe.db.commit)
 		return bench
 

--- a/benchpress/tests/test_lifecycle.py
+++ b/benchpress/tests/test_lifecycle.py
@@ -26,7 +26,6 @@ SITE = "Bench Site"
 ADMISSION = "Bench Admission"
 SETTINGS = "BenchPress Settings"
 LIFECYCLE_MODULE = "lifecycle.py"
-DB_SERVER_MODULE = "mariadb_manager.py"
 
 
 class TestOneWriterPerStatus(unittest.TestCase):
@@ -35,8 +34,8 @@ class TestOneWriterPerStatus(unittest.TestCase):
 		self.assertEqual(_status_writers("Running"), {LIFECYCLE_MODULE})
 
 	def test_only_lifecycle_writes_stopped(self):
-		"""`mariadb_manager` writes it too, on `Database Server` — a different doctype's status."""
-		self.assertEqual(_status_writers("Stopped"), {LIFECYCLE_MODULE, DB_SERVER_MODULE})
+		"""`Database Server` spells its own statuses the same, so it names them instead."""
+		self.assertEqual(_status_writers("Stopped"), {LIFECYCLE_MODULE})
 
 
 def _status_writers(status: str) -> set[str]:

--- a/benchpress/tests/test_lifecycle.py
+++ b/benchpress/tests/test_lifecycle.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+"""One writer per bench transition, and the side effects that writer must not forget."""
+
+import ast
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from benchpress import lifecycle
+from benchpress.credits import lease
+from benchpress.tests.fakes import FakeDockerMixin
+from benchpress.tests.test_deploy_manager import _delete_bench_sites, _fresh_bench, _make_lab
+
+BENCH = "Bench Instance"
+LIFECYCLE_MODULE = "lifecycle.py"
+
+
+class TestOneWriterPerStatus(unittest.TestCase):
+	def test_only_lifecycle_writes_running(self):
+		"""Four call sites used to. A fifth appearing is the bug this whole item exists to stop."""
+		self.assertEqual(_status_writers("Running"), {LIFECYCLE_MODULE})
+
+
+def _status_writers(status: str) -> set[str]:
+	"""Every non-test module that assigns or `set_value`s `status` to `status`, by file name."""
+	package = Path(lifecycle.__file__).resolve().parent
+	writers = set()
+	for path in sorted(package.rglob("*.py")):
+		if path.parent.name == "tests" or path.name.startswith("test_"):
+			continue
+		tree = ast.parse(path.read_text())
+		if any(_writes_status(node, status) for node in ast.walk(tree)):
+			writers.add(str(path.relative_to(package)))
+	return writers
+
+
+def _writes_status(node: ast.AST, status: str) -> bool:
+	if isinstance(node, ast.Assign):
+		return _assigns_status(node, status)
+	if isinstance(node, ast.Call):
+		return _set_values_status(node, status)
+	return False
+
+
+def _assigns_status(node: ast.Assign, status: str) -> bool:
+	"""`<anything>.status = "Running"`."""
+	if not (isinstance(node.value, ast.Constant) and node.value.value == status):
+		return False
+	return any(isinstance(t, ast.Attribute) and t.attr == "status" for t in node.targets)
+
+
+def _set_values_status(node: ast.Call, status: str) -> bool:
+	"""`set_value(dt, name, "status", "Running")`, or the same as a dict.
+
+	The doctype is not checked: it is a module constant as often as a literal, and no other
+	doctype in the app carries a `Running` status.
+	"""
+	if getattr(node.func, "attr", None) != "set_value":
+		return False
+	args = node.args[2:] + [kw.value for kw in node.keywords]
+	field, value = (args + [None, None])[:2]
+	if _is(field, "status") and _is(value, status):
+		return True
+	return any(isinstance(arg, ast.Dict) and _dict_maps_status(arg, status) for arg in args)
+
+
+def _is(node, value: str) -> bool:
+	return isinstance(node, ast.Constant) and node.value == value
+
+
+def _dict_maps_status(node: ast.Dict, status: str) -> bool:
+	return any(
+		_is(key, "status") and _is(value, status)
+		for key, value in zip(node.keys, node.values, strict=True)
+	)
+
+
+class TestRunning(FakeDockerMixin, IntegrationTestCase):
+	"""The four side effects, driven through the transition itself."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.lab = _make_lab("test-lab-lifecycle")
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		for name in frappe.get_all(BENCH, filters={"lab": cls.lab.name}, pluck="name"):
+			frappe.db.delete("Deploy Log", {"bench": name})
+			_delete_bench_sites(name)
+			frappe.delete_doc(BENCH, name, force=True, ignore_permissions=True)
+		cls.lab.delete(ignore_permissions=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def _stopped_bench(self):
+		bench = _fresh_bench(self, self.lab.name)
+		container = self.docker.add_container(bench.bench_name, status="exited")
+		bench.container_id = container.id
+		bench.status = "Stopped"
+		bench.save(ignore_permissions=True)
+		frappe.db.commit()
+		self.addCleanup(frappe.db.commit)
+		return bench
+
+	def test_a_start_stamps_started_at_and_writes_running(self):
+		bench = self._stopped_bench()
+		with patch.object(lifecycle.ingress, "enqueue_route_sync", autospec=True):
+			lifecycle.running(bench)
+		bench.reload()
+		self.assertEqual(bench.status, "Running")
+		self.assertIsNotNone(bench.started_at)
+
+	def test_a_restart_keeps_the_started_at_it_already_had(self):
+		bench = self._stopped_bench()
+		stamped = frappe.utils.add_to_date(frappe.utils.now_datetime(), hours=-2)
+		frappe.db.set_value(BENCH, bench.name, "started_at", stamped)
+		bench.reload()
+		with patch.object(lifecycle.ingress, "enqueue_route_sync", autospec=True):
+			lifecycle.running(bench, action="restart")
+		bench.reload()
+		self.assertEqual(bench.status, "Running")
+		self.assertEqual(frappe.utils.get_datetime(bench.started_at), stamped)
+
+	def test_the_route_sync_is_enqueued_after_the_status_is_committed(self):
+		"""The job re-reads `status`, so a route synced before the commit routes a stopped bench."""
+		bench = self._stopped_bench()
+		seen = {}
+
+		def record(bench_name):
+			seen["status"] = frappe.db.get_value(BENCH, bench_name, "status")
+
+		with patch.object(lifecycle.ingress, "enqueue_route_sync", new=record):
+			lifecycle.running(bench)
+		self.assertEqual(seen["status"], "Running")
+
+	def test_metering_runs_before_the_save(self):
+		"""The deadline and the status it pays for are written in one transaction."""
+		bench = self._stopped_bench()
+		seen = {}
+
+		def record(doc):
+			seen["status"] = frappe.db.get_value(BENCH, doc.name, "status")
+
+		with (
+			patch.object(lifecycle.metering, "on_bench_running", new=record),
+			patch.object(lifecycle.ingress, "enqueue_route_sync", autospec=True),
+		):
+			lifecycle.running(bench)
+		self.assertEqual(seen["status"], "Stopped")
+
+	def test_a_bench_with_a_passed_deadline_ends_with_one_in_the_future(self):
+		"""The grace-restart observable: before this module it kept the deadline that stopped it."""
+		if not _credits_enabled():
+			self.skipTest("credits are off on this site, so no lease is armed")
+		bench = self._stopped_bench()
+		lease.arm_at(bench, lease.now_ts() - 60)
+		frappe.db.set_value(BENCH, bench.name, "lease_state", None)
+		bench.reload()
+		with patch.object(lifecycle.ingress, "enqueue_route_sync", autospec=True):
+			lifecycle.running(bench)
+		bench.reload()
+		self.assertGreater(frappe.utils.cint(bench.expires_at_ts), lease.now_ts())
+
+
+def _credits_enabled() -> bool:
+	from benchpress.credits import config
+
+	return config.credits_enabled()

--- a/benchpress/tests/test_lifecycle.py
+++ b/benchpress/tests/test_lifecycle.py
@@ -11,12 +11,13 @@ from unittest.mock import patch
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from benchpress import lifecycle
+from benchpress import api, lifecycle
 from benchpress.credits import lease
 from benchpress.tests.fakes import FakeDockerMixin
 from benchpress.tests.test_deploy_manager import _delete_bench_sites, _fresh_bench, _make_lab
 
 BENCH = "Bench Instance"
+SETTINGS = "BenchPress Settings"
 LIFECYCLE_MODULE = "lifecycle.py"
 
 
@@ -63,7 +64,7 @@ def _set_values_status(node: ast.Call, status: str) -> bool:
 	if getattr(node.func, "attr", None) != "set_value":
 		return False
 	args = node.args[2:] + [kw.value for kw in node.keywords]
-	field, value = (args + [None, None])[:2]
+	field, value = (*args, None, None)[:2]
 	if _is(field, "status") and _is(value, status):
 		return True
 	return any(isinstance(arg, ast.Dict) and _dict_maps_status(arg, status) for arg in args)
@@ -75,8 +76,7 @@ def _is(node, value: str) -> bool:
 
 def _dict_maps_status(node: ast.Dict, status: str) -> bool:
 	return any(
-		_is(key, "status") and _is(value, status)
-		for key, value in zip(node.keys, node.values, strict=True)
+		_is(key, "status") and _is(value, status) for key, value in zip(node.keys, node.values, strict=True)
 	)
 
 
@@ -157,21 +157,39 @@ class TestRunning(FakeDockerMixin, IntegrationTestCase):
 			lifecycle.running(bench)
 		self.assertEqual(seen["status"], "Stopped")
 
-	def test_a_bench_with_a_passed_deadline_ends_with_one_in_the_future(self):
-		"""The grace-restart observable: before this module it kept the deadline that stopped it."""
-		if not _credits_enabled():
-			self.skipTest("credits are off on this site, so no lease is armed")
+	def _enable_credits(self) -> None:
+		"""Armed for this test only, and restored through a commit because the code commits."""
+		original = frappe.db.get_single_value(SETTINGS, "enable_credits")
+		self.addCleanup(self._write_credits_switch, original)
+		self._write_credits_switch(1)
+
+	def _write_credits_switch(self, value) -> None:
+		frappe.db.set_single_value(SETTINGS, "enable_credits", value)
+		frappe.db.commit()  # nosemgrep -- the restore must outlive the per-test rollback
+		frappe.clear_cache(doctype=SETTINGS)
+
+	def test_a_passed_deadline_is_replaced_rather_than_carried_into_running(self):
+		"""The grace-restart observable: the next sweep stopped a bench that kept the old one."""
+		self._enable_credits()
 		bench = self._stopped_bench()
 		lease.arm_at(bench, lease.now_ts() - 60)
-		frappe.db.set_value(BENCH, bench.name, "lease_state", None)
+		lease.disarm(bench)
 		bench.reload()
 		with patch.object(lifecycle.ingress, "enqueue_route_sync", autospec=True):
 			lifecycle.running(bench)
 		bench.reload()
 		self.assertGreater(frappe.utils.cint(bench.expires_at_ts), lease.now_ts())
 
-
-def _credits_enabled() -> bool:
-	from benchpress.credits import config
-
-	return config.credits_enabled()
+	def test_the_grace_restart_buys_its_metering_window(self):
+		"""`_restart_in_grace` reached `Running` without one, so the next sweep stopped it again."""
+		self._enable_credits()
+		bench = self._stopped_bench()
+		lease.arm_at(bench, lease.now_ts() - 60)
+		lease.disarm(bench)
+		row = frappe.db.get_value(BENCH, bench.name, api.RENEW_FIELDS, as_dict=True)
+		with patch.object(lifecycle.ingress, "enqueue_route_sync", autospec=True):
+			api._restart_in_grace(row)
+		self.assertEqual(row.status, "Running")
+		self.assertGreater(
+			frappe.utils.cint(frappe.db.get_value(BENCH, bench.name, "expires_at_ts")), lease.now_ts()
+		)

--- a/benchpress/tests/test_lifecycle.py
+++ b/benchpress/tests/test_lifecycle.py
@@ -4,6 +4,7 @@
 """One writer per bench transition, and the side effects that writer must not forget."""
 
 import ast
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -11,7 +12,7 @@ from unittest.mock import patch
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from benchpress import api, lifecycle
+from benchpress import api, ingress, lifecycle
 from benchpress.credits import account, admission, lease
 from benchpress.tests.fakes import FakeDockerMixin
 from benchpress.tests.test_deploy_manager import (
@@ -19,6 +20,7 @@ from benchpress.tests.test_deploy_manager import (
 	_fresh_bench,
 	_make_bench_site,
 	_make_lab,
+	_mounted,
 )
 
 BENCH = "Bench Instance"
@@ -112,6 +114,21 @@ class TransitionFixtures:
 		cls.lab.delete(ignore_permissions=True)
 		frappe.db.commit()  # nosemgrep -- the teardown must outlive the per-test rollback too
 		super().tearDownClass()
+
+	def _claimed_bench(self, bench):
+		"""Give this bench a slot, so a release has something to give back."""
+		account.ensure_account(bench.owner)
+		admission.claim(bench.owner, bench.name, 0)
+		self.addCleanup(self._drop_claim, bench.name)
+		frappe.db.commit()  # nosemgrep -- the transition commits, so the claim it releases must be durable
+		return bench
+
+	def _drop_claim(self, bench_name: str) -> None:
+		admission.release(bench_name)
+		frappe.db.commit()  # nosemgrep -- a leaked slot would outlive the rollback and the test
+
+	def _slots(self, owner: str) -> int:
+		return frappe.utils.cint(frappe.db.get_value("Credit Account", owner, "active_instances"))
 
 	def _bench(self, status: str, container_status: str, *, container: bool = True):
 		bench = _fresh_bench(self, self.lab.name)
@@ -224,22 +241,6 @@ class TestStopped(TransitionFixtures, FakeDockerMixin, IntegrationTestCase):
 	def _running_bench(self, *, container: bool = True):
 		return self._bench("Running", "running", container=container)
 
-	def _claimed_bench(self):
-		"""A running bench holding a slot, so the release has something to give back."""
-		bench = self._running_bench()
-		account.ensure_account(bench.owner)
-		admission.claim(bench.owner, bench.name, 0)
-		self.addCleanup(self._drop_claim, bench.name)
-		frappe.db.commit()  # nosemgrep -- the transition commits, so the claim it releases must be durable
-		return bench
-
-	def _drop_claim(self, bench_name: str) -> None:
-		admission.release(bench_name)
-		frappe.db.commit()  # nosemgrep -- a leaked slot would outlive the rollback and the test
-
-	def _slots(self, owner: str) -> int:
-		return frappe.utils.cint(frappe.db.get_value("Credit Account", owner, "active_instances"))
-
 	def test_a_stop_writes_stopped_and_stops_the_container(self):
 		bench = self._running_bench()
 		with patch.object(lifecycle.ingress, "enqueue_route_sync", autospec=True):
@@ -273,7 +274,7 @@ class TestStopped(TransitionFixtures, FakeDockerMixin, IntegrationTestCase):
 
 	def test_a_stop_gives_back_the_admission_slot(self):
 		"""Stopped is free: a caller at their cap who stopped everything could never start again."""
-		bench = self._claimed_bench()
+		bench = self._claimed_bench(self._running_bench())
 		before = self._slots(bench.owner)
 		with patch.object(lifecycle.ingress, "enqueue_route_sync", autospec=True):
 			lifecycle.stopped(bench.name)
@@ -307,3 +308,138 @@ class TestStopped(TransitionFixtures, FakeDockerMixin, IntegrationTestCase):
 		frappe.db.rollback()
 		self.assertEqual(frappe.db.get_value(BENCH, bench.name, "expiry_attempts"), 1)
 		self.assertEqual(frappe.db.get_value(BENCH, bench.name, "status"), "Running")
+
+
+class TestTornDown(TransitionFixtures, FakeDockerMixin, IntegrationTestCase):
+	"""Teardown's effects, and the two things it must leave behind for the next click."""
+
+	lab_id = "test-lab-lifecycle-teardown"
+
+	def _deployed_bench(self):
+		return self._bench("Running", "running")
+
+	def test_a_teardown_writes_draft_and_removes_the_container(self):
+		bench = self._deployed_bench()
+
+		lifecycle.torn_down(bench)
+
+		self.assertEqual(frappe.db.get_value(BENCH, bench.name, "status"), "Draft")
+		self.assertIsNone(bench.container_id)
+		self.assertEqual(self.docker.stopped, [bench.bench_name])
+		self.assertEqual(self.docker.removed, [bench.bench_name])
+
+	def test_a_teardown_of_a_reaped_instance_repeats_harmlessly(self):
+		"""The reaper and a redeploy can both reach an instance whose container is already gone."""
+		bench = self._bench("Stopped", "exited", container=False)
+
+		lifecycle.torn_down(bench)
+
+		self.assertEqual(frappe.db.get_value(BENCH, bench.name, "status"), "Draft")
+		self.assertEqual(self.docker.removed, [])
+
+	def test_a_teardown_deactivates_every_site(self):
+		bench = self._deployed_bench()
+		_make_bench_site(bench.name, f"one-{bench.name}.localhost")
+		_make_bench_site(bench.name, f"two-{bench.name}.localhost")
+
+		lifecycle.torn_down(bench)
+
+		statuses = frappe.get_all(SITE, filters={"bench": bench.name}, pluck="status")
+		self.assertEqual(set(statuses), {"Inactive"})
+
+	def test_a_teardown_keeps_the_site_rows_it_deactivated(self):
+		"""The row is the site-name claim, so deleting it would lose the name to the next caller."""
+		bench = self._deployed_bench()
+		_make_bench_site(bench.name, f"claim-{bench.name}.localhost")
+
+		lifecycle.torn_down(bench)
+
+		self.assertEqual(frappe.db.count(SITE, {"bench": bench.name}), 1)
+
+	def test_a_teardown_never_touches_volumes(self):
+		"""A reaped instance is one click from running, and the volume is what holds the work."""
+		bench = self._deployed_bench()
+
+		lifecycle.torn_down(bench)
+
+		self.assertEqual(self.docker.volume_gets, [])
+
+	def test_a_teardown_gives_back_the_admission_slot(self):
+		bench = self._claimed_bench(self._deployed_bench())
+		before = self._slots(bench.owner)
+
+		lifecycle.torn_down(bench)
+
+		self.assertEqual(self._slots(bench.owner), before - 1)
+		self.assertFalse(frappe.db.exists(ADMISSION, bench.name))
+
+	def test_a_redeploy_holds_its_slot_across_the_teardown(self):
+		"""Releasing between the two halves hands the slot away and leaves the caller over cap."""
+		bench = self._claimed_bench(self._deployed_bench())
+		before = self._slots(bench.owner)
+
+		lifecycle.torn_down(bench, release_admission=False)
+
+		self.assertEqual(self._slots(bench.owner), before)
+		self.assertTrue(frappe.db.exists(ADMISSION, bench.name))
+
+	def test_a_teardown_clears_the_metering_deadline(self):
+		"""The container it was burning for is gone, so the window must not survive into the next."""
+		bench = self._claimed_bench(self._deployed_bench())
+		frappe.db.set_value(BENCH, bench.name, "expires_at_ts", lease.now_ts() + 3600, update_modified=False)
+		frappe.db.commit()  # nosemgrep -- the transition reads the row it clears
+		bench.reload()
+
+		lifecycle.torn_down(bench)
+
+		self.assertEqual(frappe.utils.cint(frappe.db.get_value(BENCH, bench.name, "expires_at_ts")), 0)
+
+	def test_a_teardown_removes_the_instance_route_file(self):
+		"""Freed container IPs get reused by Docker, so a stale route file would keep pointing the
+		old public hostname at whoever gets that IP next."""
+		bench = self._bench("Running", "running", container=False)
+
+		with tempfile.TemporaryDirectory() as tmp:
+			with patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", _mounted(tmp)):
+				ingress.publish(bench.name, "benchpress.cloud")
+				route_file = Path(tmp) / "instances" / f"{bench.name}.yml"
+				self.assertTrue(route_file.exists())
+
+				lifecycle.torn_down(bench)
+
+				self.assertFalse(route_file.exists())
+
+	def test_a_teardown_keeps_the_wildcard_anchor(self):
+		"""The anchor outlives every bench — it is what keeps the certificate renewing, so a
+		reaper that tidied it away would silently stop renewal."""
+		bench = self._bench("Running", "running", container=False)
+
+		with tempfile.TemporaryDirectory() as tmp:
+			with patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", _mounted(tmp)):
+				ingress.ensure_anchor("benchpress.cloud")
+				ingress.publish(bench.name, "benchpress.cloud")
+				anchor = Path(tmp) / "instances" / "wildcard-anchor.yml"
+
+				lifecycle.torn_down(bench)
+
+				self.assertFalse((Path(tmp) / "instances" / f"{bench.name}.yml").exists())
+				self.assertTrue(anchor.exists())
+
+	def test_a_teardown_does_not_raise_when_no_route_file_exists(self):
+		"""The `base_domain = localhost` case: nothing wrote a route file, so teardown no-ops."""
+		bench = self._bench("Running", "running", container=False)
+
+		with tempfile.TemporaryDirectory() as tmp:
+			with patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", _mounted(tmp)):
+				lifecycle.torn_down(bench)
+
+		self.assertEqual(frappe.db.get_value(BENCH, bench.name, "status"), "Draft")
+
+	def test_the_route_goes_directly_rather_than_through_a_job(self):
+		"""Teardown already runs on `queue-long`; live routing must not depend on a second job."""
+		bench = self._deployed_bench()
+
+		with patch("frappe.enqueue") as enqueue:
+			lifecycle.torn_down(bench)
+
+		enqueue.assert_not_called()

--- a/benchpress/tests/test_lifecycle.py
+++ b/benchpress/tests/test_lifecycle.py
@@ -12,19 +12,31 @@ import frappe
 from frappe.tests import IntegrationTestCase
 
 from benchpress import api, lifecycle
-from benchpress.credits import lease
+from benchpress.credits import account, admission, lease
 from benchpress.tests.fakes import FakeDockerMixin
-from benchpress.tests.test_deploy_manager import _delete_bench_sites, _fresh_bench, _make_lab
+from benchpress.tests.test_deploy_manager import (
+	_delete_bench_sites,
+	_fresh_bench,
+	_make_bench_site,
+	_make_lab,
+)
 
 BENCH = "Bench Instance"
+SITE = "Bench Site"
+ADMISSION = "Bench Admission"
 SETTINGS = "BenchPress Settings"
 LIFECYCLE_MODULE = "lifecycle.py"
+DB_SERVER_MODULE = "mariadb_manager.py"
 
 
 class TestOneWriterPerStatus(unittest.TestCase):
 	def test_only_lifecycle_writes_running(self):
 		"""Four call sites used to. A fifth appearing is the bug this whole item exists to stop."""
 		self.assertEqual(_status_writers("Running"), {LIFECYCLE_MODULE})
+
+	def test_only_lifecycle_writes_stopped(self):
+		"""`mariadb_manager` writes it too, on `Database Server` — a different doctype's status."""
+		self.assertEqual(_status_writers("Stopped"), {LIFECYCLE_MODULE, DB_SERVER_MODULE})
 
 
 def _status_writers(status: str) -> set[str]:
@@ -56,10 +68,9 @@ def _assigns_status(node: ast.Assign, status: str) -> bool:
 
 
 def _set_values_status(node: ast.Call, status: str) -> bool:
-	"""`set_value(dt, name, "status", "Running")`, or the same as a dict.
+	"""`set_value(dt, name, "status", <status>)`, or the same as a dict.
 
-	The doctype is not checked: it is a module constant as often as a literal, and no other
-	doctype in the app carries a `Running` status.
+	The doctype is not checked: it is a module constant as often as a literal.
 	"""
 	if getattr(node.func, "attr", None) != "set_value":
 		return False
@@ -80,14 +91,16 @@ def _dict_maps_status(node: ast.Dict, status: str) -> bool:
 	)
 
 
-class TestRunning(FakeDockerMixin, IntegrationTestCase):
-	"""The four side effects, driven through the transition itself."""
+class TransitionFixtures:
+	"""A lab of its own per transition, and benches durable enough to outlive a commit."""
+
+	lab_id = ""
 
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
 		frappe.set_user("Administrator")
-		cls.lab = _make_lab("test-lab-lifecycle")
+		cls.lab = _make_lab(cls.lab_id)
 		frappe.db.commit()  # nosemgrep -- the fixtures outlive the per-test rollback
 
 	@classmethod
@@ -101,15 +114,24 @@ class TestRunning(FakeDockerMixin, IntegrationTestCase):
 		frappe.db.commit()  # nosemgrep -- the teardown must outlive the per-test rollback too
 		super().tearDownClass()
 
-	def _stopped_bench(self):
+	def _bench(self, status: str, container_status: str, *, container: bool = True):
 		bench = _fresh_bench(self, self.lab.name)
-		container = self.docker.add_container(bench.bench_name, status="exited")
-		bench.container_id = container.id
-		bench.status = "Stopped"
+		if container:
+			bench.container_id = self.docker.add_container(bench.bench_name, status=container_status).id
+		bench.status = status
 		bench.save(ignore_permissions=True)
 		frappe.db.commit()  # nosemgrep -- the transition under test commits, so its fixture has to be durable
 		self.addCleanup(frappe.db.commit)
 		return bench
+
+
+class TestRunning(TransitionFixtures, FakeDockerMixin, IntegrationTestCase):
+	"""The four side effects, driven through the transition itself."""
+
+	lab_id = "test-lab-lifecycle-running"
+
+	def _stopped_bench(self):
+		return self._bench("Stopped", "exited")
 
 	def test_a_start_stamps_started_at_and_writes_running(self):
 		bench = self._stopped_bench()
@@ -193,3 +215,96 @@ class TestRunning(FakeDockerMixin, IntegrationTestCase):
 		self.assertGreater(
 			frappe.utils.cint(frappe.db.get_value(BENCH, bench.name, "expires_at_ts")), lease.now_ts()
 		)
+
+
+class TestStopped(TransitionFixtures, FakeDockerMixin, IntegrationTestCase):
+	"""The five side effects a stop must not forget, driven through the transition itself."""
+
+	lab_id = "test-lab-lifecycle-stopped"
+
+	def _running_bench(self, *, container: bool = True):
+		return self._bench("Running", "running", container=container)
+
+	def _claimed_bench(self):
+		"""A running bench holding a slot, so the release has something to give back."""
+		bench = self._running_bench()
+		account.ensure_account(bench.owner)
+		admission.claim(bench.owner, bench.name, 0)
+		self.addCleanup(self._drop_claim, bench.name)
+		frappe.db.commit()  # nosemgrep -- the transition commits, so the claim it releases must be durable
+		return bench
+
+	def _drop_claim(self, bench_name: str) -> None:
+		admission.release(bench_name)
+		frappe.db.commit()  # nosemgrep -- a leaked slot would outlive the rollback and the test
+
+	def _slots(self, owner: str) -> int:
+		return frappe.utils.cint(frappe.db.get_value("Credit Account", owner, "active_instances"))
+
+	def test_a_stop_writes_stopped_and_stops_the_container(self):
+		bench = self._running_bench()
+		with patch.object(lifecycle.ingress, "enqueue_route_sync", autospec=True):
+			lifecycle.stopped(bench.name)
+		bench.reload()
+		self.assertEqual(bench.status, "Stopped")
+		# The fake records the container name, which is what `bench_name` holds.
+		self.assertEqual(self.docker.stopped, [bench.bench_name])
+
+	def test_a_bench_with_no_container_still_reaches_stopped(self):
+		bench = self._running_bench(container=False)
+		with patch.object(lifecycle.ingress, "enqueue_route_sync", autospec=True):
+			lifecycle.stopped(bench.name)
+		bench.reload()
+		self.assertEqual(bench.status, "Stopped")
+		self.assertEqual(self.docker.stopped, [])
+
+	def test_a_stop_deactivates_every_site_and_repeats_harmlessly(self):
+		"""Nothing answers inside a stopped container, so no row may stay Active."""
+		bench = self._running_bench()
+		_make_bench_site(bench.name, "one.localhost")
+		_make_bench_site(bench.name, "two.localhost")
+		frappe.db.commit()  # nosemgrep -- the transition commits, so the rows it reads must be durable
+
+		with patch.object(lifecycle.ingress, "enqueue_route_sync", autospec=True):
+			lifecycle.stopped(bench.name)
+			lifecycle.stopped(bench.name)
+
+		statuses = frappe.get_all(SITE, filters={"bench": bench.name}, pluck="status")
+		self.assertEqual(statuses, ["Inactive", "Inactive"])
+
+	def test_a_stop_gives_back_the_admission_slot(self):
+		"""Stopped is free: a caller at their cap who stopped everything could never start again."""
+		bench = self._claimed_bench()
+		before = self._slots(bench.owner)
+		with patch.object(lifecycle.ingress, "enqueue_route_sync", autospec=True):
+			lifecycle.stopped(bench.name)
+		self.assertEqual(self._slots(bench.owner), before - 1)
+		self.assertFalse(frappe.db.exists(ADMISSION, bench.name))
+
+	def test_the_route_sync_is_enqueued_after_the_status_is_committed(self):
+		"""The job re-reads `status`, so a route synced before the commit keeps routing a live bench."""
+		bench = self._running_bench()
+		seen = {}
+
+		def record(bench_name):
+			seen["status"] = frappe.db.get_value(BENCH, bench_name, "status")
+
+		with patch.object(lifecycle.ingress, "enqueue_route_sync", new=record):
+			lifecycle.stopped(bench.name)
+		self.assertEqual(seen["status"], "Stopped")
+
+	def test_a_failed_stop_commits_the_lease_release_before_re_raising(self):
+		"""Read back through a rollback: what survives one is what the retry will see."""
+		bench = self._running_bench()
+		frappe.db.set_value(BENCH, bench.name, "lease_state", lease.STOPPING, update_modified=False)
+		frappe.db.commit()  # nosemgrep -- the claim must be durable before the transition reads it
+
+		with (
+			patch.object(lifecycle, "stop_container", side_effect=Exception("docker is down")),
+			self.assertRaises(Exception),
+		):
+			lifecycle.stopped(bench.name)
+
+		frappe.db.rollback()
+		self.assertEqual(frappe.db.get_value(BENCH, bench.name, "expiry_attempts"), 1)
+		self.assertEqual(frappe.db.get_value(BENCH, bench.name, "status"), "Running")

--- a/benchpress/tests/test_scheduler_entries.py
+++ b/benchpress/tests/test_scheduler_entries.py
@@ -69,7 +69,7 @@ class TestJobPathsResolve(unittest.TestCase):
 	def test_the_walker_finds_the_targets(self):
 		"""A walker that matched nothing would pass the test above for the wrong reason."""
 		targets = {target for _, target in _enqueue_targets()}
-		self.assertIn("benchpress.deploy_manager.deploy_bench", targets)
+		self.assertIn("benchpress.lifecycle.deploy_bench", targets)
 		self.assertGreater(len(targets), 8)
 
 

--- a/benchpress/tests/test_site_names.py
+++ b/benchpress/tests/test_site_names.py
@@ -151,7 +151,7 @@ class TestSiteNameClaim(IntegrationTestCase):
 		return " ".join(str(entry) for entry in (frappe.local.message_log or []))
 
 	def test_an_inactive_name_is_still_claimed(self):
-		"""`stop_bench` deactivates without dropping, so the database is still on disk."""
+		"""`lifecycle.stopped` deactivates without dropping, so the database is still on disk."""
 		stopped = self._bench(self.labs[0], f"stopped.{DOMAIN}")
 		self._claimed(stopped, status="Inactive")
 

--- a/benchpress/tests/test_stats_collector.py
+++ b/benchpress/tests/test_stats_collector.py
@@ -17,7 +17,7 @@ class TestStopIfDead(unittest.TestCase):
 			patch("benchpress.stats_collector.get_container_stats", side_effect=Exception("no stats")),
 			patch("benchpress.stats_collector.get_container_health", return_value=health),
 			patch("benchpress.stats_collector.container_is_gone", return_value=gone) as gone_mock,
-			patch("benchpress.deploy_manager.stop_bench") as stop_mock,
+			patch("benchpress.lifecycle.stopped") as stop_mock,
 			patch("benchpress.notifications.notify_owner") as notify_mock,
 		):
 			frappe_mock.get_all.return_value = [dict(BENCH)]
@@ -56,7 +56,7 @@ class TestStopIfDead(unittest.TestCase):
 			patch("benchpress.stats_collector.frappe") as frappe_mock,
 			patch("benchpress.stats_collector.get_container_stats", side_effect=Exception("no stats")),
 			patch("benchpress.stats_collector.get_container_health", return_value="Unhealthy"),
-			patch("benchpress.deploy_manager.stop_bench", side_effect=[Exception("boom"), None]) as stop_mock,
+			patch("benchpress.lifecycle.stopped", side_effect=[Exception("boom"), None]) as stop_mock,
 			patch("benchpress.notifications.notify_owner"),
 		):
 			frappe_mock.get_all.return_value = [dict(BENCH), second]


### PR DESCRIPTION
Phase 1 of the bench-lifecycle-module spec: `benchpress/lifecycle.py` becomes the only writer of `Running`.

- `running(bench, action=...)` carries the four side effects in the order that is the contract: the container call, the status, metering before the save, the route sync after the commit.
- `api._start_bench`, `BenchInstance.enqueue_start` and `api._restart_in_grace` are now wrappers. The duplicate start path is deleted, and the grace restart buys its metering window instead of skipping it.
- `deploy_bench`, `_deploy_bench`, `redeploy_bench` and `_redeploy_bench` move to `lifecycle`; the three dotted job strings that named them are rewritten in the same commit. `deploy_bench:{name}` is unchanged.
- `test_lifecycle.TestOneWriterPerStatus` AST-walks the non-test tree and fails if a fifth writer of `Running` appears.