### PR TITLE
Implemented phase four

### DIFF
--- a/.claude/skills/issue-to-phases/references/ralph-loop.md
+++ b/.claude/skills/issue-to-phases/references/ralph-loop.md
@@ -87,6 +87,24 @@ subject — and verify it by hand before trusting it.
 an unguarded `grep` miss aborts the whole loop instead of reporting the failure
 the gate exists to catch. End helpers with `|| true` and an explicit `return 0`.
 
+**A helper whose stdout is the signal never counts with `grep -c`.** It prints
+`0` on no match, so `[ -z "$(helper)" ]` is false for a clean tree and false for
+a dirty one: the gate is unsatisfiable and fails every phase whatever the agent
+writes. Emit the matches themselves — `grep -o`, `grep -l` — and let empty mean
+clean. Guarding the exit code with `|| true` does not help, because the `0` is on
+stdout.
+
+> This one shipped. Two phase-1 gates read `grep -c … || true` and tested the
+> result with `-z`, so a correct implementation was retracted as a failure. Prove
+> every helper both ways before shipping the loop: break the thing on purpose and
+> watch the gate go red, then fix it and watch it go green. A gate only ever
+> observed on a clean tree is untested.
+
+**Beware an `awk` range whose start line also matches its end pattern.**
+`/def _enforce/,/^def [a-z_]+\(/` looks like "the body of `_enforce`" and selects
+the `def` line alone, because that line matches the end pattern too. The body is
+never read, so the gate sees nothing and reports clean.
+
 **Redirect stdin on every `docker compose exec`, or the loop hangs forever.**
 GNU `timeout` calls `setpgid()` to put its child in its own process group so it
 can kill the group. That group is *background* relative to the terminal, so the

--- a/.claude/skills/issue-to-phases/references/ralph-loop.md
+++ b/.claude/skills/issue-to-phases/references/ralph-loop.md
@@ -145,26 +145,14 @@ drops first when it is concentrating on code, and a shipped feature filed under
 docker compose exec backend bench --site frontend run-tests --module benchpress.tests.test_deploy_manager
 ```
 
-Three rules, and each one has cost a real run.
+Two rules, and each one has cost a real run.
 
 **Never `--app benchpress`.** The whole suite is CI's job. It takes 60 seconds
-against the live site, one of its tests fails there for good (the fence list
-below), and the rest of the run does not repeat. Three runs of the same tree gave
+against the live site and does not repeat. Three runs of the same tree gave
 one failure, then four, then one: `test_api` blew a 600 ms budget at 1,473 ms
 under whole-suite load, and `test_credit_guard` got a Docker 404 that it does not
 get on its own. Scoped `--module` runs of the same tests were stable every time.
 A red whole-suite run here tells a loop nothing it can act on.
-
-**Never name a fenced module.** `test_lease` is the only one left.
-`test_a_restarted_bench_gets_a_fresh_deadline_and_is_not_reclaimed` errors here
-because `guard._enforce` holds credits against the caller instead of the bench
-owner, so an admin restarting a bench they do not own is priced against the wrong
-account. That is a production bug, not a test one, and no phase spec works around
-it. CI stays green only because a fresh `Administrator` on `test_site` collects
-the signup grant. Tracked as
-[#202](https://github.com/Venkateshvenki404224/benchpress/issues/202) — item 9's
-spec fixes it and deletes this entry. A phase that must touch `test_lease` gates
-on CI alone, and its phase spec says so.
 
 `test_credit_sweep`, `test_demo_data` and `test_signup` were fenced here until
 [#203](https://github.com/Venkateshvenki404224/benchpress/issues/203) fixed them,

--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -25,9 +25,10 @@ from benchpress.credits.guard import (
 	build_charge,
 	cap_builds_per_day,
 	cap_devices,
+	cap_size_tier,
+	deploy_lease_cost,
 	instance_lease_cost,
 	lab_owner,
-	payload_lease_cost,
 	require_balance,
 	requires_admission,
 )
@@ -187,7 +188,7 @@ def _counts_by_bench(doctype: str, column: str, bench_names: list[str]) -> dict[
 
 
 @frappe.whitelist()
-@requires_admission(cost=payload_lease_cost)
+@requires_admission(cost=deploy_lease_cost, caps=(cap_size_tier,))
 def create_bench(data: str) -> dict:
 	require_app_user()
 	from benchpress.benchpress.doctype.bench_instance import get_instance_id
@@ -197,6 +198,10 @@ def create_bench(data: str) -> dict:
 	lab_name = data.get("lab")
 	if not lab_name:
 		frappe.throw(_("Lab is required to create a bench."))
+
+	size = data.get("instance_size")
+	if size and not frappe.db.exists("Instance Size", size):
+		frappe.throw(_("There is no instance size named '{0}'.").format(size))
 
 	lab = frappe.get_cached_doc("Lab", lab_name)
 	requested_site_name = data.get("site_name") or data.get("site")
@@ -219,6 +224,7 @@ def create_bench(data: str) -> dict:
 	frappe.enqueue(
 		"benchpress.lifecycle.deploy_bench",
 		bench_name=doc.name,
+		size=size,
 		queue="long",
 		timeout=DEPLOY_JOB_TIMEOUT,
 		job_id=f"deploy_bench:{doc.name}",

--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -26,6 +26,7 @@ from benchpress.credits.guard import (
 	cap_builds_per_day,
 	cap_devices,
 	instance_lease_cost,
+	lab_owner,
 	payload_lease_cost,
 	require_balance,
 	requires_admission,
@@ -83,7 +84,7 @@ def create_lab_from_template(template: str, lab_id: str | None = None, title: st
 
 
 @frappe.whitelist()
-@requires_admission(cost=build_charge, caps=(cap_builds_per_day,))
+@requires_admission(cost=build_charge, caps=(cap_builds_per_day,), payer=lab_owner)
 def build_lab_image(lab_name: str) -> dict:
 	require_admin()
 	frappe.enqueue(

--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -527,7 +527,7 @@ def renew_bench(bench_name: str, plan: str, request_id: str) -> dict:
 	stopped = bench.status == "Stopped"
 	if stopped:
 		_assert_inside_grace(bench)
-	require_balance(bench.owner, lease.cost_of(lab, chosen))
+	require_balance(bench.owner, lease.cost_of_bench(bench, lab, chosen))
 
 	charged = metering.charge_lease(bench, lab, chosen, request_id=request_id)
 	lease.extend(bench, chosen)

--- a/benchpress/benchpress/doctype/bench_instance/bench_instance.json
+++ b/benchpress/benchpress/doctype/bench_instance/bench_instance.json
@@ -11,6 +11,7 @@
   "column_break_basic",
   "status",
   "frappe_version",
+  "instance_size",
   "site_name",
   "ssh_access_section",
   "ssh_username",
@@ -349,6 +350,14 @@
    "label": "Expiry Lateness (s)",
    "permlevel": 1,
    "read_only": 1
+  },
+  {
+   "description": "The size this bench was deployed at. Written by the deploy, and what billing prices.",
+   "fieldname": "instance_size",
+   "fieldtype": "Link",
+   "label": "Instance Size",
+   "options": "Instance Size",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
@@ -363,7 +372,7 @@
    "link_fieldname": "bench"
   }
  ],
- "modified": "2026-08-24 19:30:00.000000",
+ "modified": "2026-08-27 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Benchpress",
  "name": "Bench Instance",

--- a/benchpress/benchpress/doctype/bench_instance/bench_instance.py
+++ b/benchpress/benchpress/doctype/bench_instance/bench_instance.py
@@ -10,7 +10,12 @@ from frappe.utils.background_jobs import is_job_enqueued
 
 from benchpress import lifecycle
 from benchpress.benchpress.doctype.bench_instance import get_instance_id
-from benchpress.credits.guard import instance_lease_cost, requires_admission
+from benchpress.credits.guard import (
+	cap_size_tier,
+	deploy_lease_cost,
+	instance_lease_cost,
+	requires_admission,
+)
 from benchpress.permissions import is_admin
 
 DEPLOY_JOB_TIMEOUT = 7200
@@ -131,7 +136,7 @@ class BenchInstance(Document):
 		return username
 
 	@frappe.whitelist()
-	@requires_admission(cost=instance_lease_cost)
+	@requires_admission(cost=deploy_lease_cost, caps=(cap_size_tier,))
 	def enqueue_deploy(self):
 		if is_job_enqueued(self._deploy_job_id()):
 			frappe.msgprint(_("A deploy is already in progress for this bench."))
@@ -153,7 +158,7 @@ class BenchInstance(Document):
 		frappe.msgprint(_("Bench stopped."))
 
 	@frappe.whitelist()
-	@requires_admission(cost=instance_lease_cost)
+	@requires_admission(cost=deploy_lease_cost, caps=(cap_size_tier,))
 	def enqueue_redeploy(self):
 		if is_job_enqueued(self._deploy_job_id()):
 			frappe.msgprint(_("A deploy is already in progress for this bench."))

--- a/benchpress/benchpress/doctype/credit_settings/credit_settings.json
+++ b/benchpress/benchpress/doctype/credit_settings/credit_settings.json
@@ -26,6 +26,7 @@
   "column_break_caps",
   "max_devices",
   "max_builds_per_day",
+  "max_size_free",
   "signup_section",
   "waitlist_open",
   "column_break_signup",
@@ -121,6 +122,13 @@
    "label": "Max Builds per Day"
   },
   {
+   "description": "The largest size a user who has never purchased may deploy at, compared by price multiplier. Empty = no ceiling.",
+   "fieldname": "max_size_free",
+   "fieldtype": "Link",
+   "label": "Max Size (Free)",
+   "options": "Instance Size"
+  },
+  {
    "fieldname": "signup_section",
    "fieldtype": "Section Break",
    "label": "Self-serve Signup"
@@ -184,7 +192,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-08-17 12:10:00.000000",
+ "modified": "2026-08-27 16:30:00.000000",
  "modified_by": "Administrator",
  "module": "Benchpress",
  "name": "Credit Settings",

--- a/benchpress/benchpress/doctype/instance_size/instance_size.json
+++ b/benchpress/benchpress/doctype/instance_size/instance_size.json
@@ -17,8 +17,13 @@
   "resources_section",
   "memory_limit",
   "cpu_cores",
+  "disk_limit",
+  "pids_limit",
   "column_break_resources",
-  "max_sites"
+  "max_sites",
+  "iops_limit",
+  "bps_limit",
+  "include_code_server"
  ],
  "fields": [
   {
@@ -63,14 +68,14 @@
    "label": "Resources"
   },
   {
-   "description": "Docker memory limit, e.g. 1g. Copied to Lab.memory_limit.",
+   "description": "Docker memory limit, e.g. 1g. Read at deploy, not copied onto the Lab.",
    "fieldname": "memory_limit",
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Memory Limit"
   },
   {
-   "description": "Copied to Lab.cpu_cores. Minimum 1.",
+   "description": "Clamped to the host's core count at deploy. Minimum 1.",
    "fieldname": "cpu_cores",
    "fieldtype": "Int",
    "in_list_view": 1,
@@ -101,12 +106,47 @@
    "fieldtype": "Link",
    "label": "Default Lease Plan",
    "options": "Lease Plan"
+  },
+  {
+   "description": "Writable-layer quota in GB. 0 = unlimited. Only enforced on overlay2 over xfs; anywhere else the deploy logs it as skipped.",
+   "fieldname": "disk_limit",
+   "fieldtype": "Int",
+   "label": "Disk Limit (GB)",
+   "non_negative": 1
+  },
+  {
+   "description": "Max number of processes (PIDs) a bench of this size may spawn. Leave 0 for the default (500).",
+   "fieldname": "pids_limit",
+   "fieldtype": "Int",
+   "label": "Max Processes (PID limit)",
+   "non_negative": 1
+  },
+  {
+   "description": "Read/write IOPS cap per host block device. Leave 0 for the default (1000).",
+   "fieldname": "iops_limit",
+   "fieldtype": "Int",
+   "label": "Max IOPS (Block I/O)",
+   "non_negative": 1
+  },
+  {
+   "description": "Read/write throughput cap in bytes/sec per host block device. Leave 0 for the default (40 MiB/s).",
+   "fieldname": "bps_limit",
+   "fieldtype": "Int",
+   "label": "Max Bytes/sec (Block I/O)",
+   "non_negative": 1
+  },
+  {
+   "default": "1",
+   "description": "Whether a bench of this size runs code-server. Off means no IDE and no public ide- hostname.",
+   "fieldname": "include_code_server",
+   "fieldtype": "Check",
+   "label": "Include Code Server"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-08-17 08:10:00.000000",
+ "modified": "2026-08-27 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Benchpress",
  "name": "Instance Size",

--- a/benchpress/benchpress/doctype/lab/lab.py
+++ b/benchpress/benchpress/doctype/lab/lab.py
@@ -20,7 +20,6 @@ LAB_READY = "Ready"
 class Lab(Document):
 	def validate(self):
 		validate_lab_id(self.lab_id)
-		self.apply_instance_size()
 		self.validate_cpu_cores()
 		self.reset_status_if_spec_changed()
 		self.clear_golden_manifest_if_image_changed()
@@ -45,20 +44,6 @@ class Lab(Document):
 		before = self.get_doc_before_save()
 		if before and before.image_tag != self.image_tag:
 			self.golden_manifest = None
-
-	def apply_instance_size(self):
-		"""Copy the chosen size's resources onto the two fields Docker actually reads.
-
-		The size is the *choice* — it carries the price, so it is what the user picks — but
-		`memory_limit` and `cpu_cores` stay the stored truth, so `docker_manager` and every screen
-		that renders limits need to know nothing about `Instance Size`. A lab with no size keeps
-		its hand-typed limits, which is what a self-hoster running with credits off wants.
-		"""
-		if not self.instance_size:
-			return
-		size = frappe.get_cached_doc("Instance Size", self.instance_size)
-		self.memory_limit = size.memory_limit
-		self.cpu_cores = size.cpu_cores
 
 	def validate_cpu_cores(self):
 		if cint(self.cpu_cores) < BASELINE_CPU_CORES:

--- a/benchpress/credits/admission_repair.py
+++ b/benchpress/credits/admission_repair.py
@@ -16,7 +16,7 @@ on the `*/5` cron beside the balance sweep, not on the daily list.
 It is pure database work: a handful of grouped reads, no Docker call anywhere, which is why it is safe
 on `queue-short` for exactly the reason `sweep.enforce_limits` is.
 
-Four rules, in order. Expiring first and healing last is what makes a double release harmless:
+Five rules, in order. Expiring first and healing last is what makes a double release harmless:
 the counter follows the rows, so it cannot be driven negative by a release that ran twice.
 """
 
@@ -49,17 +49,24 @@ CLAIM_GRACE_MINUTES = 15
 
 
 def reconcile_admissions() -> dict:
-	"""Expire stranded claims, retire stranded sites, adopt orphaned instances, heal the counters."""
+	"""Expire stranded claims, retire stranded sites, adopt orphans, re-key misattributions, heal the counters."""
 	released = _release_stranded()
 	retired = _retire_stranded_sites()
 	adopted = _adopt_orphans()
+	rekeyed = _rekey_misattributed()
 	healed = _heal_counters()
-	if released or retired or adopted or healed:
+	if released or retired or adopted or rekeyed or healed:
 		frappe.logger("benchpress").warning(
 			f"admission drift: released {len(released)}, retired {len(retired)}, "
-			f"adopted {len(adopted)}, healed {len(healed)}"
+			f"adopted {len(adopted)}, rekeyed {len(rekeyed)}, healed {len(healed)}"
 		)
-	return {"released": released, "retired": retired, "adopted": adopted, "healed": healed}
+	return {
+		"released": released,
+		"retired": retired,
+		"adopted": adopted,
+		"rekeyed": rekeyed,
+		"healed": healed,
+	}
 
 
 def _retire_stranded_sites() -> list[str]:
@@ -124,6 +131,33 @@ def _adopt_orphans() -> list[str]:
 	return adopted
 
 
+def _rekey_misattributed() -> list[str]:
+	"""Move every claim held against somebody other than its bench's owner onto that owner.
+
+	The rest of this pass cannot see the drift: `_heal_counters` sums rows by their own `account`,
+	so a claim on the wrong account and the wrong counter that follows from it agree with each
+	other forever. Only the rows move here, and the heal that runs next is what makes both
+	accounts' counters right — which is why this rule cannot be the last one.
+
+	`claimed_at` is left alone. The grace period in `_release_stranded` is about how long the
+	deploy has had, not about when the repair noticed.
+	"""
+	claims = frappe.get_all(ADMISSION, fields=["bench", "account"])
+	if not claims:
+		return []
+	owners = _bench_owners([claim.bench for claim in claims])
+	rekeyed = []
+	for claim in claims:
+		owner = owners.get(claim.bench)
+		if not owner or owner == claim.account:
+			continue
+		# The link needs somewhere to point, exactly as adoption opens one for a bench it finds.
+		account.ensure_account(owner)
+		frappe.db.set_value(ADMISSION, claim.bench, "account", owner, update_modified=False)
+		rekeyed.append(claim.bench)
+	return rekeyed
+
+
 def _heal_counters() -> list[str]:
 	"""Set every account's slot count and hold to what its own rows add up to."""
 	held = _claims_by_account()
@@ -147,6 +181,11 @@ def _heal_counters() -> list[str]:
 def _bench_statuses(bench_names: list[str]) -> dict[str, str]:
 	rows = frappe.get_all(BENCH, filters={"name": ("in", bench_names)}, fields=["name", "status"])
 	return {row.name: row.status for row in rows}
+
+
+def _bench_owners(bench_names: list[str]) -> dict[str, str]:
+	rows = frappe.get_all(BENCH, filters={"name": ("in", bench_names)}, fields=["name", "owner"])
+	return {row.name: row.owner for row in rows}
 
 
 def _claims_by_account() -> dict[str, dict]:

--- a/benchpress/credits/config.py
+++ b/benchpress/credits/config.py
@@ -68,6 +68,11 @@ def default_size():
 	return size_index().get("default")
 
 
+def size_by_name(name):
+	"""One `Instance Size` by name, or `None` — the top rung of the deploy's resolution chain."""
+	return size_index()["by_name"].get(name) if name else None
+
+
 def size_for_lab(lab_doc):
 	"""The `Instance Size` a Lab deploys at. Falls back to its resources, then to the default.
 

--- a/benchpress/credits/config.py
+++ b/benchpress/credits/config.py
@@ -86,6 +86,19 @@ def size_for_lab(lab_doc):
 	return index["by_resources"].get(key) or index["default"]
 
 
+def size_for_instance(bench_doc):
+	"""The `Instance Size` a bench was deployed at — what billing prices, not what its Lab now says.
+
+	A Lab may be re-pointed at another size while a bench of the old one is still running, so the
+	price has to follow the numbers Docker was actually given. Falls back to the Lab for a bench
+	that predates the recorded size.
+	"""
+	chosen = size_index()["by_name"].get(bench_doc.get("instance_size"))
+	if chosen:
+		return chosen
+	return size_for_lab(frappe.get_cached_doc("Lab", bench_doc.get("lab")))
+
+
 def instance_sizes() -> list[dict]:
 	"""Every size in display order. Shares the request-scoped index, so it costs no extra query."""
 	return size_index()["rows"]
@@ -128,6 +141,11 @@ def build_size_index() -> dict:
 			"price_multiplier",
 			"default_lease_plan",
 			"max_sites",
+			"pids_limit",
+			"iops_limit",
+			"bps_limit",
+			"disk_limit",
+			"include_code_server",
 			"is_default",
 			"sort_order",
 		],

--- a/benchpress/credits/guard.py
+++ b/benchpress/credits/guard.py
@@ -27,6 +27,12 @@ Costs are **holds, not debits**. Nothing here writes to a balance; `metering` st
 charge. What a start must prove is the price of one lease — the number the size picker quoted
 and the number the deploy is about to spend — and admission reserves it until that deploy
 spends it.
+
+Every one of those numbers is judged against the **payer**, not the session user: the bench's
+owner where the call carries a bench, the session user where it does not. The hold is the only
+thing in this app that can refuse a start, so pricing it against the caller removes the refusal
+for the account `metering` goes on to debit — which is how an owner reached -4.0 credits while
+somebody else held 75.
 """
 
 import functools
@@ -42,16 +48,20 @@ from benchpress.permissions import has_app_permission
 
 ACCOUNT = "Credit Account"
 BENCH = "Bench Instance"
+LAB = "Lab"
 LEDGER = "Credit Ledger Entry"
 SITE = "Bench Site"
 
 
-def requires_admission(cost=None, caps=()):
-	"""Refuse what the caller cannot pay for, or already has too many of.
+def requires_admission(cost=None, caps=(), payer=None):
+	"""Refuse what the payer cannot afford, or already has too many of.
 
-	`cost` and each entry in `caps` are called with the wrapped call's arguments by name, so they
-	read `data=` or `self=` rather than indexing a tuple. With the switch off only the slot claim
-	runs, and on a call about no instance that is nothing at all.
+	`cost`, `payer` and each entry in `caps` are called with the wrapped call's arguments by name,
+	so they read `data=` or `self=` rather than indexing a tuple. With the switch off only the slot
+	claim runs, and on a call about no instance that is nothing at all.
+
+	`payer` defaults to `payer_of_call`. An endpoint passes its own only when the account it
+	charges is not derivable from a bench, which today is the image build.
 
 	A caller without an app role is passed straight through to the endpoint's own guard. The gate
 	must never be the first thing a Guest meets: it would answer a permission question with an
@@ -63,7 +73,7 @@ def requires_admission(cost=None, caps=()):
 		@functools.wraps(method)
 		def wrapper(*args, **kwargs):
 			if has_app_permission():
-				_enforce(method, cost, caps, args, kwargs)
+				_enforce(method, cost, caps, payer or payer_of_call, args, kwargs)
 			return method(*args, **kwargs)
 
 		return wrapper
@@ -71,7 +81,7 @@ def requires_admission(cost=None, caps=()):
 	return decorator
 
 
-def _enforce(method, cost, caps, args, kwargs) -> None:
+def _enforce(method, cost, caps, payer, args, kwargs) -> None:
 	"""Claim the slot and the credits together, then the caps that are about something else.
 
 	The claim runs whatever the switch says, because concurrency is capacity rather than
@@ -83,16 +93,17 @@ def _enforce(method, cost, caps, args, kwargs) -> None:
 	admitted twice by two requests that read the same figures.
 	"""
 	arguments = _arguments_by_name(method, args, kwargs)
+	pays = payer(**arguments)
 	subject = _subject_instance(**arguments)
 	needed = flt(cost(**arguments)) if cost and config.credits_enabled() else 0.0
-	admission.claim(frappe.session.user, subject, concurrency_limit(), needed)
+	admission.claim(pays, subject, concurrency_limit(pays), needed)
 	if not config.credits_enabled():
 		return
 	for cap in caps:
 		cap(**arguments)
 	if needed and not subject:
 		# A custom image build holds no slot, so nothing held its price either: it stays a check.
-		require_balance(frappe.session.user, needed)
+		require_balance(pays, needed)
 
 
 def _arguments_by_name(method, args, kwargs) -> dict:
@@ -100,6 +111,28 @@ def _arguments_by_name(method, args, kwargs) -> dict:
 	bound = inspect.signature(method).bind(*args, **kwargs)
 	bound.apply_defaults()
 	return bound.arguments
+
+
+# --- Who pays -----------------------------------------------------------------
+
+
+def payer_of_call(**call) -> str:
+	"""The account a call is charged to: the bench's owner, or the session user where there is no bench.
+
+	`api.create_bench` needs no override — `get_instance_id` derives the instance from the caller,
+	so on a create the caller is already the owner.
+	"""
+	bench = _called_on(call)
+	return bench.owner if bench is not None else frappe.session.user
+
+
+def lab_owner(**call) -> str:
+	"""The payer for an image build: `metering.on_image_built` charges the lab's author.
+
+	The endpoint is `require_admin()`, so the caller and the author differ whenever an admin
+	builds somebody else's lab.
+	"""
+	return frappe.db.get_value(LAB, call.get("lab_name"), "owner") or frappe.session.user
 
 
 # --- What an action must be able to afford ------------------------------------
@@ -163,6 +196,10 @@ def cap_devices(**call) -> None:
 def cap_builds_per_day(**call) -> None:
 	"""Custom builds since midnight, counted from the rows the builds themselves write.
 
+	Counted against the lab's owner, because that is the account `on_image_built` writes them to.
+	Counted against the caller this cap could never fire at all: the endpoint is admin-only, so
+	the caller has no rows to find.
+
 	Only the explicit build action carries this cap. A build the *deploy* path performs is a cache
 	miss the user did not ask for, and its credit charge is the control there — asking Docker
 	whether a tag exists would put a socket round trip in front of every deploy request, which is
@@ -173,7 +210,7 @@ def cap_builds_per_day(**call) -> None:
 		return
 	built = frappe.db.count(
 		LEDGER,
-		{"account": frappe.session.user, "reference_doctype": "Lab", "creation": (">=", today())},
+		{"account": lab_owner(**call), "reference_doctype": "Lab", "creation": (">=", today())},
 	)
 	if built >= limit:
 		frappe.throw(
@@ -202,8 +239,8 @@ def _called_on(call):
 	return call.get("self") or call.get("bench")
 
 
-def concurrency_limit() -> int:
-	"""How many instances this caller may hold at once. `0` means unlimited.
+def concurrency_limit(user: str) -> int:
+	"""How many instances this account may hold at once. `0` means unlimited.
 
 	"Has paid" is the existence of a Purchase row, not a `lifetime_purchased` balance: a refund
 	clears the float, and somebody who bought and was refunded has still plainly paid.
@@ -214,7 +251,7 @@ def concurrency_limit() -> int:
 	if not config.credits_enabled():
 		return cint(config.settings().max_concurrent_uncredited)
 	settings = config.settings()
-	paid = frappe.db.exists(LEDGER, {"account": frappe.session.user, "entry_type": account.PURCHASE})
+	paid = frappe.db.exists(LEDGER, {"account": user, "entry_type": account.PURCHASE})
 	return cint(settings.max_concurrent_paid if paid else settings.max_concurrent_free)
 
 

--- a/benchpress/credits/guard.py
+++ b/benchpress/credits/guard.py
@@ -139,22 +139,47 @@ def lab_owner(**call) -> str:
 
 
 def instance_lease_cost(**call) -> float:
-	"""One lease on this instance's lab, for a call that was handed the document itself."""
-	return lab_lease_cost(_called_on(call).lab)
+	"""One lease on a bench that already exists, priced at the size its container was given."""
+	bench = _called_on(call)
+	return _lease_cost(bench.lab, config.size_for_instance(bench))
 
 
-def payload_lease_cost(**call) -> float:
-	"""The same price for `api.create_bench`, whose lab arrives inside the JSON payload."""
-	return lab_lease_cost(frappe.parse_json(call.get("data")).get("lab"))
+def deploy_lease_cost(**call) -> float:
+	"""One lease on the container a deploy is about to create, priced at the size it will get.
+
+	A hold priced under what the deploy will spend refuses nothing, and the hold is the only refusal.
+	"""
+	return _lease_cost(_lab_of_call(**call), deploy_size(**call))
 
 
-def lab_lease_cost(lab_name) -> float:
-	"""What one window on this lab costs — what the start is about to spend, not a rate."""
+def deploy_size(**call):
+	"""The `Instance Size` a deploy resolves to: the one it names, else the lab's own chain."""
+	named = config.size_by_name(_payload(**call).get("instance_size"))
+	if named:
+		return named
+	lab_name = _lab_of_call(**call)
+	return config.size_for_lab(frappe.get_cached_doc(LAB, lab_name)) if lab_name else None
+
+
+def _lease_cost(lab_name, size) -> float:
+	"""What one window on this lab costs at `size` — what the start is about to spend, not a rate."""
 	if not lab_name:
 		return 0.0
-	lab = frappe.get_cached_doc("Lab", lab_name)
-	plan = lease.plan_for(lab)
-	return lease.cost_of(lab, plan) if plan else 0.0
+	lab = frappe.get_cached_doc(LAB, lab_name)
+	plan = lease.plan_for(lab, size)
+	return lease.cost_of(lab, plan, size) if plan else 0.0
+
+
+def _lab_of_call(**call):
+	"""The lab a call is about, whether it carries a bench document or a JSON payload."""
+	bench = _called_on(call)
+	return bench.lab if bench is not None else _payload(**call).get("lab")
+
+
+def _payload(**call) -> dict:
+	"""The JSON body an endpoint was handed, or an empty dict for a call that carries none."""
+	data = call.get("data")
+	return frappe.parse_json(data) if data else {}
 
 
 def build_charge(**call) -> float:
@@ -167,7 +192,7 @@ def build_charge(**call) -> float:
 
 def cap_sites_per_instance(**call) -> None:
 	"""`Instance Size.max_sites` for the size the instance's lab deploys at."""
-	bench_name = frappe.parse_json(call.get("data")).get("bench")
+	bench_name = _payload(**call).get("bench")
 	limit = _site_limit(bench_name)
 	if not limit:
 		return
@@ -177,6 +202,31 @@ def cap_sites_per_instance(**call) -> None:
 				"This instance already has the {0} sites its size allows. Deploy the lab at a larger size, or ask an admin to remove this instance."
 			).format(limit)
 		)
+
+
+def cap_size_tier(**call) -> None:
+	"""`Credit Settings.max_size_free` — the largest size an account that never purchased may deploy at.
+
+	Compared by `price_multiplier`, so the ceiling follows the credit ladder rather than a list order.
+	"""
+	ceiling = config.size_by_name(config.settings().max_size_free)
+	if not ceiling:
+		return
+	# Resolved the way `_enforce` resolved it. This cap only rides on calls that take the default payer.
+	if has_purchased(payer_of_call(**call)):
+		return
+	requested = deploy_size(**call)
+	if not requested or flt(requested.price_multiplier) <= flt(ceiling.price_multiplier):
+		return
+	frappe.throw(
+		_(
+			"The {0} size is not available on a free account. Deploy at {1} or smaller, or buy credits at {2} to unlock every size."
+		).format(
+			requested.size_label or requested.name,
+			ceiling.size_label or ceiling.name,
+			config.TOP_UP_ROUTE,
+		)
+	)
 
 
 def cap_devices(**call) -> None:
@@ -229,8 +279,7 @@ def _subject_instance(**call) -> str | None:
 	bench = _called_on(call)
 	if bench is not None:
 		return bench.name
-	data = call.get("data")
-	lab_name = frappe.parse_json(data).get("lab") if data else None
+	lab_name = _payload(**call).get("lab")
 	return get_instance_id(frappe.session.user, lab_name) if lab_name else None
 
 
@@ -239,20 +288,24 @@ def _called_on(call):
 	return call.get("self") or call.get("bench")
 
 
+def has_purchased(user: str) -> bool:
+	"""Whether this account has ever bought credits.
+
+	The Purchase row rather than a balance: a refund clears the float, not the fact.
+	"""
+	return bool(frappe.db.exists(LEDGER, {"account": user, "entry_type": account.PURCHASE}))
+
+
 def concurrency_limit(user: str) -> int:
 	"""How many instances this account may hold at once. `0` means unlimited.
 
-	"Has paid" is the existence of a Purchase row, not a `lifetime_purchased` balance: a refund
-	clears the float, and somebody who bought and was refunded has still plainly paid.
-
-	With credits off there are no plans to read, so the cap is its own setting. It defaults to
-	`0`, which is what keeps an install that has never opted in behaving as it did.
+	With credits off the cap is its own setting, which defaults to `0`.
 	"""
 	if not config.credits_enabled():
 		return cint(config.settings().max_concurrent_uncredited)
 	settings = config.settings()
-	paid = frappe.db.exists(LEDGER, {"account": user, "entry_type": account.PURCHASE})
-	return cint(settings.max_concurrent_paid if paid else settings.max_concurrent_free)
+	limit = settings.max_concurrent_paid if has_purchased(user) else settings.max_concurrent_free
+	return cint(limit)
 
 
 def _site_limit(bench_name) -> int:

--- a/benchpress/credits/lease.py
+++ b/benchpress/credits/lease.py
@@ -97,14 +97,26 @@ def minutes_for(lab, plan) -> int:
 	return min(minutes, ceiling) if ceiling else minutes
 
 
-def cost_of(lab, plan) -> float:
-	"""`plan.credits x size.price_multiplier`, unless the lab prices its own deploys."""
+def cost_of(lab, plan, size=None) -> float:
+	"""`plan.credits x size.price_multiplier`, unless the lab prices its own deploys.
+
+	`size` defaults to the one the lab deploys at. Pass the bench's own through `cost_of_bench`
+	where the call carries a bench.
+	"""
 	override = flt(lab.get("deploy_credits"))
 	if override:
 		return override
-	size = config.size_for_lab(lab)
+	size = size or config.size_for_lab(lab)
 	multiplier = flt(size.price_multiplier) if size else 1.0
 	return flt(flt(plan.get("credits")) * multiplier, account.PRECISION)
+
+
+def cost_of_bench(bench, lab, plan) -> float:
+	"""What one window on a deployed bench costs, priced at the size it was deployed at.
+
+	Named once rather than resolved at each call site: the payer rule diverged exactly that way.
+	"""
+	return cost_of(lab, plan, config.size_for_instance(bench))
 
 
 def plan_for_size(size) -> dict | None:

--- a/benchpress/credits/lease.py
+++ b/benchpress/credits/lease.py
@@ -73,13 +73,12 @@ def now_ms() -> int:
 # --- Pricing and configuration -------------------------------------------------
 
 
-def plan_for(lab) -> dict | None:
+def plan_for(lab, size=None) -> dict | None:
 	"""The lease plan a lab deploys at: its own, else its size's, else the default.
 
-	The same precedence rule as `config.size_for_lab`, for the same reason — what the author
-	chose wins over what their resources imply.
+	`size` defaults to the one the lab deploys at, as `cost_of` does.
 	"""
-	size = config.size_for_lab(lab)
+	size = size if size is not None else config.size_for_lab(lab)
 	chosen = (
 		lab.get("default_lease_plan")
 		or (size.get("default_lease_plan") if size else None)

--- a/benchpress/credits/metering.py
+++ b/benchpress/credits/metering.py
@@ -52,7 +52,7 @@ def charge_lease(bench, lab, plan, request_id: str | None = None) -> float:
 	`request_id` makes the debit idempotent for a caller that may deliver the same click more
 	than once — a renew from three tabs. A deploy needs none: `lease_state` is its guard.
 	"""
-	cost = lease.cost_of(lab, plan)
+	cost = lease.cost_of_bench(bench, lab, plan)
 	label = bench_label(lab.lab_id) or bench.name
 	account.charge(
 		bench.owner,

--- a/benchpress/docker_manager.py
+++ b/benchpress/docker_manager.py
@@ -6,20 +6,25 @@ import os
 import re
 import subprocess
 import time
+from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import PurePosixPath
 
 import docker
 import frappe
 from frappe import _
-from frappe.utils import cint
+from frappe.utils import cint, flt
 
 from benchpress.image_cache import cache_tag, clear_cached_tags
 from benchpress.request_cache import local_cache
 
+DEFAULT_MEMORY = "512m"
 DEFAULT_PIDS_LIMIT = 500
 DEFAULT_STOP_GRACE = 5
 DEFAULT_IOPS = 1000
 DEFAULT_BPS = 40 * 1024 * 1024
+
+DISK_QUOTA_UNSUPPORTED = "this host enforces no writable-layer quota (overlay2 on xfs required)"
 
 # Field value -> the runtime name registered with the Docker daemon. None means
 # "pass no runtime", which leaves the daemon's own default-runtime in charge.
@@ -186,9 +191,67 @@ def build_lab_image(lab_doc, log_fn=None, no_cache: bool = False) -> str:
 	return image_tag
 
 
-def create_bench_container(bench_doc, lab_doc, network: str | None = None) -> str:
-	"""Create a container from a lab image with resource limits.
-	Does NOT start the container. Returns the container ID.
+@dataclass(frozen=True)
+class CreatedContainer:
+	"""A created container, and which of its limits the daemon was really asked to enforce.
+
+	`skipped` maps a knob to why it was dropped, so no deploy log can claim a quota this host
+	silently ignores.
+	"""
+
+	container_id: str
+	applied: dict
+	skipped: dict
+
+
+def _nano_cpus(cpu_cores) -> int:
+	"""Clamp to what this host will accept: the seeded Large is undeployable on 2 cores."""
+	return int(min(flt(cpu_cores) or 1.0, os.cpu_count() or 1) * 1_000_000_000)
+
+
+@lru_cache(maxsize=1)
+def _disk_quota_supported() -> bool:
+	"""True only for overlay2 on xfs. Anywhere else `storage_opt` is accepted and ignored."""
+	info = get_client().info()
+	status = dict(info.get("DriverStatus") or [])
+	backing = str(status.get("Backing Filesystem") or "").lower()
+	return (info.get("Driver") or "").lower() == "overlay2" and backing == "xfs"
+
+
+def _storage_opt(disk_limit: int) -> tuple[dict | None, str]:
+	"""The `storage_opt` for a requested quota, or `None` and why it was skipped.
+
+	Probed rather than assumed: off overlay2/xfs the flag is accepted and silently ignored, so
+	passing it anyway would report a quota that does not exist.
+	"""
+	if not disk_limit:
+		return None, ""
+	if not _disk_quota_supported():
+		return None, DISK_QUOTA_UNSUPPORTED
+	return {"size": f"{disk_limit}g"}, ""
+
+
+def _resolve_limits(size, lab_doc) -> dict:
+	"""The density knobs for one create: the size's, or the lab's own where no size resolved.
+
+	A site carrying no `Instance Size` row at all has nothing but the lab's hand-typed numbers.
+	"""
+	source = size if size else lab_doc
+	return {
+		"mem_limit": source.get("memory_limit") or DEFAULT_MEMORY,
+		"nano_cpus": _nano_cpus(source.get("cpu_cores")),
+		"pids_limit": cint(source.get("pids_limit")) or DEFAULT_PIDS_LIMIT,
+		"iops": cint(source.get("iops_limit")) or DEFAULT_IOPS,
+		"bps": cint(source.get("bps_limit")) or DEFAULT_BPS,
+		"disk_limit": cint(source.get("disk_limit")),
+	}
+
+
+def create_bench_container(bench_doc, lab_doc, size=None, network: str | None = None) -> CreatedContainer:
+	"""Create a container at a resolved `Instance Size`. Does NOT start it.
+
+	`size` is read and never copied, so a size edited in Desk reaches the next deploy without the
+	Lab being re-saved. `None` means no size resolved at all.
 
 	`network` overrides the bench's recorded bridge, which is what a roll onto the next
 	bridge needs: the row still names the bridge Docker refused.
@@ -207,9 +270,10 @@ def create_bench_container(bench_doc, lab_doc, network: str | None = None) -> st
 		"benchpress.lab": lab_doc.lab_id,
 	}
 
-	pids_limit = int(getattr(lab_doc, "pids_limit", None) or DEFAULT_PIDS_LIMIT)
-	iops = int(getattr(lab_doc, "iops_limit", None) or DEFAULT_IOPS)
-	bps = int(getattr(lab_doc, "bps_limit", None) or DEFAULT_BPS)
+	limits = _resolve_limits(size, lab_doc)
+	storage_opt, disk_skipped = _storage_opt(limits["disk_limit"])
+	iops = limits["iops"]
+	bps = limits["bps"]
 
 	runtime = resolve_runtime(bench_doc)
 	runtime_kwargs = {"runtime": runtime} if runtime else {}
@@ -239,18 +303,32 @@ def create_bench_container(bench_doc, lab_doc, network: str | None = None) -> st
 		devices=["/dev/net/tun:/dev/net/tun:rwm"],
 		# No volume over /home/frappe — a named volume forces a full copy of the bench
 		# on every create; the container's own layer is the bench's storage.
-		mem_limit=lab_doc.memory_limit or "512m",
-		nano_cpus=int((lab_doc.cpu_cores or 1) * 1e9),
-		pids_limit=pids_limit,
+		mem_limit=limits["mem_limit"],
+		nano_cpus=limits["nano_cpus"],
+		pids_limit=limits["pids_limit"],
 		device_read_iops=device_read_iops or None,
 		device_write_iops=device_write_iops or None,
 		device_read_bps=device_read_bps or None,
 		device_write_bps=device_write_bps or None,
 		network=network,
+		**({"storage_opt": storage_opt} if storage_opt else {}),
 		**runtime_kwargs,
 	)
 
-	return container.id
+	applied = {
+		"memory": limits["mem_limit"],
+		"nano_cpus": limits["nano_cpus"],
+		"pids_limit": limits["pids_limit"],
+		"iops": iops,
+		"bps": bps,
+	}
+	skipped = {}
+	if storage_opt:
+		applied["disk"] = storage_opt["size"]
+	elif disk_skipped:
+		skipped["disk_limit"] = f"{limits['disk_limit']}g — {disk_skipped}"
+
+	return CreatedContainer(container.id, applied, skipped)
 
 
 def container_runtime(container_id: str) -> str:
@@ -263,7 +341,7 @@ def container_network(container_id: str) -> str:
 	return get_client().containers.get(container_id).attrs["HostConfig"]["NetworkMode"]
 
 
-def start_bench_container(container_id: str, bench_doc, lab_doc) -> str:
+def start_bench_container(container_id: str, bench_doc, lab_doc, size=None) -> str:
 	"""Start the bench, moving it to the next bridge if this one has no address left.
 
 	Returns the id of the container that is now running — a roll recreates it, so it is
@@ -287,7 +365,7 @@ def start_bench_container(container_id: str, bench_doc, lab_doc) -> str:
 	# and the new container has to take the name the old one is still holding.
 	rolled_to = placement.next_network(container_network(container_id))
 	remove_container(container_id)
-	container_id = create_bench_container(bench_doc, lab_doc, rolled_to)
+	container_id = create_bench_container(bench_doc, lab_doc, size, rolled_to).container_id
 	start_container(container_id)
 	return container_id
 

--- a/benchpress/ingress.py
+++ b/benchpress/ingress.py
@@ -15,8 +15,14 @@ from pathlib import Path
 
 import frappe
 import yaml
+from frappe.utils import cint
 
 from benchpress import addressing, placement
+
+# By name rather than `from benchpress.credits import config`: a route mapping is what
+# `config` wants to name in this file, and a module bound to that name turns the next such
+# local into an F823.
+from benchpress.credits.config import size_for_lab, size_index
 
 # Module constant, not inlined, so tests can monkeypatch it to a tmp path.
 # Flat, not a subdirectory: Traefik's file provider does not recurse, so this must be the
@@ -54,8 +60,8 @@ class TraefikRouteDirectoryMissing(Exception):
 	"""
 
 
-def publish(instance_id: str, base_domain: str) -> None:
-	"""Write Traefik file-provider routes for this instance's site and its code-server IDE.
+def publish(instance_id: str, base_domain: str, ide: bool | None = None) -> None:
+	"""Write Traefik file-provider routes for this instance's site, and its IDE when it has one.
 
 	`tls: {}` turns TLS on and names no resolver, so these routers serve whatever
 	certificate the store already holds for the requested SNI. Deliberate, and the point
@@ -64,44 +70,75 @@ def publish(instance_id: str, base_domain: str) -> None:
 	`ensure_anchor` is what puts `*.{base_domain}` in the store, and it is the
 	only place in this app that names a resolver.
 
-	The file is a pure function of `(instance_id, base_domain)`: it names the container,
-	never an address, so no lifecycle transition can make it stale. The container name
-	*is* `instance_id` — `create_bench_container` names it `bench_doc.bench_name` and
-	`BenchInstance.autoname` sets `name = bench_name`.
+	The file names the container, never an address, so no lifecycle transition can make
+	it stale. The container name *is* `instance_id` — `create_bench_container` names it
+	`bench_doc.bench_name` and `BenchInstance.autoname` sets `name = bench_name`.
 	"""
 	if not base_domain or base_domain == "localhost":
 		return
 
-	config = {
-		"http": {
-			"routers": {
-				f"site-{instance_id}": {
-					"rule": f"Host(`{instance_id}.{base_domain}`)",
-					"entryPoints": ["websecure"],
-					"service": f"site-{instance_id}",
-					"tls": {},
-				},
-				f"ide-{instance_id}": {
-					"rule": f"Host(`ide-{instance_id}.{base_domain}`)",
-					"entryPoints": ["websecure"],
-					"service": f"ide-{instance_id}",
-					"tls": {},
-				},
-			},
-			# Resolved by Docker's embedded DNS: traefik is on the `benchpress` network.
-			"services": {
-				f"site-{instance_id}": {
-					"loadBalancer": {
-						"servers": [{"url": f"http://{instance_id}:{addressing.SITE_HTTP_PORT}"}]
-					}
-				},
-				f"ide-{instance_id}": {
-					"loadBalancer": {"servers": [{"url": f"http://{instance_id}:{addressing.IDE_HTTP_PORT}"}]}
-				},
-			},
+	# What `_routable_instances` already resolved for this bench, else the same read for one.
+	# Never the caller's own idea of the flag: the */5 pass writes this file without the
+	# deploy's context, and two writers that disagree overwrite each other every five minutes.
+	if ide is None:
+		ide = has_ide(instance_id)
+
+	routers = {
+		f"site-{instance_id}": {
+			"rule": f"Host(`{instance_id}.{base_domain}`)",
+			"entryPoints": ["websecure"],
+			"service": f"site-{instance_id}",
+			"tls": {},
 		}
 	}
-	_atomic_write(TRAEFIK_DYNAMIC_DIR / f"{instance_id}.yml", yaml.safe_dump(config))
+	# Resolved by Docker's embedded DNS: traefik is on the `benchpress` network.
+	services = {
+		f"site-{instance_id}": {
+			"loadBalancer": {"servers": [{"url": f"http://{instance_id}:{addressing.SITE_HTTP_PORT}"}]}
+		}
+	}
+
+	if ide:
+		routers[f"ide-{instance_id}"] = {
+			"rule": f"Host(`ide-{instance_id}.{base_domain}`)",
+			"entryPoints": ["websecure"],
+			"service": f"ide-{instance_id}",
+			"tls": {},
+		}
+		services[f"ide-{instance_id}"] = {
+			"loadBalancer": {"servers": [{"url": f"http://{instance_id}:{addressing.IDE_HTTP_PORT}"}]}
+		}
+
+	_atomic_write(
+		TRAEFIK_DYNAMIC_DIR / f"{instance_id}.yml",
+		yaml.safe_dump({"http": {"routers": routers, "services": services}}),
+	)
+
+
+def has_ide(instance_id: str) -> bool:
+	"""Whether this bench runs code-server — the one-bench case of `_routable_instances`."""
+	rows = _fleet_rows(names=[instance_id])
+	return _ide_for(rows[0]) if rows else False
+
+
+def lab_has_ide(lab_doc) -> bool:
+	"""Whether a bench of this Lab would run code-server, before one exists to ask about."""
+	return _ide_for(lab_doc)
+
+
+def _ide_for(row) -> bool:
+	"""The one rule: the Lab asks for an IDE and the size it resolves to includes one.
+
+	`row` is a joined fleet row or a Lab document, so every caller answers from one rule.
+	"""
+	if not cint(row.get("enable_code_server")):
+		return False
+	# The size the bench was deployed at, else its Lab's — the order billing prices at, so
+	# re-pointing a Lab leaves a running bench's routers alone.
+	size = size_index()["by_name"].get(row.get("bench_size")) or size_for_lab(row)
+	if not size:
+		return True
+	return bool(cint(size.include_code_server))
 
 
 def withdraw(instance_id: str) -> None:
@@ -338,9 +375,9 @@ def reconcile() -> dict:
 		return {"anchored": None, "written": None, "deleted": None, "kept": None, **attached}
 
 	anchored = ensure_anchor(base_domain)
-	routable = _routable_instance_ips()
-	for instance_id in routable:
-		publish(instance_id, base_domain)
+	routable = _routable_instances()
+	for instance_id, ide in routable.items():
+		publish(instance_id, base_domain, ide=ide)
 
 	stale = published() - routable.keys()
 	for instance_id in stale:
@@ -355,18 +392,41 @@ def reconcile() -> dict:
 	}
 
 
-def _routable_instance_ips() -> dict[str, str]:
-	"""Every bench that should own a route file, mapped to the address it should point at.
+def _routable_instances() -> dict[str, bool]:
+	"""Every bench that should own a route file, mapped to whether it gets an IDE router too.
 
 	`Running` and nothing else. A `Stopped`, `Draft` or `Error` bench has no container
 	answering, and its recorded `container_ip` is a freed address Docker is free to hand
 	to somebody else's bench — which is the misroute, not a dead link. A row with no IP
 	at all is dropped for the same reason a route to nowhere is worse than no route.
 	"""
+	return {row.name: _ide_for(row) for row in _fleet_rows(status="Running") if row.container_ip}
+
+
+def _fleet_rows(names: list[str] | None = None, status: str | None = None) -> list[dict]:
+	"""Bench rows beside the Lab fields the IDE flag resolves from, in one query per read.
+
+	One join rather than a read per bench: the */5 pass resolves the whole fleet here, and at
+	300 benches a per-bench read would be 300 queries a pass.
+	"""
 	instance = frappe.qb.DocType("Bench Instance")
-	rows = (
+	lab = frappe.qb.DocType("Lab")
+	query = (
 		frappe.qb.from_(instance)
-		.select(instance.name, instance.container_ip)
-		.where(instance.status == "Running")
-	).run(as_dict=True)
-	return {row.name: row.container_ip for row in rows if row.container_ip}
+		.left_join(lab)
+		.on(instance.lab == lab.name)
+		.select(
+			instance.name,
+			instance.container_ip,
+			instance.instance_size.as_("bench_size"),
+			lab.enable_code_server,
+			lab.instance_size,
+			lab.memory_limit,
+			lab.cpu_cores,
+		)
+	)
+	if names is not None:
+		query = query.where(instance.name.isin(names))
+	if status is not None:
+		query = query.where(instance.status == status)
+	return query.run(as_dict=True)

--- a/benchpress/lab_detail.py
+++ b/benchpress/lab_detail.py
@@ -18,7 +18,7 @@ output — still only have `=== … ===` markers, so both are read.
 
 import frappe
 
-from benchpress import addressing
+from benchpress import addressing, ingress
 from benchpress.credits import config, lease
 from benchpress.deploy_pipeline import scan_log
 
@@ -69,7 +69,7 @@ def get_lab(name: str) -> dict:
 		"memory_limit": size.memory_limit if size else lab.memory_limit,
 		"cpu_cores": size.cpu_cores if size else lab.cpu_cores,
 		"enable_ssh": lab.enable_ssh,
-		"enable_code_server": lab.enable_code_server,
+		"enable_code_server": ingress.lab_has_ide(lab),
 		"lease_price": _lease_price(lab),
 		# Sent beside the deadline so nothing renders a countdown against the browser's own clock.
 		"server_now_ms": lease.now_ms(),

--- a/benchpress/lab_detail.py
+++ b/benchpress/lab_detail.py
@@ -52,6 +52,10 @@ def get_lab(name: str) -> dict:
 	"""One lab, the caller's deployment of it, and why the last run failed."""
 	lab = frappe.get_cached_doc("Lab", name)
 	bench = _caller_bench(lab.name)
+	# Read through the size rather than off the Lab: the deploy resolves it the same way, and
+	# nothing copies it onto the Lab any more, so the stored fields go stale the moment a size
+	# is retuned in Desk.
+	size = config.size_for_lab(lab)
 	return {
 		"name": lab.name,
 		"lab_id": lab.lab_id,
@@ -62,8 +66,8 @@ def get_lab(name: str) -> dict:
 		"status": lab.status,
 		"image_tag": lab.image_tag,
 		"instance_size": lab.instance_size,
-		"memory_limit": lab.memory_limit,
-		"cpu_cores": lab.cpu_cores,
+		"memory_limit": size.memory_limit if size else lab.memory_limit,
+		"cpu_cores": size.cpu_cores if size else lab.cpu_cores,
 		"enable_ssh": lab.enable_ssh,
 		"enable_code_server": lab.enable_code_server,
 		"lease_price": _lease_price(lab),

--- a/benchpress/lab_templates.py
+++ b/benchpress/lab_templates.py
@@ -13,7 +13,7 @@ import frappe
 from frappe import _
 
 # Each template names its `Instance Size`. `memory_limit` / `cpu_cores` below must agree
-# with it: they are what the card renders, and `Lab.apply_instance_size` overwrites them.
+# with it: nothing rewrites them at save time, and the card renders what is stored.
 
 # "Use template" names the lab itself, so a taken id is retried with a numeric
 # suffix. The ceiling only exists so a pathological catalog cannot spin.

--- a/benchpress/lifecycle.py
+++ b/benchpress/lifecycle.py
@@ -14,7 +14,7 @@ from frappe.utils.synchronization import filelock
 
 from benchpress import addressing, ingress, placement
 from benchpress.credits import admission, lease, metering
-from benchpress.credits.config import size_for_lab
+from benchpress.credits.config import size_by_name, size_for_lab
 from benchpress.deploy_pipeline import DeployLogWriter, DeployPipeline
 from benchpress.docker_manager import (
 	container_network,
@@ -207,18 +207,21 @@ def _log_limits(pipeline, size, created) -> None:
 		pipeline.log(f"limit skipped — {knob} {reason}")
 
 
-def deploy_bench(bench_name: str) -> None:
-	"""Deploy a bench, refusing to run concurrently with another deploy of the same bench."""
+def deploy_bench(bench_name: str, size: str | None = None) -> None:
+	"""Deploy a bench, refusing to run concurrently with another deploy of the same bench.
+
+	`size` is the `Instance Size` the caller asked for; `None` falls through to the lab's own chain.
+	"""
 	from benchpress.deploy_manager import _log_deploy_skipped
 
 	try:
 		with filelock(f"bench_deploy_{bench_name}", timeout=1):
-			_deploy_bench(bench_name)
+			_deploy_bench(bench_name, size)
 	except LockTimeoutError:
 		_log_deploy_skipped(bench_name)
 
 
-def _deploy_bench(bench_name: str) -> None:
+def _deploy_bench(bench_name: str, size_name: str | None = None) -> None:
 	"""Deploy pipeline — shared MariaDB, site created at runtime via press agent pattern."""
 	# Permanent, not a step on the way to a module-scope import: image building and site
 	# creation are the remainder `deploy_manager` keeps, and importing them at module scope
@@ -312,7 +315,7 @@ def _deploy_bench(bench_name: str) -> None:
 		pipeline.step("container")
 		# Resolved here and recorded, never copied onto the Lab: a size edited in Desk reaches
 		# this deploy, and billing keeps pricing what Docker was actually given.
-		size = size_for_lab(lab)
+		size = size_by_name(size_name) or size_for_lab(lab)
 		bench.instance_size = size.name if size else None
 		created = create_bench_container(bench, lab, size)
 		container_id = created_container_id = created.container_id

--- a/benchpress/lifecycle.py
+++ b/benchpress/lifecycle.py
@@ -225,6 +225,7 @@ def _deploy_bench(bench_name: str) -> None:
 	# would make a cycle the moment anything there needs a transition.
 	from benchpress.deploy_manager import (
 		_assert_runtime_registered,
+		_forget_code_server_url,
 		_golden_matches_server,
 		_prepare_lab_image,
 		_record_primary_site,
@@ -420,10 +421,13 @@ def _deploy_bench(bench_name: str) -> None:
 			raise Exception(f"serve.sh failed (exit {exit_code}): {output}")
 		pipeline.log(f"Site served on port {addressing.SITE_HTTP_PORT}")
 
-		if getattr(lab, "enable_code_server", 0):
+		# The same resolver the route file was written from, so the router and the process
+		# cannot disagree about whether this bench has an IDE.
+		if ingress.has_ide(bench.name):
 			_start_code_server(bench, container_id, pipeline, settings)
 		else:
-			pipeline.log("Code server is disabled for this lab — skipped")
+			_forget_code_server_url(bench)
+			pipeline.log("Code server is disabled for this lab or its instance size — skipped")
 
 		# Everything above this line is free however long it took, because a deploy that never
 		# gets here never reaches `Running`.

--- a/benchpress/lifecycle.py
+++ b/benchpress/lifecycle.py
@@ -14,6 +14,7 @@ from frappe.utils.synchronization import filelock
 
 from benchpress import addressing, ingress, placement
 from benchpress.credits import admission, lease, metering
+from benchpress.credits.config import size_for_lab
 from benchpress.deploy_pipeline import DeployLogWriter, DeployPipeline
 from benchpress.docker_manager import (
 	container_network,
@@ -197,6 +198,15 @@ def _drop_site_database(bench) -> None:
 		pass  # best-effort
 
 
+def _log_limits(pipeline, size, created) -> None:
+	"""Name the size and the knobs it applied, then every quota this host would not enforce."""
+	label = size.size_label if size else "no size"
+	applied = " ".join(f"{knob}={value}" for knob, value in created.applied.items())
+	pipeline.log(f"limits {label} — {applied}")
+	for knob, reason in created.skipped.items():
+		pipeline.log(f"limit skipped — {knob} {reason}")
+
+
 def deploy_bench(bench_name: str) -> None:
 	"""Deploy a bench, refusing to run concurrently with another deploy of the same bench."""
 	from benchpress.deploy_manager import _log_deploy_skipped
@@ -299,13 +309,18 @@ def _deploy_bench(bench_name: str) -> None:
 		_remove_stale_container(bench)
 		_drop_site_database(bench)
 		pipeline.step("container")
-		container_id = create_bench_container(bench, lab)
-		created_container_id = container_id
+		# Resolved here and recorded, never copied onto the Lab: a size edited in Desk reaches
+		# this deploy, and billing keeps pricing what Docker was actually given.
+		size = size_for_lab(lab)
+		bench.instance_size = size.name if size else None
+		created = create_bench_container(bench, lab, size)
+		container_id = created_container_id = created.container_id
+		_log_limits(pipeline, size, created)
 		# Read back rather than assumed: the stored log answers what a bench was
 		# isolated by long after the run.
 		pipeline.log(f"container runtime {container_runtime(container_id)}")
 
-		container_id = created_container_id = start_bench_container(container_id, bench, lab)
+		container_id = created_container_id = start_bench_container(container_id, bench, lab, size)
 		placement.record_bridge_network(bench, container_network(container_id))
 		pipeline.log(f"bench bridge {bench.bridge_network}")
 

--- a/benchpress/tests/test_admission.py
+++ b/benchpress/tests/test_admission.py
@@ -463,6 +463,57 @@ class TestAdmission(IntegrationTestCase):
 		frappe.set_user("Administrator")
 		self.assertNotIn(bench.name, self.rows())
 
+	# --- Who pays -------------------------------------------------------------
+
+	def test_a_caller_with_credits_cannot_start_an_owner_who_has_none(self):
+		"""The measurement this rule was written from: the owner went to -4.0 while the caller held 75.
+
+		Priced against the caller the hold refuses nobody, and `metering.charge_lease` then debits
+		the owner past zero — so the account that pays is the account that must be able to afford it.
+		"""
+		self.enable_credits()
+		self.set_balance(1.0)
+		self.set_balance(75.0, OTHER)
+		bench = self.running_bench(self.benches[0])
+		frappe.set_user(OTHER)
+		with self.assertRaises(frappe.ValidationError) as refusal:
+			frappe.get_doc(BENCH, bench.name).enqueue_start()
+		frappe.set_user("Administrator")
+		self.assertIn("3.0 short", str(refusal.exception))
+		self.assertEqual(self.balance(), 1.0)
+		self.assertEqual(self.rows(), [])
+		self.assertEqual(self.rows(OTHER), [])
+
+	def test_the_same_start_is_admitted_once_the_owner_can_afford_it(self):
+		"""The positive control, and the charge that proves it: the owner pays, the caller does not."""
+		self.enable_credits()
+		self.set_balance(10.0)
+		self.set_balance(75.0, OTHER)
+		bench = self.running_bench(self.benches[0])
+		frappe.set_user(OTHER)
+		with (
+			patch("benchpress.lifecycle.start_container"),
+			patch("benchpress.ingress.enqueue_route_sync"),
+			patch("frappe.db.commit"),
+		):
+			frappe.get_doc(BENCH, bench.name).enqueue_start()
+		frappe.set_user("Administrator")
+		self.assertEqual(self.rows(), [bench.name])
+		self.assertEqual(self.balance(), 10.0 - LEASE_COST)
+		self.assertEqual(self.balance(OTHER), 75.0)
+
+	def test_the_owners_cap_is_what_a_caller_meets(self):
+		"""The slot belongs to the owner too, so a caller cannot borrow somebody else's headroom."""
+		self.set_credits_enabled(0)
+		self.set_setting("max_concurrent_uncredited", 1)
+		admission.claim(USER, self.benches[0].name, 1)
+		bench = self.running_bench(self.benches[1])
+		frappe.set_user(OTHER)
+		with self.assertRaises(frappe.ValidationError) as refusal:
+			frappe.get_doc(BENCH, bench.name).enqueue_start()
+		frappe.set_user("Administrator")
+		self.assertIn("instances running", str(refusal.exception))
+
 	# --- The reconciler -------------------------------------------------------
 
 	def test_the_reconciler_releases_a_claim_whose_bench_is_not_live(self):
@@ -515,6 +566,38 @@ class TestAdmission(IntegrationTestCase):
 		frappe.db.set_value(ACCOUNT, USER, "reserved_credits", 99.0, update_modified=False)
 		admission_repair.reconcile_admissions()
 		self.assertEqual(self.reserved(), LEASE_COST)
+
+	def test_the_reconciler_rekeys_a_claim_held_against_the_wrong_account(self):
+		"""The drift the rest of the pass cannot see, because a wrong row and a wrong counter agree."""
+		admission.claim(OTHER, self.benches[0].name, 0)
+		frappe.db.set_value(BENCH, self.benches[0].name, "status", "Running", update_modified=False)
+		self.assertEqual(admission_repair.reconcile_admissions()["rekeyed"], [self.benches[0].name])
+		self.assertEqual(self.rows(), [self.benches[0].name])
+		self.assertEqual(self.counter(), 1)
+		self.assertEqual(self.counter(OTHER), 0)
+
+	def test_rekeying_the_same_claim_twice_moves_it_once(self):
+		admission.claim(OTHER, self.benches[0].name, 0)
+		frappe.db.set_value(BENCH, self.benches[0].name, "status", "Running", update_modified=False)
+		admission_repair.reconcile_admissions()
+		self.assertEqual(admission_repair.reconcile_admissions()["rekeyed"], [])
+		self.assertEqual(self.counter(), 1)
+
+	def test_a_rekeyed_claim_carries_its_hold_to_the_owner(self):
+		self.enable_credits()
+		self.set_balance(10.0, OTHER)
+		admission.claim(OTHER, self.benches[0].name, 0, cost=LEASE_COST)
+		frappe.db.set_value(BENCH, self.benches[0].name, "status", "Running", update_modified=False)
+		admission_repair.reconcile_admissions()
+		self.assertEqual(self.reserved(), LEASE_COST)
+		self.assertEqual(self.reserved(OTHER), 0.0)
+
+	def test_a_claim_already_on_its_owner_is_left_where_it_is(self):
+		"""The positive control: the rule must move only what is wrong."""
+		admission.claim(USER, self.benches[0].name, 0)
+		frappe.db.set_value(BENCH, self.benches[0].name, "status", "Running", update_modified=False)
+		self.assertEqual(admission_repair.reconcile_admissions()["rekeyed"], [])
+		self.assertEqual(self.rows(), [self.benches[0].name])
 
 	def test_an_adopted_orphan_holds_nothing(self):
 		"""Its lease was charged when it started, so there is nothing left for a hold to cover."""
@@ -569,31 +652,31 @@ class TestAdmission(IntegrationTestCase):
 		)
 		return frappe.get_doc(BENCH, bench.name)
 
-	def opened_account(self) -> str:
+	def opened_account(self, user: str = USER) -> str:
 		from benchpress.credits import account
 
-		return account.ensure_account(USER)
+		return account.ensure_account(user)
 
-	def counter(self) -> int:
-		return frappe.db.get_value(ACCOUNT, USER, "active_instances") or 0
+	def counter(self, user: str = USER) -> int:
+		return frappe.db.get_value(ACCOUNT, user, "active_instances") or 0
 
-	def reserved(self) -> float:
-		return flt(frappe.db.get_value(ACCOUNT, USER, "reserved_credits"))
+	def reserved(self, user: str = USER) -> float:
+		return flt(frappe.db.get_value(ACCOUNT, user, "reserved_credits"))
 
-	def balance(self) -> float:
-		return flt(frappe.db.get_value(ACCOUNT, USER, "balance"))
+	def balance(self, user: str = USER) -> float:
+		return flt(frappe.db.get_value(ACCOUNT, user, "balance"))
 
 	def held(self, bench_name: str) -> float:
 		return flt(frappe.db.get_value(ADMISSION, bench_name, "held_credits"))
 
-	def set_balance(self, credits) -> None:
-		frappe.db.set_value(ACCOUNT, self.opened_account(), "balance", credits, update_modified=False)
+	def set_balance(self, credits, user: str = USER) -> None:
+		frappe.db.set_value(ACCOUNT, self.opened_account(user), "balance", credits, update_modified=False)
 
 	def enable_credits(self) -> None:
 		self.set_credits_enabled(1)
 
-	def rows(self) -> list[str]:
-		return sorted(frappe.get_all(ADMISSION, filters={"account": USER}, pluck="name"))
+	def rows(self, user: str = USER) -> list[str]:
+		return sorted(frappe.get_all(ADMISSION, filters={"account": user}, pluck="name"))
 
 	def set_credits_enabled(self, value) -> None:
 		frappe.db.set_single_value(BENCHPRESS_SETTINGS, "enable_credits", value)

--- a/benchpress/tests/test_credit_guard.py
+++ b/benchpress/tests/test_credit_guard.py
@@ -48,6 +48,12 @@ MAX_SITES = 3
 USER = "guard-user@example.com"
 ADMIN = "guard-admin@example.com"
 
+# A tier above the seeded ones, priced four times the base. The three seeded sizes all carry a
+# multiplier of 1.0, so nothing shipped can express "a size this account has not paid for".
+BIG_SIZE = "Guard Large"
+BIG_MULTIPLIER = 4.0
+BIG_LEASE_COST = LEASE_COST * BIG_MULTIPLIER
+
 # Every economic number this module retunes. `IntegrationTestCase` rolls back once per *class*,
 # not per test, so a test's edits are visible to its siblings until then — each one is snapshotted
 # before the first test and written back in `setUp`.
@@ -58,6 +64,7 @@ TUNED_SETTINGS = (
 	"max_builds_per_day",
 	"custom_build_credits",
 	"default_lease_plan",
+	"max_size_free",
 )
 
 
@@ -80,6 +87,25 @@ def _ensure_guard_plan() -> str:
 		.insert(ignore_permissions=True)
 		.name
 	)
+
+
+def _ensure_big_size() -> str:
+	"""A size whose price multiplier is `BIG_MULTIPLIER` by construction."""
+	values = {
+		"size_label": BIG_SIZE,
+		"memory_limit": "8g",
+		"cpu_cores": 8,
+		"price_multiplier": BIG_MULTIPLIER,
+		"max_sites": MAX_SITES,
+		"is_default": 0,
+		"sort_order": 90,
+	}
+	if frappe.db.exists("Instance Size", BIG_SIZE):
+		frappe.db.set_value("Instance Size", BIG_SIZE, values, update_modified=False)
+	else:
+		frappe.get_doc({"doctype": "Instance Size", **values}).insert(ignore_permissions=True)
+	config.clear_size_index()
+	return BIG_SIZE
 
 
 def _ensure_user(email: str, role: str | None = None) -> str:
@@ -146,6 +172,7 @@ class TestCreditGuard(IntegrationTestCase):
 			field: frappe.db.get_single_value(CREDIT_SETTINGS, field) for field in TUNED_SETTINGS
 		}
 		cls.max_sites_at_start = frappe.db.get_value("Instance Size", "Small", "max_sites")
+		cls.big_size = _ensure_big_size()
 		cls.user = _ensure_user(USER, "BenchPress User")
 		cls.admin = _ensure_user(ADMIN, "BenchPress Admin")
 		cls.lab = _ensure_lab("guard-lab", cls.user)
@@ -176,6 +203,7 @@ class TestCreditGuard(IntegrationTestCase):
 			self.set_setting(field, value)
 		self.set_setting("default_lease_plan", _ensure_guard_plan())
 		self.set_size_field("max_sites", self.max_sites_at_start)
+		self.set_lab_size("Small")
 
 	def tearDown(self):
 		frappe.set_user("Administrator")
@@ -347,6 +375,133 @@ class TestCreditGuard(IntegrationTestCase):
 		account.charge(self.user, 0, "Custom image build for a free size", ("Lab", self.lab.name))
 		self.assertEqual(self.build_row_count(self.user), 1)
 
+	# --- The tier ceiling: what a free account may name ----------------------
+
+	def test_a_free_account_is_refused_a_size_above_the_ceiling(self):
+		"""Funded far past the price, so only the ceiling can be what refuses this."""
+		self.enable_credits()
+		self.set_setting("max_size_free", "Small")
+		self.set_balance(GRANT * 100)
+		frappe.set_user(self.user)
+
+		with self.assertRaises(frappe.ValidationError) as refusal:
+			self.deploy_at(BIG_SIZE)
+
+		message = str(refusal.exception)
+		self.assertIn("not available on a free account", message)
+		self.assertIn("Small", message, "a refusal must name the size that is allowed")
+		self.assertNotIn("Not enough credits", message, "the ceiling must not read as a shortfall")
+
+	def test_a_free_account_may_deploy_at_the_ceiling_itself(self):
+		"""The positive control: the same call one tier down."""
+		self.enable_credits()
+		self.set_setting("max_size_free", "Small")
+		self.set_balance(GRANT)
+		frappe.set_user(self.user)
+		with patch("frappe.enqueue"):
+			self.deploy_at("Small")
+
+	def test_an_empty_ceiling_gates_nothing(self):
+		self.enable_credits()
+		self.set_setting("max_size_free", None)
+		self.set_balance(GRANT * 100)
+		frappe.set_user(self.user)
+		with patch("frappe.enqueue"):
+			self.deploy_at(BIG_SIZE)
+
+	def test_a_purchase_lifts_the_ceiling(self):
+		self.enable_credits()
+		self.set_setting("max_size_free", "Small")
+		self.record_purchase()
+		self.set_balance(GRANT * 100)
+		frappe.set_user(self.user)
+		with patch("frappe.enqueue"):
+			self.deploy_at(BIG_SIZE)
+
+	def test_a_purchased_account_short_of_the_price_is_refused_on_affordability(self):
+		"""The other refusal, and it has to read differently: topping up is what fixes this one."""
+		self.enable_credits()
+		self.set_setting("max_size_free", "Small")
+		self.record_purchase()
+		self.set_balance(BIG_LEASE_COST - 1)
+		frappe.set_user(self.user)
+
+		with self.assertRaises(frappe.ValidationError) as refusal:
+			self.deploy_at(BIG_SIZE)
+
+		message = str(refusal.exception)
+		self.assertIn("Not enough credits", message)
+		self.assertIn("short", message)
+		self.assertNotIn("not available on a free account", message)
+
+	def test_the_ceiling_is_not_consulted_with_credits_off(self):
+		"""A self-hoster running without credits must meet no gate at all."""
+		self.set_credits_enabled(0)
+		self.set_setting("max_size_free", "Small")
+		frappe.set_user(self.user)
+		with patch("frappe.enqueue"):
+			self.deploy_at(BIG_SIZE)
+
+	def test_the_ceiling_reaches_a_size_the_lab_names_itself(self):
+		"""A size chosen on the Lab is still the size this deploy asks for."""
+		self.enable_credits()
+		self.set_setting("max_size_free", "Small")
+		self.set_balance(GRANT * 100)
+		self.set_lab_size(BIG_SIZE)
+		frappe.set_user(self.user)
+
+		with self.assertRaises(frappe.ValidationError) as refusal:
+			api.create_bench(json.dumps({"lab": self.lab.name}))
+		self.assertIn("not available on a free account", str(refusal.exception))
+
+	def test_a_start_is_not_gated_by_the_ceiling(self):
+		"""This phase gates deploys. A bench that is already running keeps starting."""
+		self.enable_credits()
+		self.set_setting("max_size_free", "Small")
+		self.set_balance(GRANT * 100)
+		frappe.db.set_value(BENCH, self.bench.name, "instance_size", BIG_SIZE, update_modified=False)
+		frappe.set_user(self.user)
+		with patch("frappe.enqueue"), patch("benchpress.lifecycle.running"):
+			self.bench_document().enqueue_start()
+
+	# --- The hold is priced at the size the call asks for --------------------
+
+	def test_the_hold_is_priced_at_the_size_the_call_names(self):
+		"""Refused at the big size, admitted at the lab's own — on one unchanged balance."""
+		self.enable_credits()
+		self.set_setting("max_size_free", None)
+		self.set_balance(BIG_LEASE_COST - 1)
+		frappe.set_user(self.user)
+
+		self.assertRaises(frappe.ValidationError, self.deploy_at, BIG_SIZE)
+		with patch("frappe.enqueue"):
+			api.create_bench(json.dumps({"lab": self.lab.name}))
+
+	def test_the_signup_grant_alone_affords_two_of_the_largest_size(self):
+		"""The measurement the ceiling exists for: 40 credits is exactly two 20-credit leases."""
+		self.enable_credits()
+		self.set_setting("max_size_free", None)
+		self.set_balance(GRANT)
+		frappe.set_user(self.user)
+		with patch("frappe.enqueue"):
+			self.deploy_at(BIG_SIZE)
+			self.deploy_at(BIG_SIZE, lab=self.other_lab)
+
+	def test_the_ceiling_is_what_stops_the_grant_buying_the_host(self):
+		self.enable_credits()
+		self.set_setting("max_size_free", "Small")
+		self.set_balance(GRANT)
+		frappe.set_user(self.user)
+		self.assertRaises(frappe.ValidationError, self.deploy_at, BIG_SIZE)
+
+	def test_a_size_that_does_not_exist_is_refused_by_name(self):
+		self.enable_credits()
+		self.set_balance(GRANT)
+		frappe.set_user(self.user)
+		with self.assertRaises(frappe.ValidationError) as refusal:
+			self.deploy_at("Guard Nonexistent")
+		self.assertIn("Guard Nonexistent", str(refusal.exception))
+
 	# --- The gate never answers a permission question ------------------------
 
 	def test_a_caller_without_an_app_role_meets_the_endpoint_guard_not_the_gate(self):
@@ -374,6 +529,21 @@ class TestCreditGuard(IntegrationTestCase):
 	def set_size_field(self, field: str, value) -> None:
 		frappe.db.set_value("Instance Size", "Small", field, value, update_modified=False)
 		config.clear_size_index()
+
+	def set_lab_size(self, size_name: str) -> None:
+		frappe.db.set_value("Lab", self.lab.name, "instance_size", size_name, update_modified=False)
+		frappe.clear_cache(doctype="Lab")
+
+	def deploy_at(self, size_name: str, lab=None):
+		"""`create_bench` naming a size, which is the only path that can name one."""
+		lab = lab or self.lab
+		return api.create_bench(json.dumps({"lab": lab.name, "instance_size": size_name}))
+
+	def record_purchase(self, user: str | None = None) -> None:
+		"""The Purchase row that makes an account "has paid" for every cap that asks."""
+		user = user or self.user
+		account.ensure_account(user)
+		account.purchase(user, 1, "Guard purchase", ("Lab", self.lab.name))
 
 	def set_balance(self, credits, user: str | None = None) -> None:
 		user = user or self.user

--- a/benchpress/tests/test_credit_guard.py
+++ b/benchpress/tests/test_credit_guard.py
@@ -310,7 +310,7 @@ class TestCreditGuard(IntegrationTestCase):
 	def test_the_build_cap_refuses_one_over(self):
 		self.enable_credits()
 		self.set_setting("max_builds_per_day", 2)
-		self.record_builds(2, owner=self.admin)
+		self.record_builds(2, owner=self.user)
 		frappe.set_user(self.admin)
 		with self.assertRaises(frappe.ValidationError) as refusal:
 			api.build_lab_image(self.lab.name)
@@ -319,7 +319,7 @@ class TestCreditGuard(IntegrationTestCase):
 	def test_the_build_cap_allows_one_under(self):
 		self.enable_credits()
 		self.set_setting("max_builds_per_day", 2)
-		self.record_builds(1, owner=self.admin)
+		self.record_builds(1, owner=self.user)
 		frappe.set_user(self.admin)
 		with patch("frappe.enqueue"):
 			self.assertEqual(api.build_lab_image(self.lab.name)["status"], "Building")
@@ -327,7 +327,7 @@ class TestCreditGuard(IntegrationTestCase):
 	def test_zero_means_unlimited_builds(self):
 		self.enable_credits()
 		self.set_setting("max_builds_per_day", 0)
-		self.record_builds(5, owner=self.admin)
+		self.record_builds(5, owner=self.user)
 		frappe.set_user(self.admin)
 		with patch("frappe.enqueue"):
 			api.build_lab_image(self.lab.name)
@@ -335,7 +335,7 @@ class TestCreditGuard(IntegrationTestCase):
 	def test_yesterdays_builds_do_not_count_against_today(self):
 		self.enable_credits()
 		self.set_setting("max_builds_per_day", 1)
-		self.record_builds(1, owner=self.admin, creation=add_days(today(), -1))
+		self.record_builds(1, owner=self.user, creation=add_days(today(), -1))
 		frappe.set_user(self.admin)
 		with patch("frappe.enqueue"):
 			api.build_lab_image(self.lab.name)
@@ -344,8 +344,8 @@ class TestCreditGuard(IntegrationTestCase):
 		"""`custom_build_credits = 0` makes builds free, not uncountable."""
 		self.enable_credits()
 		self.set_setting("custom_build_credits", 0)
-		account.charge(self.admin, 0, "Custom image build for a free size", ("Lab", self.lab.name))
-		self.assertEqual(self.build_row_count(self.admin), 1)
+		account.charge(self.user, 0, "Custom image build for a free size", ("Lab", self.lab.name))
+		self.assertEqual(self.build_row_count(self.user), 1)
 
 	# --- The gate never answers a permission question ------------------------
 
@@ -406,6 +406,9 @@ class TestCreditGuard(IntegrationTestCase):
 
 	def record_builds(self, count: int, owner: str, creation=None) -> None:
 		"""The rows a custom build writes, which is what the daily cap counts.
+
+		`owner` is the lab's owner rather than the admin who presses build: `on_image_built`
+		charges the author, so those are the only rows the cap can ever find.
 
 		Funded well past the build fee on purpose: these tests are about the cap, and a shortfall
 		refusal would pass them for the wrong reason.

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -16,6 +16,7 @@ from frappe.tests import IntegrationTestCase
 
 from benchpress import deploy_manager, ingress, lifecycle
 from benchpress.benchpress.doctype.bench_instance import get_instance_id
+from benchpress.docker_manager import CreatedContainer
 from benchpress.tests.fakes import FakeDockerMixin, sql_of
 from benchpress.tests.test_docker_manager import exec_commands, exec_environments
 
@@ -538,7 +539,7 @@ class TestDeployStepMarkers(IntegrationTestCase):
 			patch.object(lifecycle, "create_bench_container", autospec=True) as mock_create,
 			# The deploy starts through the roll wrapper, so the bridge it lands on is a
 			# read-back rather than the id that went in.
-			patch.object(lifecycle, "start_bench_container", new=lambda cid, bench, lab: cid),
+			patch.object(lifecycle, "start_bench_container", new=lambda cid, bench, lab, size: cid),
 			patch.object(lifecycle, "container_network", new=lambda cid: "benchpress-0"),
 			patch.object(lifecycle, "wait_for_container_running", autospec=True) as mock_wait,
 			# Only the socket is mocked, not the reporting around it: a unit test must not
@@ -560,7 +561,7 @@ class TestDeployStepMarkers(IntegrationTestCase):
 			mock_infra.return_value = self.db_server_name
 			mock_runtimes.return_value = {"names": set(registered_runtimes), "default": "runc"}
 			mock_runtime_of.return_value = "sysbox-runc"
-			mock_create.return_value = "cid-steps"
+			mock_create.return_value = CreatedContainer("cid-steps", {}, {})
 			mock_wait.return_value = "172.30.0.11"
 			mock_exec.side_effect = _exec_results(exec_failures)
 			if write_error:
@@ -1112,7 +1113,7 @@ class TestTerminalStateNotifications(IntegrationTestCase):
 			patch.object(lifecycle, "create_bench_container", autospec=True) as mock_create,
 			# The deploy starts through the roll wrapper, so the bridge it lands on is a
 			# read-back rather than the id that went in.
-			patch.object(lifecycle, "start_bench_container", new=lambda cid, bench, lab: cid),
+			patch.object(lifecycle, "start_bench_container", new=lambda cid, bench, lab, size: cid),
 			patch.object(lifecycle, "container_network", new=lambda cid: "benchpress-0"),
 			patch.object(lifecycle, "wait_for_container_running", autospec=True) as mock_wait,
 			patch.object(ingress, "publish", autospec=True),
@@ -1126,7 +1127,7 @@ class TestTerminalStateNotifications(IntegrationTestCase):
 			mock_infra.return_value = self.db_server_name
 			mock_runtimes.return_value = {"names": {"runc", "sysbox-runc"}, "default": "runc"}
 			mock_runtime_of.return_value = "sysbox-runc"
-			mock_create.return_value = "cid-notify"
+			mock_create.return_value = CreatedContainer("cid-notify", {}, {})
 			mock_wait.return_value = "172.30.0.9"
 			mock_site.return_value = (0, "site created")
 

--- a/benchpress/tests/test_docker_manager.py
+++ b/benchpress/tests/test_docker_manager.py
@@ -13,8 +13,10 @@ import benchpress.docker_manager as docker_manager
 from benchpress.docker_manager import (
 	DEFAULT_BPS,
 	DEFAULT_IOPS,
+	DEFAULT_MEMORY,
 	DEFAULT_PIDS_LIMIT,
 	HOST_RUNTIMES_ATTRIBUTE,
+	CreatedContainer,
 	container_runtime,
 	get_container_health,
 	host_runtimes,
@@ -438,6 +440,129 @@ class TestAddressPoolExhausted(unittest.TestCase):
 		self.assertFalse(docker_manager._address_pool_exhausted(error))
 
 
+NANO = frappe._dict(
+	size_label="Nano",
+	memory_limit="512m",
+	cpu_cores=1,
+	pids_limit=128,
+	iops_limit=500,
+	bps_limit=20 * 1024 * 1024,
+	disk_limit=0,
+)
+LARGE = frappe._dict(size_label="Large", memory_limit="4g", cpu_cores=4)
+
+
+def _nano_with(**overrides):
+	return frappe._dict({**NANO, **overrides})
+
+
+class TestDockerManagerTierKnobs(FakeDockerMixin, IntegrationTestCase):
+	"""`Instance Size` owns the density knobs, and the adapter clamps and probes for itself."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+
+	def setUp(self):
+		super().setUp()
+		self.lab = _make_lab("tier-knobs")
+		self.addCleanup(frappe.delete_doc, "Lab", self.lab.name, force=True, ignore_permissions=True)
+
+	def _create(self, size, *, cpu_count=2, disk_quota=False):
+		"""Create against the fake and return what came back beside the create kwargs."""
+		bench = types.SimpleNamespace(
+			bench_name="tier-test-bench", runtime="runc", bridge_network="benchpress-0"
+		)
+		with (
+			patch.object(docker_manager.os, "cpu_count", return_value=cpu_count),
+			patch.object(docker_manager, "_disk_quota_supported", return_value=disk_quota),
+		):
+			created = docker_manager.create_bench_container(bench, self.lab, size)
+		return created, self.docker.created[-1]
+
+	def test_a_nano_bench_really_gets_its_own_pid_ceiling(self):
+		_, kwargs = self._create(NANO)
+
+		self.assertEqual(kwargs["pids_limit"], 128)
+		self.assertEqual(kwargs["mem_limit"], "512m")
+		self.assertEqual(kwargs["device_read_iops"], [{"Path": "/dev/sda", "Rate": 500}])
+		self.assertEqual(kwargs["device_write_bps"], [{"Path": "/dev/sda", "Rate": 20 * 1024 * 1024}])
+
+	def test_the_size_beats_the_lab_own_fields(self):
+		"""Nothing copies a size onto a Lab any more, so a retuned size must reach the create."""
+		self.assertEqual(self.lab.memory_limit, "512m")
+
+		_, kwargs = self._create(LARGE, cpu_count=8)
+
+		self.assertEqual(kwargs["mem_limit"], "4g")
+
+	def test_a_large_bench_is_clamped_to_the_host_core_count(self):
+		"""The seeded Large asks for four cores, and this host refuses anything over two."""
+		_, kwargs = self._create(LARGE, cpu_count=2)
+
+		self.assertEqual(kwargs["nano_cpus"], 2_000_000_000)
+
+	def test_a_host_with_the_cores_to_spare_is_not_clamped(self):
+		_, kwargs = self._create(LARGE, cpu_count=8)
+
+		self.assertEqual(kwargs["nano_cpus"], 4_000_000_000)
+
+	def test_a_disk_quota_is_passed_where_the_host_can_enforce_one(self):
+		created, kwargs = self._create(_nano_with(disk_limit=4), disk_quota=True)
+
+		self.assertEqual(kwargs["storage_opt"], {"size": "4g"})
+		self.assertEqual(created.applied["disk"], "4g")
+		self.assertEqual(created.skipped, {})
+
+	def test_a_disk_quota_this_host_ignores_is_skipped_and_named(self):
+		"""`--storage-opt size=` is accepted and ignored off xfs, so passing it would lie."""
+		created, kwargs = self._create(_nano_with(disk_limit=4), disk_quota=False)
+
+		self.assertNotIn("storage_opt", kwargs)
+		self.assertNotIn("disk", created.applied)
+		self.assertIn("4g", created.skipped["disk_limit"])
+		self.assertIn(docker_manager.DISK_QUOTA_UNSUPPORTED, created.skipped["disk_limit"])
+
+	def test_no_disk_limit_asks_for_nothing_and_skips_nothing(self):
+		created, kwargs = self._create(NANO, disk_quota=True)
+
+		self.assertNotIn("storage_opt", kwargs)
+		self.assertEqual(created.skipped, {})
+
+	def test_a_bench_that_resolves_to_no_size_falls_back_to_the_module_constants(self):
+		created, kwargs = self._create(None)
+
+		self.assertEqual(kwargs["pids_limit"], DEFAULT_PIDS_LIMIT)
+		self.assertEqual(kwargs["device_read_iops"], [{"Path": "/dev/sda", "Rate": DEFAULT_IOPS}])
+		self.assertEqual(kwargs["device_write_bps"], [{"Path": "/dev/sda", "Rate": DEFAULT_BPS}])
+		self.assertEqual(kwargs["mem_limit"], DEFAULT_MEMORY)
+		self.assertEqual(created.skipped, {})
+
+	def test_the_probe_reads_the_driver_and_its_backing_filesystem(self):
+		self.docker.info_response = {
+			"Driver": "overlay2",
+			"DriverStatus": [["Backing Filesystem", "xfs"]],
+		}
+
+		self.assertTrue(self._probe())
+
+	def test_this_host_storage_driver_fails_the_probe(self):
+		"""ext4 under the containerd snapshotter, which is what production runs on."""
+		self.docker.info_response = {
+			"Driver": "overlayfs",
+			"DriverStatus": [["driver-type", "io.containerd.snapshotter.v1"]],
+		}
+
+		self.assertFalse(self._probe())
+
+	def _probe(self) -> bool:
+		"""The real probe, around the per-process cache a second test would otherwise read."""
+		docker_manager._disk_quota_supported.cache_clear()
+		self.addCleanup(docker_manager._disk_quota_supported.cache_clear)
+		return docker_manager._disk_quota_supported()
+
+
 class TestStartBenchContainer(unittest.TestCase):
 	@patch("benchpress.docker_manager.start_container")
 	def test_a_bridge_with_room_starts_the_container_it_was_given(self, start):
@@ -445,21 +570,27 @@ class TestStartBenchContainer(unittest.TestCase):
 		start.assert_called_once_with("abc123")
 
 	@patch("benchpress.placement.next_network", return_value="benchpress-1")
-	@patch("benchpress.docker_manager.create_bench_container", return_value="def456")
+	@patch(
+		"benchpress.docker_manager.create_bench_container",
+		return_value=CreatedContainer("def456", {}, {}),
+	)
 	@patch("benchpress.docker_manager.remove_container")
 	@patch("benchpress.docker_manager.container_network", return_value="benchpress-0")
 	@patch("benchpress.docker_manager.start_container")
 	def test_a_full_bridge_rolls_once_onto_the_next(self, start, _network, remove, create, _next):
 		start.side_effect = [docker.errors.APIError(LIVE_EXHAUSTION), None]
-		bench, lab = MagicMock(), MagicMock()
+		bench, lab, size = MagicMock(), MagicMock(), MagicMock()
 
-		self.assertEqual(docker_manager.start_bench_container("abc123", bench, lab), "def456")
+		self.assertEqual(docker_manager.start_bench_container("abc123", bench, lab, size), "def456")
 
 		remove.assert_called_once_with("abc123")
-		create.assert_called_once_with(bench, lab, "benchpress-1")
+		create.assert_called_once_with(bench, lab, size, "benchpress-1")
 
 	@patch("benchpress.placement.next_network", return_value="benchpress-1")
-	@patch("benchpress.docker_manager.create_bench_container", return_value="def456")
+	@patch(
+		"benchpress.docker_manager.create_bench_container",
+		return_value=CreatedContainer("def456", {}, {}),
+	)
 	@patch("benchpress.docker_manager.remove_container")
 	@patch("benchpress.docker_manager.container_network", return_value="benchpress-0")
 	@patch("benchpress.docker_manager.start_container")

--- a/benchpress/tests/test_image_cache.py
+++ b/benchpress/tests/test_image_cache.py
@@ -21,7 +21,7 @@ import frappe
 from frappe.tests import IntegrationTestCase
 
 from benchpress import image_cache, ingress
-from benchpress.docker_manager import HOST_RUNTIMES_ATTRIBUTE
+from benchpress.docker_manager import HOST_RUNTIMES_ATTRIBUTE, CreatedContainer
 from benchpress.request_cache import clear_local_cache
 
 BUILD_STREAM = [{"stream": "Successfully built abc123"}]
@@ -226,7 +226,7 @@ class TestDeployReusesTheSharedImage(IntegrationTestCase):
 			patch.object(lifecycle, "create_bench_container", autospec=True) as mock_create,
 			# The deploy starts through the roll wrapper, so the bridge it lands on is a
 			# read-back rather than the id that went in.
-			patch.object(lifecycle, "start_bench_container", new=lambda cid, bench, lab: cid),
+			patch.object(lifecycle, "start_bench_container", new=lambda cid, bench, lab, size: cid),
 			patch.object(lifecycle, "container_network", new=lambda cid: "benchpress-0"),
 			patch.object(lifecycle, "wait_for_container_running", autospec=True) as mock_wait,
 			patch.object(deploy_manager, "_setup_container_vpn", autospec=True),
@@ -244,7 +244,7 @@ class TestDeployReusesTheSharedImage(IntegrationTestCase):
 			patch.object(ingress, "_certificate_error", autospec=True, return_value=None),
 		):
 			mock_infra.return_value = self.db_server_name
-			mock_create.return_value = "cid-image-cache"
+			mock_create.return_value = CreatedContainer("cid-image-cache", {}, {})
 			mock_wait.return_value = "172.30.0.21"
 			mock_exec.return_value = (0, "")
 			mock_site.return_value = (0, "site created")

--- a/benchpress/tests/test_ingress.py
+++ b/benchpress/tests/test_ingress.py
@@ -187,14 +187,18 @@ class TestIdeRouter(IntegrationTestCase):
 		cls.ide_size = _make_size("Phase Three IDE", 1, "777m")
 		cls.no_ide_size = _make_size("Phase Three No IDE", 0, "778m")
 		cls.lab = _make_lab("test-lab-ide-router")
+		# A second lab, because one bench exists per (user, lab) and the fleet read has to be
+		# shown resolving more than one bench in the same query.
+		cls.other_lab = _make_lab("test-lab-ide-router-other")
 		frappe.db.commit()
 
 	@classmethod
 	def tearDownClass(cls):
 		frappe.set_user("Administrator")
-		for name in frappe.get_all("Bench Instance", filters={"lab": cls.lab.name}, pluck="name"):
-			frappe.delete_doc("Bench Instance", name, force=True, ignore_permissions=True)
-		cls.lab.delete(ignore_permissions=True)
+		for lab in (cls.lab, cls.other_lab):
+			for name in frappe.get_all("Bench Instance", filters={"lab": lab.name}, pluck="name"):
+				frappe.delete_doc("Bench Instance", name, force=True, ignore_permissions=True)
+			lab.delete(ignore_permissions=True)
 		for size in (cls.ide_size, cls.no_ide_size):
 			frappe.delete_doc("Instance Size", size.name, force=True, ignore_permissions=True)
 		frappe.db.commit()
@@ -205,9 +209,10 @@ class TestIdeRouter(IntegrationTestCase):
 		super().setUp()
 		clear_size_index()
 
-	def _bench(self, *, lab_size, lab_flag=1, bench_size=None):
-		frappe.db.set_value("Lab", self.lab.name, {"instance_size": lab_size, "enable_code_server": lab_flag})
-		bench = _fresh_bench(self, self.lab.name)
+	def _bench(self, *, lab_size, lab_flag=1, bench_size=None, lab=None):
+		lab_name = (lab or self.lab).name
+		frappe.db.set_value("Lab", lab_name, {"instance_size": lab_size, "enable_code_server": lab_flag})
+		bench = _fresh_bench(self, lab_name)
 		bench.status = "Running"
 		bench.container_ip = "172.30.0.21"
 		bench.instance_size = bench_size
@@ -288,13 +293,14 @@ class TestIdeRouter(IntegrationTestCase):
 		"""One query for every bench: resolving per bench would cost the `*/5` pass one query
 		each, which is 300 a pass at the load profile this exists for."""
 		self._bench(lab_size=self.ide_size.name)
+		self._bench(lab_size=self.no_ide_size.name, lab=self.other_lab)
 
 		with _route_dir() as (ingress, _target_dir):
 			with patch.object(ingress, "_fleet_rows", wraps=ingress._fleet_rows) as fleet_rows:
 				result = ingress.reconcile()
 
 		self.assertEqual(fleet_rows.call_count, 1)
-		self.assertGreater(result["written"], 1)
+		self.assertGreaterEqual(result["written"], 2)
 
 	def test_a_lab_answers_the_same_rule_before_any_bench_exists(self):
 		"""The Lab detail screen has no bench to ask about and must not offer an IDE row for a

--- a/benchpress/tests/test_ingress.py
+++ b/benchpress/tests/test_ingress.py
@@ -14,6 +14,7 @@ import yaml
 from frappe.tests import IntegrationTestCase
 
 from benchpress import ingress
+from benchpress.credits.config import clear_size_index
 from benchpress.tests.test_deploy_manager import _fresh_bench, _make_lab
 
 # Any dotted quad, anywhere in the rendered file. The property routes must hold is that no
@@ -32,12 +33,35 @@ def _mounted(tmp) -> Path:
 	return target_dir
 
 
+def _make_size(label, include_code_server, memory_limit):
+	"""A throwaway `Instance Size`, replaced rather than reused so its flags are known."""
+	if frappe.db.exists("Instance Size", label):
+		frappe.delete_doc("Instance Size", label, force=True, ignore_permissions=True)
+	size = frappe.new_doc("Instance Size")
+	size.update(
+		{
+			"size_label": label,
+			"memory_limit": memory_limit,
+			"cpu_cores": 3,
+			"credits_per_hour": 1.0,
+			"include_code_server": include_code_server,
+		}
+	)
+	return size.insert(ignore_permissions=True)
+
+
 class TestPublish(unittest.TestCase):
-	"""Pure-function tests, no container/DB — the URL helpers moved to test_addressing.py."""
+	"""Pure-function tests, no container/DB — the URL helpers moved to test_addressing.py.
+
+	The IDE flag is forced here; whether a bench has one is `TestIdeRouter`'s subject.
+	"""
 
 	def test_publish_writes_router_and_service(self):
 		with tempfile.TemporaryDirectory() as tmp:
-			with patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", _mounted(tmp)):
+			with (
+				patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", _mounted(tmp)),
+				patch.object(ingress, "has_ide", return_value=True),
+			):
 				ingress.publish("inst-1", "benchpress.cloud")
 				config = yaml.safe_load((Path(tmp) / "instances" / "inst-1.yml").read_text())
 
@@ -66,7 +90,10 @@ class TestPublish(unittest.TestCase):
 		or a dev checkout would raise where it used to write nothing."""
 		with tempfile.TemporaryDirectory() as tmp:
 			target_dir = Path(tmp) / "instances"
-			with patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", target_dir):
+			with (
+				patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", target_dir),
+				patch.object(ingress, "has_ide", return_value=True),
+			):
 				ingress.publish("inst-1", "localhost")
 
 			self.assertFalse(target_dir.exists())
@@ -80,7 +107,10 @@ class TestPublish(unittest.TestCase):
 		the regression is a resolver at *any* depth, not one known key.
 		"""
 		with tempfile.TemporaryDirectory() as tmp:
-			with patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", _mounted(tmp)):
+			with (
+				patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", _mounted(tmp)),
+				patch.object(ingress, "has_ide", return_value=True),
+			):
 				ingress.publish("inst-1", "benchpress.cloud")
 				written_text = (Path(tmp) / "instances" / "inst-1.yml").read_text()
 
@@ -93,7 +123,10 @@ class TestPublish(unittest.TestCase):
 		"""The property this phase exists to create. Both services name the container, which
 		Docker's embedded DNS resolves, so no lifecycle transition can make the file stale."""
 		with tempfile.TemporaryDirectory() as tmp:
-			with patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", _mounted(tmp)):
+			with (
+				patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", _mounted(tmp)),
+				patch.object(ingress, "has_ide", return_value=True),
+			):
 				ingress.publish("inst-1", "benchpress.cloud")
 				written_text = (Path(tmp) / "instances" / "inst-1.yml").read_text()
 
@@ -111,7 +144,10 @@ class TestPublish(unittest.TestCase):
 		half-written file is a config-parse error on the one internet-facing container."""
 		with tempfile.TemporaryDirectory() as tmp:
 			target_dir = _mounted(tmp)
-			with patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", target_dir):
+			with (
+				patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", target_dir),
+				patch.object(ingress, "has_ide", return_value=True),
+			):
 				ingress.publish("inst-1", "benchpress.cloud")
 				ingress.publish("inst-1", "benchpress.cloud")
 
@@ -123,13 +159,155 @@ class TestPublish(unittest.TestCase):
 		route every five minutes — so an identical write has to be a no-op."""
 		with tempfile.TemporaryDirectory() as tmp:
 			target_dir = _mounted(tmp)
-			with patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", target_dir):
+			with (
+				patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", target_dir),
+				patch.object(ingress, "has_ide", return_value=True),
+			):
 				ingress.publish("inst-1", "benchpress.cloud")
 				mtime = (target_dir / "inst-1.yml").stat().st_mtime_ns
 
 				ingress.publish("inst-1", "benchpress.cloud")
 
 				self.assertEqual((target_dir / "inst-1.yml").stat().st_mtime_ns, mtime)
+
+
+class TestIdeRouter(IntegrationTestCase):
+	"""Whether `ide-<id>` exists at all — see specs/…/phase-3-code-server-router.md.
+
+	The live bug: `enable_code_server` gated the process and nothing else, so a lab with the
+	IDE off still published a public hostname pointing at a port nothing listens on.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		# Resources no seeded size claims, so `size_for_lab`'s by-resources rung cannot pick
+		# one of these by accident.
+		cls.ide_size = _make_size("Phase Three IDE", 1, "777m")
+		cls.no_ide_size = _make_size("Phase Three No IDE", 0, "778m")
+		cls.lab = _make_lab("test-lab-ide-router")
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		for name in frappe.get_all("Bench Instance", filters={"lab": cls.lab.name}, pluck="name"):
+			frappe.delete_doc("Bench Instance", name, force=True, ignore_permissions=True)
+		cls.lab.delete(ignore_permissions=True)
+		for size in (cls.ide_size, cls.no_ide_size):
+			frappe.delete_doc("Instance Size", size.name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+		clear_size_index()
+		super().tearDownClass()
+
+	def setUp(self):
+		super().setUp()
+		clear_size_index()
+
+	def _bench(self, *, lab_size, lab_flag=1, bench_size=None):
+		frappe.db.set_value("Lab", self.lab.name, {"instance_size": lab_size, "enable_code_server": lab_flag})
+		bench = _fresh_bench(self, self.lab.name)
+		bench.status = "Running"
+		bench.container_ip = "172.30.0.21"
+		bench.instance_size = bench_size
+		bench.save(ignore_permissions=True)
+		frappe.db.commit()
+		return bench
+
+	def _http(self, target_dir, bench):
+		return yaml.safe_load((target_dir / f"{bench.name}.yml").read_text())["http"]
+
+	def _assert_site_only(self, target_dir, bench):
+		text = (target_dir / f"{bench.name}.yml").read_text()
+		http = yaml.safe_load(text)["http"]
+		self.assertEqual(set(http["routers"]), {f"site-{bench.name}"})
+		self.assertEqual(set(http["services"]), {f"site-{bench.name}"})
+		# No router and no service, so Traefik matches nothing and answers 404 rather than
+		# the 502 a router pointing at a dead port would give.
+		self.assertNotIn("ide-", text)
+
+	def test_a_bench_with_an_ide_gets_both_routers(self):
+		bench = self._bench(lab_size=self.ide_size.name)
+
+		with _route_dir() as (ingress, target_dir):
+			ingress.publish(bench.name, "benchpress.cloud")
+			http = self._http(target_dir, bench)
+
+		self.assertEqual(set(http["routers"]), {f"site-{bench.name}", f"ide-{bench.name}"})
+		self.assertEqual(set(http["services"]), {f"site-{bench.name}", f"ide-{bench.name}"})
+
+	def test_a_lab_with_code_server_off_publishes_no_ide_hostname(self):
+		bench = self._bench(lab_size=self.ide_size.name, lab_flag=0)
+
+		with _route_dir() as (ingress, target_dir):
+			ingress.publish(bench.name, "benchpress.cloud")
+
+			self._assert_site_only(target_dir, bench)
+
+	def test_a_size_with_code_server_off_publishes_no_ide_hostname(self):
+		bench = self._bench(lab_size=self.no_ide_size.name)
+
+		with _route_dir() as (ingress, target_dir):
+			ingress.publish(bench.name, "benchpress.cloud")
+
+			self._assert_site_only(target_dir, bench)
+
+	def test_the_size_the_bench_deployed_at_beats_the_labs_current_one(self):
+		"""Billing prices the recorded size, and the routers follow the same rule: re-pointing
+		a Lab must not change what a bench that is already running publishes."""
+		bench = self._bench(lab_size=self.ide_size.name, bench_size=self.no_ide_size.name)
+
+		with _route_dir() as (ingress, target_dir):
+			ingress.publish(bench.name, "benchpress.cloud")
+
+			self._assert_site_only(target_dir, bench)
+
+	def test_the_reconcile_writes_the_same_bytes_the_deploy_wrote(self):
+		"""The derivability assertion, and nothing else catches it: the `*/5` pass has none of
+		the deploy's context, so a flag it resolved differently rewrites this file every pass —
+		and Traefik reloads on mtime."""
+		for size, routers in ((self.ide_size.name, 2), (self.no_ide_size.name, 1)):
+			with self.subTest(size=size):
+				bench = self._bench(lab_size=size)
+
+				with _route_dir() as (ingress, target_dir):
+					ingress.publish(bench.name, "benchpress.cloud")
+					route = target_dir / f"{bench.name}.yml"
+					deployed = route.read_bytes()
+					mtime = route.stat().st_mtime_ns
+
+					ingress.reconcile()
+
+					self.assertEqual(route.read_bytes(), deployed)
+					self.assertEqual(route.stat().st_mtime_ns, mtime)
+
+				self.assertEqual(len(yaml.safe_load(deployed)["http"]["routers"]), routers)
+
+	def test_the_flag_is_resolved_in_the_fleet_read(self):
+		"""One query for every bench: resolving per bench would cost the `*/5` pass one query
+		each, which is 300 a pass at the load profile this exists for."""
+		self._bench(lab_size=self.ide_size.name)
+
+		with _route_dir() as (ingress, _target_dir):
+			with patch.object(ingress, "_fleet_rows", wraps=ingress._fleet_rows) as fleet_rows:
+				result = ingress.reconcile()
+
+		self.assertEqual(fleet_rows.call_count, 1)
+		self.assertGreater(result["written"], 1)
+
+	def test_a_lab_answers_the_same_rule_before_any_bench_exists(self):
+		"""The Lab detail screen has no bench to ask about and must not offer an IDE row for a
+		size that has none."""
+		frappe.db.set_value(
+			"Lab", self.lab.name, {"instance_size": self.no_ide_size.name, "enable_code_server": 1}
+		)
+
+		self.assertFalse(ingress.lab_has_ide(frappe.get_doc("Lab", self.lab.name)))
+
+		frappe.db.set_value("Lab", self.lab.name, "instance_size", self.ide_size.name)
+
+		self.assertTrue(ingress.lab_has_ide(frappe.get_doc("Lab", self.lab.name)))
 
 
 class TestWildcardAnchor(unittest.TestCase):

--- a/benchpress/tests/test_signup.py
+++ b/benchpress/tests/test_signup.py
@@ -322,7 +322,7 @@ class TestSelfServeSignup(IntegrationTestCase):
 
 		frappe.set_user(EMAIL)
 
-		self.assertEqual(guard.concurrency_limit(), FREE_CEILING)
+		self.assertEqual(guard.concurrency_limit(EMAIL), FREE_CEILING)
 
 	def test_the_free_ceiling_refusal_names_the_number(self):
 		"""`test_admission` owns the claim; what matters here is that the user is told why."""

--- a/frontend/src/pages/NewLab.vue
+++ b/frontend/src/pages/NewLab.vue
@@ -222,9 +222,8 @@ function defaultSize(sizes) {
 	return (sizes ?? []).find((size) => size.is_default) ?? (sizes ?? [])[0];
 }
 
-// The server applies this too (`Lab.apply_instance_size`), but the form has to
-// carry it: the summary rail reads the limits, and the inserted document should
-// say what the user was shown rather than rely on a save-time rewrite.
+// The only writer: the deploy reads the size itself, so nothing rewrites these at
+// save time. The inserted document has to say what the user was shown.
 watch(chosenSize, (size) => {
 	if (!size) return;
 	form.memory_limit = size.memory_limit;


### PR DESCRIPTION
Phase 1 of the per-plan-resource-limits spec: the payer is the bench's owner.

The admission hold is the only thing in the app that can refuse a start, and it was priced against the caller rather than the account `metering` debits. Measured on the dev host: an owner at 1.0 credits driven to -4.0 by a caller holding 75.

- `guard._enforce` resolves a payer and prices the claim, the concurrency cap and the balance check against it.
- `requires_admission` takes a `payer` callable; `build_lab_image` names the lab's author.
- `cap_builds_per_day` counts the lab owner's rows. Counted against the caller it could never fire — the endpoint is admin-only.
- A fifth repair rule re-keys claims already on the wrong account, placed before `_heal_counters` so the heal reads corrected rows.
- `test_lease` is unfenced and its entry deleted from the ralph-loop reference.

Verified live against the dev site, credits forced in memory only and everything rolled back:

| Step | Result |
|---|---|
| Start of an owner's bench by a funded caller | `REFUSED — Not enough credits: this needs 5.0 and 1.0 are available — 4.0 short`; owner's balance unmoved, no row claimed on either account |
| Re-key a planted wrong-account claim | row moved to the owner, counters `(1, 5.0)` / `(0, 0.0)`, second pass re-keys nothing |
| Build at the owner's daily cap | `REFUSED`, with the under-cap control admitted |
| `api.get_benches` | 12 benches, every one at its expected status |

Tests, reading the exit code: `test_lease` 68 OK (was 1 error), `test_admission` 53 OK, `test_credits`, `test_api`, `test_credit_guard`, `test_signup`, `test_docker_manager`, `test_ingress` all exit 0. `pre-commit run --all-files` clean.