### PR TITLE
Implemented phase three

### DIFF
--- a/benchpress/api.py
+++ b/benchpress/api.py
@@ -342,9 +342,8 @@ def _stop_bench(bench) -> dict:
 def _delete_bench(bench) -> dict:
 	"""Remove an instance and everything it owns, then the row itself.
 
-	Container, volume, site database and metering session go through `lifecycle.torn_down`,
-	the one teardown path, where every removal is best-effort. Only what it does not cover is
-	left here.
+	`lifecycle.torn_down` is the one teardown path; the other sites' databases, and a peer it
+	reported it could not remove, are what is left here.
 	"""
 	from benchpress.vpn_adapter import remove_bench_peer
 

--- a/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
+++ b/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
@@ -36,7 +36,8 @@
   "credits_section",
   "enable_credits",
   "reconcile_section",
-  "orphan_grace_minutes"
+  "orphan_grace_minutes",
+  "deploy_log_cap"
  ],
  "fields": [
   {
@@ -238,6 +239,13 @@
    "fieldname": "orphan_grace_minutes",
    "fieldtype": "Int",
    "label": "Orphan Grace Minutes"
+  },
+  {
+   "default": "50",
+   "description": "Deploy Log rows kept per bench. Frappe's own sweep clears them at seven days; this is the second bound, for a bench redeployed in a loop inside one.",
+   "fieldname": "deploy_log_cap",
+   "fieldtype": "Int",
+   "label": "Deploy Log Cap"
   }
  ],
  "grid_page_length": 50,

--- a/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
+++ b/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.json
@@ -34,7 +34,9 @@
   "code_server_version",
   "stop_grace_seconds",
   "credits_section",
-  "enable_credits"
+  "enable_credits",
+  "reconcile_section",
+  "orphan_grace_minutes"
  ],
  "fields": [
   {
@@ -224,13 +226,25 @@
    "fieldname": "enable_credits",
    "fieldtype": "Check",
    "label": "Enable Credits"
+  },
+  {
+   "fieldname": "reconcile_section",
+   "fieldtype": "Section Break",
+   "label": "Reconciliation"
+  },
+  {
+   "default": "15",
+   "description": "A container younger than this is never named an orphan: a deploy creates the container before it writes the row.",
+   "fieldname": "orphan_grace_minutes",
+   "fieldtype": "Int",
+   "label": "Orphan Grace Minutes"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-08-27 17:20:00.000000",
+ "modified": "2026-08-28 06:00:00.000000",
  "modified_by": "Administrator",
  "module": "Benchpress",
  "name": "BenchPress Settings",

--- a/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.py
+++ b/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.py
@@ -21,7 +21,7 @@ class BenchPressSettings(Document):
 			return
 
 		frappe.enqueue(
-			"benchpress.ingress.reconcile",
+			"benchpress.reconcile.run",
 			queue="long",
 			job_id="reconcile_instance_routes",
 			deduplicate=True,

--- a/benchpress/credits/reaper.py
+++ b/benchpress/credits/reaper.py
@@ -4,9 +4,10 @@
 """The reaper: stopped is free, but not forever.
 
 "Stopped costs nothing" is only honest if a stopped instance eventually stops costing *us*
-something too — a container, a volume and a site database sit on disk whether or not anything is
-running in them. So an instance that has sat `Stopped` past `reap_after_days` is torn down, with
-an email two days before so nobody loses work to a rule they had forgotten.
+something too — a container and a site database sit on disk whether or not anything is running in
+them, and the instance holds a tunnel address the pool cannot hand out. So an instance that has sat
+`Stopped` past `reap_after_days` is torn down, with an email two days before so nobody loses work
+to a rule they had forgotten.
 
 **The `Lab` survives.** Its apps, branches, version and size are all intact, so "reaped" means one
 click to rebuild rather than lost work — which is exactly what lets us keep saying stopped is free.

--- a/benchpress/docker_events.py
+++ b/benchpress/docker_events.py
@@ -17,13 +17,10 @@ from frappe.utils import cint, convert_utc_to_system_timezone, now_datetime
 
 from benchpress import docker_manager, notifications
 
-MANAGED_LABEL = "benchpress.managed"
-BENCH_NAME_LABEL = "benchpress.bench_name"
-
 # Server-side, always. Without them the stream carries three `exec_*` events per healthcheck per
 # bench, which the fleet multiplies.
 EVENT_FILTERS = {
-	"label": f"{MANAGED_LABEL}=true",
+	"label": f"{docker_manager.MANAGED_LABEL}=true",
 	"event": ["die", "oom", "health_status"],
 }
 
@@ -127,7 +124,7 @@ def _drain(inbox: queue.Queue, pending: dict, stats: dict) -> None:
 		stats["events_seen"] += 1
 		actor = event.get("Actor") or {}
 		attributes = actor.get("Attributes") or {}
-		bench = attributes.get(BENCH_NAME_LABEL)
+		bench = attributes.get(docker_manager.BENCH_NAME_LABEL)
 		named = _incident_for(event.get("Action") or "")
 		if not bench or not named:
 			continue

--- a/benchpress/docker_manager.py
+++ b/benchpress/docker_manager.py
@@ -7,6 +7,7 @@ import re
 import subprocess
 import time
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import PurePosixPath
 
@@ -43,6 +44,12 @@ BENCH_HEALTH_PROBE = "curl -fsS -m {timeout} http://localhost:{port}/api/method/
 # Docker's health verdict -> the `container_health` label. `starting` is neither: a bench mid-deploy
 # is not healthy and is certainly not unhealthy.
 HEALTH_LABELS = {"healthy": "Healthy", "unhealthy": "Unhealthy", "starting": "Unknown"}
+
+# The stamp `create_bench_container` puts on every container and the filter `list_benches` reads
+# back. The label is the whole authority for a reconciler's removal, so it has one definition.
+MANAGED_LABEL = "benchpress.managed"
+BENCH_NAME_LABEL = "benchpress.bench_name"
+LAB_LABEL = "benchpress.lab"
 
 # Field value -> the runtime name registered with the Docker daemon. None means
 # "pass no runtime", which leaves the daemon's own default-runtime in charge.
@@ -311,9 +318,9 @@ def create_bench_container(bench_doc, lab_doc, size=None, network: str | None = 
 	name = bench_doc.bench_name
 
 	labels = {
-		"benchpress.managed": "true",
-		"benchpress.bench_name": name,
-		"benchpress.lab": lab_doc.lab_id,
+		MANAGED_LABEL: "true",
+		BENCH_NAME_LABEL: name,
+		LAB_LABEL: lab_doc.lab_id,
 	}
 
 	limits = _resolve_limits(size, lab_doc)
@@ -566,9 +573,9 @@ def container_is_down(container_id: str) -> bool:
 
 
 def get_container_health(container_id: str) -> str:
-	"""Docker's health verdict, falling back to run state on a container with no healthcheck.
+	"""Docker's health verdict for one container, or Unknown when it cannot be read.
 
-	A missing container or an inspect failure is Unknown, because callers stop benches on this.
+	Unknown rather than a raise on a missing container, because callers stop benches on this.
 	"""
 	try:
 		container = get_client().containers.get(container_id)
@@ -580,7 +587,11 @@ def get_container_health(container_id: str) -> str:
 			message=frappe.get_traceback(),
 		)
 		return "Unknown"
+	return _health_verdict(container)
 
+
+def _health_verdict(container) -> str:
+	"""The health of a container already inspected, so a fleet read costs no second call."""
 	# Run state first: the daemon keeps the last verdict on a container that has exited, and a
 	# verdict from while it ran is not a statement about a container that is no longer running.
 	if container.status != "running":
@@ -589,6 +600,34 @@ def get_container_health(container_id: str) -> str:
 	# No `Health` at all is a container created before the healthcheck existed, and it keeps
 	# answering what it always did rather than turning Unknown overnight.
 	return HEALTH_LABELS.get(health.get("Status"), "Healthy")
+
+
+def _created_at(container) -> datetime | None:
+	"""When the daemon created this container, in UTC. None when it did not say."""
+	try:
+		created = datetime.fromisoformat(container.attrs["Created"])
+	except (KeyError, TypeError, ValueError):
+		return None
+	return created if created.tzinfo else created.replace(tzinfo=UTC)
+
+
+def list_benches() -> list[dict]:
+	"""Every container this app manages, in one call, with status, health and age.
+
+	Stopped ones included: an orphan that exited still holds its writable layer.
+	"""
+	found = get_client().containers.list(all=True, filters={"label": f"{MANAGED_LABEL}=true"})
+	return [
+		{
+			"id": container.id,
+			"name": container.name,
+			"bench_name": container.labels.get(BENCH_NAME_LABEL, ""),
+			"status": container.status,
+			"health": _health_verdict(container),
+			"created": _created_at(container),
+		}
+		for container in found
+	]
 
 
 def get_container_stats(container_id: str) -> dict:

--- a/benchpress/hooks.py
+++ b/benchpress/hooks.py
@@ -213,7 +213,7 @@ website_route_rules = [
 #
 # The socket-mounted services are `queue-long` and `queue-stops`. So the entry is a small function
 # that calls `frappe.enqueue(..., queue="long")`, and the Docker call lives on the other side of
-# it. `enqueue_stats_sweep`, `enqueue_route_reconcile`, `enqueue_health_check`, `enqueue_backup`
+# it. `enqueue_stats_sweep`, `reconcile.enqueue_run`, `enqueue_health_check`, `enqueue_backup`
 # and the two in `image_cache` are all that shape.
 
 scheduler_events = {
@@ -245,9 +245,10 @@ scheduler_events = {
 			# socket, and a decision queued behind Docker I/O arrives late. The clock is not
 			# this job's business — `drain` owns expiry; this one checks balances.
 			"benchpress.credits.sweep.enforce_limits",
-			# `queue-short` has no route mount either. Lifecycle triggers already converge in
-			# seconds — this is the net under them.
-			"benchpress.ingress.enqueue_route_reconcile",
+			# `queue-short` has neither the route mount nor the Docker socket, and this pass
+			# needs both. Lifecycle triggers already converge in seconds — this is the net
+			# under them, plus the only direction that can see a container with no row.
+			"benchpress.reconcile.enqueue_run",
 			# The net under the lease warden, not the primary path: `DEFAULT_SCHEDULER_TICK` is
 			# four minutes here, so no cron entry can promise better than that. The warden claims
 			# within seconds; this catches whatever it misses while the warden is restarting.

--- a/benchpress/ingress.py
+++ b/benchpress/ingress.py
@@ -18,7 +18,7 @@ import frappe
 import yaml
 from frappe.utils import cint
 
-from benchpress import addressing, placement
+from benchpress import addressing
 
 # By name rather than `from benchpress.credits import config`: a route mapping is what
 # `config` wants to name in this file, and a module bound to that name turns the next such
@@ -40,7 +40,7 @@ WILDCARD_ANCHOR_FILE = "wildcard-anchor.yml"
 # It is not this app's to write and not this app's to remove.
 CONTROL_PLANE_ROUTE_FILE = "dynamic.yml"
 
-# The two files `reconcile` must never delete, named one by one rather
+# The two files the convergence pass must never delete, named one by one rather
 # than matched by shape. Deleting `dynamic.yml` takes the control plane off the internet;
 # deleting the anchor takes every bench's certificate with it. A filename pattern is a
 # guess about what future files will look like — a set is a decision about these two.
@@ -130,7 +130,7 @@ def publish(
 	if not base_domain or base_domain == "localhost":
 		return
 
-	# What `_routable_instances` already resolved for this bench, else the same read for one.
+	# What `routable` already resolved for this bench, else the same read for one.
 	# Never the caller's own idea of the flag: the */5 pass writes this file without the
 	# deploy's context, and two writers that disagree overwrite each other every five minutes.
 	if ide is None:
@@ -244,7 +244,7 @@ def _service_health(path: str) -> dict:
 
 
 def has_ide(instance_id: str) -> bool:
-	"""Whether this bench runs code-server — the one-bench case of `_routable_instances`."""
+	"""Whether this bench runs code-server — the one-bench case of `routable`."""
 	rows = _fleet_rows(names=[instance_id])
 	return _ide_for(rows[0]) if rows else False
 
@@ -255,7 +255,7 @@ def lab_has_ide(lab_doc) -> bool:
 
 
 def rate_limits(instance_id: str) -> RateLimits:
-	"""This bench's tier request numbers — the one-bench case of `_routable_instances`."""
+	"""This bench's tier request numbers — the one-bench case of `routable`."""
 	rows = _fleet_rows(names=[instance_id])
 	return _limits_for(rows[0]) if rows else DEFAULT_RATE_LIMITS
 
@@ -311,6 +311,11 @@ def published() -> set[str]:
 def protected_present() -> int:
 	"""How many protected files the directory holds, for the reconcile report."""
 	return sum(1 for name in PROTECTED_ROUTE_FILES if (TRAEFIK_DYNAMIC_DIR / name).exists())
+
+
+def directory_mounted() -> bool:
+	"""Whether the route directory is mounted here — asked instead of the path being handed out."""
+	return TRAEFIK_DYNAMIC_DIR.is_dir()
 
 
 def ensure_anchor(base_domain: str | None) -> bool:
@@ -478,73 +483,7 @@ def enqueue_route_sync(bench_name: str) -> None:
 	)
 
 
-def enqueue_route_reconcile() -> None:
-	"""Convergence cron: hand the whole-directory pass to `queue-long`."""
-	# Scheduled jobs land on `default`, which `queue-short` also consumes — so the cron entry
-	# is this enqueuer and never the pass itself. See `TraefikRouteDirectoryMissing`.
-	frappe.enqueue(
-		"benchpress.ingress.reconcile",
-		queue="long",
-		job_id="route_reconcile",
-		deduplicate=True,
-	)
-
-
-def reconcile() -> dict:
-	"""Make the Traefik route directory agree with the database.
-
-	The Bench Instance table is the truth and the directory follows it. Containers are not
-	inspected — an orphaned container is a real problem, but it is todo item 8's, and a
-	pass that quietly took on two jobs would be harder to trust with either. Returns counts
-	rather than a bare success: a reaper that reports "issued" instead of "converged" is how
-	a directory drifts for weeks without anyone noticing.
-
-	Deleting is the load-bearing half. Routes name containers, so a file left behind is a
-	502 rather than another tenant's site — but it is still a public hostname answering
-	for a bench that no longer exists, and only this pass removes one nothing deleted.
-
-	Running on `queue-long` is also what keeps this from racing a deploy — both are `long`
-	jobs on a single worker, so a bench part-way through `_deploy_bench` is never read here
-	between its container being created and its status reaching `Running`.
-
-	Run it by hand with:
-	    bench --site frontend execute benchpress.ingress.reconcile
-	"""
-	# Ahead of the base_domain guard because this half is about container networking rather
-	# than routing: a bench that cannot reach MariaDB is broken on a dev checkout too.
-	attached = placement.repair()
-
-	base_domain = frappe.get_cached_doc("BenchPress Settings").base_domain
-	if not base_domain or base_domain == "localhost":
-		# A dev checkout has no route directory and must stay byte-for-byte unaffected —
-		# skipped silently, exactly as the writers skip it.
-		return {"anchored": False, "written": 0, "deleted": 0, "kept": 0, **attached}
-
-	if not TRAEFIK_DYNAMIC_DIR.is_dir():
-		# Only ever a by-hand run outside queue-long — the cron reaches this through
-		# `enqueue_route_reconcile`, which pins the queue. None rather than 0, because the
-		# directory was never read and zero counts would read as a converged pass.
-		return {"anchored": None, "written": None, "deleted": None, "kept": None, **attached}
-
-	anchored = ensure_anchor(base_domain)
-	routable = _routable_instances()
-	for instance_id, (ide, limits) in routable.items():
-		publish(instance_id, base_domain, ide=ide, limits=limits)
-
-	stale = published() - routable.keys()
-	for instance_id in stale:
-		withdraw(instance_id)
-
-	return {
-		"anchored": anchored,
-		"written": len(routable),
-		"deleted": len(stale),
-		"kept": protected_present(),
-		**attached,
-	}
-
-
-def _routable_instances() -> dict[str, tuple[bool, RateLimits]]:
+def routable() -> dict[str, tuple[bool, RateLimits]]:
 	"""Every bench that should own a route file, mapped to its IDE flag and its tier's rate limits.
 
 	`Running` with an IP only: a freed `container_ip` may already belong to another tenant.

--- a/benchpress/lifecycle.py
+++ b/benchpress/lifecycle.py
@@ -33,6 +33,7 @@ from benchpress.mariadb_manager import ensure_infrastructure, wait_for_mariadb
 from benchpress.notifications import notify_owner
 
 NOTHING_TO_ROLL_BACK = "Cleanup: nothing to roll back — no container was created"
+GONE = "gone"
 
 
 def running(bench, *, action: str = "start") -> None:
@@ -104,23 +105,27 @@ def _deactivate_bench_sites(bench) -> None:
 	frappe.db.set_value("Bench Site", {"bench": bench.name}, "status", "Inactive", update_modified=False)
 
 
-def torn_down(bench, *, release_admission: bool = True) -> None:
-	"""Return an instance to `Draft`: container, volume and site database all gone.
+def torn_down(bench, *, release_admission: bool = True) -> dict[str, str]:
+	"""Return an instance to `Draft`, removing its container, site database, route and VPN peer.
 
-	`release_admission=False` keeps the slot for `_redeploy_bench`, which is this plus a deploy.
+	Never raises; each removal reports `GONE` or its failure, and `release_admission=False` holds the slot.
 	"""
-	if bench.container_id:
-		try:
-			stop_container(bench.container_id)
-		except Exception:
-			pass  # best-effort
-		_remove_container(bench.container_id)
-
-	_drop_site_database(bench)
+	container_id = bench.container_id
+	removals = {
+		"stop": _removed(stop_container, container_id) if container_id else GONE,
+		"container": _removed(remove_container, container_id) if container_id else GONE,
+		"database": _drop_site_database(bench),
+		"vpn_peer": _remove_bench_peer(bench),
+	}
 	bench.container_id = None
 	bench.container_image = None
+	bench.container_ip = None
+	# The peer is gone, so the tunnel address is back in the pool and the next claim gets it.
+	bench.wg_ip = None
 	bench.started_at = None
-	_ended(bench, "Draft", release_admission=release_admission)
+	removals["route"] = _ended(bench, "Draft", release_admission=release_admission)
+	_record_teardown_failures(bench.name, removals)
+	return removals
 
 
 def errored(bench, container_id: str | None, append_log) -> None:
@@ -131,10 +136,14 @@ def errored(bench, container_id: str | None, append_log) -> None:
 	if not container_id:
 		append_log(NOTHING_TO_ROLL_BACK)
 	else:
-		_remove_container(container_id)
-		append_log("Cleanup: removed container created by this run")
-		if _remove_bench_peer(bench):
-			append_log("Cleanup: VPN peer removed")
+		container = _removed(remove_container, container_id)
+		append_log(
+			"Cleanup: removed container created by this run"
+			if container == GONE
+			else f"Cleanup: container {container}"
+		)
+		peer = _remove_bench_peer(bench)
+		append_log("Cleanup: VPN peer removed" if peer == GONE else f"Cleanup: VPN peer {peer}")
 		# Only this run's addresses are cleared: a failure before the container leaves the
 		# previous deploy's, and that container is still running.
 		bench.container_id = None
@@ -143,20 +152,17 @@ def errored(bench, container_id: str | None, append_log) -> None:
 
 	# No `_drop_site_database` here: the `Bench Site` row is the name claim, and the retry drops
 	# the database itself before it recreates the site.
-	_ended(bench, "Error", release_admission=True)
+	append_log(f"Cleanup: route file {_ended(bench, 'Error', release_admission=True)}")
 
 
-def _ended(bench, status: str, *, release_admission: bool) -> None:
-	"""Write the end of a bench's life, with the side effects both endings share.
+def _ended(bench, status: str, *, release_admission: bool) -> str:
+	"""Write the end of a bench's life, returning how the route file's removal went.
 
 	`status` is the only difference: `Draft` discards the instance, `Error` leaves it for a retry.
 	"""
-	try:
-		# Direct, not enqueued: a lost job would leave a public hostname answering for a bench
-		# that no longer runs.
-		ingress.withdraw(bench.name)
-	except Exception:
-		pass  # best-effort
+	# Direct, not enqueued: a lost job would leave a public hostname answering for a bench that
+	# no longer runs.
+	route = _removed(ingress.withdraw, bench.name)
 
 	# Marked, not deleted: the row is the site-name claim, and a redeploy refreshes it.
 	_deactivate_bench_sites(bench)
@@ -170,35 +176,43 @@ def _ended(bench, status: str, *, release_admission: bool) -> None:
 	bench.status = status
 	bench.save(ignore_permissions=True)
 	frappe.db.commit()  # nosemgrep -- the caller may redeploy next, which must see this status
+	return route
 
 
-def _remove_container(container_id: str) -> None:
+def _removed(action, *args) -> str:
+	"""Run one teardown removal, reporting `GONE` or the failure text. This must never raise."""
 	try:
-		remove_container(container_id)
-	except Exception:
-		pass  # best-effort
+		action(*args)
+	except Exception as exc:
+		return f"failed: {exc}"
+	return GONE
 
 
-def _remove_bench_peer(bench) -> bool:
-	"""Drop the WireGuard peer, reporting whether it went, since the caller logs the outcome."""
+def _record_teardown_failures(bench_name: str, removals: dict[str, str]) -> None:
+	"""Write down what a teardown could not remove, since silence is what this replaces."""
+	failed = [f"{step}: {result}" for step, result in removals.items() if result != GONE]
+	if not failed:
+		return
+	frappe.log_error(
+		title=f"BenchPress teardown incomplete: {bench_name}",
+		message="\n".join(failed),
+	)
+	frappe.db.commit()  # nosemgrep -- a record of the failure that a rollback can lose is the silence again
+
+
+def _remove_bench_peer(bench) -> str:
+	"""Drop the WireGuard peer so its tunnel IP goes back to the pool, reporting how it went."""
 	from benchpress.vpn_adapter import remove_bench_peer
 
-	try:
-		remove_bench_peer(bench)
-		return True
-	except Exception:
-		return False
+	return _removed(remove_bench_peer, bench)
 
 
-def _drop_site_database(bench) -> None:
+def _drop_site_database(bench) -> str:
 	if not (bench.database_server and bench.site_name):
-		return
+		return GONE
 	from benchpress.mariadb_manager import drop_site_database
 
-	try:
-		drop_site_database(bench.database_server, bench.site_name)
-	except Exception:
-		pass  # best-effort
+	return _removed(drop_site_database, bench.database_server, bench.site_name)
 
 
 def _log_limits(pipeline, size, created) -> None:

--- a/benchpress/mariadb_manager.py
+++ b/benchpress/mariadb_manager.py
@@ -292,6 +292,25 @@ def drop_site_database(db_server_name: str, site_name: str, database: str | None
 	)
 
 
+# MariaDB's own schemas, which no site ever owns.
+SYSTEM_SCHEMAS = {"information_schema", "mysql", "performance_schema", "sys"}
+
+
+def list_site_databases(db_server_name: str) -> list[str]:
+	"""Schema names on this server. A read - nothing in this app drops from a sweep."""
+	exit_code, output = execute_sql(db_server_name, "SHOW DATABASES")
+	if exit_code != 0:
+		return []
+	# The client prints a `Database` header, and sometimes its own deprecation warning, into the
+	# same stream as the rows. A schema name carries no space.
+	names = (line.strip() for line in output.splitlines())
+	return [
+		name
+		for name in names
+		if name and " " not in name and name != "Database" and name not in SYSTEM_SCHEMAS
+	]
+
+
 def server_version(db_server_name: str) -> str:
 	"""The server's own `SELECT VERSION()`, or empty when it cannot be read.
 

--- a/benchpress/mariadb_manager.py
+++ b/benchpress/mariadb_manager.py
@@ -292,8 +292,10 @@ def drop_site_database(db_server_name: str, site_name: str, database: str | None
 	)
 
 
-# MariaDB's own schemas, which no site ever owns.
-SYSTEM_SCHEMAS = {"information_schema", "mysql", "performance_schema", "sys"}
+# What `SHOW DATABASES` returns that no site ever owns. `backups` is not a schema at all —
+# `backup_database_server` writes into the data directory and the server lists every directory
+# there — so a reconciler that reported it could never reach zero.
+NOT_SITE_DATABASES = {"information_schema", "mysql", "performance_schema", "sys", "backups"}
 
 
 def list_site_databases(db_server_name: str) -> list[str]:
@@ -307,7 +309,7 @@ def list_site_databases(db_server_name: str) -> list[str]:
 	return [
 		name
 		for name in names
-		if name and " " not in name and name != "Database" and name not in SYSTEM_SCHEMAS
+		if name and " " not in name and name != "Database" and name not in NOT_SITE_DATABASES
 	]
 
 

--- a/benchpress/reconcile.py
+++ b/benchpress/reconcile.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""Names the drift between the database and reality. Nothing here removes anything."""
+
+from datetime import UTC, datetime, timedelta
+
+import frappe
+from frappe.utils import cint
+
+# Matches `admission_repair.CLAIM_GRACE_MINUTES`, and for the same reason: `_deploy_bench` creates
+# the container before it writes `container_id`, so every deploy passes through a state that looks
+# exactly like an orphan.
+DEFAULT_GRACE_MINUTES = 15
+
+# Docker reports the full id and a row may hold either form; twelve characters is the form both
+# share, so a live bench is never named an orphan over a difference in notation.
+ID_KEY_LENGTH = 12
+
+
+def configured_grace_minutes() -> int:
+	"""The window a container is never an orphan in, or 15 when nothing has set one."""
+	settings = frappe.get_cached_doc("BenchPress Settings")
+	return cint(settings.get("orphan_grace_minutes")) or DEFAULT_GRACE_MINUTES
+
+
+def compare(rows: list[dict], containers: list[dict], *, grace_minutes: int | None = None) -> dict:
+	"""Name the drift both ways. It reads neither side — both arrive as arguments.
+
+	`grace_minutes` defaults to the configured window, which is the only thing this reads.
+	"""
+	window = configured_grace_minutes() if grace_minutes is None else grace_minutes
+	cutoff = datetime.now(UTC) - timedelta(minutes=window)
+
+	claimed = {_id_key(row.get("container_id")) for row in rows if row.get("container_id")}
+	live = {_id_key(container.get("id")) for container in containers if container.get("id")}
+
+	orphans, in_grace = [], []
+	for container in containers:
+		if _id_key(container.get("id")) in claimed:
+			continue
+		if _older_than(container.get("created"), cutoff):
+			orphans.append(container)
+		else:
+			in_grace.append(container)
+
+	missing = [row for row in rows if row.get("container_id") and _id_key(row["container_id"]) not in live]
+
+	return {"orphan_containers": orphans, "in_grace": in_grace, "missing_containers": missing}
+
+
+def _id_key(container_id) -> str:
+	return (container_id or "")[:ID_KEY_LENGTH]
+
+
+def _older_than(created, cutoff: datetime) -> bool:
+	"""Whether a container is old enough to be judged. A container of unknown age never is."""
+	return bool(created) and created < cutoff

--- a/benchpress/reconcile.py
+++ b/benchpress/reconcile.py
@@ -1,12 +1,18 @@
 # Copyright (c) 2026, Venkatesh and contributors
 # For license information, please see license.txt
 
-"""Names the drift between the database and reality. Nothing here removes anything."""
+"""The one pass that compares reality against the database, in both directions.
+
+Every other sweep converges from a row outwards and so cannot see a thing that has no row.
+"""
 
 from datetime import UTC, datetime, timedelta
 
 import frappe
+from frappe.query_builder.functions import Count
 from frappe.utils import cint
+
+from benchpress import docker_manager, ingress, mariadb_manager, placement
 
 # Matches `admission_repair.CLAIM_GRACE_MINUTES`, and for the same reason: `_deploy_bench` creates
 # the container before it writes `container_id`, so every deploy passes through a state that looks
@@ -17,11 +23,53 @@ DEFAULT_GRACE_MINUTES = 15
 # share, so a live bench is never named an orphan over a difference in notation.
 ID_KEY_LENGTH = 12
 
+# Frappe's own age sweep holds `Deploy Log` at seven days. This is the second bound, for the bench
+# that is redeployed in a loop and reaches thousands of rows inside one of them.
+DEFAULT_DEPLOY_LOG_CAP = 50
+
 
 def configured_grace_minutes() -> int:
 	"""The window a container is never an orphan in, or 15 when nothing has set one."""
-	settings = frappe.get_cached_doc("BenchPress Settings")
-	return cint(settings.get("orphan_grace_minutes")) or DEFAULT_GRACE_MINUTES
+	return _setting("orphan_grace_minutes", DEFAULT_GRACE_MINUTES)
+
+
+def configured_deploy_log_cap() -> int:
+	"""Deploy Log rows kept per bench, or 50 when nothing has set one."""
+	return _setting("deploy_log_cap", DEFAULT_DEPLOY_LOG_CAP)
+
+
+def enqueue_run() -> None:
+	"""Convergence cron: hand the whole pass to `queue-long`."""
+	# Scheduled jobs land on `default`, which `queue-short` also consumes — and that worker has
+	# neither the Docker socket nor the route mount. So the cron entry is this and never `run`.
+	frappe.enqueue(
+		"benchpress.reconcile.run",
+		queue="long",
+		job_id="route_reconcile",
+		deduplicate=True,
+	)
+
+
+def run() -> dict:
+	"""Converge the fleet, reporting a count for each of six steps rather than a bare success.
+
+	By hand: `bench --site frontend execute benchpress.reconcile.run`.
+	"""
+	# Bridges first: a bench that cannot reach MariaDB is broken on a dev checkout too, where
+	# there is no routing at all.
+	bridges = placement.repair()
+	routes = _converge_routes()
+	containers = _reap_orphan_containers()
+	databases = _report_orphan_databases()
+	deploy_records = _trim_deploy_records()
+	return {
+		"bridges": bridges,
+		"routes": routes,
+		"containers": containers,
+		"databases": databases,
+		"deploy_records": deploy_records,
+		"verified": _verify_reaped(containers["removed"]),
+	}
 
 
 def compare(rows: list[dict], containers: list[dict], *, grace_minutes: int | None = None) -> dict:
@@ -47,6 +95,180 @@ def compare(rows: list[dict], containers: list[dict], *, grace_minutes: int | No
 	missing = [row for row in rows if row.get("container_id") and _id_key(row["container_id"]) not in live]
 
 	return {"orphan_containers": orphans, "in_grace": in_grace, "missing_containers": missing}
+
+
+def _converge_routes() -> dict:
+	"""Make the Traefik route directory agree with the database."""
+	# The directory path and the protected filenames stay in `ingress`. One off-by-one here would
+	# take the control plane off the internet, or every bench's certificate with it.
+	base_domain = frappe.get_cached_doc("BenchPress Settings").base_domain
+	if not base_domain or base_domain == "localhost":
+		# A dev checkout has no route directory and must stay byte-for-byte unaffected.
+		return {"anchored": False, "written": 0, "deleted": 0, "kept": 0}
+
+	if not ingress.directory_mounted():
+		# Only ever a by-hand run outside queue-long. None rather than 0, because the directory
+		# was never read and zero counts would read as a converged pass.
+		return {"anchored": None, "written": None, "deleted": None, "kept": None}
+
+	anchored = ingress.ensure_anchor(base_domain)
+	routable = ingress.routable()
+	for instance_id, (ide, limits) in routable.items():
+		ingress.publish(instance_id, base_domain, ide=ide, limits=limits)
+
+	stale = ingress.published() - routable.keys()
+	for instance_id in stale:
+		ingress.withdraw(instance_id)
+
+	return {
+		"anchored": anchored,
+		"written": len(routable),
+		"deleted": len(stale),
+		"kept": ingress.protected_present(),
+	}
+
+
+def _reap_orphan_containers() -> dict:
+	"""Remove every managed container past the grace window that no row claims."""
+	# `list_benches` filters on `benchpress.managed=true` at the daemon, so a container this app
+	# did not create is never a candidate. That label is the whole authority for the removal.
+	drift = compare(_bench_rows(), docker_manager.list_benches())
+	removed = [container["id"] for container in drift["orphan_containers"]]
+	for container_id in removed:
+		_remove(container_id)
+	return {
+		"orphans": len(removed),
+		# The ids a removal was *issued* for. Whether they are gone is `_verify_reaped`'s answer.
+		"removed": removed,
+		"in_grace": len(drift["in_grace"]),
+		"missing_rows": len(drift["missing_containers"]),
+	}
+
+
+def _verify_reaped(issued: list[str]) -> dict:
+	"""Ask the daemon whether the removals took, re-issue the ones that did not, and report."""
+	# The step the pass exists for: a reaper that reports what it issued rather than what is gone
+	# is how a container keeps running underneath a report saying "converged".
+	if not issued:
+		return {"rechecked": 0, "reissued": 0, "reaped": 0, "still_present": []}
+
+	still = _present(issued)
+	for container_id in still:
+		_remove(container_id)
+	remaining = _present(still)
+	if remaining:
+		frappe.log_error(
+			title="BenchPress reconcile could not remove an orphan container",
+			message="\n".join(remaining),
+		)
+		frappe.db.commit()  # nosemgrep -- a background pass has no request boundary to commit at
+
+	return {
+		"rechecked": len(issued),
+		"reissued": len(still),
+		"reaped": len(issued) - len(remaining),
+		"still_present": remaining,
+	}
+
+
+def _report_orphan_databases() -> dict:
+	"""Count and name the schemas no row claims, per server. Nothing here drops one."""
+	# Reporting is the decision, not an omission: a `DROP` on a bench mid-deploy is a tenant's
+	# whole data with no undo, and `torn_down` now says when the drop it owns failed.
+	claimed = _claimed_databases()
+	schemas = 0
+	unclaimed = {}
+	for server in _database_servers():
+		names = _site_databases(server)
+		schemas += len(names)
+		orphans = sorted(name for name in names if name not in claimed)
+		if orphans:
+			unclaimed[server] = orphans
+	return {
+		"schemas": schemas,
+		"orphans": sum(len(names) for names in unclaimed.values()),
+		"names": unclaimed,
+	}
+
+
+def _trim_deploy_records() -> dict:
+	"""Hold each bench to the newest `cap` Deploy Log rows, on top of Frappe's 7-day age sweep."""
+	cap = configured_deploy_log_cap()
+	deleted = 0
+	over = _benches_over_cap(cap)
+	for row in over:
+		stale = frappe.get_all(
+			"Deploy Log",
+			filters={"bench": row.bench},
+			pluck="name",
+			order_by="timestamp desc, creation desc",
+			offset=cap,
+			limit=row.rows - cap,
+		)
+		if not stale:
+			continue
+		frappe.db.delete("Deploy Log", {"name": ("in", stale)})
+		deleted += len(stale)
+	if deleted:
+		frappe.db.commit()  # nosemgrep -- a background pass has no request boundary to commit at
+	return {"benches": len(over), "deleted": deleted, "cap": cap}
+
+
+def _benches_over_cap(cap: int) -> list[dict]:
+	"""Benches holding more than `cap` Deploy Log rows, and how many each holds."""
+	log = frappe.qb.DocType("Deploy Log")
+	return (
+		frappe.qb.from_(log)
+		.select(log.bench, Count(log.name).as_("rows"))
+		.where(log.bench.isnotnull())
+		.groupby(log.bench)
+		.having(Count(log.name) > cap)
+		.run(as_dict=True)
+	)
+
+
+def _bench_rows() -> list[dict]:
+	return frappe.get_all("Bench Instance", fields=["name", "container_id", "status"])
+
+
+def _database_servers() -> list[str]:
+	return frappe.get_all("Database Server", pluck="name")
+
+
+def _claimed_databases() -> set[str]:
+	"""Every schema a row accounts for. A bench holds its site name before its `Bench Site` exists."""
+	names = frappe.get_all("Bench Site", pluck="site_name") + frappe.get_all(
+		"Bench Instance", pluck="site_name"
+	)
+	return {mariadb_manager.get_database_name(name) for name in names if name}
+
+
+def _site_databases(server: str) -> list[str]:
+	"""One server's schemas, or none when it cannot be reached — a read must not end the pass."""
+	try:
+		return mariadb_manager.list_site_databases(server)
+	except Exception as exc:
+		frappe.logger("benchpress").warning(f"could not list databases on {server}: {exc}")
+		return []
+
+
+def _present(container_ids: list[str]) -> list[str]:
+	"""Which of these the daemon still lists — read from the daemon, never from the removal's report."""
+	live = {_id_key(container["id"]) for container in docker_manager.list_benches()}
+	return [container_id for container_id in container_ids if _id_key(container_id) in live]
+
+
+def _remove(container_id: str) -> None:
+	"""Issue one removal. Never raises: one container the daemon refuses must not end the pass."""
+	try:
+		docker_manager.remove_container(container_id)
+	except Exception as exc:
+		frappe.logger("benchpress").warning(f"orphan {_id_key(container_id)} not removed: {exc}")
+
+
+def _setting(fieldname: str, fallback: int) -> int:
+	"""`.get` rather than attribute access: a Single holds only the fields somebody has saved."""
+	return cint(frappe.get_cached_doc("BenchPress Settings").get(fieldname)) or fallback
 
 
 def _id_key(container_id) -> str:

--- a/benchpress/tests/fakes.py
+++ b/benchpress/tests/fakes.py
@@ -57,6 +57,8 @@ class FakeContainer:
 		self.stats_response = dict(DEFAULT_STATS)
 		self.execs: list[str] = []
 		self.start_refusal = ""
+		self.stop_refusal = ""
+		self.remove_refusal = ""
 		self.archives: dict[str, bytes] = {}
 		self.attrs = {
 			"HostConfig": {"Runtime": runtime or "runc", "NetworkMode": network},
@@ -74,6 +76,8 @@ class FakeContainer:
 		self.status = "running"
 
 	def stop(self, **kwargs):
+		if self.stop_refusal:
+			raise docker.errors.APIError(self.stop_refusal)
 		self.client.stopped.append(self.name)
 		self.status = "exited"
 
@@ -81,6 +85,8 @@ class FakeContainer:
 		self.status = "running"
 
 	def remove(self, **kwargs):
+		if self.remove_refusal:
+			raise docker.errors.APIError(self.remove_refusal)
 		self.client.removed.append(self.name)
 		self.client._store.pop(self.id, None)
 

--- a/benchpress/tests/fakes.py
+++ b/benchpress/tests/fakes.py
@@ -7,6 +7,7 @@ Tests read state (`self.docker.created[-1]`) rather than mock call records.
 """
 
 import base64
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 import docker
@@ -33,6 +34,11 @@ DEFAULT_STATS = {
 }
 
 
+def _docker_timestamp(moment: datetime) -> str:
+	"""The daemon's own `Created` form: RFC 3339 in UTC, to nanoseconds."""
+	return moment.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%S.%f000Z")
+
+
 class UnscriptedExec(AssertionError):
 	"""A strict FakeDocker was asked to run a command no test registered."""
 
@@ -47,7 +53,9 @@ def sql_of(exec_command: str) -> str:
 
 
 class FakeContainer:
-	def __init__(self, client, container_id, name, labels, network, runtime, ip, status="created"):
+	def __init__(
+		self, client, container_id, name, labels, network, runtime, ip, status="created", created=None
+	):
 		self.client = client
 		self.id = container_id
 		self.name = name
@@ -61,6 +69,7 @@ class FakeContainer:
 		self.remove_refusal = ""
 		self.archives: dict[str, bytes] = {}
 		self.attrs = {
+			"Created": created or _docker_timestamp(datetime.now(UTC)),
 			"HostConfig": {"Runtime": runtime or "runc", "NetworkMode": network},
 			"NetworkSettings": {"Networks": {network: {"IPAddress": ip}}, "IPAddress": ip},
 			"State": {"Health": {"Status": self.health}},
@@ -251,15 +260,18 @@ class FakeDocker:
 		"""Make this container's `start()` raise `APIError`, the way a daemon refusing one does."""
 		self._start_refusals[name] = message
 
-	def add_container(self, name, *, labels=None, status="running", health="", network="benchpress"):
+	def add_container(
+		self, name, *, labels=None, status="running", health="", network="benchpress", age_minutes=0
+	):
 		"""Seed a container the app did not create, for `containers.get` and `list`."""
 		return self._add(
 			{"name": name, "labels": labels, "network": network},
 			status=status,
 			health=health,
+			created=_docker_timestamp(datetime.now(UTC) - timedelta(minutes=age_minutes)),
 		)
 
-	def _add(self, kwargs, status="created", health=""):
+	def _add(self, kwargs, status="created", health="", created=None):
 		self._next_id += 1
 		container_id = f"fake{self._next_id:04d}"
 		network = kwargs.get("network") or docker_manager.LEGACY_NETWORK
@@ -272,6 +284,7 @@ class FakeDocker:
 			kwargs.get("runtime"),
 			f"172.30.0.{self._next_id % 250 + 2}",
 			status=status,
+			created=created,
 		)
 		container.health = health
 		container.start_refusal = self._start_refusals.get(container.name, "")

--- a/benchpress/tests/test_device_wrappers.py
+++ b/benchpress/tests/test_device_wrappers.py
@@ -47,6 +47,31 @@ def _peer_row(**overrides):
 	return row
 
 
+def ensure_wg0_pool():
+	"""A bare CI bench has the wg0 server but no pool; the local stack has both."""
+	if frappe.db.exists("IP Allocation", {"server": "wg0"}):
+		return
+	from vpn_management import allocation
+
+	pool = frappe.db.get_value("Network Pool", {"server": "wg0"}, "name")
+	if not pool:
+		with patch("frappe.enqueue"):
+			pool = (
+				frappe.get_doc(
+					{
+						"doctype": "Network Pool",
+						"pool_name": "pool-wg0",
+						"server": "wg0",
+						"cidr": "172.27.0.0/24",
+						"gateway_ip": "172.27.0.1",
+					}
+				)
+				.insert(ignore_permissions=True)
+				.name
+			)
+	allocation.materialize(pool)
+
+
 class TestRegisterDevice(IntegrationTestCase):
 	def test_rejects_an_unknown_device_type(self):
 		with self.assertRaises(frappe.ValidationError):
@@ -180,36 +205,12 @@ class TestDeviceRoundTrip(IntegrationTestCase):
 	def setUp(self):
 		super().setUp()
 		self._ensure_endpoint_host_configured()
-		self._ensure_wg0_pool_materialized()
+		ensure_wg0_pool()
 
 	def _ensure_endpoint_host_configured(self):
 		"""Config rendering needs a public endpoint host — set on the local stack, empty in CI."""
 		if not frappe.db.get_single_value("VPN Settings", "vpn_endpoint_host"):
 			frappe.db.set_single_value("VPN Settings", "vpn_endpoint_host", "vpn.test.local")
-
-	def _ensure_wg0_pool_materialized(self):
-		"""A bare CI bench has the wg0 server but no pool; the local stack has both."""
-		if frappe.db.exists("IP Allocation", {"server": "wg0"}):
-			return
-		from vpn_management import allocation
-
-		pool = frappe.db.get_value("Network Pool", {"server": "wg0"}, "name")
-		if not pool:
-			with patch("frappe.enqueue"):
-				pool = (
-					frappe.get_doc(
-						{
-							"doctype": "Network Pool",
-							"pool_name": "pool-wg0",
-							"server": "wg0",
-							"cidr": "172.27.0.0/24",
-							"gateway_ip": "172.27.0.1",
-						}
-					)
-					.insert(ignore_permissions=True)
-					.name
-				)
-		allocation.materialize(pool)
 
 	@patch(RECONCILE_HOOK)
 	def test_add_list_remove_round_trip(self, _reconcile):

--- a/benchpress/tests/test_docker_manager.py
+++ b/benchpress/tests/test_docker_manager.py
@@ -3,6 +3,7 @@
 
 import types
 import unittest
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import docker
@@ -724,3 +725,60 @@ class TestStartBenchContainer(unittest.TestCase):
 
 		with self.assertRaises(docker.errors.APIError):
 			docker_manager.start_bench_container("abc123", MagicMock(), MagicMock())
+
+
+def _managed_labels(bench_name="bench-one") -> dict:
+	return {docker_manager.MANAGED_LABEL: "true", docker_manager.BENCH_NAME_LABEL: bench_name}
+
+
+class TestListBenches(FakeDockerMixin, IntegrationTestCase):
+	def test_only_a_managed_container_is_returned(self):
+		"""The negative control: the label is the whole authority for a reconciler's removal."""
+		self.docker.add_container("mine", labels=_managed_labels())
+		self.docker.add_container("benchpress-mariadb", labels={"com.docker.compose.project": "x"})
+		self.docker.add_container("stranger")
+
+		self.assertEqual([c["name"] for c in docker_manager.list_benches()], ["mine"])
+
+	def test_a_stopped_container_is_returned(self):
+		"""An orphan that exited still holds its writable layer."""
+		self.docker.add_container("mine", labels=_managed_labels(), status="exited")
+
+		self.assertEqual([c["name"] for c in docker_manager.list_benches()], ["mine"])
+
+	def test_every_consumer_gets_id_status_health_and_age(self):
+		self.docker.add_container("mine", labels=_managed_labels(), health="healthy")
+
+		[entry] = docker_manager.list_benches()
+
+		self.assertTrue(entry["id"])
+		self.assertEqual(entry["bench_name"], "bench-one")
+		self.assertEqual(entry["status"], "running")
+		self.assertEqual(entry["health"], "Healthy")
+		self.assertLess((datetime.now(UTC) - entry["created"]).total_seconds(), 60)
+
+	def test_the_age_is_the_container_s_own_creation_time(self):
+		self.docker.add_container("mine", labels=_managed_labels(), age_minutes=45)
+
+		[entry] = docker_manager.list_benches()
+
+		self.assertAlmostEqual((datetime.now(UTC) - entry["created"]).total_seconds(), 45 * 60, delta=60)
+
+	def test_a_container_the_daemon_gave_no_timestamp_for_has_no_age(self):
+		container = self.docker.add_container("mine", labels=_managed_labels())
+		container.attrs.pop("Created")
+
+		self.assertIsNone(docker_manager.list_benches()[0]["created"])
+
+	def test_a_stopped_container_reports_unhealthy_not_its_last_verdict(self):
+		self.docker.add_container("mine", labels=_managed_labels(), status="exited", health="healthy")
+
+		self.assertEqual(docker_manager.list_benches()[0]["health"], "Unhealthy")
+
+	def test_the_fleet_costs_one_call(self):
+		"""107 ms for the fleet against 0.87 ms x N is only true while this stays one call."""
+		for index in range(5):
+			self.docker.add_container(f"bench-{index}", labels=_managed_labels())
+
+		with patch.object(self.docker.containers, "get", side_effect=AssertionError("inspected")):
+			self.assertEqual(len(docker_manager.list_benches()), 5)

--- a/benchpress/tests/test_ingress.py
+++ b/benchpress/tests/test_ingress.py
@@ -13,7 +13,7 @@ import frappe
 import yaml
 from frappe.tests import IntegrationTestCase
 
-from benchpress import ingress
+from benchpress import ingress, reconcile
 from benchpress.credits.config import clear_size_index
 from benchpress.tests.test_deploy_manager import _fresh_bench, _make_lab
 
@@ -371,7 +371,7 @@ class TestIdeRouter(IntegrationTestCase):
 					deployed = route.read_bytes()
 					mtime = route.stat().st_mtime_ns
 
-					ingress.reconcile()
+					reconcile._converge_routes()
 
 					self.assertEqual(route.read_bytes(), deployed)
 					self.assertEqual(route.stat().st_mtime_ns, mtime)
@@ -386,7 +386,7 @@ class TestIdeRouter(IntegrationTestCase):
 
 		with _route_dir() as (ingress, _target_dir):
 			with patch.object(ingress, "_fleet_rows", wraps=ingress._fleet_rows) as fleet_rows:
-				result = ingress.reconcile()
+				result = reconcile._converge_routes()
 
 		self.assertEqual(fleet_rows.call_count, 1)
 		self.assertGreaterEqual(result["written"], 2)
@@ -552,7 +552,7 @@ class TestPathSplitAndRateLimits(IntegrationTestCase):
 			deployed = route.read_bytes()
 			mtime = route.stat().st_mtime_ns
 
-			published_ingress.reconcile()
+			reconcile._converge_routes()
 
 			self.assertEqual(route.read_bytes(), deployed)
 			self.assertEqual(route.stat().st_mtime_ns, mtime)
@@ -568,7 +568,7 @@ class TestPathSplitAndRateLimits(IntegrationTestCase):
 			with patch.object(
 				published_ingress, "_fleet_rows", wraps=published_ingress._fleet_rows
 			) as fleet_rows:
-				published_ingress.reconcile()
+				reconcile._converge_routes()
 
 		self.assertEqual(fleet_rows.call_count, 1)
 
@@ -962,268 +962,6 @@ def _route_dir(base_domain="benchpress.cloud"):
 			patch("frappe.get_cached_doc", return_value=frappe._dict(base_domain=base_domain)),
 		):
 			yield ingress, target_dir
-
-
-class TestRouteConvergenceSchedule(unittest.TestCase):
-	"""The `*/5` convergence tick — see phase-3-invariant-and-convergence.md."""
-
-	def test_the_tick_hands_the_pass_to_the_long_queue(self):
-		from benchpress.ingress import enqueue_route_reconcile
-
-		with patch("frappe.enqueue") as enqueue:
-			enqueue_route_reconcile()
-
-		args, kwargs = enqueue.call_args
-		self.assertEqual(args[0], "benchpress.ingress.reconcile")
-		self.assertEqual(kwargs["queue"], "long")
-		# Fixed, so a pass running longer than the interval does not queue behind itself.
-		self.assertEqual(kwargs["job_id"], "route_reconcile")
-		self.assertTrue(kwargs["deduplicate"])
-
-	def test_the_cron_entry_is_the_enqueuer_and_never_the_pass(self):
-		"""Frappe sends cron to `default`, which `queue-short` also consumes — and that
-		container has no route mount, so the pass itself would raise every five minutes."""
-		from benchpress.hooks import scheduler_events
-
-		cron_methods = [method for methods in scheduler_events["cron"].values() for method in methods]
-
-		self.assertIn(
-			"benchpress.ingress.enqueue_route_reconcile",
-			scheduler_events["cron"]["*/5 * * * *"],
-		)
-		self.assertNotIn("benchpress.ingress.reconcile", cron_methods)
-
-
-class TestReconcileInstanceRoutes(IntegrationTestCase):
-	"""`reconcile` — the route directory converges on the database.
-
-	See specs/completed/wildcard-cert-routing/phase-3-route-convergence.md.
-	"""
-
-	@classmethod
-	def setUpClass(cls):
-		super().setUpClass()
-		frappe.set_user("Administrator")
-		cls.lab = _make_lab("test-lab-reconcile-routes")
-		frappe.db.commit()
-
-	@classmethod
-	def tearDownClass(cls):
-		frappe.set_user("Administrator")
-		for name in frappe.get_all("Bench Instance", filters={"lab": cls.lab.name}, pluck="name"):
-			frappe.delete_doc("Bench Instance", name, force=True, ignore_permissions=True)
-		cls.lab.delete(ignore_permissions=True)
-		frappe.db.commit()
-		super().tearDownClass()
-
-	def _bench(self, status, container_ip):
-		bench = _fresh_bench(self, self.lab.name)
-		bench.status = status
-		bench.container_ip = container_ip
-		bench.save(ignore_permissions=True)
-		frappe.db.commit()
-		return bench
-
-	def _seed(self, target_dir, name, body="stale\n"):
-		path = target_dir / name
-		path.write_text(body)
-		return path
-
-	def _instance_files(self, target_dir):
-		return sorted(p.name for p in target_dir.glob("*.yml") if p.name not in ingress.PROTECTED_ROUTE_FILES)
-
-	def test_a_route_file_naming_no_bench_instance_is_deleted(self):
-		"""The orphan case: a hostname with no document behind it still resolves and still
-		routes, so it keeps serving whichever container inherited that IP."""
-		with _route_dir() as (ingress, target_dir):
-			orphan = self._seed(target_dir, "091131f54bcdfc7bc37cbc45763547fa.yml")
-
-			result = ingress.reconcile()
-
-			self.assertFalse(orphan.exists())
-			self.assertGreaterEqual(result["deleted"], 1)
-
-	def test_a_bench_that_is_not_running_loses_its_route_file(self):
-		"""A stopped bench's recorded IP is an address Docker has already handed back, so the
-		file is not a dead link — it is the next bench's hostname collision."""
-		for status in ("Stopped", "Draft", "Error"):
-			with self.subTest(status=status):
-				bench = self._bench(status, "172.30.0.11")
-				with _route_dir() as (ingress, target_dir):
-					route_file = self._seed(target_dir, f"{bench.name}.yml")
-
-					ingress.reconcile()
-
-					self.assertFalse(route_file.exists())
-
-	def test_a_running_bench_route_is_rewritten_to_name_its_container(self):
-		"""Convergence, not merely reaping: a file that survives must also be right. Seeded with
-		an address backend so passing means the pass rewrote it to the container name."""
-		bench = self._bench("Running", "172.30.0.12")
-
-		with _route_dir() as (ingress, target_dir):
-			self._seed(target_dir, f"{bench.name}.yml", "http://172.30.0.99:8000\n")
-
-			result = ingress.reconcile()
-
-			written_text = (target_dir / f"{bench.name}.yml").read_text()
-			config = yaml.safe_load(written_text)
-			backends = [
-				server["url"]
-				for service in config["http"]["services"].values()
-				for server in service["loadBalancer"]["servers"]
-			]
-			self.assertIn(f"http://{bench.name}:8000", backends)
-			self.assertNotRegex(written_text, IPV4_IN_TEXT)
-			self.assertGreaterEqual(result["written"], 1)
-
-	def test_the_control_plane_router_and_the_anchor_survive_a_full_sweep(self):
-		"""The guard that stops this pass taking the platform off the internet. `dynamic.yml` is
-		the control plane's own router and the anchor is every bench's certificate; a run that
-		deletes every instance file must still leave both."""
-		with _route_dir() as (ingress, target_dir):
-			control_plane = self._seed(target_dir, "dynamic.yml", "control plane\n")
-			ingress.ensure_anchor("benchpress.cloud")
-			anchor = target_dir / "wildcard-anchor.yml"
-			anchor_text = anchor.read_text()
-			self._seed(target_dir, "16b283bccf6560ab1aa5f078d492d005.yml")
-			self._seed(target_dir, "5dc12efd9c154796adae757adec1b2f3.yml")
-
-			result = ingress.reconcile()
-
-			self.assertEqual(control_plane.read_text(), "control plane\n")
-			self.assertEqual(anchor.read_text(), anchor_text)
-			self.assertEqual(result["kept"], 2)
-
-	def test_a_run_always_leaves_the_certificate_anchored(self):
-		"""The anchor is what holds the wildcard the resolver-free bench routers serve, so the
-		pass writes it first rather than waiting for the next deploy."""
-		with _route_dir() as (ingress, target_dir):
-			result = ingress.reconcile()
-
-			self.assertTrue(result["anchored"])
-			config = yaml.safe_load((target_dir / "wildcard-anchor.yml").read_text())
-			router = config["http"]["routers"]["benchpress-wildcard-anchor"]
-			self.assertEqual(router["rule"], "Host(`tls-anchor.benchpress.cloud`)")
-
-	def test_the_returned_counts_match_what_happened_on_disk(self):
-		"""A reaper that reports what it attempted rather than what converged is how a directory
-		drifts for weeks without anyone noticing."""
-		bench = self._bench("Running", "172.30.0.13")
-
-		with _route_dir() as (ingress, target_dir):
-			self._seed(target_dir, "dynamic.yml", "control plane\n")
-			self._seed(target_dir, f"{bench.name}.yml")
-			self._seed(target_dir, "091131f54bcdfc7bc37cbc45763547fa.yml")
-			self._seed(target_dir, "5dc12efd9c154796adae757adec1b2f3.yml")
-
-			result = ingress.reconcile()
-
-			self.assertEqual(result["deleted"], 2)
-			self.assertEqual(result["kept"], 2)
-			self.assertEqual(result["written"], len(self._instance_files(target_dir)))
-			self.assertIn(f"{bench.name}.yml", self._instance_files(target_dir))
-
-	def test_a_second_run_deletes_nothing_and_touches_nothing(self):
-		"""Idempotence is the read side agreeing with the write side. A pass that keeps finding
-		things to delete is one that disagrees with the files it just wrote — and one that
-		rewrites unchanged files is a Traefik reload every five minutes, since it reloads on
-		mtime."""
-		self._bench("Running", "172.30.0.14")
-
-		with _route_dir() as (ingress, target_dir):
-			self._seed(target_dir, "091131f54bcdfc7bc37cbc45763547fa.yml")
-			ingress.reconcile()
-			before = {p.name: p.stat().st_mtime_ns for p in target_dir.iterdir()}
-
-			result = ingress.reconcile()
-
-			self.assertEqual(result["deleted"], 0)
-			self.assertFalse(result["anchored"])
-			self.assertEqual({p.name: p.stat().st_mtime_ns for p in target_dir.iterdir()}, before)
-
-	def test_a_container_without_the_route_mount_reports_instead_of_raising(self):
-		"""Only `queue-long` mounts the directory, so a by-hand run anywhere else used to do
-		the bridge half and then raise out of `ensure_anchor`."""
-		with tempfile.TemporaryDirectory() as tmp:
-			with (
-				patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", Path(tmp) / "dynamic"),
-				patch("frappe.get_cached_doc", return_value=frappe._dict(base_domain="benchpress.cloud")),
-				patch("benchpress.placement.repair", return_value={"attached": {}, "missing": {}}),
-			):
-				result = ingress.reconcile()
-
-		# None, not 0: nothing was read, and zero counts are what a converged pass reports.
-		self.assertEqual(
-			result,
-			{
-				"anchored": None,
-				"written": None,
-				"deleted": None,
-				"kept": None,
-				"attached": {},
-				"missing": {},
-			},
-		)
-
-	def test_reconcile_writes_nothing_at_all_without_a_public_domain(self):
-		"""A dev checkout must be byte-for-byte unaffected — and must not reap either, since a
-		directory it never writes is not a directory it understands."""
-		for base_domain in (None, "", "localhost"):
-			with (
-				self.subTest(base_domain=base_domain),
-				_route_dir(base_domain) as (
-					ingress,
-					target_dir,
-				),
-			):
-				survivor = self._seed(target_dir, "091131f54bcdfc7bc37cbc45763547fa.yml")
-
-				result = ingress.reconcile()
-
-				self.assertTrue(survivor.exists())
-				self.assertEqual(
-					result,
-					{"anchored": False, "written": 0, "deleted": 0, "kept": 0, "attached": {}, "missing": {}},
-				)
-
-
-class TestSettingsReAnchor(IntegrationTestCase):
-	"""`BenchPress Settings.on_update` hands the sweep to the worker that can do it.
-
-	`on_update` is called directly on an unsaved document. Saving the real Single would write
-	a domain to a live host, and the whole point of the controller is that it does not do the
-	work itself — what needs asserting is which queue it hands it to.
-	"""
-
-	def _settings(self, previous_domain):
-		settings = frappe.get_doc("BenchPress Settings")
-		settings._doc_before_save = frappe._dict(base_domain=previous_domain)
-		return settings
-
-	def test_a_changed_base_domain_enqueues_the_sweep_on_the_long_queue(self):
-		"""`queue-long` is the only worker that mounts the route directory. A sweep on any other
-		queue writes into that container's own filesystem, and Traefik never sees it."""
-		settings = self._settings("some-other-zone.example")
-
-		with patch("frappe.enqueue") as enqueue:
-			settings.on_update()
-
-		enqueue.assert_called_once()
-		args, kwargs = enqueue.call_args
-		self.assertEqual(args[0], "benchpress.ingress.reconcile")
-		self.assertEqual(kwargs["queue"], "long")
-		# The job re-reads `base_domain`, so it must not start before the new value is committed.
-		self.assertTrue(kwargs["enqueue_after_commit"])
-
-	def test_an_unrelated_settings_save_enqueues_nothing(self):
-		"""A toggle or a timeout is not a reason to sweep the route directory."""
-		settings = self._settings(frappe.get_cached_doc("BenchPress Settings").base_domain)
-
-		with patch("frappe.enqueue") as enqueue:
-			settings.on_update()
-
-		enqueue.assert_not_called()
 
 
 class TestSyncInstanceRoute(IntegrationTestCase):

--- a/benchpress/tests/test_lifecycle.py
+++ b/benchpress/tests/test_lifecycle.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from benchpress import api, ingress, lifecycle
+from benchpress import api, ingress, lifecycle, vpn_adapter
 from benchpress.credits import account, admission, lease
 from benchpress.tests.fakes import FakeDockerMixin
 from benchpress.tests.test_deploy_manager import (
@@ -22,10 +22,13 @@ from benchpress.tests.test_deploy_manager import (
 	_make_lab,
 	_mounted,
 )
+from benchpress.tests.test_device_wrappers import RECONCILE_HOOK, ensure_wg0_pool
 
 BENCH = "Bench Instance"
 SITE = "Bench Site"
 ADMISSION = "Bench Admission"
+ALLOCATION = "IP Allocation"
+ERROR_LOG = "Error Log"
 SETTINGS = "BenchPress Settings"
 LIFECYCLE_MODULE = "lifecycle.py"
 
@@ -129,6 +132,11 @@ class TransitionFixtures:
 
 	def _slots(self, owner: str) -> int:
 		return frappe.utils.cint(frappe.db.get_value("Credit Account", owner, "active_instances"))
+
+	def _forget_error_logs(self, bench_name: str) -> None:
+		"""One bench name serves every test here, and `log_error` commits past the rollback."""
+		frappe.db.delete(ERROR_LOG, {"method": ("like", f"%{bench_name}%")})
+		frappe.db.commit()  # nosemgrep -- the row the assertion reads was committed too
 
 	def _bench(self, status: str, container_status: str, *, container: bool = True):
 		bench = _fresh_bench(self, self.lab.name)
@@ -443,3 +451,194 @@ class TestTornDown(TransitionFixtures, FakeDockerMixin, IntegrationTestCase):
 			lifecycle.torn_down(bench)
 
 		enqueue.assert_not_called()
+
+
+class TestTeardownReports(TransitionFixtures, FakeDockerMixin, IntegrationTestCase):
+	"""What went and what did not: a teardown used to report the same silence either way."""
+
+	lab_id = "test-lab-lifecycle-teardown-reports"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		if not frappe.db.exists("Database Server", {"container_name": "test-db-teardown"}):
+			frappe.get_doc(
+				{
+					"doctype": "Database Server",
+					"container_name": "test-db-teardown",
+					"mariadb_version": "10.6",
+					"status": "Active",
+					"mariadb_root_password": "test-root-password",
+				}
+			).insert(ignore_permissions=True)
+		cls.db_server_name = frappe.db.get_value(
+			"Database Server", {"container_name": "test-db-teardown"}, "name"
+		)
+		frappe.db.commit()  # nosemgrep -- the fixture outlives the per-test rollback
+
+	@classmethod
+	def tearDownClass(cls):
+		# After the benches, which link this server: Frappe refuses to delete a linked row.
+		super().tearDownClass()
+		frappe.set_user("Administrator")
+		frappe.delete_doc("Database Server", cls.db_server_name, force=True, ignore_permissions=True)
+		frappe.db.commit()  # nosemgrep -- the fixture was committed, so its removal has to be too
+
+	def _deployed_bench(self, *, with_database: bool = False):
+		bench = self._bench("Running", "running")
+		if with_database:
+			frappe.db.set_value(BENCH, bench.name, "database_server", self.db_server_name)
+			bench.reload()
+		self._forget_error_logs(bench.name)
+		self.addCleanup(self._forget_error_logs, bench.name)
+		return bench
+
+	def _container(self, bench):
+		return self.docker.containers.get(bench.container_id)
+
+	def test_a_clean_teardown_reports_every_removal_gone(self):
+		bench = self._deployed_bench()
+
+		removals = lifecycle.torn_down(bench)
+
+		self.assertEqual(set(removals), {"stop", "container", "database", "vpn_peer", "route"})
+		self.assertEqual(set(removals.values()), {lifecycle.GONE})
+
+	def test_a_refused_stop_is_named_with_the_reason_the_daemon_gave(self):
+		bench = self._deployed_bench()
+		self._container(bench).stop_refusal = "daemon is wedged"
+
+		removals = lifecycle.torn_down(bench)
+
+		self.assertIn("daemon is wedged", removals["stop"])
+		self.assertEqual(removals["container"], lifecycle.GONE)
+
+	def test_a_refused_container_removal_is_named_with_the_reason_the_daemon_gave(self):
+		bench = self._deployed_bench()
+		self._container(bench).remove_refusal = "container is in use"
+
+		removals = lifecycle.torn_down(bench)
+
+		self.assertIn("container is in use", removals["container"])
+		self.assertEqual(frappe.db.get_value(BENCH, bench.name, "status"), "Draft")
+
+	def test_a_container_removed_by_hand_first_is_named_rather_than_passed_over(self):
+		"""The reaper's own case: the row still names a container the daemon no longer has."""
+		bench = self._deployed_bench()
+		self._container(bench).remove()
+
+		removals = lifecycle.torn_down(bench)
+
+		self.assertTrue(removals["container"].startswith("failed"))
+		self.assertEqual(frappe.db.get_value(BENCH, bench.name, "status"), "Draft")
+
+	def test_a_failed_database_drop_is_named_with_its_reason(self):
+		bench = self._deployed_bench(with_database=True)
+
+		with patch("benchpress.mariadb_manager.drop_site_database", side_effect=Exception("db unreachable")):
+			removals = lifecycle.torn_down(bench)
+
+		self.assertIn("db unreachable", removals["database"])
+
+	def test_a_failed_route_removal_is_named_with_its_reason(self):
+		bench = self._deployed_bench()
+
+		with patch.object(ingress, "withdraw", side_effect=Exception("route mount is missing")):
+			removals = lifecycle.torn_down(bench)
+
+		self.assertIn("route mount is missing", removals["route"])
+
+	def test_a_teardown_whose_every_removal_failed_still_reaches_draft(self):
+		"""The swallowing stays: an instance must not be left describing what it no longer has."""
+		bench = self._deployed_bench(with_database=True)
+		container = self._container(bench)
+		container.stop_refusal = "daemon is wedged"
+		container.remove_refusal = "container is in use"
+
+		with (
+			patch("benchpress.mariadb_manager.drop_site_database", side_effect=Exception("db unreachable")),
+			patch("benchpress.vpn_adapter.remove_bench_peer", side_effect=Exception("wg agent down")),
+			patch.object(ingress, "withdraw", side_effect=Exception("route mount is missing")),
+		):
+			removals = lifecycle.torn_down(bench)
+
+		self.assertEqual([step for step, result in removals.items() if result == lifecycle.GONE], [])
+		self.assertEqual(frappe.db.get_value(BENCH, bench.name, "status"), "Draft")
+
+	def test_a_failed_removal_is_written_down_where_an_operator_reads_it(self):
+		"""A failure nobody records is the same failure as the one that was swallowed."""
+		bench = self._deployed_bench()
+		self._container(bench).remove_refusal = "container is in use"
+
+		lifecycle.torn_down(bench)
+
+		logged = frappe.get_all(ERROR_LOG, filters={"method": ("like", f"%{bench.name}%")}, pluck="error")
+		self.assertEqual(len(logged), 1)
+		self.assertIn("container is in use", logged[0])
+
+	def test_a_clean_teardown_writes_no_error_log(self):
+		bench = self._deployed_bench()
+
+		lifecycle.torn_down(bench)
+
+		self.assertEqual(frappe.db.count(ERROR_LOG, {"method": ("like", f"%{bench.name}%")}), 0)
+
+
+class TestTeardownFreesTheTunnelIP(TransitionFixtures, FakeDockerMixin, IntegrationTestCase):
+	"""The leak: every reaped bench used to hold its WireGuard address forever."""
+
+	lab_id = "test-lab-lifecycle-teardown-vpn"
+
+	def setUp(self):
+		super().setUp()
+		ensure_wg0_pool()
+
+	def _peered_bench(self):
+		bench = self._bench("Running", "running")
+		with patch("vpn_management.tasks.reconcile_interface"):
+			peer = vpn_adapter.create_container_peer(bench)
+		bench.wg_ip = peer["assigned_ip"]
+		bench.save(ignore_permissions=True)
+		frappe.db.commit()  # nosemgrep -- the teardown under test commits, so its fixture has to be durable
+		self.addCleanup(self._drop_peer, peer["peer"])
+		self.addCleanup(self._forget_error_logs, bench.name)
+		return bench, peer
+
+	def _drop_peer(self, peer_name: str) -> None:
+		if frappe.db.exists("VPN Peer", peer_name):
+			with patch(RECONCILE_HOOK):
+				frappe.delete_doc("VPN Peer", peer_name, force=True, ignore_permissions=True)
+		frappe.db.commit()  # nosemgrep -- a leaked peer would outlive the rollback and the test
+
+	@patch(RECONCILE_HOOK)
+	def test_a_teardown_gives_the_tunnel_address_back_to_the_pool(self, _reconcile):
+		bench, peer = self._peered_bench()
+		self.assertEqual(frappe.db.count(ALLOCATION, {"ip_address": peer["assigned_ip"], "allocated": 1}), 1)
+
+		removals = lifecycle.torn_down(bench)
+
+		self.assertEqual(removals["vpn_peer"], lifecycle.GONE)
+		self.assertFalse(frappe.db.exists("VPN Peer", peer["peer"]))
+		self.assertEqual(frappe.db.count(ALLOCATION, {"ip_address": peer["assigned_ip"], "allocated": 1}), 0)
+
+	@patch(RECONCILE_HOOK)
+	def test_a_teardown_forgets_the_address_it_gave_back(self, _reconcile):
+		"""The pool hands the address to the next claim, so a bench still showing it is lying."""
+		bench, _peer = self._peered_bench()
+
+		lifecycle.torn_down(bench)
+
+		self.assertIsNone(frappe.db.get_value(BENCH, bench.name, "wg_ip"))
+		self.assertIsNone(frappe.db.get_value(BENCH, bench.name, "vpn_peer"))
+
+	@patch(RECONCILE_HOOK)
+	def test_a_peer_the_teardown_could_not_remove_is_left_linked_for_the_next_deploy(self, _reconcile):
+		"""`_setup_container_vpn` removes before it claims, so the link is what lets it retry."""
+		bench, peer = self._peered_bench()
+
+		with patch("benchpress.vpn_adapter.remove_bench_peer", side_effect=Exception("wg agent down")):
+			removals = lifecycle.torn_down(bench)
+
+		self.assertIn("wg agent down", removals["vpn_peer"])
+		self.assertEqual(frappe.db.get_value(BENCH, bench.name, "vpn_peer"), peer["peer"])
+		self.assertEqual(frappe.db.get_value(BENCH, bench.name, "status"), "Draft")

--- a/benchpress/tests/test_mariadb_manager.py
+++ b/benchpress/tests/test_mariadb_manager.py
@@ -551,3 +551,48 @@ class TestSharedSettingDrift(IntegrationTestCase):
 		_returned, log_error = self._health_check_with([([], "99.94%")])
 
 		log_error.assert_not_called()
+
+
+LIVE_SHOW_DATABASES = (
+	"Database\n"
+	"_0f466d815af80ea5\n"
+	"_30097bd7739c8788_limited\n"
+	"backups\n"
+	"information_schema\n"
+	"mysql\n"
+	"performance_schema\n"
+	"sys\n"
+)
+
+
+class TestListSiteDatabases(IntegrationTestCase):
+	def _listed(self, exit_code, output):
+		from benchpress.mariadb_manager import list_site_databases
+
+		with patch("benchpress.mariadb_manager.execute_sql", return_value=(exit_code, output)):
+			return list_site_databases("db-server-name")
+
+	def test_the_server_s_own_schemas_are_not_a_site_s(self):
+		listed = self._listed(0, LIVE_SHOW_DATABASES)
+
+		self.assertEqual(listed, ["_0f466d815af80ea5", "_30097bd7739c8788_limited", "backups"])
+
+	def test_the_column_header_is_not_a_schema(self):
+		self.assertNotIn("Database", self._listed(0, LIVE_SHOW_DATABASES))
+
+	def test_a_client_warning_in_the_same_stream_is_not_a_schema(self):
+		output = "mariadb: Deprecated program name.\n" + LIVE_SHOW_DATABASES
+
+		self.assertNotIn("mariadb: Deprecated program name.", self._listed(0, output))
+
+	def test_a_failed_read_reports_nothing_rather_than_everything(self):
+		"""An empty list read as "every database is an orphan" is the reason this is a read only."""
+		self.assertEqual(self._listed(1, "ERROR 1045: Access denied"), [])
+
+	def test_it_only_reads(self):
+		from benchpress.mariadb_manager import list_site_databases
+
+		with patch("benchpress.mariadb_manager.execute_sql", return_value=(0, LIVE_SHOW_DATABASES)) as sql:
+			list_site_databases("db-server-name")
+
+		self.assertEqual(sql.call_args.args[1], "SHOW DATABASES")

--- a/benchpress/tests/test_mariadb_manager.py
+++ b/benchpress/tests/test_mariadb_manager.py
@@ -575,7 +575,12 @@ class TestListSiteDatabases(IntegrationTestCase):
 	def test_the_server_s_own_schemas_are_not_a_site_s(self):
 		listed = self._listed(0, LIVE_SHOW_DATABASES)
 
-		self.assertEqual(listed, ["_0f466d815af80ea5", "_30097bd7739c8788_limited", "backups"])
+		self.assertEqual(listed, ["_0f466d815af80ea5", "_30097bd7739c8788_limited"])
+
+	def test_the_backup_directory_is_not_a_schema(self):
+		"""`backup_database_server` writes into the data directory, and the server lists every
+		directory there — so a reconciler that reported it could never reach zero."""
+		self.assertNotIn("backups", self._listed(0, LIVE_SHOW_DATABASES))
 
 	def test_the_column_header_is_not_a_schema(self):
 		self.assertNotIn("Database", self._listed(0, LIVE_SHOW_DATABASES))

--- a/benchpress/tests/test_reconcile.py
+++ b/benchpress/tests/test_reconcile.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+import unittest
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from benchpress import reconcile
+from benchpress.reconcile import DEFAULT_GRACE_MINUTES, compare, configured_grace_minutes
+
+LIVE_ID = "40c6dd07a12727f3648970f0a1ae5cdc912f17a6756566264687f2ede0d0ec15"
+OTHER_ID = "7716d70b337b7783837f3b515725506c593b41b7cef81dda3f96011a0f24ef66"
+
+
+def _container(container_id=LIVE_ID, *, age_minutes=60, name="bench-one"):
+	"""One entry in the shape `docker_manager.list_benches` returns."""
+	created = None if age_minutes is None else datetime.now(UTC) - timedelta(minutes=age_minutes)
+	return {
+		"id": container_id,
+		"name": name,
+		"bench_name": name,
+		"status": "running",
+		"health": "Healthy",
+		"created": created,
+	}
+
+
+class TestCompare(unittest.TestCase):
+	"""Both sides arrive as arguments, so every case here runs without a database or a daemon."""
+
+	def drift(self, rows, containers, grace_minutes=DEFAULT_GRACE_MINUTES):
+		return compare(rows, containers, grace_minutes=grace_minutes)
+
+	def test_a_container_with_no_row_is_an_orphan(self):
+		drift = self.drift([], [_container()])
+
+		self.assertEqual([c["id"] for c in drift["orphan_containers"]], [LIVE_ID])
+		self.assertEqual(drift["in_grace"], [])
+
+	def test_a_container_inside_the_grace_window_is_never_an_orphan(self):
+		"""Every deploy passes through this state: the container exists before the row names it."""
+		drift = self.drift([], [_container(age_minutes=2)])
+
+		self.assertEqual(drift["orphan_containers"], [])
+		self.assertEqual([c["id"] for c in drift["in_grace"]], [LIVE_ID])
+
+	def test_a_container_of_unknown_age_is_never_an_orphan(self):
+		drift = self.drift([], [_container(age_minutes=None)])
+
+		self.assertEqual(drift["orphan_containers"], [])
+		self.assertEqual([c["id"] for c in drift["in_grace"]], [LIVE_ID])
+
+	def test_a_wider_window_spares_an_older_container(self):
+		drift = self.drift([], [_container(age_minutes=60)], grace_minutes=120)
+
+		self.assertEqual(drift["orphan_containers"], [])
+
+	def test_a_row_whose_container_is_gone_is_named_missing(self):
+		drift = self.drift([{"name": "bench-one", "container_id": LIVE_ID, "status": "Running"}], [])
+
+		self.assertEqual([r["name"] for r in drift["missing_containers"]], ["bench-one"])
+
+	def test_a_matched_pair_is_no_drift_either_way(self):
+		rows = [{"name": "bench-one", "container_id": LIVE_ID, "status": "Running"}]
+
+		drift = self.drift(rows, [_container()])
+
+		self.assertEqual(drift, {"orphan_containers": [], "in_grace": [], "missing_containers": []})
+
+	def test_a_row_holding_the_short_id_still_matches_its_container(self):
+		rows = [{"name": "bench-one", "container_id": LIVE_ID[:12], "status": "Running"}]
+
+		drift = self.drift(rows, [_container()])
+
+		self.assertEqual(drift["orphan_containers"], [])
+		self.assertEqual(drift["missing_containers"], [])
+
+	def test_a_row_with_no_container_is_not_drift(self):
+		"""A Draft bench has no container yet, and never had one."""
+		drift = self.drift([{"name": "draft", "container_id": None, "status": "Draft"}], [])
+
+		self.assertEqual(drift["missing_containers"], [])
+
+	def test_both_directions_are_named_at_once(self):
+		rows = [{"name": "gone", "container_id": OTHER_ID, "status": "Running"}]
+
+		drift = self.drift(rows, [_container()])
+
+		self.assertEqual([c["id"] for c in drift["orphan_containers"]], [LIVE_ID])
+		self.assertEqual([r["name"] for r in drift["missing_containers"]], ["gone"])
+
+	def test_compare_reads_neither_side(self):
+		"""The guard against a second, disagreeing implementation that goes and looks for itself."""
+		with (
+			patch("frappe.get_all", side_effect=AssertionError("compare queried the database")),
+			patch(
+				"benchpress.docker_manager.get_client",
+				side_effect=AssertionError("compare asked the daemon"),
+			),
+		):
+			drift = self.drift([], [_container()])
+
+		self.assertEqual(len(drift["orphan_containers"]), 1)
+
+
+class TestConfiguredGraceWindow(IntegrationTestCase):
+	def _set_window(self, value):
+		before = frappe.db.get_single_value("BenchPress Settings", "orphan_grace_minutes")
+		frappe.db.set_single_value("BenchPress Settings", "orphan_grace_minutes", value)
+		frappe.clear_cache(doctype="BenchPress Settings")
+		self.addCleanup(frappe.clear_cache, doctype="BenchPress Settings")
+		self.addCleanup(frappe.db.set_single_value, "BenchPress Settings", "orphan_grace_minutes", before)
+
+	def test_an_unset_window_falls_back_to_fifteen(self):
+		self._set_window(0)
+
+		self.assertEqual(configured_grace_minutes(), DEFAULT_GRACE_MINUTES)
+
+	def test_the_setting_is_what_compare_uses(self):
+		self._set_window(120)
+
+		drift = compare([], [_container(age_minutes=60)])
+
+		self.assertEqual(drift["orphan_containers"], [])
+		self.assertEqual(len(drift["in_grace"]), 1)
+
+	def test_the_window_matches_the_admission_claim_grace(self):
+		"""Both exist because a deploy that has not written its row is still a deploy."""
+		from benchpress.credits import admission_repair
+
+		self.assertEqual(reconcile.DEFAULT_GRACE_MINUTES, admission_repair.CLAIM_GRACE_MINUTES)

--- a/benchpress/tests/test_reconcile.py
+++ b/benchpress/tests/test_reconcile.py
@@ -1,18 +1,38 @@
 # Copyright (c) 2026, Venkatesh and Contributors
 # See license.txt
 
+import re
+import tempfile
 import unittest
+from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from unittest.mock import patch
 
+import docker
 import frappe
+import yaml
 from frappe.tests import IntegrationTestCase
+from frappe.utils import add_to_date, now_datetime
 
-from benchpress import reconcile
-from benchpress.reconcile import DEFAULT_GRACE_MINUTES, compare, configured_grace_minutes
+from benchpress import docker_manager, ingress, reconcile
+from benchpress.reconcile import (
+	DEFAULT_DEPLOY_LOG_CAP,
+	DEFAULT_GRACE_MINUTES,
+	compare,
+	configured_grace_minutes,
+)
+from benchpress.tests.fakes import FakeDocker
+from benchpress.tests.test_deploy_manager import _fresh_bench, _make_lab
 
 LIVE_ID = "40c6dd07a12727f3648970f0a1ae5cdc912f17a6756566264687f2ede0d0ec15"
 OTHER_ID = "7716d70b337b7783837f3b515725506c593b41b7cef81dda3f96011a0f24ef66"
+
+# Any dotted quad, anywhere in the rendered file: routes must name containers, never addresses.
+IPV4_IN_TEXT = re.compile(r"\b\d{1,3}(?:\.\d{1,3}){3}\b")
+
+# What the reap reports on a host with nothing to reap, for the tests that are about another step.
+NO_CONTAINERS = {"orphans": 0, "removed": [], "in_grace": 0, "missing_rows": 0}
 
 
 def _container(container_id=LIVE_ID, *, age_minutes=60, name="bench-one"):
@@ -132,3 +152,490 @@ class TestConfiguredGraceWindow(IntegrationTestCase):
 		from benchpress.credits import admission_repair
 
 		self.assertEqual(reconcile.DEFAULT_GRACE_MINUTES, admission_repair.CLAIM_GRACE_MINUTES)
+
+
+@contextmanager
+def _route_dir(base_domain="benchpress.cloud"):
+	"""A tmp route directory, and a pass whose other steps are stubbed out.
+
+	This runs on a live host: an unstubbed `run` would remove real containers and delete real rows.
+	"""
+	with tempfile.TemporaryDirectory() as tmp:
+		target_dir = Path(tmp) / "dynamic"
+		target_dir.mkdir()
+		with (
+			patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", target_dir),
+			patch("frappe.get_cached_doc", return_value=frappe._dict(base_domain=base_domain)),
+			patch("benchpress.placement.repair", return_value={"attached": {}, "missing": {}}),
+			patch.object(reconcile, "_reap_orphan_containers", return_value=dict(NO_CONTAINERS)),
+			patch.object(reconcile, "_report_orphan_databases", return_value={}),
+			patch.object(reconcile, "_trim_deploy_records", return_value={}),
+		):
+			yield reconcile, target_dir
+
+
+class TestReconcileSchedule(IntegrationTestCase):
+	"""The `*/5` tick. The entry is the enqueuer and never the pass."""
+
+	def test_the_tick_hands_the_pass_to_the_long_queue(self):
+		with patch("frappe.enqueue") as enqueue:
+			reconcile.enqueue_run()
+
+		args, kwargs = enqueue.call_args
+		self.assertEqual(args[0], "benchpress.reconcile.run")
+		self.assertEqual(kwargs["queue"], "long")
+		# Unchanged by the move: a job id is a dedup key, not an import path, and renaming it
+		# would let a job queued under the old one run beside a new one.
+		self.assertEqual(kwargs["job_id"], "route_reconcile")
+		self.assertTrue(kwargs["deduplicate"])
+
+	def test_the_cron_entry_is_the_enqueuer_and_never_the_pass(self):
+		"""Frappe sends cron to `default`, which `queue-short` also consumes — and that container
+		has neither the route mount nor the Docker socket."""
+		from benchpress.hooks import scheduler_events
+
+		cron_methods = [method for methods in scheduler_events["cron"].values() for method in methods]
+
+		self.assertIn("benchpress.reconcile.enqueue_run", scheduler_events["cron"]["*/5 * * * *"])
+		self.assertNotIn("benchpress.reconcile.run", cron_methods)
+
+	def test_the_settings_save_reaches_the_same_pass(self):
+		"""`BenchPress Settings.on_update` re-anchors through this pass, on the queue that can."""
+		settings = frappe.get_doc("BenchPress Settings")
+		settings._doc_before_save = frappe._dict(base_domain="some-other-zone.example")
+
+		with patch("frappe.enqueue") as enqueue:
+			settings.on_update()
+
+		args, kwargs = enqueue.call_args
+		self.assertEqual(args[0], "benchpress.reconcile.run")
+		self.assertEqual(kwargs["queue"], "long")
+		self.assertEqual(kwargs["job_id"], "reconcile_instance_routes")
+
+
+class TestRunReportsEveryStep(unittest.TestCase):
+	def test_every_step_reports_its_own_count(self):
+		"""Six counts, never a bare success: a pass that reports "issued" is how drift survives."""
+		with (
+			patch("benchpress.placement.repair", return_value={"attached": {}, "missing": {}}),
+			patch.object(reconcile, "_converge_routes", return_value={"written": 3}),
+			patch.object(
+				reconcile, "_reap_orphan_containers", return_value={"orphans": 1, "removed": [LIVE_ID]}
+			),
+			patch.object(reconcile, "_report_orphan_databases", return_value={"orphans": 2}),
+			patch.object(reconcile, "_trim_deploy_records", return_value={"deleted": 4}),
+			patch.object(reconcile, "_verify_reaped", return_value={"reaped": 1}) as verify,
+		):
+			result = reconcile.run()
+
+		self.assertEqual(
+			sorted(result),
+			["bridges", "containers", "databases", "deploy_records", "routes", "verified"],
+		)
+		# The verification reads the ids the reap issued, not its own idea of what to check.
+		verify.assert_called_once_with([LIVE_ID])
+
+
+class TestReapOrphanContainers(unittest.TestCase):
+	"""The removal, and the two things that must never be removed."""
+
+	def setUp(self):
+		self.client = FakeDocker()
+		patcher = patch("benchpress.docker_manager.get_client", return_value=self.client)
+		patcher.start()
+		self.addCleanup(patcher.stop)
+
+	def _managed(self, name, **kwargs):
+		return self.client.add_container(name, labels={docker_manager.MANAGED_LABEL: "true"}, **kwargs)
+
+	def _reap(self, rows=()):
+		with patch.object(reconcile, "_bench_rows", return_value=list(rows)):
+			return reconcile._reap_orphan_containers()
+
+	def test_a_labelled_orphan_past_the_grace_window_is_removed(self):
+		orphan = self._managed("orphan-one", age_minutes=60)
+
+		report = self._reap()
+
+		self.assertEqual(report["orphans"], 1)
+		self.assertEqual(report["removed"], [orphan.id])
+		self.assertEqual(self.client.removed, ["orphan-one"])
+
+	def test_a_container_inside_the_grace_window_is_left_alone(self):
+		"""Every deploy passes through this state, so removing one destroys a deploy in flight."""
+		self._managed("deploying", age_minutes=2)
+
+		report = self._reap()
+
+		self.assertEqual(report["orphans"], 0)
+		self.assertEqual(report["in_grace"], 1)
+		self.assertEqual(self.client.removed, [])
+
+	def test_an_unlabelled_container_is_never_removed(self):
+		"""The negative control, and the worst outcome available here: it is not this app's."""
+		stranger = self.client.add_container("someone-elses-postgres", age_minutes=600)
+
+		report = self._reap()
+
+		self.assertEqual(report["orphans"], 0)
+		self.assertEqual(self.client.removed, [])
+		self.assertIn(stranger.id, self.client._store)
+
+	def test_a_claimed_container_is_not_an_orphan(self):
+		claimed = self._managed("live-bench", age_minutes=60)
+
+		report = self._reap([{"name": "bench", "container_id": claimed.id, "status": "Running"}])
+
+		self.assertEqual(report["orphans"], 0)
+		self.assertEqual(self.client.removed, [])
+
+	def test_a_refused_removal_does_not_stop_the_next_one(self):
+		stuck = self._managed("stuck", age_minutes=60)
+		stuck.remove_refusal = "device or resource busy"
+		self._managed("removable", age_minutes=60)
+
+		report = self._reap()
+
+		self.assertEqual(report["orphans"], 2)
+		self.assertEqual(self.client.removed, ["removable"])
+
+
+class TestVerifyReaped(unittest.TestCase):
+	"""The independent second opinion — read from the daemon, not from the removal's report."""
+
+	def setUp(self):
+		self.client = FakeDocker()
+		patcher = patch("benchpress.docker_manager.get_client", return_value=self.client)
+		patcher.start()
+		self.addCleanup(patcher.stop)
+		logged = patch("frappe.log_error")
+		self.log_error = logged.start()
+		self.addCleanup(logged.stop)
+		committed = patch("frappe.db.commit")
+		committed.start()
+		self.addCleanup(committed.stop)
+
+	def _managed(self, name):
+		return self.client.add_container(name, labels={docker_manager.MANAGED_LABEL: "true"}, age_minutes=60)
+
+	def test_a_removal_that_took_reports_it_reaped(self):
+		container = self._managed("gone-now")
+		container.remove()
+
+		report = reconcile._verify_reaped([container.id])
+
+		self.assertEqual(report, {"rechecked": 1, "reissued": 0, "reaped": 1, "still_present": []})
+		self.log_error.assert_not_called()
+
+	def test_a_removal_that_did_not_take_is_reported_still_present(self):
+		"""The failure the item exists for: "their reconciler reported success while the
+		container kept running"."""
+		container = self._managed("still-here")
+		container.remove_refusal = "device or resource busy"
+
+		report = reconcile._verify_reaped([container.id])
+
+		self.assertEqual(report["reaped"], 0)
+		self.assertEqual(report["reissued"], 1)
+		self.assertEqual(report["still_present"], [container.id])
+		self.assertIn(container.id, self.client._store)
+		self.log_error.assert_called_once()
+
+	def test_a_re_issued_removal_that_works_is_reported_reaped(self):
+		container = self._managed("second-time-lucky")
+
+		report = reconcile._verify_reaped([container.id])
+
+		self.assertEqual(report["reissued"], 1)
+		self.assertEqual(report["reaped"], 1)
+		self.assertEqual(self.client.removed, ["second-time-lucky"])
+
+	def test_nothing_issued_asks_the_daemon_nothing(self):
+		with patch("benchpress.docker_manager.list_benches", side_effect=AssertionError("asked anyway")):
+			report = reconcile._verify_reaped([])
+
+		self.assertEqual(report["rechecked"], 0)
+
+
+class TestOrphanDatabases(unittest.TestCase):
+	"""Counted and named, never dropped. The `DROP` assertion is the load-bearing one."""
+
+	def _report(self, schemas, claimed=frozenset()):
+		self.executed = []
+
+		def execute_sql(server, sql):
+			self.executed.append(sql)
+			return 0, "Database\n" + "\n".join(schemas) + "\n"
+
+		with (
+			patch.object(reconcile, "_database_servers", return_value=["db-one"]),
+			patch.object(reconcile, "_claimed_databases", return_value=set(claimed)),
+			patch("benchpress.mariadb_manager.execute_sql", side_effect=execute_sql),
+		):
+			return reconcile._report_orphan_databases()
+
+	def test_a_schema_no_row_claims_is_counted_and_named(self):
+		report = self._report(["_aaaa000000000000", "_bbbb111111111111"], claimed={"_aaaa000000000000"})
+
+		self.assertEqual(report["schemas"], 2)
+		self.assertEqual(report["orphans"], 1)
+		self.assertEqual(report["names"], {"db-one": ["_bbbb111111111111"]})
+
+	def test_no_drop_is_ever_issued(self):
+		"""The assertion that stops a future contributor "finishing" the feature. Dropping a
+		tenant's database is unrecoverable, and the leak's cause is upstream."""
+		self._report(["_bbbb111111111111"])
+
+		self.assertTrue(self.executed)
+		for sql in self.executed:
+			self.assertNotIn("DROP", sql.upper())
+
+	def test_a_server_that_cannot_be_read_does_not_end_the_pass(self):
+		with (
+			patch.object(reconcile, "_database_servers", return_value=["db-one"]),
+			patch.object(reconcile, "_claimed_databases", return_value=set()),
+			patch(
+				"benchpress.mariadb_manager.list_site_databases",
+				side_effect=docker.errors.NotFound("no such container"),
+			),
+		):
+			report = reconcile._report_orphan_databases()
+
+		self.assertEqual(report, {"schemas": 0, "orphans": 0, "names": {}})
+
+	def test_the_backup_directory_is_not_a_schema(self):
+		"""MariaDB lists every directory in its data dir, and `backups` is one this app writes."""
+		report = self._report(["backups", "_bbbb111111111111"])
+
+		self.assertEqual(report["names"], {"db-one": ["_bbbb111111111111"]})
+
+
+class TestTrimDeployRecords(IntegrationTestCase):
+	"""The per-bench cap that sits on top of Frappe's 7-day age sweep."""
+
+	CAP = 5
+	BENCH = "trim-cap-throwaway-bench"
+
+	def setUp(self):
+		self.addCleanup(self._forget_rows)
+
+	def _forget_rows(self):
+		frappe.db.delete("Deploy Log", {"bench": self.BENCH})
+		frappe.db.commit()
+
+	def _seed(self, count):
+		for index in range(count):
+			frappe.get_doc(
+				{
+					"doctype": "Deploy Log",
+					"bench": self.BENCH,
+					"log_type": "info",
+					"message": f"run {index}\n",
+					"timestamp": add_to_date(now_datetime(), minutes=index),
+				}
+			).insert(ignore_permissions=True, ignore_links=True)
+		frappe.db.commit()
+
+	def test_the_grouped_read_finds_a_bench_over_the_cap(self):
+		self._seed(self.CAP + 3)
+
+		over = {row.bench: row.rows for row in reconcile._benches_over_cap(self.CAP)}
+
+		self.assertEqual(over.get(self.BENCH), self.CAP + 3)
+
+	def test_a_bench_at_the_cap_is_not_over_it(self):
+		self._seed(self.CAP)
+
+		over = {row.bench for row in reconcile._benches_over_cap(self.CAP)}
+
+		self.assertNotIn(self.BENCH, over)
+
+	def test_the_trim_keeps_the_newest_rows_and_deletes_the_rest(self):
+		self._seed(self.CAP + 3)
+		over = [row for row in reconcile._benches_over_cap(self.CAP) if row.bench == self.BENCH]
+
+		with (
+			patch.object(reconcile, "configured_deploy_log_cap", return_value=self.CAP),
+			patch.object(reconcile, "_benches_over_cap", return_value=over),
+		):
+			report = reconcile._trim_deploy_records()
+
+		kept = frappe.get_all(
+			"Deploy Log", filters={"bench": self.BENCH}, pluck="message", order_by="timestamp desc"
+		)
+		self.assertEqual(report["deleted"], 3)
+		self.assertEqual(report["cap"], self.CAP)
+		self.assertEqual(kept, [f"run {index}\n" for index in range(7, 2, -1)])
+
+	def test_the_cap_is_a_setting_with_a_default(self):
+		self.assertEqual(reconcile.configured_deploy_log_cap(), DEFAULT_DEPLOY_LOG_CAP)
+
+
+class TestConvergeRoutes(IntegrationTestCase):
+	"""The route directory converges on the database — the pass `ingress.reconcile` used to be."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.lab = _make_lab("test-lab-reconcile-routes")
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		for name in frappe.get_all("Bench Instance", filters={"lab": cls.lab.name}, pluck="name"):
+			frappe.delete_doc("Bench Instance", name, force=True, ignore_permissions=True)
+		cls.lab.delete(ignore_permissions=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def _bench(self, status, container_ip):
+		bench = _fresh_bench(self, self.lab.name)
+		bench.status = status
+		bench.container_ip = container_ip
+		bench.save(ignore_permissions=True)
+		frappe.db.commit()
+		return bench
+
+	def _seed(self, target_dir, name, body="stale\n"):
+		path = target_dir / name
+		path.write_text(body)
+		return path
+
+	def _instance_files(self, target_dir):
+		return sorted(p.name for p in target_dir.glob("*.yml") if p.name not in ingress.PROTECTED_ROUTE_FILES)
+
+	def test_a_route_file_naming_no_bench_instance_is_deleted(self):
+		"""The orphan case: a hostname with no document behind it still resolves and still
+		routes, so it keeps serving whichever container inherited that IP."""
+		with _route_dir() as (reconciler, target_dir):
+			orphan = self._seed(target_dir, "091131f54bcdfc7bc37cbc45763547fa.yml")
+
+			routes = reconciler.run()["routes"]
+
+			self.assertFalse(orphan.exists())
+			self.assertGreaterEqual(routes["deleted"], 1)
+
+	def test_a_bench_that_is_not_running_loses_its_route_file(self):
+		"""A stopped bench's recorded IP is an address Docker has already handed back, so the
+		file is not a dead link — it is the next bench's hostname collision."""
+		for status in ("Stopped", "Draft", "Error"):
+			with self.subTest(status=status):
+				bench = self._bench(status, "172.30.0.11")
+				with _route_dir() as (reconciler, target_dir):
+					route_file = self._seed(target_dir, f"{bench.name}.yml")
+
+					reconciler.run()
+
+					self.assertFalse(route_file.exists())
+
+	def test_a_running_bench_route_is_rewritten_to_name_its_container(self):
+		"""Convergence, not merely reaping: a file that survives must also be right. Seeded with
+		an address backend so passing means the pass rewrote it to the container name."""
+		bench = self._bench("Running", "172.30.0.12")
+
+		with _route_dir() as (reconciler, target_dir):
+			self._seed(target_dir, f"{bench.name}.yml", "http://172.30.0.99:8000\n")
+
+			routes = reconciler.run()["routes"]
+
+			written_text = (target_dir / f"{bench.name}.yml").read_text()
+			config = yaml.safe_load(written_text)
+			backends = [
+				server["url"]
+				for service in config["http"]["services"].values()
+				for server in service["loadBalancer"]["servers"]
+			]
+			self.assertIn(f"http://{bench.name}:8000", backends)
+			self.assertNotRegex(written_text, IPV4_IN_TEXT)
+			self.assertGreaterEqual(routes["written"], 1)
+
+	def test_the_control_plane_router_and_the_anchor_survive_a_full_sweep(self):
+		"""The guard that stops this pass taking the platform off the internet. `dynamic.yml` is
+		the control plane's own router and the anchor is every bench's certificate; a run that
+		deletes every instance file must still leave both."""
+		with _route_dir() as (reconciler, target_dir):
+			control_plane = self._seed(target_dir, "dynamic.yml", "control plane\n")
+			ingress.ensure_anchor("benchpress.cloud")
+			anchor = target_dir / "wildcard-anchor.yml"
+			anchor_text = anchor.read_text()
+			self._seed(target_dir, "16b283bccf6560ab1aa5f078d492d005.yml")
+			self._seed(target_dir, "5dc12efd9c154796adae757adec1b2f3.yml")
+
+			routes = reconciler.run()["routes"]
+
+			self.assertEqual(control_plane.read_text(), "control plane\n")
+			self.assertEqual(anchor.read_text(), anchor_text)
+			self.assertEqual(routes["kept"], 2)
+
+	def test_a_run_always_leaves_the_certificate_anchored(self):
+		"""The anchor holds the wildcard the resolver-free bench routers serve, so the pass
+		writes it first rather than waiting for the next deploy."""
+		with _route_dir() as (reconciler, target_dir):
+			routes = reconciler.run()["routes"]
+
+			self.assertTrue(routes["anchored"])
+			config = yaml.safe_load((target_dir / "wildcard-anchor.yml").read_text())
+			router = config["http"]["routers"]["benchpress-wildcard-anchor"]
+			self.assertEqual(router["rule"], "Host(`tls-anchor.benchpress.cloud`)")
+
+	def test_the_returned_counts_match_what_happened_on_disk(self):
+		"""A reaper that reports what it attempted rather than what converged is how a directory
+		drifts for weeks without anyone noticing."""
+		bench = self._bench("Running", "172.30.0.13")
+
+		with _route_dir() as (reconciler, target_dir):
+			self._seed(target_dir, "dynamic.yml", "control plane\n")
+			self._seed(target_dir, f"{bench.name}.yml")
+			self._seed(target_dir, "091131f54bcdfc7bc37cbc45763547fa.yml")
+			self._seed(target_dir, "5dc12efd9c154796adae757adec1b2f3.yml")
+
+			routes = reconciler.run()["routes"]
+
+			self.assertEqual(routes["deleted"], 2)
+			self.assertEqual(routes["kept"], 2)
+			self.assertEqual(routes["written"], len(self._instance_files(target_dir)))
+			self.assertIn(f"{bench.name}.yml", self._instance_files(target_dir))
+
+	def test_a_second_run_deletes_nothing_and_touches_nothing(self):
+		"""Idempotence is the read side agreeing with the write side. A pass that keeps finding
+		things to delete disagrees with the files it just wrote — and one that rewrites unchanged
+		files is a Traefik reload every five minutes, since it reloads on mtime."""
+		self._bench("Running", "172.30.0.14")
+
+		with _route_dir() as (reconciler, target_dir):
+			self._seed(target_dir, "091131f54bcdfc7bc37cbc45763547fa.yml")
+			reconciler.run()
+			before = {p.name: p.stat().st_mtime_ns for p in target_dir.iterdir()}
+
+			routes = reconciler.run()["routes"]
+
+			self.assertEqual(routes["deleted"], 0)
+			self.assertFalse(routes["anchored"])
+			self.assertEqual({p.name: p.stat().st_mtime_ns for p in target_dir.iterdir()}, before)
+
+	def test_a_container_without_the_route_mount_reports_instead_of_raising(self):
+		"""Only `queue-long` mounts the directory, so a by-hand run anywhere else used to do the
+		bridge half and then raise out of `ensure_anchor`."""
+		with tempfile.TemporaryDirectory() as tmp:
+			with (
+				patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", Path(tmp) / "dynamic"),
+				patch("frappe.get_cached_doc", return_value=frappe._dict(base_domain="benchpress.cloud")),
+			):
+				routes = reconcile._converge_routes()
+
+		# None, not 0: nothing was read, and zero counts are what a converged pass reports.
+		self.assertEqual(routes, {"anchored": None, "written": None, "deleted": None, "kept": None})
+
+	def test_a_dev_checkout_is_left_byte_for_byte_alone(self):
+		"""No public domain means no route directory this pass understands, so it writes nothing
+		and reaps nothing."""
+		for base_domain in (None, "", "localhost"):
+			with self.subTest(base_domain=base_domain), _route_dir(base_domain) as (reconciler, target_dir):
+				survivor = self._seed(target_dir, "091131f54bcdfc7bc37cbc45763547fa.yml")
+
+				routes = reconciler.run()["routes"]
+
+				self.assertTrue(survivor.exists())
+				self.assertEqual(routes, {"anchored": False, "written": 0, "deleted": 0, "kept": 0})


### PR DESCRIPTION
Phase 1 of the one-reconcile-loop spec: the upstream fix that decides how much work phase 3's orphan reporting will find.

## What changed

`lifecycle.torn_down` swallowed four failures — the stop, the container removal, the site-database drop and the route-file delete — and then wrote `Draft` unconditionally. A teardown whose container removal failed reported exactly what one that worked reported: nothing.

- Each removal now returns `gone` or `failed: <reason>`, and `torn_down` returns the five results.
- A teardown that left something behind writes it to the Error Log, so no caller can forget to.
- The swallowing stays. An instance must not be left describing resources it no longer has.
- Teardown now calls `remove_bench_peer`. Only `api.destroy_bench` and the failed-deploy cleanup freed the VPN allocation before, so every *reaped* bench held its tunnel address forever. `wg_ip` is cleared with it — the pool has taken the address back.
- Three docstrings promised a per-bench volume. There is none; `create_bench_container` mounts none on purpose.

`FakeContainer` gained `stop_refusal` / `remove_refusal`, mirroring `start_refusal`, so a refused removal is scripted through the fake rather than mocked.

## How to verify

Scoped tests:

```
docker compose exec backend bench --site frontend run-tests --module benchpress.tests.test_lifecycle
docker compose exec backend bench --site frontend run-tests --module benchpress.tests.test_vpn_adapter
docker compose exec backend bench --site frontend run-tests --module benchpress.tests.test_docker_manager
```

Against the live stack, a throwaway bench on `client-frappe-16`:

| step | result |
|---|---|
| baseline allocated `IP Allocation` rows | 16 |
| after deploy (PEER-00115, 172.27.0.18) | 17 |
| after `reap_bench` | **16** — the leak is closed |
| container, route file, site database `_e4014d6da5aa788d` | all gone; `dynamic.yml` and `wildcard-anchor.yml` untouched |
| clean teardown | no Error Log row |
| redeploy of the torn-down bench | Running, fresh peer PEER-00116, address 172.27.0.18 reissued from the pool |
| teardown after `docker rm -f` on its container | `container: failed: 404 ... No such container: 5a0ae822…` in the Error Log, bench still reached `Draft`, allocation still returned to 16 |

The throwaway bench and its Error Log rows were deleted afterwards; the fleet is back to its baseline.