### PR TITLE
Implemented phase four

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,10 @@ jobs:
       - name: Setup
         run: |
           pip install frappe-bench
-          bench init --skip-redis-config-generation --skip-assets --python "$(which python)" ~/frappe-bench
+          # --frappe-branch, for the same reason vpn_management is pinned below: bench init
+          # defaults to frappe's develop branch, so the suite tracked a branch this app does
+          # not ship on and broke on upstream changes no pull request here contained.
+          bench init --frappe-branch version-16 --skip-redis-config-generation --skip-assets --python "$(which python)" ~/frappe-bench
 
       # benchpress declares required_apps = ["vpn_management"], a public repo,
       # so install-app benchpress only resolves if the app is already on the bench.

--- a/benchpress/benchpress/doctype/bench_event/bench_event.json
+++ b/benchpress/benchpress/doctype/bench_event/bench_event.json
@@ -1,0 +1,124 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "hash",
+ "creation": "2026-08-27 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 0,
+ "engine": "InnoDB",
+ "field_order": [
+  "bench",
+  "event_type",
+  "severity",
+  "column_break_event",
+  "occurred_at",
+  "docker_action",
+  "exit_code",
+  "detail"
+ ],
+ "fields": [
+  {
+   "fieldname": "bench",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Bench",
+   "options": "Bench Instance",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "event_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Event Type",
+   "options": "bench_died\noom_killed",
+   "reqd": 1
+  },
+  {
+   "default": "error",
+   "description": "The SPA notification badge reads this, so it is a contract and not a label.",
+   "fieldname": "severity",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Severity",
+   "options": "error\nwarning\ninfo"
+  },
+  {
+   "fieldname": "column_break_event",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "When the Docker daemon reported it, not when the row was written.",
+   "fieldname": "occurred_at",
+   "fieldtype": "Datetime",
+   "in_list_view": 1,
+   "label": "Occurred At",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "description": "The raw event action, e.g. die or health_status: unhealthy.",
+   "fieldname": "docker_action",
+   "fieldtype": "Data",
+   "label": "Docker Action",
+   "read_only": 1
+  },
+  {
+   "fieldname": "exit_code",
+   "fieldtype": "Int",
+   "label": "Exit Code",
+   "read_only": 1
+  },
+  {
+   "fieldname": "detail",
+   "fieldtype": "Small Text",
+   "label": "Detail",
+   "read_only": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-08-27 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Benchpress",
+ "name": "Bench Event",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1
+  },
+  {
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "BenchPress Admin",
+   "share": 1
+  },
+  {
+   "export": 1,
+   "read": 1,
+   "report": 1,
+   "role": "BenchPress User"
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "occurred_at",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 0
+}

--- a/benchpress/benchpress/doctype/bench_event/bench_event.json
+++ b/benchpress/benchpress/doctype/bench_event/bench_event.json
@@ -33,7 +33,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Event Type",
-   "options": "bench_died\noom_killed",
+   "options": "bench_died\noom_killed\nbench_unhealthy\nbench_healthy",
    "reqd": 1
   },
   {

--- a/benchpress/benchpress/doctype/bench_event/bench_event.py
+++ b/benchpress/benchpress/doctype/bench_event/bench_event.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class BenchEvent(Document):
+	pass

--- a/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
+++ b/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
@@ -18,6 +18,7 @@
   "bench_subnet_base",
   "bench_bridge_count",
   "bench_slots_per_bridge",
+  "bench_event_settle_seconds",
   "resource_section",
   "container_memory_limit",
   "column_break_resource",
@@ -106,6 +107,13 @@
    "label": "Bench Slots Per Bridge"
   },
   {
+   "default": "15",
+   "description": "Seconds a container death waits before the listener asks the database about it. Must exceed Stop Grace Seconds: a stop holds its transaction open for the whole grace period, so a bench being stopped on purpose still reads Running until it commits.",
+   "fieldname": "bench_event_settle_seconds",
+   "fieldtype": "Int",
+   "label": "Bench Event Settle Seconds"
+  },
+  {
    "fieldname": "resource_section",
    "fieldtype": "Section Break",
    "label": "Container Resource Limits"
@@ -158,7 +166,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-08-24 19:00:00.000000",
+ "modified": "2026-08-27 17:20:00.000000",
  "modified_by": "Administrator",
  "module": "Benchpress",
  "name": "BenchPress Settings",

--- a/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
+++ b/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
@@ -25,6 +25,8 @@
   "bench_health_retries",
   "bench_health_start_period_seconds",
   "stats_poll_max_benches",
+  "traefik_health_interval_seconds",
+  "traefik_health_timeout_seconds",
   "resource_section",
   "container_memory_limit",
   "column_break_resource",
@@ -160,6 +162,20 @@
    "fieldname": "stats_poll_max_benches",
    "fieldtype": "Int",
    "label": "Stats Poll Max Benches"
+  },
+  {
+   "default": "10",
+   "description": "Seconds between two of Traefik's own probes of a bench. This is a fleet-wide request rate against gunicorn, not a preference: Traefik probes every server on every service, so 100 benches at 10 seconds is 20 full Frappe requests a second.",
+   "fieldname": "traefik_health_interval_seconds",
+   "fieldtype": "Int",
+   "label": "Traefik Health Interval Seconds"
+  },
+  {
+   "default": "3",
+   "description": "Seconds one Traefik probe waits before it counts as a failure. A failure ejects the server from routing and the bench answers 503 until a probe succeeds again.",
+   "fieldname": "traefik_health_timeout_seconds",
+   "fieldtype": "Int",
+   "label": "Traefik Health Timeout Seconds"
   },
   {
    "fieldname": "resource_section",

--- a/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
+++ b/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
@@ -19,6 +19,12 @@
   "bench_bridge_count",
   "bench_slots_per_bridge",
   "bench_event_settle_seconds",
+  "enable_bench_healthcheck",
+  "bench_health_interval_seconds",
+  "bench_health_timeout_seconds",
+  "bench_health_retries",
+  "bench_health_start_period_seconds",
+  "stats_poll_max_benches",
   "resource_section",
   "container_memory_limit",
   "column_break_resource",
@@ -112,6 +118,48 @@
    "fieldname": "bench_event_settle_seconds",
    "fieldtype": "Int",
    "label": "Bench Event Settle Seconds"
+  },
+  {
+   "default": "1",
+   "description": "Whether a new bench container is given a Docker healthcheck that asks its site to answer. Off, a bench reports only whether its container exists, which is what every bench did before this switch. Takes effect at the next container create.",
+   "fieldname": "enable_bench_healthcheck",
+   "fieldtype": "Check",
+   "label": "Enable Bench Healthcheck"
+  },
+  {
+   "default": "30",
+   "description": "Seconds between two probes of a bench's site. Each probe is an exec, so this is also the event stream's noise floor: three events per bench per interval.",
+   "fieldname": "bench_health_interval_seconds",
+   "fieldtype": "Int",
+   "label": "Bench Health Interval Seconds"
+  },
+  {
+   "default": "5",
+   "description": "Seconds one probe waits for the site to answer before it counts as a failure.",
+   "fieldname": "bench_health_timeout_seconds",
+   "fieldtype": "Int",
+   "label": "Bench Health Timeout Seconds"
+  },
+  {
+   "default": "3",
+   "description": "Consecutive failed probes before Docker calls a bench unhealthy. With the interval above, this is how long a site may be down before anything says so.",
+   "fieldname": "bench_health_retries",
+   "fieldtype": "Int",
+   "label": "Bench Health Retries"
+  },
+  {
+   "default": "600",
+   "description": "Seconds after a container starts during which a failed probe does not count. Must exceed the longest deploy: on first boot nothing serves the site until the deploy has created it, and a seven-app site takes over three minutes to build.",
+   "fieldname": "bench_health_start_period_seconds",
+   "fieldtype": "Int",
+   "label": "Bench Health Start Period Seconds"
+  },
+  {
+   "default": "50",
+   "description": "Benches one stats poll samples, least recently checked first. Docker's stats endpoint samples twice a second apart, so an unbounded pass over a large fleet cannot finish inside its own minute. 0 removes the bound.",
+   "fieldname": "stats_poll_max_benches",
+   "fieldtype": "Int",
+   "label": "Stats Poll Max Benches"
   },
   {
    "fieldname": "resource_section",

--- a/benchpress/diagnostics.py
+++ b/benchpress/diagnostics.py
@@ -15,6 +15,7 @@ import frappe
 from frappe.query_builder.functions import Now
 
 from benchpress import placement
+from benchpress.docker_events import HEARTBEAT_STALE_SECONDS, heartbeat_value
 from benchpress.docker_manager import (
 	CONTAINER_RUNTIMES,
 	DEFAULT_PIDS_LIMIT,
@@ -30,6 +31,8 @@ from benchpress.mariadb_manager import (
 from benchpress.vpn_adapter import DEFAULT_INTERFACE
 
 DRIFT_FIX = "Recreate the shared pair: docker compose up -d in benchpress/config"
+# A row that says a listener is dead without naming what restarts it costs the reader a search.
+LISTENER_FIX = "start it with docker compose up -d docker-events"
 
 # Not an operator preference: past this, arithmetic on a stored deadline is wrong.
 # Two seconds absorbs MariaDB truncating NOW() to whole seconds; what it catches
@@ -81,6 +84,7 @@ def run_diagnostics() -> list[dict]:
 		_check_redis(),
 		_check_container_runtimes(),
 		_check_golden_images(),
+		_check_docker_events(),
 		check_vpn_server(),
 	]
 
@@ -294,6 +298,37 @@ def _check_golden_images() -> dict:
 		return check_row("golden_images", True, coverage)
 	except Exception as e:
 		return check_row("golden_images", False, f"Could not read golden image labels: {e}")
+
+
+def _check_docker_events() -> dict:
+	"""Whether the event listener's heartbeat is fresh enough to be believed.
+
+	A streaming listener that dies looks exactly like a quiet fleet, which the cron it replaced
+	never did.
+	"""
+	try:
+		published = heartbeat_value()
+		if not published:
+			return check_row(
+				"docker_events",
+				False,
+				f"The Docker event listener has published no heartbeat — {LISTENER_FIX}",
+			)
+		age = published["age"]
+		if age > HEARTBEAT_STALE_SECONDS:
+			return check_row(
+				"docker_events",
+				False,
+				f"The Docker event listener last reported {age}s ago, past the "
+				f"{HEARTBEAT_STALE_SECONDS}s it is given — {LISTENER_FIX}",
+			)
+		return check_row(
+			"docker_events",
+			True,
+			f"Docker event listener reported {age}s ago, {published['events_seen']} events seen",
+		)
+	except Exception as e:
+		return check_row("docker_events", False, f"Could not read the listener heartbeat: {e}")
 
 
 def check_vpn_server() -> dict:

--- a/benchpress/docker_events.py
+++ b/benchpress/docker_events.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""The Docker event stream, consumed rather than polled: a bench that dies is written down.
+
+It observes and never acts — no stop, no restart, no route write; `deploy_manager` owns those.
+"""
+
+import queue
+import threading
+import time
+from datetime import datetime, timezone
+
+import frappe
+from frappe import _
+from frappe.utils import cint, convert_utc_to_system_timezone, now_datetime
+
+from benchpress import docker_manager, notifications
+
+MANAGED_LABEL = "benchpress.managed"
+BENCH_NAME_LABEL = "benchpress.bench_name"
+
+# Server-side, always. Without them the stream carries three `exec_*` events per healthcheck per
+# bench, which the fleet multiplies.
+EVENT_FILTERS = {
+	"label": f"{MANAGED_LABEL}=true",
+	"event": ["die", "oom"],
+}
+
+# Action prefix -> (event_type, severity). An action carries its state after a colon
+# (`health_status: unhealthy`), so it is matched by prefix and never by equality.
+INCIDENTS = {"oom": ("oom_killed", "error"), "die": ("bench_died", "error")}
+
+SUBJECTS = {
+	"bench_died": "Bench {0} stopped unexpectedly.",
+	"oom_killed": "Bench {0} ran out of memory and was killed.",
+}
+
+# `stats_collector._update_bench_health` writes one of these before `_stop_if_dead` stops a bench,
+# and nothing writes them to a bench that was stopped on request.
+POLL_FOUND_IT_DEAD = ("Unhealthy", "Unknown")
+
+DEFAULT_SETTLE_SECONDS = 15
+TICK_SECONDS = 1
+ERROR_BACKOFF = 30
+
+HEARTBEAT_KEY = "benchpress:docker_events"
+HEARTBEAT_EXPIRY = 120
+
+
+def run() -> None:
+	"""Service entry point. Never returns; the container's restart policy is the recovery."""
+	while True:
+		try:
+			consume()
+		except Exception:
+			frappe.log_error(title="Docker events listener")
+			time.sleep(ERROR_BACKOFF)
+
+
+def consume() -> None:
+	"""Stream events into a queue on a reader thread; settle and record them on this one.
+
+	Returns when the reader dies, which is a daemon hiccup or a closed socket.
+	"""
+	inbox: queue.Queue = queue.Queue()
+	pending: dict[str, dict] = {}
+	stats = {"events_seen": 0, "orphans": 0, "connected_since": int(time.time())}
+
+	stream = docker_manager.get_client().events(decode=True, filters=EVENT_FILTERS)
+	try:
+		reader = threading.Thread(target=_read_into, args=(stream, inbox), daemon=True)
+		reader.start()
+		while True:
+			_drain(inbox, pending, stats)
+			_start_fresh()
+			_flush(pending, stats)
+			heartbeat(pending, stats)
+			time.sleep(TICK_SECONDS)
+			# Checked last, so a reader that dies mid-tick still has its events drained.
+			if not reader.is_alive():
+				return
+	finally:
+		# Unblocks the reader. Without it a failed tick leaks a thread filling an orphaned queue.
+		stream.close()
+
+
+def _read_into(stream, inbox: queue.Queue) -> None:
+	# frappe.local is thread-local: a write from here has no site, no connection and no user.
+	for event in stream:
+		inbox.put(event)
+
+
+def _drain(inbox: queue.Queue, pending: dict, stats: dict) -> None:
+	"""Park every queued event as one incident per bench, due after the settle window."""
+	while True:
+		try:
+			event = inbox.get_nowait()
+		except queue.Empty:
+			return
+		stats["events_seen"] += 1
+		actor = event.get("Actor") or {}
+		attributes = actor.get("Attributes") or {}
+		bench = attributes.get(BENCH_NAME_LABEL)
+		action = (event.get("Action") or "").split(":")[0].strip()
+		if not bench or action not in INCIDENTS:
+			continue
+
+		# One incident per bench collapses the `oom`/`die` pair — 122 ms apart — into the one
+		# incident it is, and `oom` wins the kind: exit 137 alone is not evidence of an OOM.
+		incident = pending.get(bench)
+		if incident is None:
+			incident = pending[bench] = {"due": time.time() + settle_seconds()}
+		if action == "oom" or "kind" not in incident:
+			kind, severity = INCIDENTS[action]
+			incident.update(
+				kind=kind, severity=severity, action=event.get("Action"), at=event.get("time")
+			)
+		if attributes.get("exitCode"):
+			incident["exit_code"] = cint(attributes["exitCode"])
+		incident.setdefault("exit_code", 0)
+		incident.setdefault(
+			"detail", f"container {actor.get('ID', '')[:12]} image {attributes.get('image', '')}"
+		)
+
+
+def _flush(pending: dict, stats: dict) -> None:
+	"""Record every incident whose settle window has closed, and forget the rest."""
+	due = [name for name, incident in pending.items() if incident["due"] <= time.time()]
+	for bench_name in due:
+		incident = pending.pop(bench_name)
+		row = frappe.db.get_value(
+			"Bench Instance", bench_name, ["status", "container_health"], as_dict=True
+		)
+		if not row:
+			stats["orphans"] += 1
+			continue
+		if not _unasked_for(row):
+			continue
+		record(bench_name, incident)
+	frappe.db.commit()
+
+
+def _unasked_for(row) -> bool:
+	"""Whether a settled death is one the platform did not ask for."""
+	# Read only after the settle window: `stop_bench` stops the container and commits `Stopped`
+	# afterwards, so at event time an ordinary stop still reads `Running`.
+	if row.status == "Running":
+		return True
+	# The stats poll is the other writer of `Stopped`, and it writes it for exactly the benches
+	# that died — recording the health it found on the way. A stop the platform asked for keeps
+	# the health the bench had while it was serving, which is why the field discriminates.
+	return row.status == "Stopped" and row.container_health in POLL_FOUND_IT_DEAD
+
+
+def record(bench_name: str, incident: dict) -> None:
+	"""Write the incident down, then tell the bench's owner. The row survives a failed notice."""
+	frappe.get_doc(
+		{
+			"doctype": "Bench Event",
+			"bench": bench_name,
+			"event_type": incident["kind"],
+			"severity": incident["severity"],
+			"occurred_at": _stamp(incident.get("at")),
+			"docker_action": incident.get("action"),
+			"exit_code": incident.get("exit_code") or 0,
+			"detail": incident.get("detail"),
+		}
+	).insert(ignore_permissions=True)
+
+	owner = frappe.db.get_value("Bench Instance", bench_name, "owner")
+	if owner:
+		notifications.notify_owner(
+			owner,
+			_(SUBJECTS[incident["kind"]]).format(bench_name),
+			"Bench Instance",
+			bench_name,
+		)
+
+
+def _stamp(at):
+	"""The daemon's event time in the site's timezone, or now when the event carried none."""
+	if not at:
+		return now_datetime()
+	utc = datetime.fromtimestamp(cint(at), tz=timezone.utc)
+	return convert_utc_to_system_timezone(utc).replace(tzinfo=None)
+
+
+def _start_fresh() -> None:
+	"""Drop what a request would have dropped between one request and the next."""
+	# `frappe.local` never resets in a process this long-lived: without the rollback the
+	# connection keeps reading `status` from the snapshot it opened with.
+	frappe.db.rollback()
+	frappe.local.cache.clear()
+	frappe.db.value_cache.clear()  # cleared, never replaced: it is a defaultdict
+
+
+def settle_seconds() -> int:
+	"""How long an incident waits before the database is asked about it."""
+	# `.get`, not an attribute: a Single field has no row in `tabSingles` until the settings are
+	# saved once, and an AttributeError here costs the connection and the event on it.
+	settings = frappe.get_cached_doc("BenchPress Settings")
+	return cint(settings.get("bench_event_settle_seconds")) or DEFAULT_SETTLE_SECONDS
+
+
+def heartbeat(pending: dict, stats: dict) -> None:
+	frappe.cache().set_value(
+		HEARTBEAT_KEY,
+		{
+			"ts": int(time.time()),
+			"connected_since": stats["connected_since"],
+			"events_seen": stats["events_seen"],
+			"orphans": stats["orphans"],
+			"pending": len(pending),
+		},
+		expires_in_sec=HEARTBEAT_EXPIRY,
+	)
+
+
+def heartbeat_value() -> dict | None:
+	"""What the listener last published plus its `age`, or None when nothing published."""
+	published = frappe.cache().get_value(HEARTBEAT_KEY)
+	if not published:
+		return None
+	return {**published, "age": int(time.time()) - cint(published.get("ts"))}

--- a/benchpress/docker_events.py
+++ b/benchpress/docker_events.py
@@ -44,6 +44,9 @@ PRECEDENCE = ("bench_healthy", "bench_unhealthy", "bench_died", "oom_killed")
 # instead of after a poll interval.
 HEALTH_VERDICTS = {"bench_unhealthy": "Unhealthy", "bench_healthy": "Healthy"}
 
+# Derived, so an incident recorded by `reconcile` cannot disagree with the same one off the stream.
+SEVERITY = dict(INCIDENTS.values())
+
 SUBJECTS = {
 	"bench_died": "Bench {0} stopped unexpectedly.",
 	"oom_killed": "Bench {0} ran out of memory and was killed.",
@@ -60,7 +63,12 @@ TICK_SECONDS = 1
 ERROR_BACKOFF = 30
 
 HEARTBEAT_KEY = "benchpress:docker_events"
-HEARTBEAT_EXPIRY = 120
+# Ticks of grace before the heartbeat is no longer believed, and how long it outlives that so a
+# stale beat can still name its own age. Both derived from the tick: a shorter tick must not
+# quietly become a shorter patience.
+HEARTBEAT_STALE_TICKS = 60
+HEARTBEAT_STALE_SECONDS = TICK_SECONDS * HEARTBEAT_STALE_TICKS
+HEARTBEAT_EXPIRY = HEARTBEAT_STALE_SECONDS * 2
 
 
 def run() -> None:
@@ -86,6 +94,9 @@ def consume() -> None:
 	try:
 		reader = threading.Thread(target=_read_into, args=(stream, inbox), daemon=True)
 		reader.start()
+		# After the reader, not before: anything that changes while the pass runs is then already
+		# on the stream rather than in the gap between the two.
+		reconcile()
 		while True:
 			_drain(inbox, pending, stats)
 			_start_fresh()
@@ -183,11 +194,16 @@ def _settle_health(bench_name: str, row, incident: dict) -> None:
 		{"container_health": HEALTH_VERDICTS[incident["kind"]], "last_health_check": now_datetime()},
 		update_modified=False,
 	)
-	# Recovery is news only after a failure was recorded. The first verdict a deploy produces is
-	# `starting -> healthy`, and a row for every deploy is noise rather than news.
-	if incident["kind"] == "bench_healthy" and _last_event(bench_name) != "bench_unhealthy":
+	if not _is_news(incident["kind"], bench_name):
 		return
 	record(bench_name, incident)
+
+
+def _is_news(kind: str, bench_name: str) -> bool:
+	"""Whether an incident is worth a row: recovery counts only after a failure was recorded."""
+	# The first verdict a deploy produces is `starting -> healthy`, and a row for every deploy is
+	# noise rather than news.
+	return kind != "bench_healthy" or _last_event(bench_name) == "bench_unhealthy"
 
 
 def _last_event(bench_name: str) -> str | None:
@@ -240,6 +256,83 @@ def _stamp(at):
 		return now_datetime()
 	utc = datetime.fromtimestamp(cint(at), tz=UTC)
 	return convert_utc_to_system_timezone(utc).replace(tzinfo=None)
+
+
+def enqueue_reconcile() -> None:
+	"""Convergence cron: hand the pass to `queue-long`, the worker that has the Docker socket."""
+	# The enqueuer, never `reconcile` itself — see the rule above `scheduler_events` in `hooks.py`.
+	frappe.enqueue(
+		"benchpress.docker_events.reconcile",
+		queue="long",
+		job_id="docker_events_reconcile",
+		deduplicate=True,
+	)
+
+
+def reconcile() -> dict:
+	"""Re-read health for every Running bench; the event buffer is too shallow to replay.
+
+	Returns `{checked, changed, recorded}`: a pass that reported only "ran" is how drift goes
+	unnoticed.
+	"""
+	# The daemon keeps 255 events — 74 seconds on this host, and less once every bench carries a
+	# healthcheck — so `since=<disconnect>` is a head start and never a guarantee.
+	_start_fresh()
+	counts = {"checked": 0, "changed": 0, "recorded": 0}
+	for bench in _benches_to_reconcile():
+		counts["checked"] += 1
+		health = docker_manager.get_container_health(bench.container_id)
+		if health != bench.container_health:
+			counts["changed"] += 1
+			frappe.db.set_value(
+				"Bench Instance",
+				bench.name,
+				{"container_health": health, "last_health_check": now_datetime()},
+				update_modified=False,
+			)
+		kind = _drifted_to(bench.container_id, health)
+		if _is_drift(kind, bench.name):
+			record(bench.name, _drift_incident(kind, bench.container_health, health))
+			counts["recorded"] += 1
+	frappe.db.commit()  # nosemgrep -- a background pass has no request boundary to commit at
+	return counts
+
+
+def _benches_to_reconcile() -> list[dict]:
+	"""The benches the platform believes are running, which is the only set worth an opinion."""
+	# Unbounded, unlike the stats poll: an inspect is a millisecond against 1.7 s for a stats
+	# sample. A bench stopped while the listener was blind is excluded by `status`, which is what
+	# keeps an intentional stop from producing an event.
+	return frappe.get_all(
+		"Bench Instance",
+		filters={"status": "Running", "container_id": ["is", "set"]},
+		fields=["name", "container_id", "container_health"],
+	)
+
+
+def _is_drift(kind: str, bench_name: str) -> bool:
+	"""Whether a reconciled state differs from the last thing said about the bench."""
+	# Against the last event, never against `container_health`: `stats_collector` writes that
+	# field too and records nothing, so a poll winning the race would silence the pass entirely.
+	return _last_event(bench_name) != kind and _is_news(kind, bench_name)
+
+
+def _drifted_to(container_id: str, health: str) -> str:
+	"""The incident a health change amounts to, once the container is asked whether it is still up."""
+	if health == "Healthy":
+		return "bench_healthy"
+	# `container_is_down` is the discriminator rather than the health label: `get_container_health`
+	# answers Unhealthy both for a site that stopped replying and for a container that exited.
+	return "bench_died" if docker_manager.container_is_down(container_id) else "bench_unhealthy"
+
+
+def _drift_incident(kind: str, before: str, after: str) -> dict:
+	"""An incident found by re-reading state rather than by an event, stamped at the pass."""
+	return {
+		"kind": kind,
+		"severity": SEVERITY[kind],
+		"detail": f"found by reconcile: health {before or 'unset'} -> {after}",
+	}
 
 
 def _start_fresh() -> None:

--- a/benchpress/docker_events.py
+++ b/benchpress/docker_events.py
@@ -9,7 +9,7 @@ It observes and never acts — no stop, no restart, no route write; `deploy_mana
 import queue
 import threading
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import frappe
 from frappe import _
@@ -113,9 +113,7 @@ def _drain(inbox: queue.Queue, pending: dict, stats: dict) -> None:
 			incident = pending[bench] = {"due": time.time() + settle_seconds()}
 		if action == "oom" or "kind" not in incident:
 			kind, severity = INCIDENTS[action]
-			incident.update(
-				kind=kind, severity=severity, action=event.get("Action"), at=event.get("time")
-			)
+			incident.update(kind=kind, severity=severity, action=event.get("Action"), at=event.get("time"))
 		if attributes.get("exitCode"):
 			incident["exit_code"] = cint(attributes["exitCode"])
 		incident.setdefault("exit_code", 0)
@@ -129,9 +127,7 @@ def _flush(pending: dict, stats: dict) -> None:
 	due = [name for name, incident in pending.items() if incident["due"] <= time.time()]
 	for bench_name in due:
 		incident = pending.pop(bench_name)
-		row = frappe.db.get_value(
-			"Bench Instance", bench_name, ["status", "container_health"], as_dict=True
-		)
+		row = frappe.db.get_value("Bench Instance", bench_name, ["status", "container_health"], as_dict=True)
 		if not row:
 			stats["orphans"] += 1
 			continue
@@ -182,7 +178,7 @@ def _stamp(at):
 	"""The daemon's event time in the site's timezone, or now when the event carried none."""
 	if not at:
 		return now_datetime()
-	utc = datetime.fromtimestamp(cint(at), tz=timezone.utc)
+	utc = datetime.fromtimestamp(cint(at), tz=UTC)
 	return convert_utc_to_system_timezone(utc).replace(tzinfo=None)
 
 

--- a/benchpress/docker_events.py
+++ b/benchpress/docker_events.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Venkatesh and contributors
 # For license information, please see license.txt
 
-"""The Docker event stream, consumed rather than polled: a bench that dies is written down.
+"""The Docker event stream, consumed rather than polled: a bench that dies or goes quiet is written down.
 
 It observes and never acts — no stop, no restart, no route write; `deploy_manager` owns those.
 """
@@ -24,16 +24,31 @@ BENCH_NAME_LABEL = "benchpress.bench_name"
 # bench, which the fleet multiplies.
 EVENT_FILTERS = {
 	"label": f"{MANAGED_LABEL}=true",
-	"event": ["die", "oom"],
+	"event": ["die", "oom", "health_status"],
 }
 
-# Action prefix -> (event_type, severity). An action carries its state after a colon
-# (`health_status: unhealthy`), so it is matched by prefix and never by equality.
-INCIDENTS = {"oom": ("oom_killed", "error"), "die": ("bench_died", "error")}
+# Action, with its state kept, -> (event_type, severity).
+INCIDENTS = {
+	"die": ("bench_died", "error"),
+	"oom": ("oom_killed", "error"),
+	"health_status:unhealthy": ("bench_unhealthy", "error"),
+	"health_status:healthy": ("bench_healthy", "info"),
+}
+
+# Which incident wins when two arrive for one bench inside the settle window. An OOM outranks the
+# `die` 122 ms behind it, and a death outranks a health verdict: a site that stopped answering on
+# its way out is one incident, and the death is the half the owner has to be told about.
+PRECEDENCE = ("bench_healthy", "bench_unhealthy", "bench_died", "oom_killed")
+
+# The `container_health` a verdict writes, which is how the field becomes fresh in seconds
+# instead of after a poll interval.
+HEALTH_VERDICTS = {"bench_unhealthy": "Unhealthy", "bench_healthy": "Healthy"}
 
 SUBJECTS = {
 	"bench_died": "Bench {0} stopped unexpectedly.",
 	"oom_killed": "Bench {0} ran out of memory and was killed.",
+	"bench_unhealthy": "Bench {0} has stopped answering on its site.",
+	"bench_healthy": "Bench {0} is answering again.",
 }
 
 # `stats_collector._update_bench_health` writes one of these before `_stop_if_dead` stops a bench,
@@ -102,17 +117,18 @@ def _drain(inbox: queue.Queue, pending: dict, stats: dict) -> None:
 		actor = event.get("Actor") or {}
 		attributes = actor.get("Attributes") or {}
 		bench = attributes.get(BENCH_NAME_LABEL)
-		action = (event.get("Action") or "").split(":")[0].strip()
-		if not bench or action not in INCIDENTS:
+		named = _incident_for(event.get("Action") or "")
+		if not bench or not named:
 			continue
+		kind, severity = named
 
 		# One incident per bench collapses the `oom`/`die` pair — 122 ms apart — into the one
-		# incident it is, and `oom` wins the kind: exit 137 alone is not evidence of an OOM.
+		# incident it is, and `PRECEDENCE` decides which of them it is reported as: exit 137
+		# alone is not evidence of an OOM.
 		incident = pending.get(bench)
 		if incident is None:
 			incident = pending[bench] = {"due": time.time() + settle_seconds()}
-		if action == "oom" or "kind" not in incident:
-			kind, severity = INCIDENTS[action]
+		if _outranks(kind, incident.get("kind")):
 			incident.update(kind=kind, severity=severity, action=event.get("Action"), at=event.get("time"))
 		if attributes.get("exitCode"):
 			incident["exit_code"] = cint(attributes["exitCode"])
@@ -120,6 +136,23 @@ def _drain(inbox: queue.Queue, pending: dict, stats: dict) -> None:
 		incident.setdefault(
 			"detail", f"container {actor.get('ID', '')[:12]} image {attributes.get('image', '')}"
 		)
+
+
+def _incident_for(action: str) -> tuple[str, str] | None:
+	"""The (event_type, severity) an action names, or None for an action not worth a row.
+
+	Matched on the action's state when it carries one and on the action alone otherwise:
+	`health_status: unhealthy` keeps its state after a colon and a space, so a lookup on
+	`health_status` matches neither verdict.
+	"""
+	head, _colon, state = action.partition(":")
+	head, state = head.strip(), state.strip()
+	return INCIDENTS.get(f"{head}:{state}") or INCIDENTS.get(head)
+
+
+def _outranks(kind: str, parked: str | None) -> bool:
+	"""Whether this incident replaces the one already parked for the bench."""
+	return parked is None or PRECEDENCE.index(kind) > PRECEDENCE.index(parked)
 
 
 def _flush(pending: dict, stats: dict) -> None:
@@ -131,10 +164,37 @@ def _flush(pending: dict, stats: dict) -> None:
 		if not row:
 			stats["orphans"] += 1
 			continue
-		if not _unasked_for(row):
-			continue
-		record(bench_name, incident)
+		if incident["kind"] in HEALTH_VERDICTS:
+			_settle_health(bench_name, row, incident)
+		elif _unasked_for(row):
+			record(bench_name, incident)
 	frappe.db.commit()  # nosemgrep -- no request boundary here, and the next tick rolls back
+
+
+def _settle_health(bench_name: str, row, incident: dict) -> None:
+	"""Freshen the health field from Docker's verdict, and record the transition if it is news."""
+	# A verdict about a bench the platform is no longer running is neither news nor a field worth
+	# writing: `lifecycle` owns the field across a stop and a start.
+	if row.status != "Running":
+		return
+	frappe.db.set_value(
+		"Bench Instance",
+		bench_name,
+		{"container_health": HEALTH_VERDICTS[incident["kind"]], "last_health_check": now_datetime()},
+		update_modified=False,
+	)
+	# Recovery is news only after a failure was recorded. The first verdict a deploy produces is
+	# `starting -> healthy`, and a row for every deploy is noise rather than news.
+	if incident["kind"] == "bench_healthy" and _last_event(bench_name) != "bench_unhealthy":
+		return
+	record(bench_name, incident)
+
+
+def _last_event(bench_name: str) -> str | None:
+	"""The event type most recently recorded for a bench, or None when it has none."""
+	return frappe.db.get_value(
+		"Bench Event", {"bench": bench_name}, "event_type", order_by="occurred_at desc"
+	)
 
 
 def _unasked_for(row) -> bool:

--- a/benchpress/docker_events.py
+++ b/benchpress/docker_events.py
@@ -134,7 +134,7 @@ def _flush(pending: dict, stats: dict) -> None:
 		if not _unasked_for(row):
 			continue
 		record(bench_name, incident)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep -- no request boundary here, and the next tick rolls back
 
 
 def _unasked_for(row) -> bool:

--- a/benchpress/docker_manager.py
+++ b/benchpress/docker_manager.py
@@ -15,6 +15,7 @@ import frappe
 from frappe import _
 from frappe.utils import cint, flt
 
+from benchpress import addressing
 from benchpress.image_cache import cache_tag, clear_cached_tags
 from benchpress.request_cache import local_cache
 
@@ -25,6 +26,23 @@ DEFAULT_IOPS = 1000
 DEFAULT_BPS = 40 * 1024 * 1024
 
 DISK_QUOTA_UNSUPPORTED = "this host enforces no writable-layer quota (overlay2 on xfs required)"
+
+DEFAULT_HEALTH_INTERVAL = 30
+DEFAULT_HEALTH_TIMEOUT = 5
+DEFAULT_HEALTH_RETRIES = 3
+DEFAULT_HEALTH_START_PERIOD = 600
+
+# Docker's healthcheck durations are nanoseconds. Passing seconds gives an interval of a few
+# nanoseconds that the daemon clamps, and an inspect then makes the wrong value look right.
+NANOSECONDS = 1_000_000_000
+
+# `localhost`, so the probe tests the server and not the bridge. Any Host header resolves:
+# `common_site_config.json` names the bench's own site as `default_site`.
+BENCH_HEALTH_PROBE = "curl -fsS -m {timeout} http://localhost:{port}/api/method/ping || exit 1"
+
+# Docker's health verdict -> the `container_health` label. `starting` is neither: a bench mid-deploy
+# is not healthy and is certainly not unhealthy.
+HEALTH_LABELS = {"healthy": "Healthy", "unhealthy": "Unhealthy", "starting": "Unknown"}
 
 # Field value -> the runtime name registered with the Docker daemon. None means
 # "pass no runtime", which leaves the daemon's own default-runtime in charge.
@@ -247,6 +265,34 @@ def _resolve_limits(size, lab_doc) -> dict:
 	}
 
 
+def bench_healthcheck() -> dict | None:
+	"""The Docker healthcheck for a bench container, or None when the switch is off."""
+	settings = frappe.get_cached_doc("BenchPress Settings")
+	# A Single stores only the fields somebody has written, so an unset Check reads None here. The
+	# switch exists to turn a healthcheck off, never to be off because nothing has written it.
+	switch = settings.get("enable_bench_healthcheck")
+	if switch is not None and not cint(switch):
+		return None
+
+	timeout = _health_setting(settings, "bench_health_timeout_seconds", DEFAULT_HEALTH_TIMEOUT)
+	interval = _health_setting(settings, "bench_health_interval_seconds", DEFAULT_HEALTH_INTERVAL)
+	start_period = _health_setting(settings, "bench_health_start_period_seconds", DEFAULT_HEALTH_START_PERIOD)
+	return {
+		"Test": ["CMD-SHELL", BENCH_HEALTH_PROBE.format(timeout=timeout, port=addressing.SITE_HTTP_PORT)],
+		"Interval": interval * NANOSECONDS,
+		"Timeout": timeout * NANOSECONDS,
+		"StartPeriod": start_period * NANOSECONDS,
+		"Retries": _health_setting(settings, "bench_health_retries", DEFAULT_HEALTH_RETRIES),
+	}
+
+
+def _health_setting(settings, field: str, default: int) -> int:
+	"""A healthcheck setting, or its default when the field is unset or zero."""
+	# `.get`, not attribute access: a Single field has no row in `tabSingles` until the settings
+	# are saved once, and an AttributeError here would take the container create with it.
+	return cint(settings.get(field)) or default
+
+
 def create_bench_container(bench_doc, lab_doc, size=None, network: str | None = None) -> CreatedContainer:
 	"""Create a container at a resolved `Instance Size`. Does NOT start it.
 
@@ -277,6 +323,8 @@ def create_bench_container(bench_doc, lab_doc, size=None, network: str | None = 
 
 	runtime = resolve_runtime(bench_doc)
 	runtime_kwargs = {"runtime": runtime} if runtime else {}
+
+	healthcheck = bench_healthcheck()
 
 	devices = _get_host_block_devices()
 	device_read_iops = [{"Path": dev, "Rate": iops} for dev in devices]
@@ -311,6 +359,7 @@ def create_bench_container(bench_doc, lab_doc, size=None, network: str | None = 
 		device_read_bps=device_read_bps or None,
 		device_write_bps=device_write_bps or None,
 		network=network,
+		**({"healthcheck": healthcheck} if healthcheck else {}),
 		**({"storage_opt": storage_opt} if storage_opt else {}),
 		**runtime_kwargs,
 	)
@@ -503,14 +552,13 @@ def _decoded(output) -> str:
 	return "" if output is None else str(output)
 
 
-def container_is_gone(container_id: str) -> bool:
-	"""True only when Docker positively reports the container does not exist.
+def container_is_down(container_id: str) -> bool:
+	"""True only when Docker positively reports the container absent or not running.
 
-	A daemon error is not "gone": callers stop benches on this answer.
+	A daemon error is not "down": callers stop benches on this answer.
 	"""
 	try:
-		get_client().containers.get(container_id)
-		return False
+		return get_client().containers.get(container_id).status != "running"
 	except docker.errors.NotFound:
 		return True
 	except Exception:
@@ -518,17 +566,12 @@ def container_is_gone(container_id: str) -> bool:
 
 
 def get_container_health(container_id: str) -> str:
-	"""Return a coarse health label for a bench container.
+	"""Docker's health verdict, falling back to run state on a container with no healthcheck.
 
-	A "running" container is Healthy; any other known Docker state (exited,
-	paused, dead, restarting) is Unhealthy; a missing container or inspect
-	failure is Unknown. This deliberately mirrors the actual container state so
-	a bench whose DB status drifts from reality is flagged.
+	A missing container or an inspect failure is Unknown, because callers stop benches on this.
 	"""
-	client = get_client()
 	try:
-		container = client.containers.get(container_id)
-		return "Healthy" if container.status == "running" else "Unhealthy"
+		container = get_client().containers.get(container_id)
 	except docker.errors.NotFound:
 		return "Unknown"
 	except Exception:
@@ -537,6 +580,15 @@ def get_container_health(container_id: str) -> str:
 			message=frappe.get_traceback(),
 		)
 		return "Unknown"
+
+	# Run state first: the daemon keeps the last verdict on a container that has exited, and a
+	# verdict from while it ran is not a statement about a container that is no longer running.
+	if container.status != "running":
+		return "Unhealthy"
+	health = (container.attrs.get("State") or {}).get("Health") or {}
+	# No `Health` at all is a container created before the healthcheck existed, and it keeps
+	# answering what it always did rather than turning Unknown overnight.
+	return HEALTH_LABELS.get(health.get("Status"), "Healthy")
 
 
 def get_container_stats(container_id: str) -> dict:

--- a/benchpress/hooks.py
+++ b/benchpress/hooks.py
@@ -257,6 +257,10 @@ scheduler_events = {
 			# Not the daily list: a slot leaked by a killed worker is a lockout for a caller at
 			# their cap, and it costs three grouped reads and no Docker call to find.
 			"benchpress.credits.admission_repair.reconcile_admissions",
+			# The net under the event listener. Enqueued, never run inline: the pass needs the
+			# Docker socket, which only `queue-long` and `backend` carry. A listener that stays
+			# down then degrades to the convergence BenchPress had before it, not to silence.
+			"benchpress.docker_events.enqueue_reconcile",
 		],
 		"0 2 * * *": [
 			"benchpress.mariadb_manager.enqueue_backup",

--- a/benchpress/hooks.py
+++ b/benchpress/hooks.py
@@ -138,6 +138,7 @@ permission_query_conditions = {
 	"Build Log": "benchpress.permissions.build_log_query_conditions",
 	"Credit Account": "benchpress.permissions.credit_account_query_conditions",
 	"Credit Ledger Entry": "benchpress.permissions.credit_ledger_query_conditions",
+	"Bench Event": "benchpress.permissions.bench_event_query_conditions",
 }
 
 # Not the `has_permission` key inside `add_to_apps_screen` above — that one gates the apps screen.
@@ -146,6 +147,7 @@ has_permission = {
 	"Credit Ledger Entry": "benchpress.permissions.credit_ledger_has_permission",
 	"Deploy Log": "benchpress.permissions.deploy_log_has_permission",
 	"Build Log": "benchpress.permissions.build_log_has_permission",
+	"Bench Event": "benchpress.permissions.bench_event_has_permission",
 }
 
 # DocType Class
@@ -321,4 +323,7 @@ ignore_links_on_delete = ["Deploy Log", "Build Log", "Database Server"]
 default_log_clearing_doctypes = {
 	"Deploy Log": 7,
 	"Build Log": 7,
+	# Longer than the logs: this is the evidence trail for a failure that may not be looked
+	# at the same week.
+	"Bench Event": 30,
 }

--- a/benchpress/ingress.py
+++ b/benchpress/ingress.py
@@ -50,6 +50,15 @@ PROTECTED_ROUTE_FILES = frozenset({CONTROL_PLANE_ROUTE_FILE, WILDCARD_ANCHOR_FIL
 # checking anything else would prove something else.
 TRAEFIK_HOST = "traefik"
 
+# Each service probes the path it serves, verified 200 inside a live bench. Pointing both at
+# the site path would eject a working code-server every time gunicorn hiccuped, and pointing
+# the site at /healthz would eject nothing, because code-server answers it while Frappe is dead.
+SITE_HEALTH_PATH = "/api/method/ping"
+IDE_HEALTH_PATH = "/healthz"
+
+DEFAULT_TRAEFIK_HEALTH_INTERVAL = 10
+DEFAULT_TRAEFIK_HEALTH_TIMEOUT = 3
+
 
 class TraefikRouteDirectoryMissing(Exception):
 	"""Raised when the Traefik route directory is not mounted in this container.
@@ -94,7 +103,10 @@ def publish(instance_id: str, base_domain: str, ide: bool | None = None) -> None
 	# Resolved by Docker's embedded DNS: traefik is on the `benchpress` network.
 	services = {
 		f"site-{instance_id}": {
-			"loadBalancer": {"servers": [{"url": f"http://{instance_id}:{addressing.SITE_HTTP_PORT}"}]}
+			"loadBalancer": {
+				"servers": [{"url": f"http://{instance_id}:{addressing.SITE_HTTP_PORT}"}],
+				"healthCheck": _service_health(SITE_HEALTH_PATH),
+			}
 		}
 	}
 
@@ -106,13 +118,31 @@ def publish(instance_id: str, base_domain: str, ide: bool | None = None) -> None
 			"tls": {},
 		}
 		services[f"ide-{instance_id}"] = {
-			"loadBalancer": {"servers": [{"url": f"http://{instance_id}:{addressing.IDE_HTTP_PORT}"}]}
+			"loadBalancer": {
+				"servers": [{"url": f"http://{instance_id}:{addressing.IDE_HTTP_PORT}"}],
+				"healthCheck": _service_health(IDE_HEALTH_PATH),
+			}
 		}
 
 	_atomic_write(
 		TRAEFIK_DYNAMIC_DIR / f"{instance_id}.yml",
 		yaml.safe_dump({"http": {"routers": routers, "services": services}}),
 	)
+
+
+def _service_health(path: str) -> dict:
+	"""Traefik's own probe of one service — the only thing that can eject a server from routing.
+
+	Docker's verdict cannot: Traefik reads the file provider and has no socket to hear it on.
+	"""
+	settings = frappe.get_cached_doc("BenchPress Settings")
+	# `.get`, not attribute access, and `or` on the value: a Single holds only what has been
+	# written, so an untouched field reads None and a settings save materialises it as zero.
+	interval = cint(settings.get("traefik_health_interval_seconds")) or DEFAULT_TRAEFIK_HEALTH_INTERVAL
+	timeout = cint(settings.get("traefik_health_timeout_seconds")) or DEFAULT_TRAEFIK_HEALTH_TIMEOUT
+	# No `hostname` key, deliberately: the probe goes to the server URL, so the Host header is
+	# the container name, and any Host resolves to the bench's own site through `default_site`.
+	return {"path": path, "interval": f"{interval}s", "timeout": f"{timeout}s"}
 
 
 def has_ide(instance_id: str) -> bool:

--- a/benchpress/lifecycle.py
+++ b/benchpress/lifecycle.py
@@ -47,6 +47,9 @@ def running(bench, *, action: str = "start") -> None:
 		bench.started_at = frappe.utils.now_datetime()
 
 	bench.status = "Running"
+	# A verdict from before the container was restarted is not a verdict about this one, and
+	# `docker_events._unasked_for` reads the field to tell a death from a stop that was asked for.
+	bench.container_health = ""
 	# Before the save, so the deadline and the status it belongs to are written together. A
 	# restart does not interrupt the window the user already bought: this only buys one for a
 	# bench that had none.

--- a/benchpress/overview.py
+++ b/benchpress/overview.py
@@ -37,7 +37,17 @@ INFRASTRUCTURE_LABELS = {
 	"redis": "Redis",
 	"container_runtimes": "Container runtimes",
 	"golden_images": "Golden images",
+	"docker_events": "Event listener",
 	"vpn_server": "WireGuard",
+}
+
+# A bench event gets its own sentence rather than riding through `_deploy_event`, whose fallback
+# reads "is deploying" — worse than not showing a dead bench at all.
+BENCH_EVENT_MESSAGES = {
+	"bench_died": "{0} stopped unexpectedly",
+	"oom_killed": "{0} ran out of memory and was stopped",
+	"bench_unhealthy": "{0} is not responding",
+	"bench_healthy": "{0} is responding again",
 }
 
 
@@ -201,12 +211,12 @@ def format_duration(seconds: float | None) -> str:
 
 
 def _activity(admin: bool) -> list[dict]:
-	"""Deploy activity for everyone; build activity for admins only.
+	"""Deploy and bench activity for everyone; build activity for admins only.
 
 	Build Log carries no permission query condition, so including it for a
 	non-admin would leak every other user's builds.
 	"""
-	events = _deploy_events()
+	events = _deploy_events() + _bench_events()
 	if admin:
 		events += _build_events()
 	events.sort(key=lambda event: event["timestamp"], reverse=True)
@@ -236,6 +246,32 @@ def _deploy_event(log: dict, subject: str) -> dict:
 		"log_type": log.log_type,
 		"timestamp": log.timestamp,
 		"bench": log.bench,
+	}
+
+
+def _bench_events() -> list[dict]:
+	# `bench_event_query_conditions` scopes the rows, so this is safe for everyone in the way
+	# `_deploy_events` is and `_build_events` is not.
+	events = frappe.get_list(
+		"Bench Event",
+		filters={"occurred_at": (">=", window_start())},
+		fields=["name", "bench", "event_type", "severity", "occurred_at"],
+		order_by="occurred_at desc",
+		limit=ACTIVITY_LIMIT,
+	)
+	labels = _bench_labels([event.bench for event in events])
+	return [_bench_event(event, labels.get(event.bench) or event.bench) for event in events]
+
+
+def _bench_event(event: dict, subject: str) -> dict:
+	message = BENCH_EVENT_MESSAGES.get(event.event_type) or "{0} reported {1}"
+	return {
+		"message": _(message).format(subject, event.event_type),
+		# `severity` is already the feed's vocabulary, so a dead bench counts on the badge the way
+		# a failed deploy does.
+		"log_type": event.severity,
+		"timestamp": event.occurred_at,
+		"bench": event.bench,
 	}
 
 
@@ -270,7 +306,7 @@ def _bench_labels(bench_names: list[str]) -> dict:
 
 
 def _infrastructure(admin: bool) -> list[dict] | None:
-	"""The ten real diagnostics checks — admins only, never a placeholder."""
+	"""The eleven real diagnostics checks — admins only, never a placeholder."""
 	if not admin:
 		return None
 	from benchpress.diagnostics import display_row, run_diagnostics

--- a/benchpress/patches.txt
+++ b/benchpress/patches.txt
@@ -27,3 +27,4 @@ benchpress.patches.drop_burn_fields
 benchpress.patches.name_bench_sites_by_site_name
 benchpress.patches.backfill_bench_bridge_network
 benchpress.patches.default_golden_switches
+benchpress.patches.backfill_bench_health

--- a/benchpress/patches.txt
+++ b/benchpress/patches.txt
@@ -28,3 +28,4 @@ benchpress.patches.name_bench_sites_by_site_name
 benchpress.patches.backfill_bench_bridge_network
 benchpress.patches.default_golden_switches
 benchpress.patches.backfill_bench_health
+benchpress.patches.default_traefik_health

--- a/benchpress/patches/backfill_bench_health.py
+++ b/benchpress/patches/backfill_bench_health.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""Stop existing rows claiming a health verdict their container cannot produce, then write the defaults.
+
+A container's healthcheck is fixed when it is created, so every bench that already exists has none
+and gains one only at its next redeploy. Until then Docker has no verdict about it and
+`get_container_health` answers from run state, which is the honest answer and the one stamped here
+— notably over the `Healthy` that every stopped bench still reads, left by the last poll that saw
+it running.
+
+A Single stores only the fields somebody has written, so the defaults in the DocType JSON reach a
+fresh install and never a site that already had the Single: there the switch would read as off and
+every duration as zero. They are written here instead, read from the DocType so this patch holds no
+second copy of any number.
+"""
+
+import frappe
+
+from benchpress.docker_manager import get_container_health
+
+SETTINGS = "BenchPress Settings"
+FIELDS = (
+	"enable_bench_healthcheck",
+	"bench_health_interval_seconds",
+	"bench_health_timeout_seconds",
+	"bench_health_retries",
+	"bench_health_start_period_seconds",
+	"stats_poll_max_benches",
+)
+
+
+def execute():
+	for bench in frappe.get_all(
+		"Bench Instance", filters={"container_id": ("is", "set")}, fields=["name", "container_id"]
+	):
+		frappe.db.set_value(
+			"Bench Instance",
+			bench.name,
+			"container_health",
+			get_container_health(bench.container_id),
+			update_modified=False,
+		)
+
+	stored = frappe.db.get_singles_dict(SETTINGS)
+	meta = frappe.get_meta(SETTINGS)
+	for field in FIELDS:
+		if field not in stored:
+			frappe.db.set_single_value(SETTINGS, field, meta.get_field(field).default)

--- a/benchpress/patches/default_traefik_health.py
+++ b/benchpress/patches/default_traefik_health.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""Write the Traefik probe defaults, so Desk shows the numbers actually in force.
+
+Over a stored zero as well as over nothing: `_service_health` reads both as "use the default".
+"""
+
+import frappe
+from frappe.utils import cint
+
+SETTINGS = "BenchPress Settings"
+FIELDS = ("traefik_health_interval_seconds", "traefik_health_timeout_seconds")
+
+
+def execute():
+	stored = frappe.db.get_singles_dict(SETTINGS)
+	meta = frappe.get_meta(SETTINGS)
+	for field in FIELDS:
+		if not cint(stored.get(field)):
+			frappe.db.set_single_value(SETTINGS, field, meta.get_field(field).default)

--- a/benchpress/permissions.py
+++ b/benchpress/permissions.py
@@ -103,6 +103,21 @@ def deploy_log_has_permission(doc, ptype=None, user=None) -> bool:
 	return _own_doc_only(user, frappe.db.get_value("Bench Instance", doc.bench, "owner"))
 
 
+def bench_event_query_conditions(user):
+	if not user:
+		user = frappe.session.user
+	if user == "Administrator":
+		return ""
+	if not set(frappe.get_roles(user)).isdisjoint(ADMIN_ROLES):
+		return ""
+	return f"`tabBench Event`.bench IN (SELECT name FROM `tabBench Instance` WHERE owner = {frappe.db.escape(user)})"
+
+
+def bench_event_has_permission(doc, ptype=None, user=None) -> bool:
+	"""A bench event belongs to its bench's owner, scoped the same way its list rule is."""
+	return _own_doc_only(user, frappe.db.get_value("Bench Instance", doc.bench, "owner"))
+
+
 def build_log_query_conditions(user):
 	"""`run_history._build_filters` applied this rule by hand; it belongs here."""
 	return _own_rows_only(user, "`tabBuild Log`.owner")

--- a/benchpress/stats_collector.py
+++ b/benchpress/stats_collector.py
@@ -3,10 +3,12 @@
 
 import frappe
 from frappe import _
-from frappe.utils import now_datetime
+from frappe.utils import cint, now_datetime
 
 from benchpress import lifecycle
-from benchpress.docker_manager import container_is_gone, get_container_health, get_container_stats
+from benchpress.docker_manager import container_is_down, get_container_health, get_container_stats
+
+DEFAULT_POLL_MAX_BENCHES = 50
 
 
 def enqueue_stats_sweep() -> None:
@@ -27,13 +29,7 @@ def collect_bench_stats() -> None:
 	`status` drives billing, so a bench whose container died must be stopped,
 	not just marked unhealthy.
 	"""
-	running_benches = frappe.get_all(
-		"Bench Instance",
-		filters={"status": "Running", "container_id": ["is", "set"]},
-		fields=["name", "container_id", "owner"],
-	)
-
-	for bench in running_benches:
+	for bench in _benches_to_poll():
 		try:
 			stats = get_container_stats(bench["container_id"])
 			frappe.db.set_value(
@@ -60,7 +56,30 @@ def collect_bench_stats() -> None:
 				message=frappe.get_traceback(),
 			)
 
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep -- a background sweep has no request boundary to commit at
+
+
+def _benches_to_poll() -> list[dict]:
+	"""The Running benches this pass samples, least recently checked first.
+
+	Bounded because Docker's stats endpoint samples twice a second apart: at 1.7 s a bench, an
+	unbounded pass over a large fleet cannot finish inside its own minute, and a `*/1` job that
+	overruns stacks up behind itself. The stalest benches go first so a bounded pass still
+	reaches every one of them, just over more ticks.
+	"""
+	return frappe.get_all(
+		"Bench Instance",
+		filters={"status": "Running", "container_id": ["is", "set"]},
+		fields=["name", "container_id", "owner"],
+		order_by="last_health_check asc",
+		limit_page_length=_poll_max_benches(),
+	)
+
+
+def _poll_max_benches() -> int:
+	"""Benches one pass may sample; 0 removes the bound, which is what `get_all` reads it as."""
+	limit = frappe.get_cached_doc("BenchPress Settings").get("stats_poll_max_benches")
+	return DEFAULT_POLL_MAX_BENCHES if limit is None else cint(limit)
 
 
 def _update_bench_health(bench: dict) -> str:
@@ -79,14 +98,16 @@ def _update_bench_health(bench: dict) -> str:
 
 
 def _stop_if_dead(bench: dict, health: str) -> None:
-	"""Stop a bench whose container died.
+	"""Stop a bench whose container is no longer running.
 
-	Unknown health is acted on only when the container is positively gone —
-	an inspect error must never stop a bench.
+	Acted on only when Docker positively reports the container down — an inspect error must
+	never stop a bench, and neither must an unhealthy site: `Unhealthy` now also means the site
+	stopped answering inside a container that is running perfectly well, which is a thing to
+	report and route around, not a reason to stop a bench and take the tenant's work with it.
 	"""
 	if health == "Healthy":
 		return
-	if health == "Unknown" and not container_is_gone(bench["container_id"]):
+	if not container_is_down(bench["container_id"]):
 		return
 
 	from benchpress.notifications import notify_owner

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -286,6 +286,14 @@ class TestApi(IntegrationTestCase):
 
 	def test_get_lab_carries_both_status_axes_of_the_bench(self):
 		"""A Running bench can be Unhealthy — the card cannot draw one from the other."""
+		# Set here rather than in the fixture: a start clears the health verdict, and a sibling
+		# test starts this same shared bench.
+		frappe.db.set_value(
+			"Bench Instance",
+			self.bench.name,
+			{"container_health": "Unhealthy", "last_health_check": frappe.utils.now_datetime()},
+			update_modified=False,
+		)
 		bench = api.get_lab(self.lab.name)["bench"]
 
 		self.assertEqual(bench["name"], self.bench.name)

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -46,7 +46,7 @@ BUDGETS_MS = {
 	"get_deploy_history": 600,
 }
 
-# The ten rows benchpress.diagnostics always returns; the real checks talk to
+# The eleven rows benchpress.diagnostics always returns; the real checks talk to
 # Docker and MariaDB, so the Overview timing test never runs them.
 DIAGNOSTICS_ROWS = [
 	{"check": "docker_socket", "status": "pass", "hint": "Docker daemon reachable"},
@@ -58,6 +58,7 @@ DIAGNOSTICS_ROWS = [
 	{"check": "redis", "status": "fail", "hint": "benchpress-redis container not found"},
 	{"check": "container_runtimes", "status": "pass", "hint": "Docker has sysbox-runc registered"},
 	{"check": "golden_images", "status": "pass", "hint": "8 of 8 built labs carry a golden dump"},
+	{"check": "docker_events", "status": "pass", "hint": "Docker event listener reported 2s ago"},
 	{"check": "vpn_server", "status": "pass", "hint": "WireGuard server 'wg0' configured"},
 ]
 

--- a/benchpress/tests/test_api_authorization.py
+++ b/benchpress/tests/test_api_authorization.py
@@ -544,6 +544,29 @@ class TestApiAuthorization(IntegrationTestCase):
 		activity = api.get_overview()["activity"]
 		self.assertFalse([event for event in activity if event.get("bench") == self.bench.name])
 
+	def test_overview_activity_hides_another_users_bench_events(self):
+		"""The panel is the only place a tenant reads these, so the scoping is exercised there."""
+		frappe.set_user("Administrator")
+		event = frappe.get_doc(
+			{
+				"doctype": "Bench Event",
+				"bench": self.bench.name,
+				"event_type": "bench_died",
+				"severity": "error",
+				"occurred_at": frappe.utils.now_datetime(),
+			}
+		).insert(ignore_permissions=True)
+		self.addCleanup(frappe.delete_doc, "Bench Event", event.name, force=True, ignore_permissions=True)
+
+		frappe.set_user(self.user_a)
+		mine = [row for row in api.get_overview()["activity"] if "stopped unexpectedly" in row["message"]]
+		self.assertTrue(mine, "the bench's own owner must see it")
+		self.assertEqual(mine[0]["log_type"], "error")
+
+		frappe.set_user(self.user_b)
+		theirs = api.get_overview()["activity"]
+		self.assertFalse([row for row in theirs if "stopped unexpectedly" in row["message"]])
+
 	def test_app_user_allowed_to_read_vpn_status(self):
 		frappe.set_user(self.user_a)
 		status = api.get_vpn_status()

--- a/benchpress/tests/test_diagnostics.py
+++ b/benchpress/tests/test_diagnostics.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Venkatesh and Contributors
 # See license.txt
 
-"""run_diagnostics contract: ten rows, fixed order, never raises, never mutates."""
+"""run_diagnostics contract: eleven rows, fixed order, never raises, never mutates."""
 
 import inspect
 import unittest
@@ -12,6 +12,7 @@ import docker
 import frappe
 
 from benchpress.diagnostics import check_row, display_row, run_diagnostics
+from benchpress.docker_events import HEARTBEAT_STALE_SECONDS
 from benchpress.image_cache import clear_cached_tags
 
 CHECK_ORDER = [
@@ -24,9 +25,10 @@ CHECK_ORDER = [
 	"redis",
 	"container_runtimes",
 	"golden_images",
+	"docker_events",
 	"vpn_server",
 ]
-COUNT_WORDS = {6: "six", 7: "seven", 8: "eight", 9: "nine", 10: "ten"}
+COUNT_WORDS = {6: "six", 7: "seven", 8: "eight", 9: "nine", 10: "ten", 11: "eleven"}
 HOST_RUNTIMES = {"names": {"runc", "sysbox-runc"}, "default": "runc"}
 # Small enough that a full bridge leaves the family with no headroom, which is the only
 # way `bridge_capacity` reports a fail.
@@ -45,6 +47,8 @@ NO_DRIFT = ([], "99.94%")
 # What this host really answers: MariaDB is UTC, Python is Asia/Calcutta.
 DB_CLOCK = datetime(2026, 8, 24, 23, 11, 53)
 IST_OFFSET = timedelta(hours=5, minutes=30)
+
+FRESH_HEARTBEAT = {"age": 2, "events_seen": 41, "orphans": 0, "pending": 0}
 
 
 def _lab_image(tag, golden=True):
@@ -78,6 +82,8 @@ class TestDiagnostics(unittest.TestCase):
 		ceilings=None,
 		mariadb_drift=None,
 		redis_drift=None,
+		heartbeat=FRESH_HEARTBEAT,
+		heartbeat_error=None,
 	):
 		"""Run run_diagnostics with everything healthy unless overridden.
 
@@ -103,6 +109,11 @@ class TestDiagnostics(unittest.TestCase):
 			patch("benchpress.placement.bridge_count", return_value=BRIDGE_COUNT),
 			patch("benchpress.placement.slots_per_bridge", return_value=BRIDGE_SLOTS),
 			patch("benchpress.diagnostics._read_sysctl", side_effect=ceilings.get),
+			patch(
+				"benchpress.diagnostics.heartbeat_value",
+				side_effect=heartbeat_error,
+				return_value=heartbeat,
+			),
 			patch("benchpress.diagnostics.frappe") as frappe_mock,
 		):
 			frappe_mock.get_all.return_value = [DB_ROW] if db_rows is None else db_rows
@@ -187,6 +198,7 @@ class TestDiagnostics(unittest.TestCase):
 			installed_apps=["frappe"],
 			db_clock_error=Exception("down"),
 			ceilings={},
+			heartbeat=None,
 		)
 		# Capacity is the one exception: a family with no bridge yet is the lazy-creation
 		# invariant, not a broken environment.
@@ -274,6 +286,42 @@ class TestDiagnostics(unittest.TestCase):
 		self.assertEqual(
 			display_row({"check": "redis", "status": "fail", "hint": ""}, "Redis")["status"], "Error"
 		)
+
+	def test_a_fresh_heartbeat_passes_and_reports_what_the_listener_has_seen(self):
+		by_check, _rows = self._run()
+		row = by_check["docker_events"]
+		self.assertEqual(row["status"], "pass")
+		self.assertIn("2s ago", row["hint"])
+		self.assertIn("41 events seen", row["hint"])
+
+	def test_a_stale_heartbeat_fails_and_names_the_service_to_start(self):
+		"""The row this phase exists for: a listener that dies otherwise looks like a quiet fleet."""
+		stale = {**FRESH_HEARTBEAT, "age": HEARTBEAT_STALE_SECONDS + 1}
+		by_check, _rows = self._run(heartbeat=stale)
+
+		row = by_check["docker_events"]
+		self.assertEqual(row["status"], "fail")
+		self.assertIn(f"{HEARTBEAT_STALE_SECONDS + 1}s ago", row["hint"])
+		self.assertIn("docker compose up -d docker-events", row["hint"])
+
+	def test_a_heartbeat_exactly_at_the_threshold_is_still_believed(self):
+		by_check, _rows = self._run(heartbeat={**FRESH_HEARTBEAT, "age": HEARTBEAT_STALE_SECONDS})
+		self.assertEqual(by_check["docker_events"]["status"], "pass")
+
+	def test_no_heartbeat_at_all_fails_and_names_the_service_to_start(self):
+		by_check, _rows = self._run(heartbeat=None)
+
+		row = by_check["docker_events"]
+		self.assertEqual(row["status"], "fail")
+		self.assertIn("no heartbeat", row["hint"])
+		self.assertIn("docker compose up -d docker-events", row["hint"])
+
+	def test_an_unreachable_cache_is_a_fail_row_not_an_exception(self):
+		by_check, rows = self._run(heartbeat_error=Exception("redis is gone"))
+
+		self.assertEqual(len(rows), len(CHECK_ORDER))
+		self.assertEqual(by_check["docker_events"]["status"], "fail")
+		self.assertIn("redis is gone", by_check["docker_events"]["hint"])
 
 	def test_the_diagnostics_row_count_moved_in_both_places(self):
 		"""One count, stated twice: the test_api fixture and the overview docstring."""

--- a/benchpress/tests/test_docker_events.py
+++ b/benchpress/tests/test_docker_events.py
@@ -78,10 +78,39 @@ class TestDrain(unittest.TestCase):
 		# The exit code survives the kind being overwritten; an oom event carries none.
 		self.assertEqual(pending[BENCH]["exit_code"], 137)
 
-	def test_the_action_is_matched_by_prefix(self):
-		"""Docker's action carries its state: `health_status: unhealthy`, never `health_status`."""
+	def test_an_action_with_a_state_nobody_named_still_matches_the_action(self):
 		pending, _stats = _drain({**event("die"), "Action": "die: whatever"})
 		self.assertEqual(pending[BENCH]["kind"], "bench_died")
+
+	def test_a_health_verdict_is_matched_on_its_state(self):
+		"""Docker's action carries the state after a colon and a space, and it is the whole point."""
+		pending, _stats = _drain(event("health_status: unhealthy"))
+		self.assertEqual(pending[BENCH]["kind"], "bench_unhealthy")
+		self.assertEqual(pending[BENCH]["severity"], "error")
+		self.assertEqual(pending[BENCH]["action"], "health_status: unhealthy")
+
+	def test_a_recovery_is_the_other_verdict_and_is_not_an_error(self):
+		pending, _stats = _drain(event("health_status: healthy"))
+		self.assertEqual(pending[BENCH]["kind"], "bench_healthy")
+		self.assertEqual(pending[BENCH]["severity"], "info")
+
+	def test_a_bare_health_status_names_no_verdict_and_is_dropped(self):
+		pending, _stats = _drain(event("health_status"))
+		self.assertEqual(pending, {})
+
+	def test_a_death_outranks_a_verdict_it_arrives_with(self):
+		"""A site that stopped answering on its way out is one incident, and it is the death."""
+		for events in (
+			(event("health_status: unhealthy"), event("die", exit_code=137)),
+			(event("die", exit_code=137), event("health_status: unhealthy")),
+		):
+			pending, _stats = _drain(*events)
+			self.assertEqual(len(pending), 1)
+			self.assertEqual(pending[BENCH]["kind"], "bench_died")
+
+	def test_a_flap_inside_the_window_is_reported_as_the_failure(self):
+		pending, _stats = _drain(event("health_status: unhealthy"), event("health_status: healthy"))
+		self.assertEqual(pending[BENCH]["kind"], "bench_unhealthy")
 
 	def test_two_benches_are_two_incidents(self):
 		pending, _stats = _drain(event("die", bench="a"), event("die", bench="b"))
@@ -147,6 +176,52 @@ class TestFlush(unittest.TestCase):
 		self.assertEqual(list(pending), [BENCH])
 
 
+class TestHealthVerdicts(unittest.TestCase):
+	def _flush(self, kind, status="Running", last_event=None):
+		"""Flush one parked health verdict and report what it recorded and what it wrote."""
+		pending = {BENCH: {"due": 0, "kind": kind, "severity": "error", "exit_code": 0}}
+		stats = {"events_seen": 1, "orphans": 0, "connected_since": 0}
+		with (
+			patch("benchpress.docker_events.frappe") as frappe_mock,
+			patch("benchpress.docker_events.record") as record_mock,
+			patch("benchpress.docker_events._last_event", return_value=last_event),
+			patch("benchpress.docker_events.now_datetime", return_value="2026-08-27 12:00:00"),
+		):
+			frappe_mock.db.get_value.return_value = frappe._dict(status=status, container_health="Healthy")
+			docker_events._flush(pending, stats)
+		return record_mock, frappe_mock.db.set_value
+
+	def test_a_failure_freshens_the_field_and_is_recorded(self):
+		record_mock, set_value = self._flush("bench_unhealthy")
+		record_mock.assert_called_once()
+		self.assertEqual(set_value.call_args.args[2]["container_health"], "Unhealthy")
+
+	def test_a_recovery_after_a_recorded_failure_is_news(self):
+		record_mock, set_value = self._flush("bench_healthy", last_event="bench_unhealthy")
+		record_mock.assert_called_once()
+		self.assertEqual(set_value.call_args.args[2]["container_health"], "Healthy")
+
+	def test_a_recovery_with_no_failure_behind_it_writes_the_field_and_no_row(self):
+		"""Every deploy's first verdict is `starting -> healthy`, which is noise and not news."""
+		record_mock, set_value = self._flush("bench_healthy", last_event=None)
+		record_mock.assert_not_called()
+		self.assertEqual(set_value.call_args.args[2]["container_health"], "Healthy")
+
+	def test_a_recovery_after_a_death_is_not_a_recovery_from_anything_said(self):
+		record_mock, _set_value = self._flush("bench_healthy", last_event="bench_died")
+		record_mock.assert_not_called()
+
+	def test_a_verdict_about_a_bench_the_platform_stopped_writes_nothing(self):
+		record_mock, set_value = self._flush("bench_unhealthy", status="Stopped")
+		record_mock.assert_not_called()
+		set_value.assert_not_called()
+
+	def test_a_verdict_mid_deploy_writes_nothing(self):
+		record_mock, set_value = self._flush("bench_unhealthy", status="Deploying")
+		record_mock.assert_not_called()
+		set_value.assert_not_called()
+
+
 class TestRecord(unittest.TestCase):
 	def _record(self, kind="bench_died", owner="tenant@example.com"):
 		incident = {
@@ -176,6 +251,12 @@ class TestRecord(unittest.TestCase):
 		self.assertEqual(doc["exit_code"], 137)
 		self.assertEqual(doc["docker_action"], "die")
 		insert.assert_called_once_with(ignore_permissions=True)
+
+	def test_every_incident_can_be_ranked_and_has_something_to_say_to_the_owner(self):
+		"""An unranked kind raises inside the drain, and a subject-less one inside the record."""
+		kinds = {kind for kind, _severity in docker_events.INCIDENTS.values()}
+		self.assertEqual(kinds, set(docker_events.SUBJECTS))
+		self.assertEqual(kinds, set(docker_events.PRECEDENCE))
 
 	def test_the_owner_is_told(self):
 		_doc, _insert, notify = self._record()

--- a/benchpress/tests/test_docker_events.py
+++ b/benchpress/tests/test_docker_events.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+"""The listener must not alert on an ordinary stop, and must call an oom-then-die pair one death.
+
+Plain dicts throughout: the drain and flush functions take events, never a Docker client.
+"""
+
+import queue
+import unittest
+from unittest.mock import patch
+
+import frappe
+
+from benchpress import docker_events
+
+BENCH = "bench-001"
+SETTLE = 15
+
+
+def event(action: str, bench: str | None = BENCH, exit_code: int | None = None, at: int = 1787722107):
+	attributes = {"benchpress.managed": "true", "image": "benchpress/lab:v16"}
+	if bench:
+		attributes["benchpress.bench_name"] = bench
+	if exit_code is not None:
+		attributes["exitCode"] = str(exit_code)
+	return {"Action": action, "time": at, "Actor": {"ID": "c0ffee1234567890", "Attributes": attributes}}
+
+
+def _inbox(*events) -> queue.Queue:
+	inbox: queue.Queue = queue.Queue()
+	for item in events:
+		inbox.put(item)
+	return inbox
+
+
+def _drain(*events) -> tuple[dict, dict]:
+	"""Drain the given events and report `(pending, stats)`."""
+	pending: dict = {}
+	stats = {"events_seen": 0, "orphans": 0, "connected_since": 0}
+	with patch("benchpress.docker_events.settle_seconds", return_value=SETTLE):
+		docker_events._drain(_inbox(*events), pending, stats)
+	return pending, stats
+
+
+class TestDrain(unittest.TestCase):
+	def test_the_label_names_the_bench(self):
+		pending, stats = _drain(event("die", exit_code=137))
+		self.assertEqual(list(pending), [BENCH])
+		self.assertEqual(stats["events_seen"], 1)
+
+	def test_an_event_with_no_bench_label_is_ignored(self):
+		pending, stats = _drain(event("die", bench=None))
+		self.assertEqual(pending, {})
+		self.assertEqual(stats["events_seen"], 1)
+
+	def test_an_unwatched_action_is_ignored(self):
+		pending, _stats = _drain(event("start"))
+		self.assertEqual(pending, {})
+
+	def test_a_die_alone_is_a_death_carrying_its_exit_code(self):
+		pending, _stats = _drain(event("die", exit_code=137))
+		self.assertEqual(pending[BENCH]["kind"], "bench_died")
+		self.assertEqual(pending[BENCH]["severity"], "error")
+		self.assertEqual(pending[BENCH]["exit_code"], 137)
+		self.assertEqual(pending[BENCH]["action"], "die")
+
+	def test_an_oom_then_a_die_is_one_incident(self):
+		pending, _stats = _drain(event("oom"), event("die", exit_code=137))
+		self.assertEqual(len(pending), 1)
+		self.assertEqual(pending[BENCH]["kind"], "oom_killed")
+		self.assertEqual(pending[BENCH]["exit_code"], 137)
+
+	def test_a_die_then_an_oom_is_the_same_one_incident(self):
+		pending, _stats = _drain(event("die", exit_code=137), event("oom"))
+		self.assertEqual(len(pending), 1)
+		self.assertEqual(pending[BENCH]["kind"], "oom_killed")
+		# The exit code survives the kind being overwritten; an oom event carries none.
+		self.assertEqual(pending[BENCH]["exit_code"], 137)
+
+	def test_the_action_is_matched_by_prefix(self):
+		"""Docker's action carries its state: `health_status: unhealthy`, never `health_status`."""
+		pending, _stats = _drain({**event("die"), "Action": "die: whatever"})
+		self.assertEqual(pending[BENCH]["kind"], "bench_died")
+
+	def test_two_benches_are_two_incidents(self):
+		pending, _stats = _drain(event("die", bench="a"), event("die", bench="b"))
+		self.assertEqual(sorted(pending), ["a", "b"])
+
+	def test_the_settle_window_is_read_once_per_incident(self):
+		with patch("benchpress.docker_events.settle_seconds", return_value=SETTLE) as settle:
+			pending: dict = {}
+			stats = {"events_seen": 0, "orphans": 0, "connected_since": 0}
+			docker_events._drain(_inbox(event("oom"), event("die")), pending, stats)
+		self.assertEqual(settle.call_count, 1)
+
+
+class TestFlush(unittest.TestCase):
+	def _flush(self, status, health="Healthy", settled=True):
+		"""Flush one parked incident against a bench row reading `status` and `health`."""
+		due = 0 if settled else float("inf")
+		pending = {BENCH: {"due": due, "kind": "bench_died", "severity": "error", "exit_code": 137}}
+		stats = {"events_seen": 1, "orphans": 0, "connected_since": 0}
+		row = None if status is None else frappe._dict(status=status, container_health=health)
+		with (
+			patch("benchpress.docker_events.frappe") as frappe_mock,
+			patch("benchpress.docker_events.record") as record_mock,
+		):
+			frappe_mock.db.get_value.return_value = row
+			docker_events._flush(pending, stats)
+		return record_mock, stats, pending
+
+	def test_a_running_bench_is_recorded_once(self):
+		record_mock, _stats, pending = self._flush("Running")
+		record_mock.assert_called_once()
+		self.assertEqual(record_mock.call_args.args[0], BENCH)
+		self.assertEqual(pending, {})
+
+	def test_a_bench_stopped_on_request_writes_nothing(self):
+		"""The negative control: a stop keeps the health it had while it was serving."""
+		record_mock, _stats, _pending = self._flush("Stopped", health="Healthy")
+		record_mock.assert_not_called()
+
+	def test_a_bench_never_polled_and_then_stopped_writes_nothing(self):
+		record_mock, _stats, _pending = self._flush("Stopped", health="")
+		record_mock.assert_not_called()
+
+	def test_a_bench_the_poll_stopped_because_it_died_is_recorded(self):
+		"""`_stop_if_dead` can beat the settle window, and it stamps what it found first."""
+		for health in ("Unhealthy", "Unknown"):
+			record_mock, _stats, _pending = self._flush("Stopped", health=health)
+			record_mock.assert_called_once()
+
+	def test_a_deploying_bench_writes_nothing(self):
+		record_mock, _stats, _pending = self._flush("Deploying")
+		record_mock.assert_not_called()
+
+	def test_a_bench_with_no_row_is_counted_and_dropped(self):
+		record_mock, stats, pending = self._flush(None)
+		record_mock.assert_not_called()
+		self.assertEqual(stats["orphans"], 1)
+		self.assertEqual(pending, {})
+
+	def test_an_incident_still_settling_is_left_alone(self):
+		record_mock, _stats, pending = self._flush("Running", settled=False)
+		record_mock.assert_not_called()
+		self.assertEqual(list(pending), [BENCH])
+
+
+class TestRecord(unittest.TestCase):
+	def _record(self, kind="bench_died", owner="tenant@example.com"):
+		incident = {
+			"kind": kind,
+			"severity": "error",
+			"action": "die",
+			"at": 1787722107,
+			"exit_code": 137,
+			"detail": "container c0ffee123456 image benchpress/lab:v16",
+		}
+		with (
+			patch("benchpress.docker_events.frappe") as frappe_mock,
+			patch("benchpress.docker_events.notifications") as notify_mock,
+			patch("benchpress.docker_events._stamp", return_value="2026-08-27 12:00:00"),
+			patch("benchpress.docker_events._", lambda text: text),
+		):
+			frappe_mock.db.get_value.return_value = owner
+			docker_events.record(BENCH, incident)
+			doc = frappe_mock.get_doc.call_args.args[0]
+		return doc, frappe_mock.get_doc.return_value.insert, notify_mock.notify_owner
+
+	def test_the_row_carries_the_incident(self):
+		doc, insert, _notify = self._record()
+		self.assertEqual(doc["doctype"], "Bench Event")
+		self.assertEqual(doc["bench"], BENCH)
+		self.assertEqual(doc["event_type"], "bench_died")
+		self.assertEqual(doc["exit_code"], 137)
+		self.assertEqual(doc["docker_action"], "die")
+		insert.assert_called_once_with(ignore_permissions=True)
+
+	def test_the_owner_is_told(self):
+		_doc, _insert, notify = self._record()
+		notify.assert_called_once()
+		self.assertEqual(notify.call_args.args[0], "tenant@example.com")
+		self.assertIn(BENCH, notify.call_args.args[1])
+
+	def test_an_ownerless_bench_is_still_recorded(self):
+		_doc, insert, notify = self._record(owner=None)
+		insert.assert_called_once()
+		notify.assert_not_called()
+
+
+class TestHeartbeat(unittest.TestCase):
+	def test_the_reader_gets_the_age_the_writer_could_not_know(self):
+		with (
+			patch("benchpress.docker_events.frappe") as frappe_mock,
+			patch("benchpress.docker_events.time") as time_mock,
+		):
+			time_mock.time.return_value = 1000.0
+			frappe_mock.cache.return_value.get_value.return_value = {"ts": 940, "events_seen": 3}
+			self.assertEqual(docker_events.heartbeat_value(), {"ts": 940, "events_seen": 3, "age": 60})
+
+	def test_nothing_published_is_none_and_not_a_stale_zero(self):
+		with patch("benchpress.docker_events.frappe") as frappe_mock:
+			frappe_mock.cache.return_value.get_value.return_value = None
+			self.assertIsNone(docker_events.heartbeat_value())

--- a/benchpress/tests/test_docker_events.py
+++ b/benchpress/tests/test_docker_events.py
@@ -270,6 +270,101 @@ class TestRecord(unittest.TestCase):
 		notify.assert_not_called()
 
 
+def _running(name=BENCH, health="Healthy"):
+	return frappe._dict(name=name, container_id="c0ffee123456", container_health=health)
+
+
+class TestReconcile(unittest.TestCase):
+	"""The blind window is closed by re-reading state, because the daemon's buffer is 74s deep."""
+
+	def _reconcile(self, stored="Healthy", observed="Healthy", down=False, last_event=None, rows=None):
+		"""One pass over one Running bench; reports the counts, the recorder and the frappe mock."""
+		with (
+			patch("benchpress.docker_events.frappe") as frappe_mock,
+			patch("benchpress.docker_events.record") as record_mock,
+			patch("benchpress.docker_events._last_event", return_value=last_event),
+			patch("benchpress.docker_events.now_datetime", return_value="2026-08-27 12:00:00"),
+			patch("benchpress.docker_events.docker_manager") as docker_mock,
+		):
+			frappe_mock.get_all.return_value = [_running(health=stored)] if rows is None else rows
+			docker_mock.get_container_health.return_value = observed
+			docker_mock.container_is_down.return_value = down
+			counts = docker_events.reconcile()
+		return counts, record_mock, frappe_mock
+
+	def test_only_the_benches_the_platform_believes_are_running_are_asked(self):
+		"""A bench stopped while the listener was blind is excluded here, and so produces nothing."""
+		_counts, _record, frappe_mock = self._reconcile()
+		self.assertEqual(frappe_mock.get_all.call_args.kwargs["filters"]["status"], "Running")
+
+	def test_a_bench_that_did_not_change_is_counted_and_left_alone(self):
+		counts, record_mock, frappe_mock = self._reconcile(
+			stored="Healthy", observed="Healthy", last_event="bench_healthy"
+		)
+		self.assertEqual(counts, {"checked": 1, "changed": 0, "recorded": 0})
+		frappe_mock.db.set_value.assert_not_called()
+		record_mock.assert_not_called()
+
+	def test_a_bench_still_unhealthy_is_not_reported_a_second_time(self):
+		"""The pass runs every five minutes; a standing failure is one event, not twelve an hour."""
+		counts, record_mock, _frappe = self._reconcile(
+			stored="Unhealthy", observed="Unhealthy", last_event="bench_unhealthy"
+		)
+		self.assertEqual(counts, {"checked": 1, "changed": 0, "recorded": 0})
+		record_mock.assert_not_called()
+
+	def test_a_failure_the_stats_poll_already_wrote_down_is_still_reported(self):
+		"""`_update_bench_health` writes the field and records nothing, and it can win the race."""
+		counts, record_mock, frappe_mock = self._reconcile(stored="Unhealthy", observed="Unhealthy")
+
+		self.assertEqual(counts, {"checked": 1, "changed": 0, "recorded": 1})
+		frappe_mock.db.set_value.assert_not_called()
+		self.assertEqual(record_mock.call_args.args[1]["kind"], "bench_unhealthy")
+
+	def test_a_site_that_stopped_answering_while_blind_is_found_and_recorded(self):
+		counts, record_mock, frappe_mock = self._reconcile(stored="Healthy", observed="Unhealthy")
+
+		self.assertEqual(counts, {"checked": 1, "changed": 1, "recorded": 1})
+		self.assertEqual(frappe_mock.db.set_value.call_args.args[2]["container_health"], "Unhealthy")
+		self.assertEqual(record_mock.call_args.args[1]["kind"], "bench_unhealthy")
+
+	def test_a_container_that_exited_while_blind_is_a_death_and_not_a_silence(self):
+		"""`get_container_health` answers Unhealthy for both, so the run state is the discriminator."""
+		_counts, record_mock, _frappe = self._reconcile(observed="Unhealthy", down=True)
+		self.assertEqual(record_mock.call_args.args[1]["kind"], "bench_died")
+
+	def test_the_incident_is_stamped_at_the_pass_and_says_where_it_came_from(self):
+		_counts, record_mock, _frappe = self._reconcile(observed="Unhealthy")
+
+		incident = record_mock.call_args.args[1]
+		self.assertEqual(incident["severity"], "error")
+		self.assertIn("reconcile", incident["detail"])
+		self.assertNotIn("at", incident)
+
+	def test_a_first_healthy_reading_writes_the_field_and_no_row(self):
+		"""`lifecycle` blanks the field on start, so every deploy would otherwise post a recovery."""
+		counts, record_mock, frappe_mock = self._reconcile(stored="", observed="Healthy")
+
+		self.assertEqual(counts, {"checked": 1, "changed": 1, "recorded": 0})
+		self.assertEqual(frappe_mock.db.set_value.call_args.args[2]["container_health"], "Healthy")
+		record_mock.assert_not_called()
+
+	def test_a_recovery_after_a_recorded_failure_is_news(self):
+		counts, record_mock, _frappe = self._reconcile(
+			stored="Unhealthy", observed="Healthy", last_event="bench_unhealthy"
+		)
+		self.assertEqual(counts["recorded"], 1)
+		self.assertEqual(record_mock.call_args.args[1]["kind"], "bench_healthy")
+
+	def test_the_counts_report_the_drift_rather_than_that_the_pass_ran(self):
+		rows = [_running(name="bench-001", health="Healthy"), _running(name="bench-002", health="")]
+		counts, _record, _frappe = self._reconcile(observed="Healthy", rows=rows)
+		self.assertEqual(counts, {"checked": 2, "changed": 1, "recorded": 0})
+
+	def test_every_kind_the_pass_can_report_carries_a_severity(self):
+		self.assertEqual(set(docker_events.SEVERITY), set(docker_events.SUBJECTS))
+
+
 class TestHeartbeat(unittest.TestCase):
 	def test_the_reader_gets_the_age_the_writer_could_not_know(self):
 		with (
@@ -284,3 +379,7 @@ class TestHeartbeat(unittest.TestCase):
 		with patch("benchpress.docker_events.frappe") as frappe_mock:
 			frappe_mock.cache.return_value.get_value.return_value = None
 			self.assertIsNone(docker_events.heartbeat_value())
+
+	def test_the_beat_outlives_the_patience_so_a_stale_one_can_name_its_own_age(self):
+		"""A key that expired first would report "never published" for a listener that just died."""
+		self.assertGreater(docker_events.HEARTBEAT_EXPIRY, docker_events.HEARTBEAT_STALE_SECONDS)

--- a/benchpress/tests/test_docker_manager.py
+++ b/benchpress/tests/test_docker_manager.py
@@ -17,6 +17,8 @@ from benchpress.docker_manager import (
 	DEFAULT_PIDS_LIMIT,
 	HOST_RUNTIMES_ATTRIBUTE,
 	CreatedContainer,
+	bench_healthcheck,
+	container_is_down,
 	container_runtime,
 	get_container_health,
 	host_runtimes,
@@ -27,15 +29,22 @@ from benchpress.request_cache import clear_local_cache
 from benchpress.tests.fakes import FakeDockerMixin
 
 
-def _client_returning(status):
+def _client_returning(status, health=None):
+	"""Docker client whose one container reports `status` and, if given, that health verdict."""
 	client = MagicMock()
-	client.containers.get.return_value.status = status
+	container = client.containers.get.return_value
+	container.status = status
+	state = {"Status": status}
+	if health:
+		state["Health"] = {"Status": health}
+	container.attrs = {"State": state}
 	return client
 
 
 class TestContainerHealth(unittest.TestCase):
 	@patch("benchpress.docker_manager.get_client")
-	def test_running_container_is_healthy(self, get_client):
+	def test_a_container_with_no_healthcheck_falls_back_to_run_state(self, get_client):
+		"""Every bench created before the healthcheck existed, which must keep its old answer."""
 		get_client.return_value = _client_returning("running")
 		self.assertEqual(get_container_health("abc123"), "Healthy")
 
@@ -50,6 +59,94 @@ class TestContainerHealth(unittest.TestCase):
 		client.containers.get.side_effect = docker.errors.NotFound("no such container")
 		get_client.return_value = client
 		self.assertEqual(get_container_health("gone"), "Unknown")
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_a_site_that_answers_is_healthy(self, get_client):
+		get_client.return_value = _client_returning("running", health="healthy")
+		self.assertEqual(get_container_health("abc123"), "Healthy")
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_a_dead_site_in_a_running_container_is_unhealthy(self, get_client):
+		"""The gap this exists to close: the container runs, the site answers nothing."""
+		get_client.return_value = _client_returning("running", health="unhealthy")
+		self.assertEqual(get_container_health("abc123"), "Unhealthy")
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_a_bench_inside_its_start_period_is_unknown(self, get_client):
+		get_client.return_value = _client_returning("running", health="starting")
+		self.assertEqual(get_container_health("abc123"), "Unknown")
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_a_stopped_container_is_unhealthy_whatever_its_last_verdict_was(self, get_client):
+		"""The daemon keeps the verdict it had while running; it is not about this container."""
+		get_client.return_value = _client_returning("exited", health="healthy")
+		self.assertEqual(get_container_health("abc123"), "Unhealthy")
+
+
+class TestContainerIsDown(unittest.TestCase):
+	@patch("benchpress.docker_manager.get_client")
+	def test_a_running_container_is_not_down(self, get_client):
+		get_client.return_value = _client_returning("running")
+		self.assertFalse(container_is_down("abc123"))
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_an_exited_container_is_down(self, get_client):
+		get_client.return_value = _client_returning("exited")
+		self.assertTrue(container_is_down("abc123"))
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_a_missing_container_is_down(self, get_client):
+		client = MagicMock()
+		client.containers.get.side_effect = docker.errors.NotFound("no such container")
+		get_client.return_value = client
+		self.assertTrue(container_is_down("gone"))
+
+	@patch("benchpress.docker_manager.get_client")
+	def test_a_daemon_error_is_not_down(self, get_client):
+		"""Callers stop benches on this answer, so a socket hiccup must not be one."""
+		client = MagicMock()
+		client.containers.get.side_effect = Exception("socket gone")
+		get_client.return_value = client
+		self.assertFalse(container_is_down("abc123"))
+
+
+class TestBenchHealthcheck(unittest.TestCase):
+	def _healthcheck(self, **settings):
+		with patch("benchpress.docker_manager.frappe") as frappe_mock:
+			frappe_mock.get_cached_doc.return_value = frappe._dict(settings)
+			return bench_healthcheck()
+
+	def test_the_durations_are_nanoseconds(self):
+		"""`"Interval": 30` is thirty nanoseconds, which the daemon clamps out of sight."""
+		probe = self._healthcheck()
+		self.assertEqual(probe["Interval"], 30 * 1_000_000_000)
+		self.assertEqual(probe["Timeout"], 5 * 1_000_000_000)
+		self.assertEqual(probe["StartPeriod"], 600 * 1_000_000_000)
+
+	def test_the_retry_count_is_a_count_and_not_a_duration(self):
+		self.assertEqual(self._healthcheck()["Retries"], 3)
+
+	def test_the_probe_asks_the_site_to_answer(self):
+		probe = self._healthcheck()
+		self.assertEqual(
+			probe["Test"],
+			["CMD-SHELL", "curl -fsS -m 5 http://localhost:8000/api/method/ping || exit 1"],
+		)
+
+	def test_the_configured_timeout_reaches_both_the_probe_and_docker(self):
+		probe = self._healthcheck(bench_health_timeout_seconds=2)
+		self.assertIn("-m 2 ", probe["Test"][1])
+		self.assertEqual(probe["Timeout"], 2 * 1_000_000_000)
+
+	def test_the_switch_off_means_no_healthcheck_at_all(self):
+		self.assertIsNone(self._healthcheck(enable_bench_healthcheck=0))
+
+	def test_an_install_that_never_saved_its_settings_still_gets_one(self):
+		"""A Single stores only what somebody wrote, so an unset Check reads None, not 1."""
+		self.assertIsNotNone(self._healthcheck())
+
+	def test_a_zeroed_duration_falls_back_rather_than_asking_docker_for_zero(self):
+		self.assertEqual(self._healthcheck(bench_health_interval_seconds=0)["Interval"], 30 * 1_000_000_000)
 
 
 def _reloading_container(states):
@@ -210,6 +307,26 @@ class TestDockerManagerBlockIO(FakeDockerMixin, IntegrationTestCase):
 		kwargs = self._container_create_kwargs(lab)
 
 		self.assertNotIn("volumes", kwargs)
+
+	def test_the_container_is_given_the_bench_healthcheck(self):
+		lab = _make_lab("healthcheck-on")
+		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
+		probe = {"Test": ["CMD-SHELL", "curl -fsS -m 5 http://localhost:8000/api/method/ping || exit 1"]}
+
+		with patch("benchpress.docker_manager.bench_healthcheck", return_value=probe):
+			kwargs = self._container_create_kwargs(lab)
+
+		self.assertEqual(kwargs["healthcheck"], probe)
+
+	def test_the_switch_off_leaves_the_key_off_the_create(self):
+		"""Not an empty healthcheck: the daemon reads one as a healthcheck that always fails."""
+		lab = _make_lab("healthcheck-off")
+		self.addCleanup(frappe.delete_doc, "Lab", lab.name, force=True, ignore_permissions=True)
+
+		with patch("benchpress.docker_manager.bench_healthcheck", return_value=None):
+			kwargs = self._container_create_kwargs(lab)
+
+		self.assertNotIn("healthcheck", kwargs)
 
 	def test_the_container_is_stamped_with_the_managed_labels(self):
 		"""`containers.list` filtering and every reconcile pass key off these."""

--- a/benchpress/tests/test_doctype_scoping.py
+++ b/benchpress/tests/test_doctype_scoping.py
@@ -30,6 +30,7 @@ TENANT_SCOPED = {
 	"Credit Ledger Entry",  # what that balance is made of
 	"Deploy Log",  # one deployment's output
 	"Build Log",  # one image build's output, which is credential-adjacent
+	"Bench Event",  # when somebody's bench died, and why
 }
 
 # Shared catalogues. Every app user may read every row, and no user can create one.

--- a/benchpress/tests/test_ingress.py
+++ b/benchpress/tests/test_ingress.py
@@ -171,6 +171,78 @@ class TestPublish(unittest.TestCase):
 				self.assertEqual((target_dir / "inst-1.yml").stat().st_mtime_ns, mtime)
 
 
+class TestServiceHealthCheck(unittest.TestCase):
+	"""Traefik's own probe, which is the only thing that ejects a server from routing.
+
+	Docker's verdict cannot: Traefik reads the file provider and has no socket to hear it on.
+	"""
+
+	def _config(self, **settings):
+		with tempfile.TemporaryDirectory() as tmp:
+			with (
+				patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", _mounted(tmp)),
+				patch.object(ingress, "has_ide", return_value=True),
+				patch.object(ingress, "frappe") as frappe_mock,
+			):
+				frappe_mock.get_cached_doc.return_value = frappe._dict(settings)
+				ingress.publish("inst-1", "benchpress.cloud")
+				return yaml.safe_load((Path(tmp) / "instances" / "inst-1.yml").read_text())
+
+	def _health(self, service, **settings):
+		return self._config(**settings)["http"]["services"][service]["loadBalancer"]["healthCheck"]
+
+	def test_both_services_carry_a_health_check(self):
+		services = self._config()["http"]["services"]
+		for name in ("site-inst-1", "ide-inst-1"):
+			self.assertIn("healthCheck", services[name]["loadBalancer"])
+
+	def test_the_site_service_probes_the_site(self):
+		self.assertEqual(self._health("site-inst-1")["path"], "/api/method/ping")
+
+	def test_the_ide_service_probes_the_ide(self):
+		"""Asserted apart from the site's: a copy-paste that gives both the same path passes
+		any test that only asks whether a health check exists."""
+		self.assertEqual(self._health("ide-inst-1")["path"], "/healthz")
+
+	def test_the_probe_rate_comes_from_settings(self):
+		health = self._health(
+			"site-inst-1", traefik_health_interval_seconds=7, traefik_health_timeout_seconds=2
+		)
+		self.assertEqual((health["interval"], health["timeout"]), ("7s", "2s"))
+
+	def test_an_install_that_never_saved_its_settings_still_gets_a_rate(self):
+		"""A Single holds only what somebody wrote, and a settings save materialises the rest
+		as zero — so both readings have to fall back rather than probe every zero seconds."""
+		self.assertEqual(self._health("ide-inst-1")["interval"], "10s")
+		self.assertEqual(self._health("ide-inst-1", traefik_health_interval_seconds=0)["interval"], "10s")
+
+	def test_the_probe_names_no_hostname(self):
+		"""It is sent to the server URL, so the Host header is the container name and the
+		bench's `default_site` resolves it. A `hostname` key would look like a fix and be none."""
+		self.assertEqual(sorted(self._health("site-inst-1")), ["interval", "path", "timeout"])
+
+	def test_the_router_half_is_untouched(self):
+		"""This phase changes what a service does and nothing about how a request is matched.
+		A lost `tls: {}` is a TLS outage and a changed rule is a bench nobody can reach."""
+		self.assertEqual(
+			self._config()["http"]["routers"],
+			{
+				"site-inst-1": {
+					"rule": "Host(`inst-1.benchpress.cloud`)",
+					"entryPoints": ["websecure"],
+					"service": "site-inst-1",
+					"tls": {},
+				},
+				"ide-inst-1": {
+					"rule": "Host(`ide-inst-1.benchpress.cloud`)",
+					"entryPoints": ["websecure"],
+					"service": "ide-inst-1",
+					"tls": {},
+				},
+			},
+		)
+
+
 class TestIdeRouter(IntegrationTestCase):
 	"""Whether `ide-<id>` exists at all — see specs/…/phase-3-code-server-router.md.
 

--- a/benchpress/tests/test_stats_collector.py
+++ b/benchpress/tests/test_stats_collector.py
@@ -6,17 +6,21 @@
 import unittest
 from unittest.mock import patch
 
+import frappe
+
+from benchpress import stats_collector
+
 BENCH = {"name": "bench-001", "container_id": "c0ffee", "owner": "user@example.com"}
 
 
 class TestStopIfDead(unittest.TestCase):
-	def _run(self, health, gone=False):
+	def _run(self, health, down=False):
 		"""Run one poll over a single Running bench and report what it did."""
 		with (
 			patch("benchpress.stats_collector.frappe") as frappe_mock,
 			patch("benchpress.stats_collector.get_container_stats", side_effect=Exception("no stats")),
 			patch("benchpress.stats_collector.get_container_health", return_value=health),
-			patch("benchpress.stats_collector.container_is_gone", return_value=gone) as gone_mock,
+			patch("benchpress.stats_collector.container_is_down", return_value=down) as down_mock,
 			patch("benchpress.lifecycle.stopped") as stop_mock,
 			patch("benchpress.notifications.notify_owner") as notify_mock,
 		):
@@ -26,27 +30,34 @@ class TestStopIfDead(unittest.TestCase):
 			from benchpress.stats_collector import collect_bench_stats
 
 			collect_bench_stats()
-		return stop_mock, notify_mock, gone_mock
+		return stop_mock, notify_mock, down_mock
 
 	def test_healthy_bench_is_left_alone(self):
 		stop_mock, notify_mock, _ = self._run("Healthy")
 		stop_mock.assert_not_called()
 		notify_mock.assert_not_called()
 
-	def test_unhealthy_container_stops_the_bench_and_tells_the_owner(self):
-		stop_mock, notify_mock, _ = self._run("Unhealthy")
+	def test_a_container_that_stopped_stops_the_bench_and_tells_the_owner(self):
+		stop_mock, notify_mock, _ = self._run("Unhealthy", down=True)
 		stop_mock.assert_called_once_with(BENCH["name"])
 		notify_mock.assert_called_once()
 		self.assertEqual(notify_mock.call_args.args[0], BENCH["owner"])
 
+	def test_a_dead_site_in_a_running_container_is_never_stopped(self):
+		"""Unhealthy now also means the site went quiet, which is a bench to route around."""
+		stop_mock, notify_mock, down_mock = self._run("Unhealthy", down=False)
+		down_mock.assert_called_once_with(BENCH["container_id"])
+		stop_mock.assert_not_called()
+		notify_mock.assert_not_called()
+
 	def test_vanished_container_stops_the_bench(self):
-		stop_mock, _notify, _ = self._run("Unknown", gone=True)
+		stop_mock, _notify, _ = self._run("Unknown", down=True)
 		stop_mock.assert_called_once_with(BENCH["name"])
 
 	def test_inspect_error_never_stops_a_bench(self):
 		# Unknown can mean a socket hiccup, not a missing container.
-		stop_mock, notify_mock, gone_mock = self._run("Unknown", gone=False)
-		gone_mock.assert_called_once_with(BENCH["container_id"])
+		stop_mock, notify_mock, down_mock = self._run("Unknown", down=False)
+		down_mock.assert_called_once_with(BENCH["container_id"])
 		stop_mock.assert_not_called()
 		notify_mock.assert_not_called()
 
@@ -56,6 +67,7 @@ class TestStopIfDead(unittest.TestCase):
 			patch("benchpress.stats_collector.frappe") as frappe_mock,
 			patch("benchpress.stats_collector.get_container_stats", side_effect=Exception("no stats")),
 			patch("benchpress.stats_collector.get_container_health", return_value="Unhealthy"),
+			patch("benchpress.stats_collector.container_is_down", return_value=True),
 			patch("benchpress.lifecycle.stopped", side_effect=[Exception("boom"), None]) as stop_mock,
 			patch("benchpress.notifications.notify_owner"),
 		):
@@ -67,3 +79,38 @@ class TestStopIfDead(unittest.TestCase):
 			collect_bench_stats()
 
 		self.assertEqual(stop_mock.call_count, 2)
+
+
+class TestPollBound(unittest.TestCase):
+	"""At 1.7 s a bench an unbounded pass cannot finish inside the `*/1` cron that starts it."""
+
+	def _get_all_kwargs(self, limit):
+		with (
+			patch("benchpress.stats_collector.frappe") as frappe_mock,
+			patch("benchpress.stats_collector._poll_max_benches", return_value=limit),
+		):
+			frappe_mock.get_all.return_value = []
+			stats_collector._benches_to_poll()
+			return frappe_mock.get_all.call_args.kwargs
+
+	def test_the_stalest_benches_go_first_so_a_bounded_pass_still_reaches_them_all(self):
+		kwargs = self._get_all_kwargs(50)
+		self.assertEqual(kwargs["order_by"], "last_health_check asc")
+		self.assertEqual(kwargs["limit_page_length"], 50)
+
+	def test_zero_removes_the_bound(self):
+		self.assertEqual(self._get_all_kwargs(0)["limit_page_length"], 0)
+
+	def _limit(self, **settings):
+		with patch("benchpress.stats_collector.frappe") as frappe_mock:
+			frappe_mock.get_cached_doc.return_value = frappe._dict(settings)
+			return stats_collector._poll_max_benches()
+
+	def test_an_install_that_never_saved_its_settings_gets_the_default(self):
+		self.assertEqual(self._limit(), stats_collector.DEFAULT_POLL_MAX_BENCHES)
+
+	def test_a_configured_zero_is_kept_rather_than_defaulted_away(self):
+		self.assertEqual(self._limit(stats_poll_max_benches=0), 0)
+
+	def test_a_configured_bound_is_used(self):
+		self.assertEqual(self._limit(stats_poll_max_benches=5), 5)


### PR DESCRIPTION
Phase 1 of the docker-events-listener spec: the Docker daemon's event stream reaches the database.

## What this adds

- **`benchpress/docker_events.py`** — a long-lived consumer, shaped like `credits/warden.py`. A reader thread does no Frappe work (`frappe.local` is thread-local) and appends to a queue; the main loop parks each incident with a due timestamp and judges it after the settle window.
- **`Bench Event`** — a log-shaped doctype, tenant-scoped with both permission halves, 30-day retention in `default_log_clearing_doctypes`.
- **`bench_event_settle_seconds`** on BenchPress Settings, default 15. It must exceed `stop_grace_seconds`.
- **`docker-events`** compose service in the base file and the prod overlay (the base file's `deploy.restart_policy` is a Swarm field `up` ignores).

## Why it decides nothing at event time

`stop_bench` stops the container and commits `Stopped` afterwards, so a `die` arrives while the row still says `Running`. A listener reading the database at event time alerts on every ordinary stop.

Two corrections the live system forced:

1. **`Stopped` alone does not mean "the platform asked".** `stats_collector._stop_if_dead` also writes it, for exactly the benches that died — and it beat the 15-second window on the first drill. It stamps the health it found on the way, so `Stopped` + `Unhealthy`/`Unknown` is a death and `Stopped` + the health it had while serving is a stop.
2. **A start now clears `container_health`** (`lifecycle.running`). A stale `Unhealthy` surviving a restart would otherwise read as a death for a poll interval.

## How to verify it

    cd /home/ubuntu/benchpress_devops
    docker compose up -d --no-deps docker-events
    </dev/null docker compose exec -T backend bench --site frontend execute benchpress.docker_events.heartbeat_value

Measured on staging with drill bench `31bc285092e6d65263d849f9549defea`:

| Step | Result |
|---|---|
| `docker kill` the bench | one row, `bench_died`, `error`, exit 137, action `die`, `occurred_at` = the daemon's time; one `Alert` to the owner |
| scratch container OOM under the bench's labels | one row, `oom_killed`, exit 137 — not an `oom_killed` **and** a `bench_died` |
| stop the bench through `api.bench_action` | `events_seen` rises, row count unchanged |
| non-owner `BenchPress User` | lists 0 rows, `frappe.client.get` raises; the owner lists and reads its own |

`run-tests --app benchpress` 857 + 218 tests, exit 0. `uvx pre-commit@4.3.0 run --all-files` clean.

Traefik was not restarted, no certificate was issued, and the host is untouched.