### PR TITLE
fix: make the install path work and the public surfaces true

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -85,18 +85,44 @@ inaccurate.
 
 ## How to sign
 
-Signing is automated. Open a pull request; the CLA Assistant bot comments with a
-link, and you sign in-thread with your GitHub account. One signature covers all
-of your future contributions.
+Sign in the pull request thread. Post this comment on your pull request:
+
+```
+I have read the CLA Document and I hereby sign the CLA.
+```
+
+The comment must come from the GitHub account that authored the commits. One
+signature covers every contribution you make afterwards, so you do this once.
 
 If you are contributing on behalf of a company, have someone authorised to bind
-the company sign instead.
+the company post it instead.
 
 ## Why a CLA and not a DCO
 
-A Developer Certificate of Origin certifies provenance but grants no
-sublicensing right. Under a DCO, every file an outside contributor touches would
-become permanently un-relicensable — which would foreclose offering commercial
-licence exceptions for the project, and would make any future licence change
-impossible. The grant above is the narrowest thing that keeps those options open
-while leaving your copyright with you.
+Read this before you sign. It is the part that costs you something.
+
+A Developer Certificate of Origin certifies provenance and nothing else. It
+grants no sublicensing right. Under a DCO, every file an outside contributor
+touched would be permanently locked to AGPL-3.0, and two doors would close:
+
+- **Commercial exceptions.** Some companies cannot accept AGPL-3.0 at all.
+  Selling them an exception means shipping the same code under different terms,
+  and that needs a sublicensing right from every copyright holder in the file.
+- **A future licence change.** Relicensing under a DCO means finding and getting
+  written agreement from every past contributor. In practice that is not
+  possible, so the licence is frozen for good.
+
+**What that means for you.** Section 2 lets the Project Owner distribute your
+contribution under terms other than AGPL-3.0 — including a proprietary
+commercial licence — without asking you again. You do not get a veto and you do
+not share in what such a licence earns. That is a real asymmetry, and it is the
+whole cost of the agreement.
+
+**What you keep.** The copyright. This is a licence grant, not an assignment, so
+your contribution stays yours: use it, publish it elsewhere, sell it, relicense
+it, nothing here restricts you. The grant is also non-exclusive, so the Project
+Owner's rights take nothing away from your own.
+
+If that trade is not one you want to make, do not sign. Open an issue describing
+the bug or the change instead. That is a real contribution, it needs no CLA, and
+it is welcome.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,15 @@
+# bug_report.md is the only template, so a "how do I ...?" has nowhere to go
+# but the bug tracker. These links give the chooser somewhere else to send it.
+#
+# blank_issues_enabled stays true, unlike frappe core's config.yml. Core can
+# set it false because it also ships feature_request.md; this repo does not,
+# so false would leave an enhancement no route at all. Flip it once a feature
+# request template exists.
+blank_issues_enabled: true
+contact_links:
+  - name: Questions and discussion
+    url: https://github.com/Venkateshvenki404224/benchpress/discussions
+    about: Ask how to do something, or propose an idea before opening an issue.
+  - name: Documentation
+    url: https://docs.benchpress.cloud/docs
+    about: Install, deploy and configure BenchPress.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+# pip-audit in linter.yml reports a vulnerable dependency but opens nothing.
+# This is the half that opens the pull request.
+#
+# Cadence follows frappe core (.github/dependabot.yml there): weekly, default
+# day. Core registers github-actions only and sets no groups, so the grouping
+# below is this repo's own: minor and patch updates arrive as one pull request
+# per ecosystem, majors stay separate because they need reading.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # pyproject.toml. `docker` is the only runtime pin; frappe itself is supplied
+  # by bench and is deliberately not a dependency here.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Root package.json — the docs pipeline (leadtype) and @playwright/test.
+  # Both package-lock.json and yarn.lock are committed here; dependabot
+  # updates whichever lockfiles it finds beside the manifest.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      docs-tooling:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # The SPA. Its own manifest and lockfile, and the only tree the Frontend job
+  # installs.
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    groups:
+      frontend:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - develop
+      - version-16
   pull_request:
   schedule:
     - cron: '0 0 * * *'
@@ -17,12 +17,12 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: develop-benchpress-${{ github.event.number || github.ref }}
+  group: ci-benchpress-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   # Job-level filtering instead of workflow-level paths-ignore: Server and
-  # Frontend are required checks on develop, and a workflow that never runs
+  # Frontend are required checks on version-16, and a workflow that never runs
   # leaves them pending forever, while a skipped job counts as passing.
   changes:
     runs-on: ubuntu-latest
@@ -37,10 +37,19 @@ jobs:
         with:
           predicate-quantifier: 'every'
           filters: |
+            # A docs-only pull request must not wake the 60-minute Server
+            # job. `!**/*.md` never stopped it: docs/ holds 40 .mdx and 57
+            # images, and docs-site/ ships .txt, .json and .xml beside its .md.
+            # Exclude the three docs trees whole — the Docs job is ungated and
+            # still lints and regenerates the docs trees.
             backend:
               - '**'
               - '!frontend/**'
+              - '!docs/**'
+              - '!docs-site/**'
+              - '!docs-bundle/**'
               - '!**/*.md'
+              - '!**/*.mdx'
             frontend:
               - '{frontend/**,.github/workflows/ci.yml}'
 
@@ -201,6 +210,13 @@ jobs:
       - name: Install
         working-directory: frontend
         run: yarn install --frozen-lockfile
+
+      # `yarn build` only proves the bundle compiles. The vitest suite matched
+      # by frontend/vitest.config.js (src/**/*.spec.js) is the only thing that
+      # runs the SPA's own logic, and until now nothing ran it.
+      - name: Unit tests
+        working-directory: frontend
+        run: yarn test:run
 
       - name: Build
         working-directory: frontend

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,6 +1,11 @@
 name: Linters
 
 on:
+  # The README badge reports the newest run on the default branch. Without a
+  # push trigger there is no such run and the badge renders blank.
+  push:
+    branches:
+      - version-16
   pull_request:
   workflow_dispatch:
 
@@ -15,6 +20,9 @@ jobs:
   linter:
     name: 'Frappe Linter'
     runs-on: ubuntu-latest
+    # `semgrep ci` diff-scans against the merge base on pull_request and
+    # full-scans on push, so a push run can fail on findings no pull request
+    # has ever seen. Keep it on pull requests only.
     if: github.event_name == 'pull_request'
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 >
 > This changelog was introduced partway through development, so it does not
 > restate the project's full early history — for changes before the first entry
-> below, see the git log and GitHub release notes.
+> below, read the git log. From v0.1.0 on, every release also has a
+> [GitHub Release](https://github.com/Venkateshvenki404224/benchpress/releases)
+> carrying the entries under its heading here.
 
 **Maintaining this changelog**
 
@@ -26,10 +28,80 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
   commit `vX.Y.Z`, and open a fresh empty `## [Unreleased]` above it. Bump the
   version per Semantic Versioning: MAJOR for breaking changes, MINOR for
   backwards-compatible features, PATCH for fixes.
+- The version lives in [`benchpress/__init__.py`](benchpress/__init__.py) as
+  `__version__`, and [`package.json`](package.json) mirrors it. Bump both in the
+  release commit. `frontend/package.json` is a private workspace and stays at
+  `0.0.0`; nothing reads it.
+- Publish the GitHub Release for the new tag with the entries under its heading
+  here, so the two never disagree.
 
 ## [Unreleased]
 
-Nothing yet.
+### Added
+
+- One click builds and deploys a bench. `launch_template` and `launch_lab` claim
+  the instance and hand the whole run — the image build, then the deploy — to a
+  single background job. Deploying from a template used to take two calls from
+  the browser — create the lab, then deploy it — and a tab closed between them
+  lost the deploy. A lab with no image needed a separate admin build before the
+  deploy would run at all. A template someone has already built is reused, so the
+  next person rides the image the first one paid for, and a second click no
+  longer queues a second build of the same tag or charges for it. The build log
+  and the deploy log stream into one dialog, and the outcome is announced from
+  the app shell.
+  ([#262](https://github.com/Venkateshvenki404224/benchpress/pull/262))
+- Documentation is built from one MDX source for three readers: rendered pages, a
+  bundled `AGENTS.md` for an agent reading a clone, and `llms.txt` for one
+  fetching over HTTP. Forty pages ship — twelve user, sixteen operator, eleven
+  reference, and an index. The loose Markdown guides they replace are deleted and
+  every link into them is repointed. CI regenerates both outputs and fails when a
+  generated file is stale or hand-edited. The README stops repeating those pages
+  and becomes a map into the three tracks.
+  ([#261](https://github.com/Venkateshvenki404224/benchpress/pull/261))
+- The site serves its own discovery files verbatim: `/llms.txt`,
+  `/llms-full.txt`, `/robots.txt`, `/sitemap.xml`, and the `/.well-known/` tree.
+  Frappe compiles every file under `www/` as Jinja and converts Markdown to HTML,
+  which broke the Docker examples in `llms-full.txt` and the sha256 digests in
+  `.well-known/agent-skills/index.json`. A path that resolves outside the docs
+  directory is refused.
+  ([#262](https://github.com/Venkateshvenki404224/benchpress/pull/262))
+
+### Changed
+
+- `version-16` is the trunk. It is the GitHub default branch and carries every
+  commit since the v0.1.0 tag; `main` and `develop` have not moved since that
+  tag. This supersedes the branch roles stated in 0.1.0 below. Pin an install
+  with `--branch v0.1.0`.
+- The shared cache container runs `valkey/valkey:8-alpine` in place of
+  `redis:7-alpine`. The service name, command and memory settings are unchanged.
+  **Requires recreating the shared services — see the upgrade notes.**
+  ([#262](https://github.com/Venkateshvenki404224/benchpress/pull/262))
+- A deploy re-picks a bench bridge whenever the bench has no container, rather
+  than only when it is in `Draft`. Retrying a bench left in `Error` used to keep
+  it pinned to the bridge it was first placed on.
+  ([#262](https://github.com/Venkateshvenki404224/benchpress/pull/262))
+
+### Fixed
+
+- A shared database server row in `Error` no longer breaks every deploy. The
+  lookup keyed on a status whitelist, so an `Error` row read as no server at all
+  and the insert that followed hit the unique index on `container_name` — the
+  deploy failed with a duplicate-key error naming neither MariaDB nor a status.
+  The lookup now keys on the container name and accepts any status, and recovery
+  does the least that works: a stopped server is started, an `Error` server that
+  still answers a health check has its status flipped back rather than its
+  container rebuilt under every running bench, and anything else is set up again.
+  ([#262](https://github.com/Venkateshvenki404224/benchpress/pull/262))
+
+### Upgrade notes
+
+1. **Recreate the shared services** so the cache image change takes effect:
+   `cd benchpress/config && docker compose up -d redis`. This briefly interrupts
+   every running bench's connection to the cache. Name the service: a bare
+   `up -d` also creates the `docker-events` listener, and a second listener
+   records every incident twice.
+2. **No `bench migrate` is needed.** This release changes no DocType schema and
+   adds no patch.
 
 ## [0.1.0] - 2026-08-28
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,28 @@ BenchPress is licensed under the **GNU Affero General Public License v3.0 only**
 ([license.txt](license.txt)). Contributions are accepted under the same licence.
 
 Before your first pull request can be merged you must sign the
-[Contributor License Agreement](.github/CLA.md). It is a one-time, in-thread
-signature: open a PR, and a bot comments with the document and a line to reply
-with. **You keep the copyright in your work** — the CLA is a broad, sublicensable
-licence grant, not an assignment. [.github/CLA.md](.github/CLA.md) explains why a
-CLA rather than a DCO.
+[Contributor License Agreement](.github/CLA.md). Sign it by posting this comment
+on your pull request:
+
+```
+I have read the CLA Document and I hereby sign the CLA.
+```
+
+One signature covers every contribution you make afterwards.
+
+**What you are granting, plainly.** You keep the copyright in your work. The CLA
+is a licence grant, not an assignment, so your own code stays yours to use, sell
+or relicense however you like. But the grant is **sublicensable**: the project
+owner may ship your contribution under licence terms other than AGPL-3.0,
+including a commercial licence, without asking you again. That asymmetry is
+real, and this is the place to weigh it.
+
+**Why we ask for it.** A Developer Certificate of Origin grants no sublicensing
+right, so under a DCO every contributed file would be locked to AGPL-3.0 for
+good. If that trade is not one you want to make, open an issue and describe the
+fix instead of sending a patch — that costs you nothing and still helps.
+
+[.github/CLA.md](.github/CLA.md) is the full text.
 
 The BenchPress name and logo are *not* covered by the AGPL grant — see
 [TRADEMARKS.md](TRADEMARKS.md).
@@ -22,8 +39,9 @@ The BenchPress name and logo are *not* covered by the AGPL grant — see
 ```bash
 cd /path/to/your/frappe-bench
 
-# Get the app
-bench get-app https://github.com/Venkateshvenki404224/benchpress --branch develop
+# Get the dependency first, then the app
+bench get-app https://github.com/Venkateshvenki404224/vpn_management --branch version-16
+bench get-app https://github.com/Venkateshvenki404224/benchpress --branch version-16
 bench pip install docker
 bench --site your-site.localhost install-app benchpress
 bench --site your-site.localhost migrate
@@ -34,28 +52,31 @@ yarn install
 yarn dev
 ```
 
-BenchPress declares `required_apps = ["vpn_management"]` and will not install
-without it; `bench get-app` resolves it automatically from
-[Venkateshvenki404224/vpn_management](https://github.com/Venkateshvenki404224/vpn_management).
+BenchPress declares `required_apps = ["vpn_management"]` in `hooks.py` and will
+not install without it. `bench get-app` does **not** fetch it for you: the
+`--resolve-deps` flag defaults to off, and without it bench prints an
+`Ignoring dependencies of ...` warning and carries on. Fetch
+[vpn_management](https://github.com/Venkateshvenki404224/vpn_management) first,
+as above, or pass `--resolve-deps` to the `benchpress` get-app.
 
 ## Branch Strategy
 
-Three long-lived branches, promoted in one direction and never the other:
+**One trunk: `version-16`.** It is the default branch on GitHub, it carries the
+`v0.1.0` tag, and it is what the install instructions in
+[docs/operator/install.mdx](docs/operator/install.mdx) fetch. Branch from it,
+merge back into it. GitHub already preselects it as the base for a new pull
+request, so leave the base alone.
 
-- **`develop` — development.** Feature and fix branches start here and merge back
-  here. This is where work lands first.
-- **`version-16` — staging.** What the staging deployment runs, and the
-  repository's default branch. `develop` merges here once it holds together.
-- **`main` — production.** A release *is* a merge into `main` plus a `vX.Y.Z` tag.
-  The README's install instructions point here, so whatever is on `main` is what
-  a new user gets.
+`main` and `develop` also exist. Both were left at the 0.1.0 release commit and
+neither is updated any more. Do not branch from them, do not target them, and do
+not treat anything on them as current.
+
+A release is a `vX.Y.Z` tag on `version-16`.
 
 Work branches take the commit type as their prefix: `feat/<name>`, `fix/<name>`,
 `docs/<name>`, `refactor/<name>`, `test/<name>`, `chore/<name>`.
 
-Never commit directly to any of the three. Note that GitHub will offer
-`version-16` as the base for a new PR because it is the default branch — change
-it to `develop`.
+Never commit directly to `version-16`.
 
 ## Commit Messages
 
@@ -77,7 +98,7 @@ Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `perf`
 
 ## Verification before you push
 
-Run these three, in this order. Together they are what CI checks.
+Run these four, in this order.
 
 **1. Formatting and linting — everything, Python and frontend:**
 
@@ -101,15 +122,37 @@ bench --site <your-site> run-tests --app benchpress
 cd frontend && yarn test:run
 ```
 
-End-to-end tests are optional locally, and must be run from `e2e/` — invoking
-Playwright from the app root resolves no config and every test fails
-unauthenticated:
+**4. End-to-end tests.** Run these from `e2e/`. Invoking Playwright from the app
+root resolves no config, and every test then fails unauthenticated:
 
 ```bash
 cd e2e && FRAPPE_BASE_URL=http://localhost:8080 \
   FRAPPE_ADMIN_USER=administrator FRAPPE_ADMIN_PASSWORD=<password> \
   npx playwright test
 ```
+
+### What CI checks
+
+Two workflows, five checking jobs. Commands 1 to 3 above are gated here.
+Command 4 is not:
+
+| Job | Workflow | What it runs |
+|---|---|---|
+| Frappe Linter | `linter.yml` | `pre-commit`, then the frappe semgrep rules plus `r/python.lang.correctness` |
+| Vulnerable Dependency Check | `linter.yml` | `pip-audit` over the Python dependencies |
+| Server | `ci.yml` | `run-tests --app benchpress` on a fresh bench, then a page-load check on `/frontend` |
+| Frontend | `ci.yml` | `yarn install --frozen-lockfile`, `yarn test:run`, `yarn build` |
+| Docs | `ci.yml` | `docs:build`, `docs:lint`, `docs:score`, and a check that `docs-site/` and `docs-bundle/` are committed and current |
+
+The Playwright suite is **local only**. It needs a running site with
+administrator credentials, which no CI job provisions. Run it yourself against
+your bench before you push anything that touches a page or a route.
+
+`Server` and `Frontend` are path-filtered on pull requests. A change under
+`frontend/` alone skips `Server`, and so does a docs-only change: the `Server`
+filter excludes `docs/`, `docs-site/`, `docs-bundle/` and every `.md` and
+`.mdx`. A change that touches neither `frontend/` nor `.github/workflows/ci.yml`
+skips `Frontend`. A skipped job counts as passing.
 
 ## Key Rules
 
@@ -137,13 +180,13 @@ source-available with a commercial-use restriction) cannot be merged.
 
 ## Pull Requests
 
-1. Create a branch from `develop`
+1. Create a branch from `version-16`
 2. Make your changes with conventional commit messages
-3. Run the three verification commands above before pushing
-4. Open a PR targeting `develop` — GitHub will preselect `version-16`, so change it
+3. Run the four verification commands above before pushing
+4. Open a PR targeting `version-16` — GitHub preselects it, so leave the base alone
 5. Describe **what** changed and **why** in the PR description
 6. Link any related issues
-7. Sign the CLA when the bot asks
+7. Sign the CLA on your first PR, as described above
 
 ## Reporting Bugs
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 **Press a button. Get a Frappe bench. Self-hosted, Docker-powered, VPN-secured.**
 
-[![CI](https://github.com/Venkateshvenki404224/benchpress/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/Venkateshvenki404224/benchpress/actions/workflows/ci.yml)
-[![Linters](https://github.com/Venkateshvenki404224/benchpress/actions/workflows/linter.yml/badge.svg)](https://github.com/Venkateshvenki404224/benchpress/actions/workflows/linter.yml)
+[![CI](https://github.com/Venkateshvenki404224/benchpress/actions/workflows/ci.yml/badge.svg?branch=version-16)](https://github.com/Venkateshvenki404224/benchpress/actions/workflows/ci.yml?query=branch%3Aversion-16)
+[![Linters](https://github.com/Venkateshvenki404224/benchpress/actions/workflows/linter.yml/badge.svg?branch=version-16)](https://github.com/Venkateshvenki404224/benchpress/actions/workflows/linter.yml?query=branch%3Aversion-16)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-green.svg)](license.txt)
 [![Frappe Framework](https://img.shields.io/badge/Built%20on-Frappe%20v16-blue)](https://frappeframework.com)
 [![FOSS Hack 2026 Winner](https://img.shields.io/badge/FOSS%20Hack%202026-Winner-FFB300)](https://fossunited.org/hack/fosshack26/p/f5fk2d9gqd)
@@ -48,10 +48,20 @@ BenchPress is itself a Frappe app. It installs into a bench you already run. A
 Vue 3 single-page app sits on the front. `frappe.qb` queries and background jobs
 sit on the back.
 
-> **Disposable sandboxes, not production hosting.** A lab is a throwaway
-> development environment, and its screens show credentials in plain text. Read
-> [Production safety](docs/operator/production-safety.mdx) before you point
-> anything important at it.
+> **BenchPress is alpha software. Do not run it on a host you cannot afford to
+> lose.**
+>
+> It takes host-level privilege. `setup.sh` adds your user to the `docker`
+> group, starts the shared MariaDB and Redis containers, and enables IP
+> forwarding under `/etc/sysctl.d`. A lab user holds root inside their bench,
+> and without a user namespace that is host root. A lab is a throwaway
+> development environment, and its screens show credentials in plain text.
+> Database backups are automatic; restore is manual. Quotas, rate limits and
+> audit trails are still in progress.
+>
+> Run it on a dedicated dev box, a VM, or a cloud instance you can rebuild. Not
+> on your daily-driver workstation, and not on a shared production server. Read
+> [Production safety](docs/operator/production-safety.mdx) first.
 
 ---
 
@@ -170,7 +180,7 @@ names all four and says who can reach each one.
 - **Lifecycle actions.** Start, stop, restart, redeploy and delete, each stating
   what it keeps and what it destroys.
 - **Stats and health.** CPU, memory and container health sampled for every
-  running bench, with eleven read-only host checks beside them.
+  running bench, with twelve read-only host checks beside them.
 - **Two roles.** BenchPress Admin and BenchPress User. Ownership, not the role,
   decides which benches a person sees.
 - **Optional metering.** Credits, leases, concurrency caps and self-serve signup
@@ -246,7 +256,7 @@ points at the flattened copy in `docs-bundle/`.
 | [Users and roles](docs/operator/users-and-roles.mdx) | The two roles, and why ownership rather than a role decides who sees a bench |
 | [Upgrading](docs/operator/upgrading.mdx) | The backup gate, the five steps, the scripted path and the rollback |
 | [Production safety](docs/operator/production-safety.mdx) | The alpha verdict, the privilege boundary, and the release checklist |
-| [Diagnostics](docs/operator/diagnostics.mdx) | The eleven read-only checks, and the four things they do not cover |
+| [Diagnostics](docs/operator/diagnostics.mdx) | The twelve read-only checks, and the four things they do not cover |
 | [Credits and billing](docs/operator/credits-and-billing.mdx) | Optional, off by default. Leases, balances, the ledger and the Razorpay handoff |
 | [Admission and limits](docs/operator/admission-and-limits.mdx) | Optional, off by default. Concurrency caps, size ceilings and quotas |
 | [Self-serve signup](docs/operator/hosted-signup.mdx) | Optional, off by default. Retire the waitlist |
@@ -258,7 +268,7 @@ points at the flattened copy in `docs-bundle/`.
 | [Reference track](docs/reference/index.mdx) | The counts every other reference page is held to |
 | [Architecture](docs/reference/architecture.mdx) | Every module in the package, and the concern it owns |
 | [Data model](docs/reference/data-model.mdx) | All 20 DocTypes, their fields, and the permission rule that scopes each one |
-| [API](docs/reference/api.mdx) | All 50 whitelisted endpoints, and the check each one makes for itself |
+| [API](docs/reference/api.mdx) | Every whitelisted endpoint, and the check each one makes for itself |
 | [Deploy pipeline](docs/reference/deploy-pipeline.mdx) | The eleven deploy steps, the function behind each, and the log line it writes |
 | [Lifecycle and events](docs/reference/lifecycle-and-events.mdx) | The bench states, the Docker event listener, and the eleven scheduled jobs |
 | [Networking](docs/reference/networking.mdx) | The four addresses, the bench bridges, and the Traefik route files |
@@ -283,15 +293,19 @@ points at the flattened copy in `docs-bundle/`.
 Contributions are welcome. [CONTRIBUTING.md](CONTRIBUTING.md) is the full guide.
 It covers setup, the commands CI runs, and the dependency policy.
 
+`version-16` is the trunk. It is the default branch on GitHub and it carries the
+`v0.1.0` tag. Branch from it and merge back into it. `main` and `develop` are
+legacy branches left at the 0.1.0 release point and are not updated.
+
 1. Fork the repository.
-2. Create a feature branch from `develop`.
+2. Create a work branch from `version-16`.
 3. Follow the Frappe coding conventions in the code you touch.
 4. Run the tests: `bench --site your-site.localhost run-tests --app benchpress`.
 5. Run every linter: `uvx pre-commit@4.3.0 run --all-files`.
 6. Commit with Conventional Commits, such as `feat(lab): add batch deploy`.
-7. Open a pull request against `develop`.
-8. Sign the [Contributor License Agreement](.github/CLA.md) when the bot asks.
-   You sign once, and it covers everything you contribute afterwards.
+7. Open a pull request against `version-16`.
+8. Sign the [Contributor License Agreement](.github/CLA.md) on your first pull
+   request. You sign once, and it covers everything you contribute afterwards.
 
 Report a security issue through [SECURITY.md](SECURITY.md), never a public issue.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,14 @@
 
 ## Supported Versions
 
+`version-16` is the trunk. It is the default branch on GitHub and carries the
+`v0.1.0` tag.
+
 | Version | Supported |
 |---------|-----------|
-| `develop` (latest) | Yes |
-| Older branches | No |
+| `version-16` (trunk) | Yes |
+| `v0.1.0` tag | No. A fix lands on `version-16`; there are no backports |
+| `main`, `develop` | No. Both are legacy branches, left at the 0.1.0 release commit and not updated |
 
 ## Reporting a Vulnerability
 
@@ -46,8 +50,20 @@ require an attacker to already hold administrator credentials on the host.
 
 ## A note on what BenchPress is
 
-BenchPress provisions **disposable development sandboxes**. Each Lab is a
-throwaway Frappe bench, reachable over WireGuard, with credentials shown in the
-UI. It is not hardened for production workloads or untrusted tenants, and a
-finding that amounts to "a Lab owner can reach their own Lab's data" is expected
-behaviour rather than a vulnerability.
+**BenchPress is alpha software. Do not run it on a host you cannot afford to
+lose.**
+
+It provisions **disposable development sandboxes**. Each Lab is a throwaway
+Frappe bench, reachable over WireGuard, with credentials shown in the UI. It is
+not hardened for production workloads or untrusted tenants.
+
+Two consequences for a report:
+
+- A finding that amounts to "a Lab owner can reach their own Lab's data" is
+  expected behaviour, not a vulnerability.
+- A lab user holds root **inside** their bench. Without a user namespace,
+  in-container UID 0 is host UID 0. That is a documented deployment
+  precondition, not a bug: close it with sysbox, `userns-remap`, or a rootless
+  daemon, as [Production safety](docs/operator/production-safety.mdx) sets out.
+  A report that the boundary can be escaped **with** one of those in place is
+  in scope.

--- a/benchpress/config/docker-compose.yml
+++ b/benchpress/config/docker-compose.yml
@@ -35,6 +35,66 @@ services:
     networks:
       - benchpress
 
+  # The Docker event stream, consumed rather than polled: a bench that dies, is OOM-killed
+  # or stops answering is written down within seconds of the daemon saying so. The daemon
+  # keeps only its last few hundred events, so a cron reading `--since` loses them; this
+  # holds the stream open instead. It observes only — no stop, no restart, no route write.
+  #
+  # `benchpress.docker_events.run` republishes a heartbeat every tick, and the Diagnostics
+  # `docker_events` row fails once that heartbeat is older than HEARTBEAT_STALE_SECONDS
+  # (benchpress/docker_events.py). The listener therefore has to reach the same site, the
+  # same database and the same Redis as the backend — which is the `bench` network below,
+  # not the `benchpress` lab network the shared database and cache sit on.
+  #
+  #   docker compose -f <this file> up -d docker-events
+  #
+  # Run ONE listener per site. If the stack that runs your bench already defines a
+  # docker-events service, start that one instead: two listeners record every incident
+  # twice and notify the bench owner twice.
+  docker-events:
+    image: ${IMAGE_NAME:-benchpress:latest}
+    container_name: benchpress-docker-events
+    hostname: benchpress-docker-events
+    # A real `restart:`, not `deploy.restart_policy`, which `docker compose up` ignores.
+    # Without one the listener does not come back after a reboot and the fleet goes blind.
+    restart: unless-stopped
+    command:
+      - bench
+      - --site
+      - ${SITE_NAME:-frontend}
+      - execute
+      - benchpress.docker_events.run
+    # The backend's own mounts, taken from the running container. This file is run from
+    # inside the backend container, so it cannot name the host path behind the `apps`
+    # bind; `volumes_from` is how the listener gets it without guessing.
+    #
+    # Docker resolves `volumes_from` ONCE, at container create, and never re-resolves it.
+    # So recreate this container every time the backend container is recreated — both
+    # `./entry.py --pull` and `./entry.py --build` recreate it:
+    #
+    #   docker compose -f <this file> up -d --force-recreate docker-events
+    #
+    # Skip that and the listener keeps the pre-upgrade apps bind and the old sites volume,
+    # runs old code, and still publishes its heartbeat — so the Diagnostics `docker_events`
+    # row reads pass while the listener is stale. `restart: unless-stopped` above keeps a
+    # stale container alive indefinitely. tests/test_shared_compose.py does not catch this:
+    # it reads `volumes:` keys, and this service declares none.
+    #
+    # `volumes_from` is also all-or-nothing. It inherits every mount the backend has, not
+    # just sites, logs, apps and the socket: on this stack that is `${HOME}/.ssh`
+    # (read-only) and the wg-agent socket, neither of which the listener uses.
+    #
+    # The backend container must exist when this service is created.
+    volumes_from:
+      - container:${BENCH_BACKEND_CONTAINER:-benchpress_backend}
+    # The group that owns /var/run/docker.sock on the host: `getent group docker | cut -d: -f3`.
+    # Wrong number and the listener cannot read the socket, publishes no heartbeat, and the
+    # docker_events row stays red however often it is restarted.
+    group_add:
+      - "${DOCKER_GID:-988}"
+    networks:
+      - bench
+
 volumes:
   mariadb-data:
     name: benchpress-mariadb-data
@@ -43,6 +103,14 @@ volumes:
     name: benchpress-redis-data
 
 networks:
+  # The lab network every bench container and the shared database join, created by
+  # benchpress/docker_manager.py (ensure_network) on first deploy.
   benchpress:
     name: benchpress
+    external: true
+  # The network the BenchPress site itself runs on, so the listener can reach the site's
+  # database and Redis. `<compose project>_frappe_network` for a compose-run bench; the
+  # project defaults to `benchpress`. Only docker-events joins it.
+  bench:
+    name: ${BENCH_NETWORK:-benchpress_frappe_network}
     external: true

--- a/benchpress/diagnostics.py
+++ b/benchpress/diagnostics.py
@@ -14,7 +14,7 @@ import docker
 import frappe
 from frappe.query_builder.functions import Now
 
-from benchpress import placement
+from benchpress import ingress, placement
 from benchpress.docker_events import HEARTBEAT_STALE_SECONDS, heartbeat_value
 from benchpress.docker_manager import (
 	CONTAINER_RUNTIMES,
@@ -31,6 +31,13 @@ from benchpress.mariadb_manager import (
 from benchpress.vpn_adapter import DEFAULT_INTERFACE
 
 DRIFT_FIX = "Recreate the shared pair: docker compose up -d in benchpress/config"
+# What refreshes the route-directory report. Named in every row that has none to read, because a
+# row that says only "no report" leaves the reader with nothing to start it.
+ROUTE_STATE_FIX = "the scheduler and queue-long refresh it every reconcile pass, so check both"
+ROUTE_STATE_UNREPORTED = (
+	"No worker has reported on the Traefik route directory yet. The first deploy records it, and "
+	f"so does every reconcile pass — until one does, no public URL is verified: {ROUTE_STATE_FIX}"
+)
 # A row that says a listener is dead without naming what restarts it costs the reader a search.
 LISTENER_FIX = "start it with docker compose up -d docker-events"
 
@@ -85,6 +92,7 @@ def run_diagnostics() -> list[dict]:
 		_check_container_runtimes(),
 		_check_golden_images(),
 		_check_docker_events(),
+		_check_route_directory(),
 		check_vpn_server(),
 	]
 
@@ -329,6 +337,76 @@ def _check_docker_events() -> dict:
 		)
 	except Exception as e:
 		return check_row("docker_events", False, f"Could not read the listener heartbeat: {e}")
+
+
+def _check_route_directory() -> dict:
+	"""Whether the route directory the advertised public URL depends on is mounted and rendered.
+
+	Read from what a worker recorded: this screen renders in `backend`, which never mounts it.
+	"""
+	# The one check that fails on a stock install: `base_domain` is required, so step 5 of
+	# docs/operator/install.mdx advertises `<bench>.<domain>` on a checkout whose queue-long has
+	# no route mount, because only docker-compose.prod.yml declares one. Without this row every
+	# other check passes on a host where no public URL can ever answer.
+	try:
+		base_domain = frappe.get_cached_doc("BenchPress Settings").base_domain
+		if not base_domain or base_domain == "localhost":
+			return check_row("route_directory", True, "No public base domain, so no route is published")
+
+		state = ingress.directory_state()
+		if not state:
+			return check_row("route_directory", False, ROUTE_STATE_UNREPORTED, severity="Warning")
+		if state["age"] > ingress.ROUTE_STATE_STALE_SECONDS:
+			return check_row(
+				"route_directory",
+				False,
+				f"The route directory was last reported on {state['age']}s ago, past the "
+				f"{ingress.ROUTE_STATE_STALE_SECONDS}s it is given — {ROUTE_STATE_FIX}",
+				severity="Warning",
+			)
+
+		if not state["mounted"]:
+			return check_row("route_directory", False, ingress.route_directory_fix())
+
+		missing = state["missing"]
+		if ingress.CONTROL_PLANE_ROUTE_FILE in missing:
+			# The failure this row exists to name: docker turns a bind source that does not exist
+			# into an empty directory, which passes every "is the path there" test there is.
+			return check_row(
+				"route_directory",
+				False,
+				f"The route directory holds no {ingress.CONTROL_PLANE_ROUTE_FILE}, so it is an "
+				"empty directory docker created for a bind source that was never rendered, not "
+				"the mount. Render it on the host: ./entry.py --domain <fqdn>",
+			)
+
+		if ingress.WILDCARD_ANCHOR_FILE not in missing:
+			return check_row(
+				"route_directory",
+				True,
+				f"{state['published']} bench routes published beside "
+				f"{ingress.CONTROL_PLANE_ROUTE_FILE}, *.{base_domain} anchored",
+			)
+		if not state["published"]:
+			return check_row(
+				"route_directory",
+				True,
+				"Route directory mounted and rendered, no bench route published yet — the first "
+				f"deploy writes {ingress.WILDCARD_ANCHOR_FILE}",
+			)
+		# Warning, not Error: every deploy and every reconcile pass writes the anchor, so this is a
+		# state that heals itself. Still worth a row, because until it does each of those published
+		# hostnames answers on a certificate the browser refuses.
+		return check_row(
+			"route_directory",
+			False,
+			f"{state['published']} bench routes are published but no {ingress.WILDCARD_ANCHOR_FILE} "
+			f"holds *.{base_domain} in Traefik's certificate store, so those URLs fail TLS. The "
+			"next deploy or reconcile pass writes it",
+			severity="Warning",
+		)
+	except Exception as e:
+		return check_row("route_directory", False, f"Could not read the route directory report: {e}")
 
 
 def check_vpn_server() -> dict:

--- a/benchpress/ingress.py
+++ b/benchpress/ingress.py
@@ -11,6 +11,7 @@ rather than learning the path.
 import os
 import socket
 import ssl
+import time
 from pathlib import Path
 from typing import NamedTuple
 
@@ -87,6 +88,16 @@ DEFAULT_RATE_BURST = 60
 # exhaust the pool.
 INFLIGHT_CEILING = 24
 
+# Only `queue-long` (read-write) and `traefik` (read-only) mount the route directory —
+# docker-compose.prod.yml, and no other service — so `backend`, which serves the diagnostics screen
+# in a web request, cannot stat it and reads what a worker last saw instead. Same shape as the
+# heartbeat `docker_events` publishes for a listener the web process cannot see either.
+ROUTE_STATE_KEY = "benchpress:route_directory"
+# The reconcile pass (hooks.py, `*/5`) refreshes this, so three missed passes are what it takes to
+# stop believing it. It outlives that so a stale record can still name its own age.
+ROUTE_STATE_STALE_SECONDS = 15 * 60
+ROUTE_STATE_EXPIRY = ROUTE_STATE_STALE_SECONDS * 2
+
 
 class RateLimits(NamedTuple):
 	"""The per-tier request numbers a bench's routers carry. An `inflight` of 0 is no cap at all."""
@@ -108,12 +119,27 @@ class TraefikRouteDirectoryMissing(Exception):
 	"""
 
 
+def route_directory_fix() -> str:
+	"""Why routing cannot be written and what fixes it — one wording for the log and the screen."""
+	# Read at call time, never baked into a module constant, so a test that repoints
+	# TRAEFIK_DYNAMIC_DIR gets a message about the directory it repointed to. It names
+	# `queue-long` rather than "this container" because the diagnostics screen renders it from
+	# `backend`, where the directory is absent by design and says nothing about routing.
+	return (
+		f"{TRAEFIK_DYNAMIC_DIR} is not mounted in queue-long, the one worker that writes routes. "
+		"Only docker-compose.prod.yml mounts it, and only a checkout brought up with "
+		"./entry.py --domain <fqdn> loads that overlay — so a Base Domain saved without one "
+		"advertises a public URL that cannot route. Set the domain on the host, or set Base "
+		"Domain to localhost to advertise no public URL."
+	)
+
+
 def publish(
 	instance_id: str,
 	base_domain: str,
 	ide: bool | None = None,
 	limits: RateLimits | None = None,
-) -> None:
+) -> bool:
 	"""Write Traefik file-provider routes for this instance's site, and its IDE when it has one.
 
 	`tls: {}` turns TLS on and names no resolver, so these routers serve whatever
@@ -128,7 +154,17 @@ def publish(
 	`bench_doc.bench_name` and `BenchInstance.autoname` sets `name = bench_name`.
 	"""
 	if not base_domain or base_domain == "localhost":
-		return
+		return False
+
+	# Reported, not raised. `base_domain` is a required field, so the documented install fills
+	# it (docs/operator/install.mdx step 5) on a checkout whose queue-long has no route mount,
+	# and the raise inside `_atomic_write` then killed the deploy after the container was already
+	# built. The advice it carried — reach routing through `enqueue_route_sync` — was also
+	# already satisfied: this is queue-long. Creating the directory is not the alternative; a
+	# container without the mount cannot, `/etc` is root-owned and bench runs as uid 1000.
+	# `route_directory` in diagnostics.py is where the operator meets this state.
+	if not directory_mounted():
+		return False
 
 	# What `routable` already resolved for this bench, else the same read for one.
 	# Never the caller's own idea of the flag: the */5 pass writes this file without the
@@ -198,6 +234,9 @@ def publish(
 		TRAEFIK_DYNAMIC_DIR / f"{instance_id}.yml",
 		yaml.safe_dump({"http": {"routers": routers, "middlewares": middlewares, "services": services}}),
 	)
+	# True is "the route file is on disk", not "the file changed" — an unchanged route is
+	# published just as much as a rewritten one.
+	return True
 
 
 def _router(rule: str, service: str, middlewares: list[str], priority: int) -> dict:
@@ -313,9 +352,42 @@ def protected_present() -> int:
 	return sum(1 for name in PROTECTED_ROUTE_FILES if (TRAEFIK_DYNAMIC_DIR / name).exists())
 
 
+def protected_missing() -> list[str]:
+	"""Which protected files are absent, named — the two fail differently, so a count cannot say."""
+	# `dynamic.yml` absent means the directory is not the rendered bind source at all, and an
+	# absent anchor means no certificate. Named here rather than the path being handed out, for
+	# the same reason `published` is a call: one off-by-one on either name is an outage.
+	return sorted(name for name in PROTECTED_ROUTE_FILES if not (TRAEFIK_DYNAMIC_DIR / name).exists())
+
+
 def directory_mounted() -> bool:
 	"""Whether the route directory is mounted here — asked instead of the path being handed out."""
 	return TRAEFIK_DYNAMIC_DIR.is_dir()
+
+
+def record_directory_state() -> dict:
+	"""Publish what this worker sees of the route directory, for a reader that cannot stat it."""
+	# Not called per bench: `publish` runs once per routable bench in the convergence loop, and a
+	# record written there would be the same answer 300 times a pass. The two callers are the
+	# once-per-deploy and once-per-transition paths, and both record before their own mount gate —
+	# the state worth reporting is exactly the one that makes those gates close.
+	mounted = directory_mounted()
+	state = {
+		"ts": int(time.time()),
+		"mounted": mounted,
+		"missing": protected_missing() if mounted else sorted(PROTECTED_ROUTE_FILES),
+		"published": len(published()) if mounted else 0,
+	}
+	frappe.cache().set_value(ROUTE_STATE_KEY, state, expires_in_sec=ROUTE_STATE_EXPIRY)
+	return state
+
+
+def directory_state() -> dict | None:
+	"""What the last worker to reach routing saw, plus its `age`, or None when none has."""
+	state = frappe.cache().get_value(ROUTE_STATE_KEY)
+	if not state:
+		return None
+	return {**state, "age": int(time.time()) - cint(state.get("ts"))}
 
 
 def ensure_anchor(base_domain: str | None) -> bool:
@@ -325,6 +397,13 @@ def ensure_anchor(base_domain: str | None) -> bool:
 	the certificate renewing.
 	"""
 	if not base_domain or base_domain == "localhost":
+		return False
+
+	# Same gate as `publish`, and for the same reason: this runs at the first step of every
+	# deploy, so a raise here fails the run before any bench work starts. Recorded rather than
+	# only tested, because this is the one call every deploy makes and the reconcile pass makes
+	# every five minutes — it is what keeps the `route_directory` diagnostics row current.
+	if not record_directory_state()["mounted"]:
 		return False
 
 	wanted = yaml.safe_dump(_wildcard_anchor_config(base_domain))
@@ -343,6 +422,13 @@ def log_certificate_state(instance_id: str, base_domain: str | None, pipeline) -
 	re-prove the first one.
 	"""
 	if not base_domain or base_domain == "localhost":
+		return
+
+	# Ahead of the handshake, because it outranks it: with no route directory there is no
+	# Traefik to hand a certificate to, and `_certificate_error` would report the same host
+	# state as "could not reach Traefik" — true, and the wrong thing to go fix.
+	if not directory_mounted():
+		pipeline.log(f"WARNING: {route_directory_fix()}")
 		return
 
 	hostname = f"{instance_id}.{base_domain}"
@@ -393,6 +479,8 @@ def _atomic_write(path: Path, text: str) -> bool:
 	that is absent is a container that cannot reach Traefik, and creating it would turn
 	that into a file nobody reads.
 	"""
+	# `publish` and `ensure_anchor` both gate on `directory_mounted` and return instead, so this
+	# is now the invariant under a future writer that forgets to, not a path an operator meets.
 	if not path.parent.is_dir():
 		raise TraefikRouteDirectoryMissing(
 			f"{path.parent} is not mounted in this container. It is a bind mount of "
@@ -450,18 +538,25 @@ def _wildcard_anchor_config(base_domain: str) -> dict:
 
 
 def sync_instance_route(bench_name: str) -> str:
-	"""Make this bench's route file agree with its status; returns `written`, `deleted` or `skipped`.
+	"""Make this bench's route file agree with its status.
 
-	The one decision point for whether a bench should own a route at all, so a lifecycle
-	transition has one thing to remember rather than a write call in the start path and a
-	delete call in the stop path. A bench that no longer exists reads as no status, which
-	deletes — the same answer as `Stopped`, and the reason this does not raise.
-
-	Reach it through `enqueue_route_sync`, never directly from a web request.
+	Returns `written`, `deleted`, `skipped` (no public domain) or `unmounted` (no route directory).
 	"""
+	# The one decision point for whether a bench should own a route at all, so a lifecycle
+	# transition has one thing to remember rather than a write call in the start path and a
+	# delete call in the stop path. A bench that no longer exists reads as no status, which
+	# deletes — the same answer as `Stopped`, and the reason this does not raise.
+	#
+	# Reach it through `enqueue_route_sync`, never directly from a web request.
 	base_domain = frappe.get_cached_doc("BenchPress Settings").base_domain
 	if not base_domain or base_domain == "localhost":
 		return "skipped"
+
+	# Its own result, never folded into `skipped`: `skipped` is an operator who advertises no
+	# public URL, and this is one who advertises a URL the host cannot serve. A job that raised
+	# here failed on every start, stop and restart of every bench on such a host.
+	if not record_directory_state()["mounted"]:
+		return "unmounted"
 
 	if frappe.db.get_value("Bench Instance", bench_name, "status") == "Running":
 		publish(bench_name, base_domain)

--- a/benchpress/overview.py
+++ b/benchpress/overview.py
@@ -38,6 +38,7 @@ INFRASTRUCTURE_LABELS = {
 	"container_runtimes": "Container runtimes",
 	"golden_images": "Golden images",
 	"docker_events": "Event listener",
+	"route_directory": "Route directory",
 	"vpn_server": "WireGuard",
 }
 
@@ -306,7 +307,7 @@ def _bench_labels(bench_names: list[str]) -> dict:
 
 
 def _infrastructure(admin: bool) -> list[dict] | None:
-	"""The eleven real diagnostics checks — admins only, never a placeholder."""
+	"""The twelve real diagnostics checks — admins only, never a placeholder."""
 	if not admin:
 		return None
 	from benchpress.diagnostics import display_row, run_diagnostics

--- a/benchpress/public/css/landing.css
+++ b/benchpress/public/css/landing.css
@@ -452,6 +452,13 @@ h2 {
 	font-size: 14px;
 	color: rgba(255, 255, 255, 0.6);
 }
+/* Inline code in prose: the agents section and the FAQ name endpoints inline, and without
+   this they fall back to the browser default instead of the page's mono stack. */
+code {
+	font-family: var(--mono);
+	font-size: 0.92em;
+}
+
 .hero__endcard code {
 	font-family: var(--mono);
 	font-size: 12px;

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -59,6 +59,11 @@ DIAGNOSTICS_ROWS = [
 	{"check": "container_runtimes", "status": "pass", "hint": "Docker has sysbox-runc registered"},
 	{"check": "golden_images", "status": "pass", "hint": "8 of 8 built labs carry a golden dump"},
 	{"check": "docker_events", "status": "pass", "hint": "Docker event listener reported 2s ago"},
+	{
+		"check": "route_directory",
+		"status": "pass",
+		"hint": "2 bench routes published beside benchpress.yml, *.example.test anchored",
+	},
 	{"check": "vpn_server", "status": "pass", "hint": "WireGuard server 'wg0' configured"},
 ]
 

--- a/benchpress/tests/test_diagnostics.py
+++ b/benchpress/tests/test_diagnostics.py
@@ -1,17 +1,27 @@
 # Copyright (c) 2026, Venkatesh and Contributors
 # See license.txt
 
-"""run_diagnostics contract: eleven rows, fixed order, never raises, never mutates."""
+"""run_diagnostics contract: twelve rows, fixed order, never raises, never mutates."""
 
 import inspect
+import tempfile
+import time
 import unittest
 from datetime import datetime, timedelta
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import docker
 import frappe
 
-from benchpress.diagnostics import check_row, display_row, run_diagnostics
+from benchpress import ingress
+from benchpress.diagnostics import (
+	ROUTE_STATE_UNREPORTED,
+	_check_route_directory,
+	check_row,
+	display_row,
+	run_diagnostics,
+)
 from benchpress.docker_events import HEARTBEAT_STALE_SECONDS
 from benchpress.image_cache import clear_cached_tags
 
@@ -26,9 +36,10 @@ CHECK_ORDER = [
 	"container_runtimes",
 	"golden_images",
 	"docker_events",
+	"route_directory",
 	"vpn_server",
 ]
-COUNT_WORDS = {6: "six", 7: "seven", 8: "eight", 9: "nine", 10: "ten", 11: "eleven"}
+COUNT_WORDS = {6: "six", 7: "seven", 8: "eight", 9: "nine", 10: "ten", 11: "eleven", 12: "twelve"}
 HOST_RUNTIMES = {"names": {"runc", "sysbox-runc"}, "default": "runc"}
 # Small enough that a full bridge leaves the family with no headroom, which is the only
 # way `bridge_capacity` reports a fail.
@@ -50,6 +61,13 @@ IST_OFFSET = timedelta(hours=5, minutes=30)
 
 FRESH_HEARTBEAT = {"age": 2, "events_seen": 41, "orphans": 0, "pending": 0}
 
+# What a rendered, mounted route directory holds before any bench deploys. Named from `ingress`
+# rather than spelled out, so a rename there fails here rather than passing against a stale name.
+PROTECTED_FILES = (ingress.CONTROL_PLANE_ROUTE_FILE, ingress.WILDCARD_ANCHOR_FILE)
+BASE_DOMAIN = "benchpress.cloud"
+# Its own key, so a test run on a live host never clobbers the report its dashboard is reading.
+TEST_ROUTE_STATE_KEY = "benchpress:route_directory:test_diagnostics"
+
 
 def _lab_image(tag, golden=True):
 	return MagicMock(tags=[tag], labels={"benchpress.golden": "1"} if golden else {})
@@ -66,6 +84,11 @@ def _healthy_client(bridge_endpoints=4):
 
 
 class TestDiagnostics(unittest.TestCase):
+	def setUp(self):
+		"""The route-directory report is a cache key, so every test starts with none of its own."""
+		frappe.cache().delete_value(TEST_ROUTE_STATE_KEY)
+		self.addCleanup(frappe.cache().delete_value, TEST_ROUTE_STATE_KEY)
+
 	def _run(
 		self,
 		client=None,
@@ -84,6 +107,11 @@ class TestDiagnostics(unittest.TestCase):
 		redis_drift=None,
 		heartbeat=FRESH_HEARTBEAT,
 		heartbeat_error=None,
+		base_domain=BASE_DOMAIN,
+		route_dir_mounted=True,
+		route_files=PROTECTED_FILES,
+		published_routes=(),
+		route_state_reported=True,
 	):
 		"""Run run_diagnostics with everything healthy unless overridden.
 
@@ -91,6 +119,12 @@ class TestDiagnostics(unittest.TestCase):
 		client = client or _healthy_client()
 		ceilings = HEALTHY_CEILINGS if ceilings is None else ceilings
 		with (
+			# A real directory recorded through the real recorder, rather than a patched
+			# `directory_state`: what is on disk is the subject, and the empty-directory case
+			# this row exists to catch is invisible to a mocked answer.
+			tempfile.TemporaryDirectory() as tmp,
+			patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", Path(tmp) / "dynamic"),
+			patch.object(ingress, "ROUTE_STATE_KEY", TEST_ROUTE_STATE_KEY),
 			patch("benchpress.diagnostics.get_client", side_effect=client_error, return_value=client),
 			# A separate patch, because the runtime check reads `docker info` through
 			# its own memoised helper rather than through this client.
@@ -116,6 +150,14 @@ class TestDiagnostics(unittest.TestCase):
 			),
 			patch("benchpress.diagnostics.frappe") as frappe_mock,
 		):
+			if route_dir_mounted:
+				ingress.TRAEFIK_DYNAMIC_DIR.mkdir()
+				for name in (*route_files, *(f"{route}.yml" for route in published_routes)):
+					(ingress.TRAEFIK_DYNAMIC_DIR / name).write_text("")
+			if route_state_reported:
+				# What queue-long does on every deploy and every reconcile pass.
+				ingress.record_directory_state()
+			frappe_mock.get_cached_doc.return_value = frappe._dict(base_domain=base_domain)
 			frappe_mock.get_all.return_value = [DB_ROW] if db_rows is None else db_rows
 			frappe_mock.get_installed_apps.return_value = installed_apps or [
 				"frappe",
@@ -199,6 +241,7 @@ class TestDiagnostics(unittest.TestCase):
 			db_clock_error=Exception("down"),
 			ceilings={},
 			heartbeat=None,
+			route_dir_mounted=False,
 		)
 		# Capacity is the one exception: a family with no bridge yet is the lazy-creation
 		# invariant, not a broken environment.
@@ -347,6 +390,138 @@ class TestDiagnostics(unittest.TestCase):
 		self.assertIn("max_connections is 151, declared 500", row["hint"])
 		self.assertIn("88.00%", row["hint"])
 		self.assertIn("docker compose up -d", row["hint"])
+
+	def test_a_missing_route_directory_fails_and_names_what_mounts_it(self):
+		"""The stock install: Base Domain is required, so it is filled on a host with no mount."""
+		by_check, _rows = self._run(route_dir_mounted=False)
+
+		row = by_check["route_directory"]
+		self.assertEqual(row["status"], "fail")
+		self.assertEqual(row["severity"], "Error")
+		self.assertIn("queue-long", row["hint"])
+		self.assertIn("docker-compose.prod.yml", row["hint"])
+		self.assertIn("./entry.py --domain", row["hint"])
+
+	def test_the_row_reads_a_workers_report_never_this_containers_filesystem(self):
+		"""`backend` serves this screen and mounts no route directory — only queue-long and
+		traefik do — so a stat here would fail on a correctly configured host."""
+		with tempfile.TemporaryDirectory() as tmp:
+			route_dir = Path(tmp) / "dynamic"
+			route_dir.mkdir()
+			for name in PROTECTED_FILES:
+				(route_dir / name).write_text("")
+			with (
+				patch.object(ingress, "ROUTE_STATE_KEY", TEST_ROUTE_STATE_KEY),
+				patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", route_dir),
+			):
+				ingress.record_directory_state()
+
+			# The reader's own view of the path: absent, exactly as in `backend`.
+			with (
+				patch.object(ingress, "ROUTE_STATE_KEY", TEST_ROUTE_STATE_KEY),
+				patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", Path(tmp) / "not-here"),
+				patch("benchpress.diagnostics.frappe") as frappe_mock,
+			):
+				frappe_mock.get_cached_doc.return_value = frappe._dict(base_domain=BASE_DOMAIN)
+				row = _check_route_directory()
+
+		self.assertEqual(row["status"], "pass")
+		self.assertIn(f"*.{BASE_DOMAIN} anchored", row["hint"])
+
+	def test_no_report_at_all_is_a_warning_that_names_what_writes_one(self):
+		"""A public install nothing has reported on is unverified, not healthy."""
+		by_check, _rows = self._run(route_state_reported=False)
+
+		row = by_check["route_directory"]
+		self.assertEqual(row["status"], "fail")
+		self.assertEqual(row["severity"], "Warning")
+		self.assertEqual(row["hint"], ROUTE_STATE_UNREPORTED)
+
+	def test_a_stale_report_is_named_by_its_age_and_not_believed(self):
+		"""The reconcile pass refreshes it, so a report this old means the pass stopped running."""
+		age = ingress.ROUTE_STATE_STALE_SECONDS + 60
+		with patch.object(ingress, "ROUTE_STATE_KEY", TEST_ROUTE_STATE_KEY):
+			frappe.cache().set_value(
+				TEST_ROUTE_STATE_KEY,
+				{"ts": int(time.time()) - age, "mounted": True, "missing": [], "published": 3},
+			)
+			with patch("benchpress.diagnostics.frappe") as frappe_mock:
+				frappe_mock.get_cached_doc.return_value = frappe._dict(base_domain=BASE_DOMAIN)
+				row = _check_route_directory()
+
+		self.assertEqual(row["status"], "fail")
+		self.assertEqual(row["severity"], "Warning")
+		self.assertIn(f"{age}s ago", row["hint"])
+		self.assertIn(str(ingress.ROUTE_STATE_STALE_SECONDS), row["hint"])
+
+	def test_an_empty_route_directory_is_a_fail_not_a_mounted_pass(self):
+		"""Docker turns a bind source that does not exist into an empty directory, which is how
+		this bug hides from every check that only asks whether the path is there."""
+		by_check, _rows = self._run(route_files=())
+
+		row = by_check["route_directory"]
+		self.assertEqual(row["status"], "fail")
+		self.assertIn(ingress.CONTROL_PLANE_ROUTE_FILE, row["hint"])
+		self.assertIn("never rendered", row["hint"])
+
+	def test_a_rendered_directory_passes_and_counts_what_is_published(self):
+		by_check, _rows = self._run(published_routes=("inst-1", "inst-2"))
+
+		row = by_check["route_directory"]
+		self.assertEqual(row["status"], "pass")
+		self.assertIn("2 bench routes published", row["hint"])
+		self.assertIn(f"*.{BASE_DOMAIN} anchored", row["hint"])
+
+	def test_an_install_that_has_never_deployed_is_not_a_failure(self):
+		"""The anchor is written by the first deploy, so its absence before one is normal."""
+		by_check, _rows = self._run(route_files=(ingress.CONTROL_PLANE_ROUTE_FILE,))
+
+		row = by_check["route_directory"]
+		self.assertEqual(row["status"], "pass")
+		self.assertIn("no bench route published yet", row["hint"])
+
+	def test_published_routes_with_no_anchor_are_a_warning_naming_the_certificate(self):
+		by_check, _rows = self._run(
+			route_files=(ingress.CONTROL_PLANE_ROUTE_FILE,), published_routes=("inst-1",)
+		)
+
+		row = by_check["route_directory"]
+		self.assertEqual(row["status"], "fail")
+		self.assertEqual(row["severity"], "Warning")
+		self.assertIn("fail TLS", row["hint"])
+
+	def test_a_dev_checkout_advertising_no_public_url_passes(self):
+		for base_domain in ("localhost", ""):
+			with self.subTest(base_domain=base_domain):
+				by_check, _rows = self._run(base_domain=base_domain, route_dir_mounted=False)
+
+				self.assertEqual(by_check["route_directory"]["status"], "pass")
+				self.assertIn("No public base domain", by_check["route_directory"]["hint"])
+
+	def test_the_route_directory_check_writes_nothing(self):
+		"""Every diagnostics check is read-only, and this one names a directory Traefik reads live
+		and a report the workers own — it must leave both exactly as it found them."""
+		with tempfile.TemporaryDirectory() as tmp:
+			route_dir = Path(tmp) / "dynamic"
+			route_dir.mkdir()
+			for name in PROTECTED_FILES:
+				(route_dir / name).write_text("")
+
+			with (
+				patch.object(ingress, "ROUTE_STATE_KEY", TEST_ROUTE_STATE_KEY),
+				patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", route_dir),
+			):
+				ingress.record_directory_state()
+				before = {path.name: path.stat().st_mtime_ns for path in route_dir.iterdir()}
+				reported = frappe.cache().get_value(TEST_ROUTE_STATE_KEY)
+
+				with patch("benchpress.diagnostics.frappe") as frappe_mock:
+					frappe_mock.get_cached_doc.return_value = frappe._dict(base_domain=BASE_DOMAIN)
+					self.assertEqual(_check_route_directory()["status"], "pass")
+
+				self.assertEqual(frappe.cache().get_value(TEST_ROUTE_STATE_KEY), reported)
+
+			self.assertEqual({path.name: path.stat().st_mtime_ns for path in route_dir.iterdir()}, before)
 
 	def test_a_redis_on_the_declared_settings_passes(self):
 		by_check, _rows = self._run()

--- a/benchpress/tests/test_ingress.py
+++ b/benchpress/tests/test_ingress.py
@@ -22,6 +22,22 @@ from benchpress.tests.test_deploy_manager import _fresh_bench, _make_lab
 IPV4_IN_TEXT = re.compile(r"\b\d{1,3}(?:\.\d{1,3}){3}\b")
 
 
+# The report `ensure_anchor` and `sync_instance_route` publish is a cache key, and these tests
+# write it for real. Redirected for the whole module so a run on a live host never clobbers the
+# report its own dashboard is reading.
+TEST_ROUTE_STATE_KEY = "benchpress:route_directory:test_ingress"
+_ROUTE_STATE_PATCH = patch.object(ingress, "ROUTE_STATE_KEY", TEST_ROUTE_STATE_KEY)
+
+
+def setUpModule():
+	_ROUTE_STATE_PATCH.start()
+
+
+def tearDownModule():
+	_ROUTE_STATE_PATCH.stop()
+	frappe.cache().delete_value(TEST_ROUTE_STATE_KEY)
+
+
 def _mounted(tmp) -> Path:
 	"""The route directory arranged the way production has it: a bind mount that exists.
 
@@ -86,9 +102,20 @@ class TestPublish(unittest.TestCase):
 			ide_service = config["http"]["services"]["ide-inst-1"]
 			self.assertEqual(ide_service["loadBalancer"]["servers"], [{"url": "http://inst-1:8080"}])
 
+	def test_publish_reports_the_route_is_on_disk_not_that_it_changed(self):
+		"""Two calls, one file, True both times — an unchanged route is published just as much
+		as a rewritten one, and the caller asks the first question, never the second."""
+		with tempfile.TemporaryDirectory() as tmp:
+			with (
+				patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", _mounted(tmp)),
+				patch.object(ingress, "has_ide", return_value=False),
+			):
+				self.assertTrue(ingress.publish("inst-1", "benchpress.cloud"))
+				self.assertTrue(ingress.publish("inst-1", "benchpress.cloud"))
+
 	def test_publish_no_ops_for_localhost(self):
-		"""Runs unmounted: the localhost return has to come before the missing-mount guard,
-		or a dev checkout would raise where it used to write nothing."""
+		"""Runs unmounted: the localhost return has to come before the missing-mount gate, or a
+		dev checkout could not tell "advertises no public URL" from "cannot publish one"."""
 		with tempfile.TemporaryDirectory() as tmp:
 			target_dir = Path(tmp) / "instances"
 			with (
@@ -760,10 +787,13 @@ class TestWildcardAnchor(unittest.TestCase):
 
 
 class TestRouteDirectoryGuard(unittest.TestCase):
-	"""A routing write from a container without the mount fails loudly.
+	"""A routing write from a container without the mount reports, and still creates nothing.
 
 	See specs/in-progress/restart-free-dynamic-routing/phase-3-invariant-and-convergence.md.
 	"""
+
+	# `base_domain` is a required field, so the documented install (docs/operator/install.mdx
+	# step 5) reaches this state on any checkout brought up without `./entry.py --domain`.
 
 	@contextmanager
 	def _unmounted(self):
@@ -772,32 +802,51 @@ class TestRouteDirectoryGuard(unittest.TestCase):
 			with patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", target_dir):
 				yield target_dir
 
-	def test_writing_a_route_without_the_mount_raises_and_creates_nothing(self):
-		"""Creating the directory is the defect being replaced: the file then lands in this
-		container's own filesystem, which is the same outcome with none of the evidence."""
+	def test_writing_a_route_without_the_mount_creates_nothing_and_does_not_raise(self):
+		"""Creating the directory is not the alternative and never was: `/etc` is root-owned and
+		bench runs as uid 1000, so a container without the mount cannot make one."""
 		with self._unmounted() as target_dir:
-			with self.assertRaises(ingress.TraefikRouteDirectoryMissing):
-				ingress.publish("inst-1", "benchpress.cloud")
+			self.assertFalse(ingress.publish("inst-1", "benchpress.cloud"))
 
 			self.assertFalse(target_dir.exists())
 
 	def test_the_anchor_write_is_guarded_too(self):
-		"""Both writers go through `_atomic_write`, so the guard cannot drift between them."""
+		"""Both writers gate on `directory_mounted`, so the answer cannot drift between them."""
 		with self._unmounted() as target_dir:
-			with self.assertRaises(ingress.TraefikRouteDirectoryMissing):
-				ingress.ensure_anchor("benchpress.cloud")
+			self.assertFalse(ingress.ensure_anchor("benchpress.cloud"))
 
 			self.assertFalse(target_dir.exists())
 
+	def test_a_deploy_is_not_failed_by_a_host_that_publishes_no_routes(self):
+		"""The defect: `publish` raised out of the deploy after the container was already built,
+		on the one path the install guide walks. A bench still works over the VPN."""
+		with self._unmounted():
+			for base_domain in ("benchpress.cloud", "localhost", ""):
+				with self.subTest(base_domain=base_domain):
+					self.assertFalse(ingress.publish("inst-1", base_domain))
+					self.assertFalse(ingress.ensure_anchor(base_domain))
+
 	def test_the_error_names_the_queue_that_has_the_mount(self):
-		"""The whole value of a custom exception here: a bare `FileNotFoundError` leaves the
-		reader to rediscover the mount topology from a traceback that shows none of it."""
-		with self._unmounted() as _target_dir:
+		"""The guard under `_atomic_write` is now the invariant for a future writer that forgets
+		to gate. A bare `FileNotFoundError` there shows none of the mount topology."""
+		with self._unmounted() as target_dir:
 			with self.assertRaises(ingress.TraefikRouteDirectoryMissing) as raised:
-				ingress.publish("inst-1", "benchpress.cloud")
+				ingress._atomic_write(target_dir / "inst-1.yml", "http: {}\n")
+
+			self.assertFalse(target_dir.exists())
 
 		self.assertIn("queue-long", str(raised.exception))
 		self.assertIn("enqueue_route_sync", str(raised.exception))
+
+	def test_the_reported_fix_names_the_directory_and_both_ways_out(self):
+		"""One wording behind the deploy-log line and the diagnostics row, so they cannot drift."""
+		with self._unmounted() as target_dir:
+			fix = ingress.route_directory_fix()
+
+		self.assertIn(str(target_dir), fix)
+		self.assertIn("docker-compose.prod.yml", fix)
+		self.assertIn("./entry.py --domain", fix)
+		self.assertIn("localhost", fix)
 
 
 class TestDirectoryReads(unittest.TestCase):
@@ -833,6 +882,98 @@ class TestDirectoryReads(unittest.TestCase):
 		with self._dir_holding("wildcard-anchor.yml"):
 			self.assertEqual(ingress.protected_present(), 1)
 
+	def test_protected_missing_names_the_absent_file_rather_than_counting(self):
+		"""`route_directory` acts on which one is gone: no `dynamic.yml` is an unrendered bind
+		source, and no anchor is a certificate that was never asked for."""
+		with self._dir_holding("dynamic.yml", "inst-1.yml"):
+			self.assertEqual(ingress.protected_missing(), ["wildcard-anchor.yml"])
+
+		with self._dir_holding("wildcard-anchor.yml"):
+			self.assertEqual(ingress.protected_missing(), ["dynamic.yml"])
+
+	def test_protected_missing_is_empty_on_a_rendered_directory(self):
+		with self._dir_holding("dynamic.yml", "wildcard-anchor.yml"):
+			self.assertEqual(ingress.protected_missing(), [])
+
+	def test_an_empty_directory_reports_both_protected_files_missing(self):
+		"""What docker leaves behind for a bind source that was never rendered."""
+		with self._dir_holding():
+			self.assertEqual(ingress.protected_missing(), ["dynamic.yml", "wildcard-anchor.yml"])
+
+
+class TestRouteDirectoryReport(unittest.TestCase):
+	"""What a worker records about the route directory, for the screen that cannot stat it.
+
+	`backend` renders diagnostics and mounts no route directory; queue-long and traefik do.
+	"""
+
+	def setUp(self):
+		frappe.cache().delete_value(TEST_ROUTE_STATE_KEY)
+		self.addCleanup(frappe.cache().delete_value, TEST_ROUTE_STATE_KEY)
+
+	@contextmanager
+	def _directory(self, *names, mounted=True):
+		with tempfile.TemporaryDirectory() as tmp:
+			target_dir = Path(tmp) / "dynamic"
+			if mounted:
+				target_dir.mkdir()
+				for name in names:
+					(target_dir / name).write_text("")
+			with patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", target_dir):
+				yield target_dir
+
+	def test_nothing_recorded_reads_as_no_report_rather_than_a_healthy_one(self):
+		self.assertIsNone(ingress.directory_state())
+
+	def test_a_rendered_directory_is_recorded_with_what_it_holds(self):
+		with self._directory("dynamic.yml", "wildcard-anchor.yml", "inst-1.yml", "inst-2.yml"):
+			ingress.record_directory_state()
+
+			state = ingress.directory_state()
+
+		self.assertTrue(state["mounted"])
+		self.assertEqual(state["missing"], [])
+		self.assertEqual(state["published"], 2)
+		self.assertLess(state["age"], 5)
+
+	def test_an_absent_directory_is_recorded_as_absent_and_not_as_silence(self):
+		"""Silence is the fresh install; this is the host that cannot route, and the row for the
+		two must differ."""
+		with self._directory(mounted=False):
+			ingress.record_directory_state()
+
+			state = ingress.directory_state()
+
+		self.assertFalse(state["mounted"])
+		self.assertEqual(state["missing"], ["dynamic.yml", "wildcard-anchor.yml"])
+		self.assertEqual(state["published"], 0)
+
+	def test_the_anchor_write_records_before_its_own_gate(self):
+		"""The one call every deploy makes on its first step, and the reconcile pass makes every
+		time — so the host that publishes nothing is exactly the host that reports."""
+		with self._directory(mounted=False):
+			self.assertFalse(ingress.ensure_anchor("benchpress.cloud"))
+
+		self.assertFalse(ingress.directory_state()["mounted"])
+
+	def test_a_dev_checkout_records_nothing_at_all(self):
+		"""No public URL is advertised, so there is nothing to report on and nothing to alarm."""
+		with self._directory(mounted=False):
+			for base_domain in (None, "", "localhost"):
+				with self.subTest(base_domain=base_domain):
+					ingress.ensure_anchor(base_domain)
+
+		self.assertIsNone(ingress.directory_state())
+
+	def test_publishing_one_bench_route_records_nothing(self):
+		"""The convergence loop calls `publish` once per bench, and 300 identical reports a pass
+		is what recording there would cost."""
+		with self._directory("dynamic.yml", "wildcard-anchor.yml"):
+			with patch.object(ingress, "has_ide", return_value=False):
+				self.assertTrue(ingress.publish("inst-1", "benchpress.cloud"))
+
+		self.assertIsNone(ingress.directory_state())
+
 
 class TestCertificateVerification(unittest.TestCase):
 	"""`log_certificate_state` / `_certificate_error` — phase 2.
@@ -843,6 +984,14 @@ class TestCertificateVerification(unittest.TestCase):
 
 	See specs/completed/wildcard-cert-routing/phase-2-certificate-verification.md.
 	"""
+
+	def setUp(self):
+		"""The route directory is present for every test here — its absence outranks the handshake."""
+		tmp = tempfile.TemporaryDirectory()
+		self.addCleanup(tmp.cleanup)
+		patcher = patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", _mounted(tmp.name))
+		patcher.start()
+		self.addCleanup(patcher.stop)
 
 	def _pipeline(self):
 		pipeline = MagicMock()
@@ -897,6 +1046,24 @@ class TestCertificateVerification(unittest.TestCase):
 
 				mock_check.assert_not_called()
 				self.assertEqual(pipeline.logged, [])
+
+	def test_a_missing_route_directory_is_reported_instead_of_the_handshake(self):
+		"""The deploy-log line for the stock install. `could not reach Traefik` is true of the
+		same host and sends the operator to look at TLS, which is not what is wrong."""
+		pipeline = self._pipeline()
+		with tempfile.TemporaryDirectory() as tmp:
+			with (
+				patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", Path(tmp) / "dynamic"),
+				patch.object(ingress, "_certificate_error", autospec=True) as mock_check,
+			):
+				ingress.log_certificate_state("inst-1", "benchpress.cloud", pipeline)
+
+			mock_check.assert_not_called()
+
+		self.assertEqual(len(pipeline.logged), 1)
+		self.assertIn("WARNING:", pipeline.logged[0])
+		self.assertIn("is not mounted in queue-long", pipeline.logged[0])
+		self.assertIn("./entry.py --domain", pipeline.logged[0])
 
 	def test_an_unreachable_traefik_is_not_reported_as_a_bad_certificate(self):
 		"""The two causes call for different actions, so they must stay apart in a log
@@ -1046,6 +1213,29 @@ class TestSyncInstanceRoute(IntegrationTestCase):
 
 			self.assertEqual(ingress.sync_instance_route(bench.name), "skipped")
 			self.assertEqual(seeded.read_text(), "untouched\n")
+
+	def test_a_host_with_no_route_directory_reports_unmounted_rather_than_raising(self):
+		"""The job ran on `queue-long` already, so the exception's advice — reach routing through
+		`enqueue_route_sync` — was met. Every start, stop and restart raised it instead."""
+		bench = self._bench("Running")
+
+		with _route_dir() as (ingress, target_dir):
+			with patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", target_dir / "absent"):
+				result = ingress.sync_instance_route(bench.name)
+
+			self.assertEqual(result, "unmounted")
+			self.assertFalse((target_dir / "absent").exists())
+
+	def test_unmounted_is_its_own_answer_and_not_skipped(self):
+		"""`skipped` is an operator advertising no public URL; this one advertises one the host
+		cannot serve. Folding them together loses the only difference worth acting on."""
+		bench = self._bench("Stopped")
+
+		with _route_dir() as (ingress, target_dir):
+			with patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", target_dir / "absent"):
+				self.assertEqual(ingress.sync_instance_route(bench.name), "unmounted")
+
+			self.assertEqual(ingress.sync_instance_route(bench.name), "deleted")
 
 	def test_the_written_route_names_the_container_and_no_address(self):
 		"""Phase 1's property has to survive this path too, since it is now the common one."""

--- a/benchpress/tests/test_landing.py
+++ b/benchpress/tests/test_landing.py
@@ -21,6 +21,7 @@ from benchpress.credits.seed import seed_defaults
 from benchpress.www import home
 
 PACK = "Landing Test Pack"
+BENCHPRESS_SETTINGS = "BenchPress Settings"
 
 
 def _delete_pack():
@@ -34,26 +35,41 @@ class TestLanding(IntegrationTestCase):
 		super().setUpClass()
 		frappe.set_user("Administrator")
 		seed_defaults()
+		cls.switch_at_start = frappe.db.get_single_value(BENCHPRESS_SETTINGS, "enable_credits")
 		frappe.db.commit()  # nosemgrep -- class fixtures must outlive the per-test transaction
 
 	def setUp(self):
 		config.clear_size_index()
 		self.addCleanup(frappe.set_user, "Administrator")
 
+	def enable_credits(self) -> None:
+		self.addCleanup(self.set_credits_enabled, self.switch_at_start)
+		self.set_credits_enabled(1)
+
+	def disable_credits(self) -> None:
+		self.addCleanup(self.set_credits_enabled, self.switch_at_start)
+		self.set_credits_enabled(0)
+
+	def set_credits_enabled(self, value) -> None:
+		frappe.db.set_single_value(BENCHPRESS_SETTINGS, "enable_credits", value)
+		frappe.clear_cache(doctype=BENCHPRESS_SETTINGS)
+
 	def render_as_guest(self) -> str:
 		frappe.set_user("Guest")
 		return get_response_content("/home")
 
 	def test_page_renders_for_guest(self):
+		self.disable_credits()
 		html = self.render_as_guest()
 		self.assertIn("Pick a template.", html)
-		self.assertIn("Join the waitlist.", html)
+		self.assertNotIn("Join the waitlist.", html)
 
 	def test_pricing_is_read_from_the_documents(self):
 		"""The Pricing section is commented out in home.html until the pack/rate numbers are
 		final (see the block's disabled-for-now note), so nothing here reaches the page yet --
 		assert the context assembles it correctly instead. Restore the `html`-based assertions
 		below once the section is back."""
+		self.enable_credits()
 		context = home.get_context(frappe._dict())
 		self.assertEqual(
 			{pack.pack_label for pack in config.active_packs()},
@@ -71,6 +87,7 @@ class TestLanding(IntegrationTestCase):
 	def test_a_price_edited_in_desk_changes_the_page(self):
 		"""Same disabled-section caveat as above: a new price now only has to reach the
 		context, not the page. Restore the `html`-based assertions once Pricing is back."""
+		self.enable_credits()
 		frappe.set_user("Administrator")
 		self.addCleanup(_delete_pack)
 		frappe.get_doc(
@@ -92,6 +109,7 @@ class TestLanding(IntegrationTestCase):
 		self.assertNotIn(PACK, html)
 
 	def test_an_inactive_pack_is_not_offered(self):
+		self.enable_credits()
 		frappe.set_user("Administrator")
 		self.addCleanup(_delete_pack)
 		frappe.get_doc(
@@ -121,12 +139,32 @@ class TestLanding(IntegrationTestCase):
 		self.assertLess(gallery, disclaimer)
 		self.assertLess(disclaimer, how_it_works)
 
-	def test_the_page_never_claims_a_public_url(self):
+	def test_the_page_states_the_real_address_model(self):
+		"""A bench answers on public names too once base_domain is set, so the page may only
+		claim the narrower truth: no bench port is published on the host."""
+		self.disable_credits()
 		html = self.render_as_guest()
 		self.assertIn("Unreachable", html)
-		self.assertIn("Nothing is published to the internet.", html)
+		self.assertIn("No bench port is published on the host.", html)
+		self.assertNotIn("Nothing is published to the internet.", html)
+
+	def test_the_hosted_surfaces_wait_for_metering(self):
+		self.disable_credits()
+		self.assertNotIn("Join the waitlist.", self.render_as_guest())
+		self.enable_credits()
+		self.assertIn("Join the waitlist.", self.render_as_guest())
+
+	def test_metering_off_costs_fewer_queries_than_metering_on(self):
+		self.disable_credits()
+		self._build_context()  # warm the doctype meta and Singles caches
+		off = _count_queries(self._build_context)
+		self.enable_credits()
+		self._build_context()
+		self.assertLess(off, _count_queries(self._build_context))
 
 	def test_context_cost_does_not_grow_with_the_catalogue(self):
+		self.enable_credits()
+		self._build_context()  # warm the doctype meta and Singles caches the switch just cleared
 		baseline = _count_queries(self._build_context)
 
 		self.addCleanup(_delete_pack)
@@ -145,6 +183,7 @@ class TestLanding(IntegrationTestCase):
 		self.assertEqual(grown, baseline, "another pack cost another query — the read path is per-row")
 
 	def test_context_is_two_queries(self):
+		self.enable_credits()
 		self._build_context()  # warm the doctype meta and Singles caches
 		self.assertEqual(_count_queries(self._build_context), 2)
 

--- a/benchpress/www/home.html
+++ b/benchpress/www/home.html
@@ -1,7 +1,15 @@
 {#-
-  Public landing page. Ported from the design handoff section for section — the copy is approved,
-  so treat the wording as fixed. Every number that could change commercially (pack prices, credits,
-  hourly rates, the custom-build charge) is read from Desk through home.py; nothing is hardcoded.
+  Public landing page. The layout came from the design handoff; the copy did not survive it. Every
+  sentence here has to be answerable from the code — endpoint names from `benchpress/api.py`, step
+  names and log lines from `deploy_pipeline.DEPLOY_STEPS` and `lifecycle._deploy_bench`, addresses
+  from `addressing.py`, template counts from `lab_templates.SEED_TEMPLATES`, and the deploy timings
+  from docs/operator/golden-images.mdx, which states its host. If a claim cannot be traced, cut it.
+
+  Every number that could change commercially (pack prices, credits, hourly rates, the custom-build
+  charge) is read from Desk through home.py; nothing is hardcoded.
+
+  `credits_enabled` is the same switch every other credits surface in the app checks. Off means the
+  feature does not exist, so nothing priced, metered or waitlisted may render inside that guard.
 
   Two palettes on purpose: marketing chrome uses the navy/blue set (landing.css), and anything
   inside `.ui-mock` keeps the Frappe/Espresso palette (landing-mock.css) because those blocks are
@@ -18,7 +26,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{ title | e }}</title>
-  <meta name="description" content="Pre-configured Frappe sites — ERPNext, HR, CRM, Helpdesk — deployed in one click as containers on your own server, reachable only over your private VPN.">
+  <meta name="description" content="Pre-configured Frappe sites — ERPNext, HR, CRM, Helpdesk — deployed in one click as containers on your own server. No bench port is published on the host.">
   <link rel="icon" type="image/svg+xml" href="/assets/benchpress/images/logo/favicon.svg?v={{ asset_version | e }}">
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/benchpress/images/logo/favicon-32.png?v={{ asset_version | e }}">
   <link rel="icon" type="image/png" sizes="64x64" href="/assets/benchpress/images/logo/favicon-64.png?v={{ asset_version | e }}">
@@ -45,7 +53,7 @@
 <header class="header">
   <div class="shell">
     <a class="header__brand" href="#start">
-      <img src="/assets/benchpress/images/logo/logo-dark.png?v={{ asset_version | e }}" alt="Benchpress">
+      <img src="/assets/benchpress/images/logo/logo-dark.png?v={{ asset_version | e }}" alt="BenchPress">
     </a>
     <nav class="header__nav">
       <a href="#templates">Templates</a>
@@ -55,7 +63,11 @@
     </nav>
     <div class="header__actions">
       <a class="button button--ghost-dark" href="{{ repo_url | e }}" aria-label="GitHub"><i class="icon" data-lucide="github"></i><span class="button__label">GitHub</span></a>
+      {%- if credits_enabled %}
       <a class="button button--primary" href="{{ start_route | e }}">Start free</a>
+      {%- else %}
+      <a class="button button--primary" href="#start">Self-host it</a>
+      {%- endif %}
     </div>
   </div>
 </header>
@@ -66,13 +78,18 @@
     <div class="hero__intro">
       <div class="hero__pill">Open source · Self-hostable</div>
       <h1>Pick a template.<br>Press deploy. <span class="accent-green">Done.</span></h1>
-      <p class="hero__copy">Benchpress turns a Frappe bench into one button. Pre-configured sites — ERPNext, HR, CRM, Helpdesk — provisioned as containers, reachable only over your private VPN. No bench commands, no SSH, no waiting on an engineer.</p>
+      <p class="hero__copy">BenchPress turns a Frappe bench into one button. Pre-configured sites — ERPNext, HR, CRM, Helpdesk — provisioned as containers on your own server. No bench commands to type, no server to prepare per person, no waiting on an engineer.</p>
       <div class="hero__ctas">
+        {%- if credits_enabled %}
         <a class="button button--primary button--large" href="{{ start_route | e }}">Start free — {{ free_credits | e }} credits<i class="icon" data-lucide="arrow-right"></i></a>
-        <a class="button button--ghost-dark button--large" href="{{ repo_url | e }}"><i class="icon" data-lucide="github"></i>Clone the repo</a>
+        {%- else %}
+        <a class="button button--primary button--large" href="#start">Install it on your server<i class="icon" data-lucide="arrow-right"></i></a>
+        {%- endif %}
+        <a class="button button--ghost-dark button--large" href="{{ repo_url | e }}"><i class="icon" data-lucide="github"></i>Read the source</a>
       </div>
       <div class="hero__trust">
-        <span>No card required</span><span>Bring your own server</span><span>{{ license_label | e }} licensed</span>
+        {%- if credits_enabled %}<span>No card required</span>{% endif %}
+        <span>Bring your own server</span><span>{{ license_label | e }} licensed</span>
       </div>
     </div>
 
@@ -81,7 +98,7 @@
       <video src="{{ hero_media.video | e }}" autoplay muted loop playsinline controls preload="metadata"
              {% if hero_media.poster %}poster="{{ hero_media.poster | e }}"{% endif %}></video>
       {%- elif hero_media.poster %}
-      <img src="{{ hero_media.poster | e }}" alt="Benchpress deploying an ERPNext site">
+      <img src="{{ hero_media.poster | e }}" alt="BenchPress deploying an ERPNext site">
       {%- else %}
       {#- The film is exported from the design tool after launch; until the mp4 lands, the frame
           holds the endcard rather than a black box. -#}
@@ -111,47 +128,63 @@
     <div class="lede">
       <div class="eyebrow">Template gallery</div>
       <h2>Every site starts from something known-good.</h2>
-      <p class="body">Templates pin the app set, the Frappe version and the seed data. Deploying one is free — you pay for the hours it runs. Or build a custom image once and reuse it forever.</p>
+      <p class="body">A template pins the app set, the Frappe version and the instance size. Fourteen ship in the catalog — these seven stacks, each seeded on both version-15 and version-16. Templates are records, so an admin adds, edits or retires one in Desk without a deploy.</p>
     </div>
     <div class="grid grid--3">
       <div class="card">
-        <div class="card__icon" style="background-image:url(/assets/benchpress/images/apps/erpnext.svg)"></div>
-        <div class="card__title">ERPNext v15</div>
-        <p class="card__text">Full ERP — accounting, stock, manufacturing. Demo company optional.</p>
-        <div class="card__meta">Free to deploy · ~90s</div>
+        <div class="card__icon" style="background-image:url(/assets/benchpress/images/apps/frappe.svg)"></div>
+        <div class="card__title">Frappe Framework</div>
+        <p class="card__text">Bare Frappe bench with no extra apps — the lightest starting point.</p>
+        <div class="card__meta">version-15 · version-16</div>
       </div>
       <div class="card">
-        <div class="card__icon" style="background-image:url(/assets/benchpress/images/apps/hrms.svg)"></div>
-        <div class="card__title">Frappe HR</div>
-        <p class="card__text">Payroll, leaves, attendance and onboarding on top of ERPNext.</p>
-        <div class="card__meta">Free to deploy · ~2m</div>
+        <div class="card__icon" style="background-image:url(/assets/benchpress/images/apps/erpnext.svg)"></div>
+        <div class="card__title">ERPNext</div>
+        <p class="card__text">Full ERP suite: accounting, inventory, manufacturing and more.</p>
+        <div class="card__meta">version-15 · version-16</div>
       </div>
       <div class="card">
         <div class="card__icon" style="background-image:url(/assets/benchpress/images/apps/crm.svg)"></div>
         <div class="card__title">Frappe CRM</div>
-        <p class="card__text">Pipelines, deals and call logs. Lean site, fastest to spin up.</p>
-        <div class="card__meta">Free to deploy · ~60s</div>
+        <p class="card__text">Lightweight sales CRM on Frappe — leads, deals and contacts.</p>
+        <div class="card__meta">version-15 · version-16</div>
       </div>
       <div class="card">
-        <div class="card__icon" style="background-image:url(/assets/benchpress/images/apps/helpdesk.svg)"></div>
-        <div class="card__title">Helpdesk</div>
-        <p class="card__text">Ticketing with a customer portal and canned responses.</p>
-        <div class="card__meta">Free to deploy · ~75s</div>
+        <div class="card__icon" style="background-image:url(/assets/benchpress/images/apps/hrms.svg)"></div>
+        <div class="card__title">Frappe HR</div>
+        <p class="card__text">HR and payroll suite — employees, leaves, attendance and payroll, on top of ERPNext.</p>
+        <div class="card__meta">version-15 · version-16</div>
       </div>
       <div class="card">
         <div class="card__icon" style="background-image:url(/assets/benchpress/images/apps/lms.svg)"></div>
-        <div class="card__title">Learning</div>
-        <p class="card__text">Courses, batches and certificates for internal training.</p>
-        <div class="card__meta">Free to deploy · ~90s</div>
+        <div class="card__title">Frappe Learning</div>
+        <p class="card__text">Learning management system — courses, quizzes and batches.</p>
+        <div class="card__meta">version-15 · version-16</div>
+      </div>
+      <div class="card">
+        <div class="card__icon" style="background-image:url(/assets/benchpress/images/apps/helpdesk.svg)"></div>
+        <div class="card__title">Frappe Helpdesk</div>
+        <p class="card__text">Customer support desk — tickets, SLAs and a knowledge base.</p>
+        <div class="card__meta">version-15 · version-16</div>
+      </div>
+      <div class="card">
+        <div class="card__icon" style="background-image:url(/assets/benchpress/images/apps/india_compliance.svg)"></div>
+        <div class="card__title">ERPNext + India Compliance</div>
+        <p class="card__text">ERPNext with GST, e-invoicing and TDS for Indian businesses.</p>
+        <div class="card__meta">version-15 · version-16</div>
       </div>
       <div class="card card--dashed">
         <div class="card__icon" style="background-image:url(/assets/benchpress/images/apps/frappe.svg)"></div>
-        <div class="card__title">Custom image</div>
-        <p class="card__text">Point Benchpress at your own apps repo and branch. Build once, deploy from it like any template.</p>
+        <div class="card__title">Custom lab</div>
+        <p class="card__text">No template matching your app set? Point BenchPress at your own repos and branches. Build the image once, then deploy from it like any template.</p>
+        {%- if credits_enabled %}
         <div class="card__meta">{{ build_credits | e }} credits to build · free if it fails</div>
+        {%- else %}
+        <div class="card__meta">Build once · deploy many times</div>
+        {%- endif %}
       </div>
     </div>
-    <p class="disclaimer">Frappe, ERPNext, Frappe HR, Frappe CRM, Helpdesk and Frappe Learning are trademarks of Frappe Technologies Pvt. Ltd., used here only to name the software each template installs. Benchpress is an independent project, not affiliated with, endorsed by or sponsored by Frappe Technologies.</p>
+    <p class="disclaimer">Frappe, ERPNext, Frappe HR, Frappe CRM, Frappe Helpdesk and Frappe Learning are trademarks of Frappe Technologies Pvt. Ltd.; India Compliance is published by Resilient Tech. Both are named here only to say what each template installs. BenchPress is an independent project, not affiliated with, endorsed by or sponsored by either.</p>
   </div>
 </section>
 
@@ -161,7 +194,7 @@
     <div class="lede">
       <div class="eyebrow">How it works</div>
       <h2>One click, four phases, eleven steps.</h2>
-      <p class="body">Benchpress is a control plane, not a host. It talks to the Docker daemon on your own server, runs the bench commands you would have typed, and hands the finished site to your WireGuard mesh. Pick a phase to follow what moves where.</p>
+      <p class="body">BenchPress is a control plane, not a host. It talks to a Docker daemon on your own server, runs the bench commands you would have typed, and reports each step into the deploy log as it goes. These eleven are the pipeline's own, in the order the code runs them. Pick a phase to follow what moves where.</p>
     </div>
 
     <div class="tabs" role="tablist">
@@ -189,9 +222,9 @@
             <div class="node__head">
               <i class="icon" data-lucide="laptop"></i>
               <span>Your device</span>
-              <span class="node__addr">10.13.13.2</span>
+              <span class="node__addr">browser · wg client</span>
             </div>
-            <div class="node__note">Browser + WireGuard client. The only way in.</div>
+            <div class="node__note">A browser for the public name, a WireGuard client for the private one.</div>
           </div>
 
           <div class="wire"></div>
@@ -199,13 +232,13 @@
           <div class="node" data-node="control" data-active="{{ node_state('control') }}">
             <div class="node__head">
               <i class="icon" data-lucide="cpu"></i>
-              <span>Benchpress control plane</span>
+              <span>BenchPress control plane</span>
               <span class="node__addr">Frappe app</span>
             </div>
             <div class="chips">
-              <span class="chip" data-chip="api" data-active="{{ chip_state('api') }}">REST / API keys</span>
-              <span class="chip" data-chip="queue" data-active="{{ chip_state('queue') }}">Deploy queue</span>
-              <span class="chip" data-chip="ledger" data-active="{{ chip_state('ledger') }}">Credit ledger</span>
+              <span class="chip" data-chip="api" data-active="{{ chip_state('api') }}">Whitelisted endpoints</span>
+              <span class="chip" data-chip="queue" data-active="{{ chip_state('queue') }}">Long queue</span>
+              {%- if credits_enabled %}<span class="chip" data-chip="ledger" data-active="{{ chip_state('ledger') }}">Credit ledger</span>{% endif %}
             </div>
           </div>
 
@@ -215,19 +248,19 @@
             <div class="node__head">
               <i class="icon" data-lucide="server"></i>
               <span>Your server · Docker daemon</span>
-              <span class="node__addr">unix:///var/run/docker.sock</span>
+              <span class="node__addr">docker_socket</span>
             </div>
             <div class="node__pair">
               <div class="subnode" data-node="container" data-active="{{ node_state('container') }}">
                 <div class="subnode__title">bench container</div>
                 <div class="subnode__lines">
-                  <span>frappe + apps</span><span>gunicorn · socketio</span><span>nginx :80</span>
+                  <span>frappe + apps</span><span>bench serve :8000</span><span>code-server :8080</span>
                 </div>
               </div>
               <div class="subnode" data-node="services" data-active="{{ node_state('services') }}">
                 <div class="subnode__title">shared services</div>
                 <div class="subnode__lines">
-                  <span>mariadb :3306</span><span>redis cache · queue</span><span>volume /sites</span>
+                  <span>benchpress-mariadb :3306</span><span>benchpress-redis :6379</span><span>one database per site</span>
                 </div>
               </div>
             </div>
@@ -239,9 +272,9 @@
             <div class="node__head">
               <i class="icon" data-lucide="shield"></i>
               <span>WireGuard mesh</span>
-              <span class="node__addr">10.13.13.0/24</span>
+              <span class="node__addr">vpn_management</span>
             </div>
-            <div class="node__note">Every site answers on a mesh address. Nothing is published to the internet.</div>
+            <div class="node__note">Every bench claims a tunnel address, and every device gets its own key.</div>
           </div>
         </div>
 
@@ -276,7 +309,7 @@
 
     <div class="notice">
       <strong>If a step fails</strong>
-      <span>the run stops at that step, the container is discarded, and nothing is metered — a failed run costs nothing.</span>
+      <span>the run stops at that step, the container it created is removed and its VPN peer withdrawn, and the log keeps the failing line verbatim.{% if credits_enabled %} Nothing is metered — a failed run costs nothing.{% endif %}</span>
       {#- Pricing section is disabled below until the pack/rate numbers are final; drop this link back in alongside it. -#}
     </div>
   </div>
@@ -288,22 +321,23 @@
     <div>
       <div class="eyebrow">Inside the app</div>
       <h2>Status you can read at a glance.</h2>
-      <p class="body">One list of instances, one status word each. Build history keeps every log. Devices shows who is on the VPN. Credits and plans live in Settings, admin-only.</p>
+      <p class="body">One list of instances, one status word each. Deploy history and build history keep every run's log. Devices shows the WireGuard peers you have registered.</p>
       <div class="features">
         <div class="feature">
           <i class="icon" data-lucide="check"></i>
           <div>
             <div class="feature__title">Role-aware</div>
-            <div class="feature__text">Users see instances and deploy. Admins get templates, build logs, devices and billing.</div>
+            <div class="feature__text">A user sees the benches they own, deploys and registers devices. The template catalog, the new-lab form, build history and Settings are admin-only.</div>
           </div>
         </div>
         <div class="feature">
           <i class="icon" data-lucide="clock"></i>
           <div>
             <div class="feature__title">Live logs</div>
-            <div class="feature__text">Elapsed time per step, collapsible output, and the exact failing command when a build breaks.</div>
+            <div class="feature__text">Each of the eleven steps writes a marker with its position and how far into the run it started, so the stepper is a reading of the log rather than a timer.</div>
           </div>
         </div>
+        {%- if credits_enabled %}
         <div class="feature">
           <i class="icon" data-lucide="credit-card"></i>
           <div>
@@ -311,32 +345,41 @@
             <div class="feature__text">Stopped instances and failed builds cost nothing. Every transaction lands in the ledger.</div>
           </div>
         </div>
+        {%- else %}
+        <div class="feature">
+          <i class="icon" data-lucide="terminal"></i>
+          <div>
+            <div class="feature__title">SSH and a browser IDE</div>
+            <div class="feature__text">Every bench mints its own account inside the container and, when the lab and its instance size include it, a code-server session on port 8080.</div>
+          </div>
+        </div>
+        {%- endif %}
       </div>
     </div>
 
     <div class="ui-mock">
       <div class="ui-mock__head">
-        <span class="ui-mock__title">Build logs</span>
+        <span class="ui-mock__title">Deploy history</span>
         <span class="ui-mock__sub">last 24 hours</span>
-        <span class="ui-mock__chip">1,342 credits left</span>
+        {%- if credits_enabled %}<span class="ui-mock__chip">1,342 credits left</span>{% endif %}
       </div>
       <div class="ui-mock__row ui-mock__row--head"><span>Run</span><span>Lab</span><span>Duration</span><span>Result</span></div>
       <div class="ui-mock__row">
-        <span class="ui-mock__name">bench-erpnext-demo</span><span class="ui-mock__cell">erpnext-demo</span><span class="ui-mock__cell">5:12</span>
+        <span class="ui-mock__name">crm-demo</span><span class="ui-mock__cell">crm-16</span><span class="ui-mock__cell">0:13</span>
         <span class="ui-pill ui-pill--ok"><i></i>Success</span>
       </div>
       <div class="ui-mock__row ui-mock__row--zebra">
-        <span class="ui-mock__name">bench-hr-v16</span><span class="ui-mock__cell">hr-v16</span><span class="ui-mock__cell">0:19</span>
+        <span class="ui-mock__name">hr-demo</span><span class="ui-mock__cell">hrms-16</span><span class="ui-mock__cell">—</span>
         <span class="ui-pill ui-pill--err"><i></i>Failed</span>
       </div>
       <div class="ui-mock__row">
-        <span class="ui-mock__name">bench-crm-sandbox</span><span class="ui-mock__cell">crm-sandbox</span><span class="ui-mock__cell">3:48</span>
+        <span class="ui-mock__name">erp-sandbox</span><span class="ui-mock__cell">erpnext-16</span><span class="ui-mock__cell">0:21</span>
         <span class="ui-pill ui-pill--ok"><i></i>Success</span>
       </div>
       <div class="ui-mock__failure">
-        <div class="ui-mock__failure-head"><i data-lucide="triangle-alert"></i>Failed at step 2 — Build the lab image</div>
-        <div class="ui-mock__failure-log">no branch version-16 on github.com/frappe/hrms<br>build discarded · 0 credits charged</div>
-        <div class="ui-mock__failure-actions"><span>Rebuild image</span><span>View raw log</span></div>
+        <div class="ui-mock__failure-head"><i data-lucide="triangle-alert"></i>Failed at step 2 — Preparing the lab image</div>
+        <div class="ui-mock__failure-log">No built image for lab 'Frappe HR'. Build it first from the Lab record.<br>Cleanup: nothing to roll back — no container was created{% if credits_enabled %} · 0 credits charged{% endif %}</div>
+        <div class="ui-mock__failure-actions"><span>Build the image</span><span>View raw log</span></div>
       </div>
     </div>
   </div>
@@ -347,27 +390,28 @@
   <div class="shell grid grid--2">
     <div>
       <div class="eyebrow eyebrow--dark">For AI agents</div>
-      <h2>Disposable Frappe containers, spawned by API.</h2>
-      <p class="body">Everything the UI does is an endpoint. An agent can ask for a fresh ERPNext site, run against it, read the logs and tear it down — inside the VPN, with a credit ceiling so a runaway loop can't run up a bill.</p>
+      <h2>Disposable Frappe containers, driven by the same endpoints the dashboard uses.</h2>
+      <p class="body">There is no private API behind the dashboard: every screen in it is a call to <code>benchpress.api.*</code>, and an agent authenticating with a Frappe API key reaches exactly those. Launch a template, poll the deploy log, stop the bench when the work is done.</p>
       <div class="features">
-        <div class="feature"><i class="icon" data-lucide="bot"></i><div>One container per agent run — no shared state</div></div>
-        <div class="feature"><i class="icon" data-lucide="terminal"></i><div>Logs and bench output returned as JSON</div></div>
-        <div class="feature"><i class="icon" data-lucide="lock"></i><div>Scoped tokens, per-key credit limits, auto-expiry</div></div>
+        <div class="feature"><i class="icon" data-lucide="bot"></i><div><code>launch_template</code> claims one bench and hands the whole run to a single background job — building the lab image first if the host has none</div></div>
+        <div class="feature"><i class="icon" data-lucide="terminal"></i><div><code>get_deploy_logs</code> returns the bench's twenty most recent log lines as JSON, step markers included</div></div>
+        <div class="feature"><i class="icon" data-lucide="lock"></i><div>Every endpoint checks permissions itself: launching needs an app role, deleting needs an admin, and reads are scoped to benches you own</div></div>
       </div>
     </div>
     <div class="api">
-      <div class="api__head">POST /api/method/benchpress.deploy</div>
-      <pre>{
-  "template": "erpnext-v15",
-  "name": "agent-run-4821",
-  "ttl_minutes": 30,
-  "credit_ceiling": 20
-}
+      <div class="api__head">POST /api/method/benchpress.api.launch_template</div>
+      <pre>Authorization: token &lt;api_key&gt;:&lt;api_secret&gt;
 
-→ 202 { "instance": "agent-run-4821",
-        "status": "deploying",
-        "url": "https://agent-run-4821.vpn",
-        "logs": "/api/.../BLD-26-242" }</pre>
+{ "template": "crm-16" }
+
+→ 200 { "message": {
+    "name":       "7d8c889741dd47f182e87794201173d3",
+    "bench":      "7d8c889741dd47f182e87794201173d3",
+    "lab":        "crm-16",
+    "lab_title":  "Frappe CRM",
+    "lab_status": "Ready",
+    "will_build": false,
+    "eta_minutes": 4 } }</pre>
     </div>
   </div>
 </section>
@@ -382,27 +426,27 @@
         <span class="ui-mock__button">Add device</span>
       </div>
       <div class="ui-mock__row ui-mock__row--device">
-        <span class="ui-mock__device"><b>Priya · MacBook Pro</b><span>10.13.13.2 · handshake 12s ago</span></span>
-        <span class="ui-pill ui-pill--ok"><i></i>Connected</span>
+        <span class="ui-mock__device"><b>Priya's MacBook</b><span>Laptop · registered 12 Mar</span></span>
+        <span class="ui-pill ui-pill--ok"><i></i>Active</span>
       </div>
       <div class="ui-mock__row ui-mock__row--device ui-mock__row--zebra">
-        <span class="ui-mock__device"><b>Ravi · Windows desktop</b><span>10.13.13.7 · handshake 40s ago</span></span>
-        <span class="ui-pill ui-pill--ok"><i></i>Connected</span>
+        <span class="ui-mock__device"><b>Ravi's desktop</b><span>Desktop · registered 3 Apr</span></span>
+        <span class="ui-pill ui-pill--ok"><i></i>Active</span>
       </div>
       <div class="ui-mock__row ui-mock__row--device">
-        <span class="ui-mock__device"><b>demo-laptop</b><span>config downloaded, never connected</span></span>
-        <span class="ui-pill ui-pill--warn"><i></i>Not connected</span>
+        <span class="ui-mock__device"><b>demo-laptop</b><span>Laptop · registered 9 Apr</span></span>
+        <span class="ui-pill ui-pill--warn"><i></i>Pending</span>
       </div>
     </div>
 
     <div>
-      <div class="eyebrow">Private by default</div>
-      <h2>Nothing is on the public internet.</h2>
-      <p class="body">Sites are only reachable from a device on your VPN. Until a device is added and connected, Benchpress shows the instance as <span class="warn-word">Unreachable</span> rather than pretending it works. Add a device, connect, and the same URL resolves — no ports opened, no reverse proxy to babysit.</p>
+      <div class="eyebrow">Addressing</div>
+      <h2>No bench port is published on the host.</h2>
+      <p class="body">A bench answers on up to four addresses, and they are not alternatives. Two are public names Traefik terminates TLS for — the site and its browser IDE, under the base domain you set. Two are private: the same site and IDE on the container's tunnel address, on ports 8000 and 8080. Nothing is bound to a host port either way, so nobody reaches a bench by scanning the server. Until the tunnel is up, a private address shows as <span class="warn-word">Unreachable</span> rather than pretending it works.</p>
       <div class="pills">
-        <span class="pill">WireGuard mesh</span>
+        <span class="pill">WireGuard peer per bench</span>
         <span class="pill">Per-device keys</span>
-        <span class="pill">Revoke in one click</span>
+        <span class="pill">Remove a device, its peer is deleted</span>
         <span class="pill">Your own server</span>
       </div>
     </div>
@@ -469,40 +513,42 @@
       <h2>The same site, minus the afternoon.</h2>
     </div>
     <div class="compare">
-      <div class="compare__row compare__row--head"><span></span><span>Manual bench</span><span>Benchpress</span></div>
-      <div class="compare__row"><span>New ERPNext site</span><span>30–90 min, SSH required</span><span>One click, ~90 seconds</span></div>
-      <div class="compare__row"><span>Who can do it</span><span>Someone who knows bench</span><span>Anyone on the team</span></div>
-      <div class="compare__row"><span>When it breaks</span><span>Scroll the terminal, guess</span><span>Named failing step + rebuild</span></div>
-      <div class="compare__row"><span>Access</span><span>Open a port, hope</span><span>VPN-only, per-device keys</span></div>
-      <div class="compare__row"><span>Automation</span><span>Shell scripts you maintain</span><span>HTTP API with credit ceilings</span></div>
+      <div class="compare__row compare__row--head"><span></span><span>Manual bench</span><span>BenchPress</span></div>
+      <div class="compare__row"><span>New site</span><span>Install bench, match app versions, create the site, install each app</span><span>One click. For a CRM lab: 13.3s on an idle 2-vCPU host from a golden image, 43.3s without one</span></div>
+      <div class="compare__row"><span>Who can do it</span><span>Someone who knows bench</span><span>Anyone with a login and the app role</span></div>
+      <div class="compare__row"><span>When it breaks</span><span>Scroll the terminal, guess</span><span>The step that failed, by name, with its own log</span></div>
+      <div class="compare__row"><span>Access</span><span>Open a port, hope</span><span>No published port — Traefik for the public name, WireGuard for the private one</span></div>
+      <div class="compare__row"><span>Automation</span><span>Shell scripts you maintain</span><span>The same whitelisted endpoints the dashboard calls</span></div>
     </div>
   </div>
 </section>
 
-<!-- 11 · Open source CTA + the way in (waitlist form, or self-serve signup) -->
+<!-- 11 · Install it yourself, and — only while metering is on — the hosted way in -->
 <section class="section section--cta" id="start">
   <div class="shell">
     <div class="grid grid--2">
       <div>
         <div class="eyebrow">Open source</div>
-        <h2>Want to try it yourself? Clone the repo.</h2>
-        <p class="body">Benchpress is {{ license_label | e }} licensed. Download it, run it on your own server, and keep every container and credential in-house. The hosted build is the same code with billing attached.</p>
+        <h2>It installs into a bench you already have.</h2>
+        <p class="body">BenchPress is {{ license_label | e }} licensed and it is a Frappe app, not a distribution — <code>bench get-app</code> into an existing v16 bench, then one setup script for the host's Docker, network and IP forwarding. Every container and credential stays on your server.{% if credits_enabled %} The hosted build is the same code with metering switched on.{% endif %}</p>
       </div>
       <div class="panel">
         <div class="eyebrow eyebrow--muted">Get started</div>
-        <div class="terminal">git clone {{ repo_url | e }}<br>cd benchpress &amp;&amp; ./setup.sh</div>
+        <div class="terminal">cd /path/to/frappe-bench<br>bench get-app https://github.com/Venkateshvenki404224/vpn_management --branch version-16<br>bench get-app {{ repo_url | e }} --branch version-16<br>bench pip install docker<br>bench --site &lt;site&gt; install-app benchpress<br>bench --site &lt;site&gt; migrate<br>bash apps/benchpress/setup.sh &lt;site&gt;</div>
+        <p class="disclaimer">vpn_management is cloned first because BenchPress names it in <code>required_apps</code> and <code>install-app</code> will not fetch it for you. setup.sh takes the site name and must run on the host, not inside a container. The full runbook — the frontend build, the firewall and the base domain — is in docs/operator/install.mdx.</p>
         <div class="panel__buttons">
           <a class="button button--primary" href="{{ repo_url | e }}"><i class="icon" data-lucide="github"></i>View on GitHub</a>
-          <a class="button button--outline" href="{{ start_route | e }}">Use hosted</a>
+          <a class="button button--outline" href="{{ repo_url | e }}/blob/HEAD/docs/operator/install.mdx">Read the install guide</a>
         </div>
       </div>
     </div>
 
+    {%- if credits_enabled %}
     <div class="panel waitlist" id="waitlist">
-      <div class="eyebrow eyebrow--muted">Hosted Benchpress</div>
+      <div class="eyebrow eyebrow--muted">Hosted BenchPress</div>
       {%- if waitlist_open %}
       <h2>Join the waitlist.</h2>
-      <p class="body">Hosted access is invite-only while we size the first server. Leave an address and we'll email you a login with {{ free_credits | e }} credits when a slot opens. Self-hosting needs no invite — clone the repo above.</p>
+      <p class="body">Hosted access is invite-only while we size the first server. Leave an address and we'll email you a login with {{ free_credits | e }} credits when a slot opens. Self-hosting needs no invite — the install steps are above.</p>
       <form class="waitlist__form" data-waitlist novalidate>
         <input type="email" name="email" required autocomplete="email" placeholder="Work email" aria-label="Work email">
         <input type="text" name="full_name" autocomplete="name" placeholder="Name (optional)" aria-label="Name">
@@ -516,13 +562,14 @@
       </form>
       {%- else %}
       <h2>Start free.</h2>
-      <p class="body">Sign in with GitHub or Google, or use an email address — either way you land on {{ free_credits | e }} credits, no card and no invite. Self-hosting needs no account at all; clone the repo above.</p>
+      <p class="body">Sign in with GitHub or Google, or use an email address — either way you land on {{ free_credits | e }} credits, no card and no invite. Self-hosting needs no account at all; the install steps are above.</p>
       <div class="waitlist__actions">
         <a class="button button--primary button--large" href="{{ start_route | e }}">Start free — {{ free_credits | e }} credits<i class="icon" data-lucide="arrow-right"></i></a>
         <span class="waitlist__note">GitHub is one click, and needs no email verification.</span>
       </div>
       {%- endif %}
     </div>
+    {%- endif %}
   </div>
 </section>
 
@@ -537,20 +584,30 @@
       </details>
       <details>
         <summary>Where do the sites actually run?<i class="icon" data-lucide="chevron-down"></i></summary>
-        <p>As containers on a server you connect — your VPS, your bare metal, or a machine in the office. Benchpress orchestrates; it doesn't hold your data.</p>
+        <p>As containers on the Docker daemon you point BenchPress at — your VPS, your bare metal, or a machine in the office. BenchPress orchestrates; it doesn't hold your data.</p>
       </details>
       <details>
         <summary>Can an agent spin sites up and down on its own?<i class="icon" data-lucide="chevron-down"></i></summary>
-        <p>Yes. Issue a scoped API key with a credit ceiling and a TTL. The agent deploys, works, reads logs and destroys the instance; the ceiling stops a runaway loop.</p>
+        <p>Yes, with a Frappe API key and the app role. <code>launch_template</code> starts a bench, <code>get_deploy_logs</code> follows the run, and <code>bench_action</code> stops or restarts it. Deleting a bench is admin-only, so an agent that should be able to clean up after itself needs an admin key.</p>
       </details>
+      <details>
+        <summary>Do I have to run the VPN?<i class="icon" data-lucide="chevron-down"></i></summary>
+        <p>Yes — <code>vpn_management</code> is a required app, every deploy claims a WireGuard peer for its container, and the tunnel addresses are how you reach a bench over SSH. The public site and IDE names, which Traefik serves under your base domain, work without it.</p>
+      </details>
+      <details>
+        <summary>Does a bench keep running forever?<i class="icon" data-lucide="chevron-down"></i></summary>
+        {%- if credits_enabled %}
+        <p>It runs until its lease runs out or someone stops it. Renew from the lab page; an expired lease stops the container and the meter with it.</p>
+        {%- else %}
+        <p>It runs until someone stops or deletes it. Leases, expiry and automatic stops belong to the credits feature, which is off on this install.</p>
+        {%- endif %}
+      </details>
+      {%- if credits_enabled %}
       <details>
         <summary>What happens to credits if a build fails?<i class="icon" data-lucide="chevron-down"></i></summary>
-        <p>Nothing is charged. Failed builds and stopped instances are free; the ledger in Settings shows every line so you can check.</p>
+        <p>Nothing is charged. Failed builds and stopped instances are free; the ledger shows every line so you can check.</p>
       </details>
-      <details>
-        <summary>Is the VPN optional?<i class="icon" data-lucide="chevron-down"></i></summary>
-        <p>On the hosted build, no — it's the access path. Self-hosted, you can expose sites yourself, but the default assumes private.</p>
-      </details>
+      {%- endif %}
     </div>
   </div>
 </section>
@@ -561,7 +618,7 @@
     <div class="footer__grid">
       <div>
         <img src="/assets/benchpress/images/logo/logo-dark.png?v={{ asset_version | e }}" alt="BenchPress">
-        <p class="footer__blurb">Pre-configured Frappe sites, deployed in one click and kept on your private network.</p>
+        <p class="footer__blurb">Pre-configured Frappe sites, deployed in one click as containers on your own server.</p>
       </div>
       <div class="footer__column">
         <span>Product</span>
@@ -573,17 +630,17 @@
         <span>Developers</span>
         <a href="#agents">Agent API</a>
         <a href="{{ repo_url | e }}">GitHub</a>
-        <a href="{{ repo_url | e }}#quickstart">Self-hosting guide</a>
+        <a href="{{ repo_url | e }}/blob/HEAD/docs/operator/install.mdx">Self-hosting guide</a>
       </div>
       <div class="footer__column">
-        <span>Company</span>
-        <a href="{{ start_route | e }}">Contact</a>
+        <span>Project</span>
+        <a href="{{ repo_url | e }}/issues">Report an issue</a>
         <a href="#how">How it works</a>
-        <a href="{{ repo_url | e }}#licence">Licence</a>
+        <a href="{{ repo_url | e }}/blob/HEAD/license.txt">Licence</a>
       </div>
     </div>
     <div class="footer__legal">
-      <span>© 2026 Benchpress. {{ license_label | e }} licensed.</span>
+      <span>© 2026 BenchPress. {{ license_label | e }} licensed.</span>
       <span>Not affiliated with Frappe Technologies.</span>
     </div>
   </div>

--- a/benchpress/www/home.py
+++ b/benchpress/www/home.py
@@ -1,16 +1,8 @@
 # Copyright (c) 2026, Venkatesh and contributors
 # For license information, please see license.txt
 
-"""Context for the public landing page.
-
-The pricing on this page is not written into the markup — it is read from `Credit Pack` and
-`Instance Size`, so an operator retunes a price in Desk and the page changes on the next request
-with no deploy. That single requirement is why the landing page is a Jinja `www` page and not a
-static file or a route in the Vue SPA (whose router redirects every guest to `/login`).
-
-The whole page costs two queries: one for the packs, one for the sizes. Everything else is either
-a Single served from cache or a module constant, and the price strings are formatted in Python
-rather than through `fmt_money`, which reads number-format defaults from the database.
+"""Context for the public landing page: a Jinja `www` page, because prices are read from Desk.
+With `enable_credits` off it costs no queries at all — the hosted half of the page is not rendered.
 """
 
 import os
@@ -21,6 +13,7 @@ from frappe.utils import cint, flt
 from benchpress.credits.config import (
 	SIGNUP_ROUTE,
 	active_packs,
+	credits_enabled,
 	default_size,
 	instance_sizes,
 	settings,
@@ -44,34 +37,52 @@ CACHE_BUST_PATHS = (
 
 no_cache = 1
 
+# What the hosted surfaces read when there are no hosted surfaces. `enable_credits` off means the
+# feature does not exist, so the page renders the self-hosted story and asks the database nothing.
+NO_COMMERCE = {
+	"sizes": [],
+	"default_size": None,
+	"packs": [],
+	"build_credits": 0,
+	"free_credits": 0,
+	"waitlist_open": False,
+	"start_route": SIGNUP_ROUTE,
+}
+
 
 def get_context(context):
 	context.no_cache = 1
 	context.title = "BenchPress — pick a template, press deploy"
-	context.sizes = rate_rows()
-	context.default_size = default_size()
-	context.packs = priced_packs()
-	context.build_credits = cint(settings().custom_build_credits)
-	context.free_credits = cint(settings().signup_grant_credits)
+	context.credits_enabled = credits_enabled()
 	context.repo_url = REPO_URL
 	context.license_label = LICENSE_LABEL
-	context.waitlist_open = waitlist_open()
-	context.start_route = start_route(context.waitlist_open)
 	context.phases = PHASES
 	context.active_phase = ACTIVE_PHASE
 	context.csrf_token = session_csrf_token()
 	context.asset_version = asset_version()
 	context.hero_media = hero_media(context.asset_version)
+	context.update(commercial_context() if context.credits_enabled else dict(NO_COMMERCE))
 	return context
 
 
-def start_route(is_waitlist_open: bool) -> str:
-	"""Where every "Start free" on the page points.
+def commercial_context() -> dict:
+	"""Prices, credits and the way in — read only when metering is on, which is the only
+	state in which anything on the page renders them."""
+	is_waitlist_open = waitlist_open()
+	return {
+		"sizes": rate_rows(),
+		"default_size": default_size(),
+		"packs": priced_packs(),
+		"build_credits": cint(settings().custom_build_credits),
+		"free_credits": cint(settings().signup_grant_credits),
+		"waitlist_open": is_waitlist_open,
+		"start_route": start_route(is_waitlist_open),
+	}
 
-	One value, resolved once, because the page carries five of these buttons — header, hero, each
-	pack card, the open-source panel and the footer — and a switch that moved four of them would
-	be worse than one that moved none.
-	"""
+
+def start_route(is_waitlist_open: bool) -> str:
+	"""Where every "Start free" on the page points. One value, resolved once, because the page
+	carries several of these buttons and a switch that moved some of them would be worse."""
 	return "#waitlist" if is_waitlist_open else SIGNUP_ROUTE
 
 

--- a/benchpress/www/home_content.py
+++ b/benchpress/www/home_content.py
@@ -1,124 +1,118 @@
 # Copyright (c) 2026, Venkatesh and contributors
 # For license information, please see license.txt
 
-"""The eleven deploy steps, as the landing page tells them.
-
-Ported from the design handoff. The only edits are the ones the credit decisions force: a deploy
-is free, so nothing is "held" and nothing is "spent" — the hourly meter starts when the container
-is handed over, and a run that never gets there costs nothing.
-
-This is copy, not configuration. The rates on the page come from `Credit Pack` / `Instance Size`;
-these strings describe the mechanism and change with the code, not in Desk.
+"""The eleven deploy steps as `deploy_pipeline.DEPLOY_STEPS` runs them, grouped into four phases.
+Every `cmd` is a line the pipeline actually writes or a command it actually runs — quote, don't invent.
 """
 
 PHASES = [
 	{
-		"key": "request",
-		"label": "Request",
+		"key": "prepare",
+		"label": "Prepare",
 		"range": "Steps 1-2",
-		"summary": "Benchpress checks the plan, confirms your balance and reserves room on your host before anything is pulled.",
-		"timing": "Under a second — deploying is free; nothing is metered until the container runs.",
-		"nodes": ["device", "control"],
-		"chips": ["api", "queue", "ledger"],
+		"summary": "The run proves the shared database is up and the lab's image is on the host. The deploy itself never builds one.",
+		"timing": "One click on an unbuilt lab builds the image ahead of this step, under a lock so two clicks cannot build the same tag twice.",
+		"nodes": ["control", "host"],
+		"chips": ["api", "queue"],
 		"steps": [
 			{
 				"n": 1,
-				"title": "Reserve a container slot",
-				"detail": "The API validates the template, checks concurrency against your plan and reserves CPU, memory and a site name on the target host.",
-				"cmd": 'POST /api/method/benchpress.deploy { template: "erpnext-v15" }',
+				"title": "Check the shared infrastructure",
+				"detail": "One MariaDB and one Redis are shared by every bench. Both are started if they are down, and the run waits until MariaDB accepts connections.",
+				"cmd": "MariaDB reachable at benchpress-mariadb:3306",
 			},
 			{
 				"n": 2,
-				"title": "Check the balance",
-				"detail": "Deploying costs nothing. Benchpress confirms the account can cover the first hour of runtime and that you are inside your concurrency cap.",
-				"cmd": 'credits.check(user="you@example.com", size="Small")',
+				"title": "Resolve the lab image",
+				"detail": "The lab's tag has to be on the host already, or this step stops the run and says to build it — a deploy is never a 10-40 minute build in disguise. The log also says whether the image carries a golden database dump.",
+				"cmd": "Using built image benchpress/crm:lab",
 			},
 		],
 	},
 	{
-		"key": "image",
-		"label": "Image",
-		"range": "Steps 3-4",
-		"summary": "The app list becomes a layer. Templates reuse a cached image; a custom lab builds one once and keeps it.",
-		"timing": "Cached template: ~10s. First custom build: 3-6 minutes.",
-		"nodes": ["control", "host"],
-		"chips": ["queue"],
+		"key": "container",
+		"label": "Container",
+		"range": "Steps 3-5",
+		"summary": "The container is created at its instance size, started on a BenchPress bridge, and given a tunnel address.",
+		"timing": "No port is published on the host — the bench is reached through the bridge or the tunnel.",
+		"nodes": ["host", "container", "wg"],
+		"chips": [],
 		"steps": [
 			{
 				"n": 3,
-				"title": "Resolve the app list",
-				"detail": "Frappe version, apps and branches are pinned into an apps.json — the same file a manual bench build would use.",
-				"cmd": "apps.json → frappe@version-15, erpnext@version-15",
+				"title": "Create the container",
+				"detail": "Memory, CPU, PIDs and disk come from the Instance Size, read at deploy time. The container is never privileged; isolation comes from the runtime.",
+				"cmd": "container runtime sysbox-runc",
 			},
 			{
 				"n": 4,
-				"title": "Pull or build the image",
-				"detail": "A matching layer is pulled from the registry. Custom labs run a real image build, and its log is streamed into Build logs line by line.",
-				"cmd": "docker build --build-arg APPS_JSON_BASE64=… -t bp/erpnext-v15 .",
+				"title": "Wait for the container IP",
+				"detail": "Nothing can be written into the bench or routed at it until it reports an address on its bridge.",
+				"cmd": "container_ip <address on the bench bridge>",
+			},
+			{
+				"n": 5,
+				"title": "Configure the WireGuard peer",
+				"detail": "Any stale peer is removed, a fresh tunnel IP is claimed from vpn_management, and the container is configured with it.",
+				"cmd": "VPN peer <peer> registered, claimed IP <tunnel ip>",
 			},
 		],
 	},
 	{
 		"key": "site",
 		"label": "Site",
-		"range": "Steps 5-8",
-		"summary": "The container comes up and Benchpress runs the exact bench commands you would have typed, in order.",
-		"timing": "Roughly 60-120 seconds depending on the app set.",
+		"range": "Steps 6-8",
+		"summary": "Config is written into the container and the site is made — restored from the image's dump when it has one, created app by app when it does not.",
+		"timing": "For a CRM lab on an idle 2-vCPU host, the site step is 9.1s of a 13.3s deploy when the dump is restored; 37.2s of 43.3s when it is refused.",
 		"nodes": ["host", "container", "services"],
 		"chips": [],
 		"steps": [
 			{
-				"n": 5,
-				"title": "Start the container and services",
-				"detail": "The bench container starts alongside MariaDB and Redis, with the sites directory on a named volume so data survives a restart.",
-				"cmd": "docker run -v bp_sites:/home/frappe/frappe-bench/sites …",
-			},
-			{
 				"n": 6,
-				"title": "Create the site",
-				"detail": "A fresh site is created with a generated administrator password, which is stored encrypted and revealed only to you.",
-				"cmd": "bench new-site erpnext-demo.bp.local --admin-password ****",
+				"title": "Write common_site_config.json",
+				"detail": "The shared database host and credentials, three Redis URLs, the socket.io port and the site's own port, written into the container.",
+				"cmd": "/home/frappe/frappe-bench/sites/common_site_config.json written",
 			},
 			{
 				"n": 7,
-				"title": "Install apps and migrate",
-				"detail": "Every app in the template is installed, then migrations run. This is the step that fails loudest, so its output is kept verbatim.",
-				"cmd": "bench --site erpnext-demo.bp.local install-app erpnext && bench migrate",
+				"title": "Create the site",
+				"detail": "setup-site.sh runs as the bench user against a temporary MariaDB account that is dropped afterwards. It restores the image's golden dump when restore is left on in Settings, the image carries a dump and the server's MariaDB major version matches; it installs the apps itself when any of the three does not hold.",
+				"cmd": "bash /opt/benchpress/scripts/setup-site.sh",
 			},
 			{
 				"n": 8,
-				"title": "Build assets",
-				"detail": "Frontend bundles are built inside the container and served by its own nginx — no shared asset host to drift out of sync.",
-				"cmd": "bench build --production",
+				"title": "Assets",
+				"detail": "Nothing is built here. Frontend bundles are baked into the lab image at build time; a stale bundle is fixed by rebuilding the lab.",
+				"cmd": "Assets ship in the image — bundled at build time",
 			},
 		],
 	},
 	{
-		"key": "network",
-		"label": "Network",
+		"key": "access",
+		"label": "Access",
 		"range": "Steps 9-11",
-		"summary": "The site joins your mesh, gets health-checked, and only then are the credentials handed over and the meter started.",
-		"timing": "5-10 seconds, then the site is yours.",
-		"nodes": ["host", "wg", "device"],
-		"chips": ["ledger"],
+		"summary": "The tenant's account is made inside the container, the site is served, and only then is the instance marked Running.",
+		"timing": "Nothing before this line counts: a deploy that never reaches step 11 leaves no running bench.",
+		"nodes": ["host", "container", "device"],
+		"chips": [],
 		"steps": [
 			{
 				"n": 9,
-				"title": "Attach the WireGuard route",
-				"detail": "The container is given a mesh address and a peer entry per registered device. Nothing is bound to a public interface.",
-				"cmd": "wg set wg0 peer <pubkey> allowed-ips 10.13.13.24/32",
+				"title": "Provision the SSH user",
+				"detail": "linkuser.sh creates the account inside the container with a generated password. The app's own copy of the script is written in first, so it wins over the one baked into the image.",
+				"cmd": "bash /opt/benchpress/scripts/linkuser.sh <username>",
 			},
 			{
 				"n": 10,
-				"title": "Health check",
-				"detail": "Benchpress fetches the site over the mesh until it answers. If it never does, the run is marked failed and the container is torn down.",
-				"cmd": "GET https://erpnext-demo.bp.local/api/method/ping → pong",
+				"title": "Start the lab's services",
+				"detail": "serve.sh serves the site on port 8000. code-server is configured and started on 8080 when the lab and its size include it, and the log says so when it is skipped.",
+				"cmd": "bash /opt/benchpress/scripts/serve.sh <username>",
 			},
 			{
 				"n": 11,
-				"title": "Hand over credentials",
-				"detail": "Site URL, mesh IP, code-server link and passwords appear on the lab page. The hourly meter starts at this point, and only this point.",
-				"cmd": 'ledger.start(lab="erpnext-demo", size="Small")',
+				"title": "Deploy complete",
+				"detail": "The instance goes to Running, the deploy log is marked a success and the owner is notified. The last line carries the run's total elapsed time.",
+				"cmd": "=== Step 11/11: Deploy complete [complete @13.3s] ===",
 			},
 		],
 	},

--- a/docs-bundle/AGENTS.md
+++ b/docs-bundle/AGENTS.md
@@ -39,7 +39,7 @@ is done.
 ## Operator Track
 
 - [Operator track](./docs/operator/index.md): Run BenchPress on your own box — install, the VPN plane, settings, the shared database, images, upgrades, safety and diagnostics.
-- [Prerequisites](./docs/operator/prerequisites.md): What a BenchPress host needs before you install — supported platforms, versions, Docker socket access, IP forwarding, sysbox, and the measured CPU sizing.
+- [Prerequisites](./docs/operator/prerequisites.md): What a BenchPress host needs before you install — the four preconditions, supported platforms, versions, Docker socket access, and the measured CPU and disk sizing.
 - [Install](./docs/operator/install.md): Install BenchPress into a Frappe v16 bench — get-app, setup.sh, the frontend build, the base domain, and the first screen.
 - [WireGuard and the VPN plane](./docs/operator/wireguard-setup.md): How the vpn_management app owns the tunnel, what BenchPress consumes from it, the measured server and pool values, and why userns-remap matters.
 - [Settings reference](./docs/operator/settings-reference.md): Every field on BenchPress Settings and Credit Settings, with the value measured on a live host, where each one is edited, and what changing it costs.
@@ -49,8 +49,8 @@ is done.
 - [The image cache](./docs/operator/image-cache.md): One image per lab, tagged benchpress/<lab_id>:lab — what it costs on disk, how the weekly prewarm and sweep work, and what is safe to prune.
 - [Users and roles](./docs/operator/users-and-roles.md): The two BenchPress roles, what each one may read and write, which screens are admin-only, and how ownership rather than a role decides who sees a bench.
 - [Upgrading](./docs/operator/upgrading.md): Move a BenchPress install to a newer release — the backup gate, the five steps, the scripted path, rollback, and why lab images are a separate opt-in.
-- [Production safety](./docs/operator/production-safety.md): What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the endpoint-by-endpoint release checklist.
-- [Diagnostics](./docs/operator/diagnostics.md): The eleven read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
+- [Production safety](./docs/operator/production-safety.md): What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the release checklist that covers 25 of 52 whitelisted callables.
+- [Diagnostics](./docs/operator/diagnostics.md): The twelve read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
 - [Credits and billing](./docs/operator/credits-and-billing.md): Optional and off by default — the metering half of BenchPress, covering leases, balances, the ledger, admin adjustments, and the optional Razorpay handoff.
 - [Admission and limits](./docs/operator/admission-and-limits.md): Optional and off by default — concurrency caps, size ceilings, device and build quotas, how a slot is claimed as a row, and the acceptance run that proves access still works.
 - [Self-serve signup](./docs/operator/hosted-signup.md): Optional and off by default — retire the waitlist and let people sign themselves up, with GitHub and Google as the primary paths and the abuse controls that make a free grant safe.
@@ -60,7 +60,7 @@ is done.
 - [Reference track](./docs/reference/index.md): The data model, the whitelisted API, the eleven deploy steps, the reconcilers, the address plan and the configuration split — for a contributor or an integrator.
 - [Architecture](./docs/reference/architecture.md): The moving parts of BenchPress — the control plane, the bench containers, the shared infrastructure, and which Python module owns each concern.
 - [Data model](./docs/reference/data-model.md): All 20 BenchPress DocTypes with their fields, links, naming and the permission rule that scopes each one — plus why there is no Device DocType.
-- [API](./docs/reference/api.md): All 50 whitelisted BenchPress endpoints, with arguments, what each returns, and the permission check each one makes for itself.
+- [API](./docs/reference/api.md): Every whitelisted BenchPress endpoint, with arguments, what each returns, and the permission check each one makes for itself.
 - [Deploy pipeline](./docs/reference/deploy-pipeline.md): The eleven steps of a BenchPress deploy, in the order the code runs them, with the function behind each step and the log line it writes.
 - [Lifecycle and events](./docs/reference/lifecycle-and-events.md): The bench states and their transitions, the Docker event listener, Bench Event incidents, the stats collector, and the eleven scheduled jobs that correct the database.
 - [Networking](./docs/reference/networking.md): The BenchPress address plan — bench bridges, WireGuard tunnel addresses, the two container ports, Traefik route files and the wildcard certificate anchor.
@@ -141,7 +141,7 @@ so `enable_credits` is `0` and no page about billing applies to a plain install.
 
 ### Stand a host up
 
-- [Prerequisites](./docs/operator/prerequisites.md): What a BenchPress host needs before you install — supported platforms, versions, Docker socket access, IP forwarding, sysbox, and the measured CPU sizing.
+- [Prerequisites](./docs/operator/prerequisites.md): What a BenchPress host needs before you install — the four preconditions, supported platforms, versions, Docker socket access, and the measured CPU and disk sizing.
 - [Install](./docs/operator/install.md): Install BenchPress into a Frappe v16 bench — get-app, setup.sh, the frontend build, the base domain, and the first screen.
 - [WireGuard and the VPN plane](./docs/operator/wireguard-setup.md): How the vpn_management app owns the tunnel, what BenchPress consumes from it, the measured server and pool values, and why userns-remap matters.
 
@@ -160,8 +160,8 @@ so `enable_credits` is `0` and no page about billing applies to a plain install.
 ### Keep it safe
 
 - [Upgrading](./docs/operator/upgrading.md): Move a BenchPress install to a newer release — the backup gate, the five steps, the scripted path, rollback, and why lab images are a separate opt-in.
-- [Production safety](./docs/operator/production-safety.md): What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the endpoint-by-endpoint release checklist.
-- [Diagnostics](./docs/operator/diagnostics.md): The eleven read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
+- [Production safety](./docs/operator/production-safety.md): What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the release checklist that covers 25 of 52 whitelisted callables.
+- [Diagnostics](./docs/operator/diagnostics.md): The twelve read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
 
 ### Optional — running it for a team
 
@@ -179,7 +179,7 @@ so `enable_credits` is `0` and no page about billing applies to a plain install.
 
 - [Architecture](./docs/reference/architecture.md): The moving parts of BenchPress — the control plane, the bench containers, the shared infrastructure, and which Python module owns each concern.
 - [Data model](./docs/reference/data-model.md): All 20 BenchPress DocTypes with their fields, links, naming and the permission rule that scopes each one — plus why there is no Device DocType.
-- [API](./docs/reference/api.md): All 50 whitelisted BenchPress endpoints, with arguments, what each returns, and the permission check each one makes for itself.
+- [API](./docs/reference/api.md): Every whitelisted BenchPress endpoint, with arguments, what each returns, and the permission check each one makes for itself.
 
 ### What it does at runtime
 

--- a/docs-bundle/docs/index.md
+++ b/docs-bundle/docs/index.md
@@ -2,7 +2,7 @@
 title: BenchPress documentation
 description: Start here. Three tracks — use a bench, run the server that hosts
   one, or read the data model and the API.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T08:05:07-04:00"
 lastAuthor: Venkatesh
 ---
 # BenchPress documentation

--- a/docs-bundle/docs/index.md
+++ b/docs-bundle/docs/index.md
@@ -34,8 +34,12 @@ cached image, creates a site, and puts the container on a WireGuard network.
 You get a site address, an SSH login and a browser VS Code session. When the
 work is done, you destroy the environment. Spin up, use, tear down.
 
-No bench is on the public internet. Every site, SSH port and IDE session is
-reachable only from a device that joined the VPN.
+A bench answers on up to four addresses at once: two public HTTPS addresses
+served by Traefik, which anyone on the internet can reach once `base_domain` is
+set, and two tunnel addresses that only a device on the VPN can reach.
+`base_domain` is a required setting, so a bench is not VPN-only on the
+documented install. [Networking](/docs/reference/networking) states the address
+plan in full.
 
 ## Reference
 
@@ -59,3 +63,4 @@ the page is still complete.
 ## Related
 
 * [Quick tour](/docs/user/quick-tour) — the five screens, and what the dashboard reports.
+* [Networking](/docs/reference/networking) — the four addresses a bench answers on, and who can reach each one.

--- a/docs-bundle/docs/operator/diagnostics.md
+++ b/docs-bundle/docs/operator/diagnostics.md
@@ -1,6 +1,6 @@
 ---
 title: Diagnostics
-description: The eleven read-only checks that ask Docker, MariaDB, Redis and the
+description: The twelve read-only checks that ask Docker, MariaDB, Redis and the
   kernel what is true — how to run them, what each failure means, and the four
   things they do not cover.
 lastModified: "2026-08-28T22:10:21+05:30"
@@ -32,7 +32,7 @@ one you have already made worse.
 2. **Or read them in the app.** Open **Overview** as an admin and look at the
    **Shared infrastructure** panel, which renders the same eleven rows.
 
-   ![The Shared infrastructure panel on the BenchPress Overview, listing eleven checks with a status badge each. Docker socket, Docker network, Bridge capacity, MariaDB, Redis, Container runtimes, Event listener and WireGuard read Active. Kernel ceilings and Clock skew read Error, and Golden images reads Warning.](../images/operator/diagnostics/01-shared-infrastructure.png)
+   ![The Shared infrastructure panel on the BenchPress Overview, listing the shared-infrastructure checks with a status badge each. Docker socket, Docker network, Bridge capacity, MariaDB, Redis, Container runtimes, Event listener and WireGuard read Active. Kernel ceilings and Clock skew read Error, and Golden images reads Warning.](../images/operator/diagnostics/01-shared-infrastructure.png)
 
    On this host eight rows read **Active**, `kernel_ceilings` and `clock_skew`
    read **Error**, and `golden_images` reads **Warning**. A badge is the
@@ -43,7 +43,7 @@ one you have already made worse.
    checks again. Several rows fail together for one cause, and the first fix
    often clears three.
 
-## The eleven checks
+## The twelve checks
 
 |Check|On screen|What it asks|Severity of a failure|
 |--|--|--|--|
@@ -57,6 +57,7 @@ one you have already made worse.
 |`container_runtimes`|Container runtimes|`sysbox-runc` is registered with Docker|Error|
 |`golden_images`|Golden images|how many built labs carry a golden dump|Warning|
 |`docker_events`|Event listener|the listener's heartbeat is newer than 60 seconds|Error|
+|`route_directory`|Route directory|a worker has reported the Traefik route directory mounted, with the control-plane route and the wildcard anchor rendered|Error, or Warning when the report is stale or the anchor is merely late|
 |`vpn_server`|WireGuard|`vpn_management` is installed, `wg0` exists, and it has a public key|Error|
 
 ## Severity is not status

--- a/docs-bundle/docs/operator/diagnostics.md
+++ b/docs-bundle/docs/operator/diagnostics.md
@@ -3,7 +3,7 @@ title: Diagnostics
 description: The twelve read-only checks that ask Docker, MariaDB, Redis and the
   kernel what is true — how to run them, what each failure means, and the four
   things they do not cover.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T08:05:07-04:00"
 lastAuthor: Venkatesh
 ---
 # Diagnostics

--- a/docs-bundle/docs/operator/install.md
+++ b/docs-bundle/docs/operator/install.md
@@ -2,7 +2,7 @@
 title: Install
 description: Install BenchPress into a Frappe v16 bench — get-app, setup.sh, the
   frontend build, the base domain, and the first screen.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T08:04:44-04:00"
 lastAuthor: Venkatesh
 ---
 # Install

--- a/docs-bundle/docs/operator/install.md
+++ b/docs-bundle/docs/operator/install.md
@@ -20,18 +20,33 @@ Throughout, replace `<site>` with your real site name.
 
 ## Steps
 
-1. **Install the app into the bench.**
+1. **Install the apps into the bench.** There are two repositories, and you
+   clone both.
+
+   `benchpress` names `vpn_management` in `required_apps`, so
+   `install-app benchpress` installs `vpn_management` first — but only from a
+   copy already on the bench, listed in `sites/apps.txt`. Clone it yourself.
+   `bench get-app` resolves a bare
+   `required_apps` name under the `frappe` and `erpnext` GitHub accounts only,
+   and [vpn\_management](https://github.com/Venkateshvenki404224/vpn_management)
+   is under neither, so `--resolve-deps` does not find it either.
 
    ```bash
    cd /path/to/your/frappe-bench
+   bench get-app https://github.com/Venkateshvenki404224/vpn_management --branch version-16
    bench get-app https://github.com/Venkateshvenki404224/benchpress --branch version-16
    bench pip install docker
    bench --site <site> install-app benchpress
    bench --site <site> migrate
    ```
 
-   `benchpress` declares `vpn_management` as a required app, so Frappe
-   installs that first. It refuses to install without `vpn_endpoint_host` in
+   Skip the first `get-app` and `install-app` fails with
+   `frappe.exceptions.InvalidRemoteException`, raised with an empty message.
+   Frappe resolves the `required_apps` name the same way — against the `frappe`
+   and `erpnext` accounts — and gives up there, before it ever reports a
+   missing app.
+
+   `vpn_management` itself refuses to install without `vpn_endpoint_host` in
    `common_site_config.json` and without a reachable wg-agent socket. See
    [WireGuard and the VPN plane](/docs/operator/wireguard-setup).
 
@@ -47,13 +62,15 @@ Throughout, replace `<site>` with your real site name.
    |Step|What it does|Skipped when|
    |--|--|--|
    |1 of 4|Adds the bench user to the `docker` group|the user is already a member|
-   |2 of 4|Checks Docker `userns-remap` or rootless mode|never — it only warns|
+   |2 of 4|Checks the container-root privilege boundary: a registered `sysbox-runc` runtime, or Docker `userns-remap` (or rootless)|never — it warns, or exits under `--strict`|
    |3 of 4|Starts `benchpress-mariadb` and `benchpress-redis`, and creates the `benchpress` network and the data volume|the containers are already up|
    |4 of 4|Writes `net.ipv4.ip_forward = 1` under `/etc/sysctl.d`|forwarding is already on|
 
    Step 2 warns and continues by default. On a host that will carry anything
    you care about, run it as `bash apps/benchpress/setup.sh <site> --strict`
-   instead, which exits non-zero rather than warning. See
+   instead, which exits non-zero rather than warning. Either boundary
+   satisfies `--strict`. sysbox is checked first: it is the recommended one,
+   and a lab set to the `sysbox` runtime needs it registered anyway. See
    [Production safety](/docs/operator/production-safety).
 
 3. **Build the frontend.** The dashboard is a Vue single-page app and ships as
@@ -98,7 +115,7 @@ Throughout, replace `<site>` with your real site name.
 
    The first screen is the **Overview**: how many environments are running,
    stopped or broken, the average deploy time over the last seven days, and a
-   **Shared infrastructure** panel reporting eleven checks. Seven days is not
+   **Shared infrastructure** panel reporting twelve checks. Seven days is not
    a choice — deploy logs are cleared on that schedule, so no longer window
    has data behind it.
 
@@ -146,11 +163,11 @@ that image in seconds. See [The image cache](/docs/operator/image-cache).
 
 |Symptom|Cause|Fix|
 |--|--|--|
-|`install-app` fails naming `vpn_management`|The required app is missing or refuses to install|Install `vpn_management` first and set `vpn_endpoint_host`|
+|`install-app` fails with a bare `InvalidRemoteException`|The repository was never cloned into `apps/`|Run the first `get-app` in step 1, then re-run `install-app`|
 |The dashboard is blank or unstyled|The frontend was never built|Step 3, then `bench --site <site> clear-cache`|
 |Settings will not save|`base_domain` is empty, and it is required|Fill it. Sites are addressed under it|
 |Every deploy fails on a Docker call|The bench started before the group change took effect|Log out, log back in, restart the bench|
-|`setup.sh` warns about `userns-remap`|Container root maps to host root|See [Production safety](/docs/operator/production-safety) before running anything real|
+|`setup.sh` warns that there is no privilege boundary|Neither `sysbox-runc` nor `userns-remap` is present, so container root is host root|See [Production safety](/docs/operator/production-safety) before running anything real|
 |The Overview shows `Kernel ceilings Error`|Host-wide sysctl limits are below what a dense fleet needs|`sudo scripts/tune-host.sh`, from the `benchpress_devops` checkout|
 
 ## Reference
@@ -158,6 +175,8 @@ that image in seconds. See [The image cache](/docs/operator/image-cache).
 |Item|Value|
 |--|--|
 |App branch|`version-16`|
+|App repository|[Venkateshvenki404224/benchpress](https://github.com/Venkateshvenki404224/benchpress)|
+|Required app|[Venkateshvenki404224/vpn\_management](https://github.com/Venkateshvenki404224/vpn_management), branch `version-16`|
 |Setup script|`bash apps/benchpress/setup.sh <site> [--strict]`|
 |Shared containers|`benchpress-mariadb`, `benchpress-redis`|
 |Docker network|`benchpress`|

--- a/docs-bundle/docs/operator/prerequisites.md
+++ b/docs-bundle/docs/operator/prerequisites.md
@@ -1,8 +1,8 @@
 ---
 title: Prerequisites
-description: What a BenchPress host needs before you install — supported
-  platforms, versions, Docker socket access, IP forwarding, sysbox, and the
-  measured CPU sizing.
+description: What a BenchPress host needs before you install — the four
+  preconditions, supported platforms, versions, Docker socket access, and the
+  measured CPU and disk sizing.
 lastModified: "2026-08-28T22:10:21+05:30"
 lastAuthor: Venkatesh
 ---
@@ -16,6 +16,21 @@ will work, and how much of it to buy.
 **Before you start.** BenchPress installs into an existing Frappe bench and
 drives that host's Docker. It is not a standalone service, and it is Linux
 only — the setup script uses `apt` and `sysctl`.
+
+## The four preconditions
+
+Get these four before you read anything else on this page. Each one blocks the
+install or the first deploy, and none of them can be fixed from inside the app.
+
+|Precondition|Why it blocks|Set it in|
+|--|--|--|
+|`sysbox-runc` registered with Docker|`default_bench_runtime` is `sysbox`, so a deploy has no runtime without it. `runc` without `userns-remap` makes in-container root host root|[Step 5](#steps)|
+|`net.ipv4.ip_forward = 1`|The kernel drops tunnel traffic on its way to a bench, so a deploy fails on the network step|[Step 4](#steps)|
+|44556/UDP open, on `ufw` **and** on any cloud firewall|A WireGuard peer never handshakes, so nothing reaches a bench over the tunnel|[Step 7](#steps)|
+|A domain you control, for `base_domain`|`base_domain` is `reqd` on **BenchPress Settings**, so the settings form will not save without it. Sites are addressed as `<instance id>.<base domain>`|[Install, step 5](/docs/operator/install)|
+
+Size the host before you buy it as well. [Sizing](#sizing) holds the CPU floor
+and [Disk](#disk) the disk floor. Disk is the one that fails a default VPS.
 
 ## Steps
 
@@ -134,7 +149,7 @@ Three criteria, each with its own minimum:
 |Tier|Minimum CPU|Evidence at the minimum|
 |--|--:|--|
 |Boot and lifecycle|0.5|migration 13.22 s, login HTTP 200 in 192 ms, `/frontend` HTTP 200 in 27 ms|
-|Test suite|0.5|the 124-test suite passed in 11.59 s, with every endpoint timing budget met|
+|Test suite|0.5|the suite passed in 11.59 s, with every endpoint timing budget met. It held 124 tests that day. The suite has since grown by roughly an order of magnitude, so 11.59 s no longer describes a full run|
 |Concurrent reads|0.5|`get_labs` p95 127 ms, `get_benches` p95 48 ms, 0 of 60 requests failed|
 
 Concurrent reads at each candidate cap, 30 authenticated requests per endpoint
@@ -157,10 +172,50 @@ did not visibly degrade this workload, so the measurements do not support
 calling one core a minimum. Re-run the benchmark after the application grows,
 or when you change the host class.
 
-**RAM and disk are the real constraints, not CPU.** A lab image is 5.5 GB to
-19.7 GB, and one deploy costs roughly 0.2 GB to 1 GB more. See
-[The image cache](/docs/operator/image-cache) for what that grows into and how
-the sweep holds it down.
+**Of the two resources measured here, disk is the constraint, not CPU.** Size
+it before you buy the host. See [Disk](#disk).
+
+**RAM was not sized.** The benchmark capped CPU only, so the 7.8 GiB above
+describes the benchmark host and is not a floor. Watch `free -h` on your own
+host until someone measures it.
+
+## Disk
+
+**A 20 GB or 40 GB VPS root disk fails mid-build.** No setting in the app
+compensates for it, and the failure lands in the middle of an image build
+rather than at install.
+
+Measured on this host with `docker images` and `docker system df`, and listed
+per image in [The image cache](/docs/operator/image-cache):
+
+|Measurement|Value|
+|--|--:|
+|Smallest lab image|5.5 GB|
+|Largest lab image|19.7 GB|
+|Twelve lab images together|54.74 GB|
+|Reclaimable from that set|19.12 GB|
+
+Three costs sit on top of that image figure. A build holds the new image while
+its base layers are still on disk. Every bench has its own container layer and
+volumes — one deploy costs roughly 0.2 GB to 1 GB, measured in
+[The image cache](/docs/operator/image-cache). The shared MariaDB carries its
+data volume. The build headroom and the MariaDB volume are not measured.
+
+So provision against the catalog you will hold, not against one image:
+
+|The host will carry|Free disk to provision|Basis|
+|--|--:|--|
+|One lab image|100 GB|19.7 GB for the largest measured image, with room to rebuild it beside the copy in use|
+|A catalog the size of this host's|250 GB|54.74 GB measured for twelve images, plus the same rebuild headroom, plus bench volumes|
+
+Those two rows are recommendations derived from the measurements above. They
+are not themselves measured. Watch `df -h /` and `docker system df` on your own
+host, and raise them if either climbs.
+
+Building is also the slowest thing a fresh host does. Full builds on this host
+ran **4 to 26 minutes**, and the golden pass 5 to 11 — see
+[The image cache](/docs/operator/image-cache). The build job's own timeout is
+10,800 s, three hours, which is a ceiling and not an expected duration.
 
 ## Troubleshooting
 
@@ -171,6 +226,8 @@ the sweep holds it down.
 |Diagnostics reports `container_runtimes` as failed|`sysbox-runc` is not registered with Docker|Install sysbox, or set `default_bench_runtime` to `runc` and read [Production safety](/docs/operator/production-safety)|
 |Diagnostics reports `kernel_ceilings` as failed|The host ceilings are below what the fleet needs|`sudo scripts/tune-host.sh --benches <n>`, from the `benchpress_devops` checkout|
 |A peer never handshakes|UDP 44556 is closed|Step 7, and check the cloud firewall as well as `ufw`|
+|A build fails part-way with no space left|The host was sized for the OS, not for lab images|[Disk](#disk). Never run `docker image prune -a` on this host|
+|**BenchPress Settings** will not save|`base_domain` is required and empty|Point a domain you control at this host, then fill it in [Install, step 5](/docs/operator/install)|
 
 ## Reference
 
@@ -182,6 +239,9 @@ the sweep holds it down.
 |WireGuard port|44556/UDP|the `WireGuard Server` document in `vpn_management`|
 |Frappe version, host bench|v16|the bench itself|
 |CPU floor per bench|1 core|`Lab.cpu_cores`, an integer field|
+|Base domain|required, no default|`BenchPress Settings.base_domain`, `reqd`|
+|Free disk, one lab image|100 GB recommended|the host you buy|
+|Free disk, a full catalog|250 GB recommended|the host you buy|
 
 ## Related
 

--- a/docs-bundle/docs/operator/prerequisites.md
+++ b/docs-bundle/docs/operator/prerequisites.md
@@ -3,7 +3,7 @@ title: Prerequisites
 description: What a BenchPress host needs before you install — the four
   preconditions, supported platforms, versions, Docker socket access, and the
   measured CPU and disk sizing.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T08:05:07-04:00"
 lastAuthor: Venkatesh
 ---
 # Prerequisites

--- a/docs-bundle/docs/operator/production-safety.md
+++ b/docs-bundle/docs/operator/production-safety.md
@@ -3,7 +3,7 @@ title: Production safety
 description: What BenchPress is and is not ready to carry — the alpha verdict,
   the container privilege boundary, what is backed up, and the release checklist
   that covers 25 of 52 whitelisted callables.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T08:05:07-04:00"
 lastAuthor: Venkatesh
 ---
 # Production safety

--- a/docs-bundle/docs/operator/production-safety.md
+++ b/docs-bundle/docs/operator/production-safety.md
@@ -1,8 +1,8 @@
 ---
 title: Production safety
 description: What BenchPress is and is not ready to carry — the alpha verdict,
-  the container privilege boundary, what is backed up, and the
-  endpoint-by-endpoint release checklist.
+  the container privilege boundary, what is backed up, and the release checklist
+  that covers 25 of 52 whitelisted callables.
 lastModified: "2026-08-28T22:10:21+05:30"
 lastAuthor: Venkatesh
 ---
@@ -36,6 +36,10 @@ ERPNext environments. It is not built to host customer data. Concretely:
   up. See [Backup and restore](/docs/operator/backup-and-restore).
 * **Single-tenant assumption.** Quotas, rate limits and audit trails are still
   in progress. Run BenchPress for people you trust, on a host dedicated to it.
+* **The security review is partial.** It covers 25 of the app's 52 whitelisted
+  callables. The credit-purchase path and the per-bench credential endpoint are
+  among the 27 it never reached. See
+  [the release checklist](#the-release-checklist).
 
 Use it on a dedicated dev box, a VM, or a cloud instance you can rebuild. Not
 on your daily-driver workstation, and not on a shared production server.
@@ -92,31 +96,53 @@ All three must pass on a host carrying anything you would miss.
 
 ## The release checklist
 
-Last reviewed 2026-07-02, from the authorization suite, the contract and
-timing suite, a branch security review, and a sweep of every
-`ignore_permissions=True` and secret-handling path.
+Reviewed 2026-07-02, from the authorization suite, the contract and timing
+suite, a branch security review, and a sweep of every `ignore_permissions=True`
+and secret-handling path. Every row below was re-checked against the code on
+2026-08-30. Two findings had been fixed, one described an endpoint that never
+existed, and several guard descriptions were wrong.
 
-Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
+**What the audit covered.** The app exposes **52** whitelisted callables. This
+checklist covers **25** of them: 16 endpoints and 9 controller methods. It also
+carried a row for a `create_site` endpoint, which does not exist in the code —
+that row is gone. **27 whitelisted callables have never been reviewed**, and
+that is the largest gap on this page. They are:
+
+|Never reviewed|Where|
+|--|--|
+|`buy_credits`, `get_purchase_options`, `get_credit_summary`, `get_credit_statement`, `get_lease_plans`, `renew_bench`|the credit and lease path, including the one that takes money|
+|`get_bench_credentials`|decrypts SSH, admin and code-server passwords for one bench|
+|`launch_template`, `launch_lab`, `build_lab_golden`, `prewarm_catalog`|the one-click deploy and golden-build path|
+|`sign_up`, `join`, `notify_of_signup`, `approve`|`signup.py` and `waitlist.py`, the only self-service entry points|
+|`Credit Account.post_adjustment`, `post_refund`|controller methods that move a balance|
+|`server_time`, `get_lab_form_options`, `get_device_types`, `get_build_history`, `get_deploy_history`, `get_overview`, `get_vpn_status`, `run_connection_test`, `run_diagnostics`, `preflight_runtime`|the rest|
+
+Treat an unreviewed endpoint as unreviewed, not as safe.
+
+Read the verdicts as: **Ready**, **Ready with a follow-up**, **Not ready**.
 
 ### Whitelisted endpoints
 
+`require_app_user` admits `System Manager`, `BenchPress Admin` and
+`BenchPress User`. `require_admin` admits the first two. Both are
+`frappe.only_for`, so neither is satisfied by login alone.
+
 |Endpoint|Guard|Verdict|Note|
 |--|--|--|--|
-|`get_labs`|login only|Ready|A shared admin-curated catalog. No per-user data|
-|`get_lab`|login only|Ready|One catalog row|
-|`get_lab_templates`|login only|Ready|A static list|
+|`get_labs`|`require_app_user`|Ready|A shared admin-curated catalog. No per-user data|
+|`get_lab`|`require_app_user`|Ready|One catalog row|
+|`get_lab_templates`|`require_app_user`|Ready|A static list|
 |`create_lab_from_template`|`require_admin`|Ready|Admin-only, proven by test|
 |`build_lab_image`|`require_admin`|Ready|Admin-only, proven by test|
-|`get_benches`|owner filter|Follow-up|Returns decrypted SSH, admin and code-server passwords in the list payload. Owner-scoped, but secrets belong in an on-demand call|
-|`create_bench`|login, own deterministic id|Ready|The id embeds the caller, so a user can only create their own|
+|`get_benches`|`require_app_user`, owner filter|Ready|No longer returns any password. The field list holds no secret, and a test asserts their absence. Retrieval moved to `get_bench_credentials`|
+|`create_bench`|`require_app_user`, own deterministic id|Ready|The id embeds the caller, so a user can only create their own|
 |`bench_action`|`require_bench_access`, delete admin-only|Ready|Start, stop and restart are owner-scoped. Delete is admin-gated|
 |`get_deploy_logs`|`require_bench_access`|Ready|Cross-user access denied by test|
-|`add_device`|login, peer owned by caller|Ready|Creates only the caller's peer|
-|`remove_device`|owner or admin|Ready|Ownership enforced before delete|
-|`list_devices`|owner filter|Ready|Bench peers excluded|
-|`get_device_wg_config`|owner or admin|Follow-up|The guard exists. The cross-user negative test does not|
-|`create_site`|`require_bench_access` **only when `bench` is set**|Follow-up|A bench-less call skips the guard and creates an orphan `Bench Site`|
-|`get_user_context`|login, own session|Ready|Returns only the caller's identity and roles|
+|`add_device`|`require_app_user`, peer owned by caller|Ready|Writes `owner_user` as the session user, so it creates only the caller's peer|
+|`remove_device`|`require_app_user`, then an owned-peer lookup|Ready|Ownership resolved before the delete|
+|`list_devices`|`require_app_user`, `owner_user` filter|Ready|Bench peers excluded|
+|`get_device_wg_config`|`require_app_user`, then an owned-peer lookup|Follow-up|The guard exists. The cross-user negative test still does not|
+|`get_user_context`|login only|Ready|No role check, deliberately: the SPA calls it on boot. Returns the caller's own identity, roles and credit summary, and nothing about another user|
 |`get_code_server_credentials`|`require_bench_access`|Ready|Decrypted only after the ownership check|
 |`restart_code_server`|`require_bench_access`|Ready|Cross-user denied by test|
 
@@ -128,7 +154,7 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 |`Bench Instance.enqueue_redeploy`|same|Ready||
 |`Bench Instance.enqueue_stop`|same|Ready||
 |`Bench Instance.enqueue_start`|same|Ready||
-|`Database Server.setup_mariadb`|read permission, admin-only doctype|Follow-up|A state-changing operation should check `write`, and it has no authorization test|
+|`Database Server.setup_mariadb`|`frappe.has_permission` with no `ptype`, so `read`|Follow-up|A state-changing operation should check `write`, and it has no authorization test. The doctype grants `read` only to `System Manager` and `BenchPress Admin`, both of which also hold `write`, so the gap is hardening rather than an open door|
 |`Database Server.start_mariadb`|same|Follow-up|As above|
 |`Database Server.stop_mariadb`|same|Follow-up|As above|
 |`Database Server.retry_setup`|same|Follow-up|As above|
@@ -139,8 +165,8 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 |Component|Verdict|Note|
 |--|--|--|
 |Permission model|Ready|Guest, wrong role and cross-user are all rejected. `only_for` raises for non-administrators|
-|Secret handling|Ready|Decryption only behind an owner or admin guard. The database root password is never logged|
-|`ignore_permissions=True`, 39 uses|Ready|Confined to enqueued and system flows. Ownership is tracked on `owner` and `owner_user`|
+|Secret handling|Ready|Both decryptions a whitelisted endpoint can reach sit behind `require_bench_access`. The database root password is never logged. One of the two, `get_bench_credentials`, was never in this audit — see the coverage list above|
+|`ignore_permissions=True`, 53 uses outside tests|Ready|Confined to enqueued and system flows. Ownership is tracked on `owner` and `owner_user`. The count was 39 at the 2026-07-02 review|
 |SQL construction|Ready|Identifiers are hashed and SQL is base64-wrapped before shelling. Not injectable|
 |Container isolation|**Not ready without a precondition**|Non-privileged, but a lab user holds in-container root. Ship only on a host with sysbox, userns-remap or a rootless daemon|
 
@@ -148,15 +174,16 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 
 1. **The container privilege boundary.** Ship only on a host that closes it.
    This is a deployment precondition, not an app default.
-2. **`create_site` with no bench.** Make `bench` mandatory, or guard the empty
-   case, so the endpoint cannot create an orphan `Bench Site` that bypasses
-   the access check.
-3. **`Database Server` state-changing methods.** Move them to a `write`
-   permission check and add authorization tests.
-4. **`get_benches` secret exposure.** Move SSH, admin and code-server password
-   retrieval out of the bulk list payload into an on-demand per-bench call.
-5. **`get_device_wg_config` test gap.** Add an explicit cross-user negative
+2. **The 27 unreviewed endpoints.** Review them, starting with `buy_credits`,
+   which takes money, and `get_bench_credentials`, which decrypts passwords.
+3. **`Database Server` state-changing methods.** They call
+   `frappe.has_permission` with no `ptype`, which checks `read`. Move them to
+   `write` and add authorization tests.
+4. **`get_device_wg_config` test gap.** Add an explicit cross-user negative
    test. The guard exists. The coverage does not.
+
+Two items from the 2026-07-02 list are closed. `get_benches` no longer returns
+any password. The `create_site` item described an endpoint that does not exist.
 
 ## Troubleshooting
 
@@ -177,7 +204,10 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 |Default runtime|`sysbox`|
 |Backed up|the shared MariaDB, nightly, 7 dumps|
 |Not backed up|bench Docker volumes|
-|Checklist last reviewed|2026-07-02|
+|Checklist reviewed|2026-07-02, re-verified against the code 2026-08-30|
+|Whitelisted callables|52|
+|Covered by this checklist|25|
+|Never reviewed|27|
 
 ## Related
 

--- a/docs-bundle/docs/reference/api.md
+++ b/docs-bundle/docs/reference/api.md
@@ -1,6 +1,6 @@
 ---
 title: API
-description: All 50 whitelisted BenchPress endpoints, with arguments, what each
+description: Every whitelisted BenchPress endpoint, with arguments, what each
   returns, and the permission check each one makes for itself.
 lastModified: "2026-08-28T22:10:21+05:30"
 lastAuthor: Venkatesh
@@ -29,9 +29,12 @@ curl -s https://<host>/api/method/benchpress.api.get_labs \
 Arguments go as query parameters on a `GET` or as form fields on a `POST`.
 Frappe decides the method from the function, not from a route table.
 
-Thirty-five of the fifty are in `benchpress.api`. Four more are module functions
-elsewhere. The remaining eleven are document methods, called through
-`run_doc_method` rather than by path. All three kinds are marked below.
+Endpoints come in three kinds. Most are module functions in `benchpress.api`. A
+few more are module functions elsewhere, in `benchpress.waitlist` and
+`benchpress.signup`. The rest are document methods on controllers, called
+through `run_doc_method` rather than by path. All three kinds are marked below.
+[The whole list, counted](#the-whole-list-counted) has the breakdown and the
+command that derives it.
 
 ## How an endpoint is guarded
 
@@ -107,6 +110,61 @@ MD5 of the two, so a second call redeploys rather than making a second bench.
 
 `server_time` exists so a countdown in the browser corrects against the server
 clock instead of the laptop's.
+
+## Launch
+
+`create_bench` deploys a lab whose image already exists. The two launch
+endpoints do not require one. They build the image first, when there is no
+image, and deploy from it in the same job.
+
+|Endpoint|Arguments|Returns|Checks|
+|--|--|--|--|
+|`launch_template`|`template`, `instance_size`, `site_name`|the launch response below|`require_app_user`, then `is_active` on the `Lab Template` row, then `requires_admission` inside `_launch`|
+|`launch_lab`|`data` (JSON, with at least `lab`)|the launch response below|`require_app_user`, then `requires_admission` inside `_launch`|
+
+Both live in `benchpress/api.py`. Both call the private
+`_launch`, which claims the instance and enqueues
+`benchpress.launch.run_launch` on `queue-long` under the deduplicated job id
+`launch:<bench name>`. The job timeout is the image build timeout plus the
+deploy timeout, because one job does both.
+
+**The admission gate is on `_launch`, not on the published function.** This
+looks like a missing decorator and is not. `requires_admission` binds its cost
+and cap arguments by name and needs a lab that exists, which is only true after
+`launch_template` has resolved a template to one. `launch_template` resolves or
+creates that lab first, so a caller the gate then refuses can leave a new `Lab`
+row behind. The gate still runs before any work is queued, which is the property
+that matters.
+
+`launch_template` checks `is_active` on the `Lab Template` itself.
+`lab_templates.get_template` checks only that the key exists, so without this
+check a user could materialise a template an admin had retired.
+
+`launch_template` reuses a lab before it makes one. It takes the newest lab
+built from that template whose recipe still matches the template's own, and
+creates a lab only when there is no match. A second developer launching the same
+template rides the image the first launch paid for. A lab an admin has edited
+away from the template is skipped, because deploying it would install apps the
+template never named.
+
+Both endpoints claim the bench through the same path `create_bench` uses, so the
+same pair of caller and lab is the same bench. A second launch redeploys.
+
+The launch response carries seven keys:
+
+|Key|Is|
+|--|--|
+|`name`|the bench id|
+|`bench`|the same string as `name`, so a caller still reading `name` keeps working|
+|`lab`|the lab this bench came from|
+|`lab_title`|that lab's title|
+|`lab_status`|that lab's status, read from the row|
+|`will_build`|`true` when `lab_status` is not `Ready`|
+|`eta_minutes`|`eta_minutes` from the `Lab Template` row, or `0`|
+
+`will_build` is that status read alone. It does not ask Docker whether the image
+is on the host. It is opening copy for the launch dialog, and the job decides
+what actually happens.
 
 ## History
 
@@ -204,7 +262,7 @@ not from now.
 
 |Endpoint|Arguments|Returns|Checks|
 |--|--|--|--|
-|`run_diagnostics`|—|eleven read-only environment checks|`require_admin`|
+|`run_diagnostics`|—|twelve read-only environment checks|`require_admin`|
 |`preflight_runtime`|`runtime`|whether that runtime can actually start a container|`require_admin`|
 
 `run_diagnostics` reads. `preflight_runtime` creates a container, which is why
@@ -284,22 +342,33 @@ Two more waitlist functions are admin-only and not guest-reachable.
 
 ## The whole list, counted
 
-Fifty `@frappe.whitelist()` functions. Every one is in a table above.
+**Count the code, not this page.** Run the command before you quote a number
+anywhere:
+
+```bash
+grep -rn "@frappe.whitelist" --include=*.py benchpress/ | wc -l
+```
+
+Per file:
+
+```bash
+grep -rc "@frappe.whitelist" --include=*.py benchpress/ | grep -v ':0$' | sort -t: -k2 -rn
+```
+
+What those two commands returned when this page was last checked:
 
 |Location|Count|
 |--|--|
-|`benchpress/api.py`|35|
+|`benchpress/api.py`|37|
 |`benchpress/benchpress/doctype/database_server/database_server.py`|5|
 |`benchpress/benchpress/doctype/bench_instance/bench_instance.py`|4|
 |`benchpress/waitlist.py`|3|
 |`benchpress/benchpress/doctype/credit_account/credit_account.py`|2|
 |`benchpress/signup.py`|1|
+|**Total**|**52**|
 
-Recount after a change:
-
-```bash
-grep -rn "@frappe.whitelist" --include=*.py benchpress/ | wc -l
-```
+Every one of those 52 has a row in a table above. That is the claim to keep
+true when you add an endpoint.
 
 ## Adding an endpoint
 
@@ -309,6 +378,8 @@ grep -rn "@frappe.whitelist" --include=*.py benchpress/ | wc -l
    `@frappe.whitelist()`.
 4. Query with `frappe.qb`. A raw `frappe.db.sql` string is a lint failure.
 5. Add the endpoint to the table on this page.
+6. Re-run the two commands in [The whole list, counted](#the-whole-list-counted)
+   and paste what they return over that table.
 
 The decorator order matters. `@frappe.whitelist()` goes on top, and
 `@requires_admission(...)` below it, so the gate runs inside the published

--- a/docs-bundle/docs/reference/api.md
+++ b/docs-bundle/docs/reference/api.md
@@ -2,7 +2,7 @@
 title: API
 description: Every whitelisted BenchPress endpoint, with arguments, what each
   returns, and the permission check each one makes for itself.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T08:05:07-04:00"
 lastAuthor: Venkatesh
 ---
 # API

--- a/docs-bundle/docs/reference/architecture.md
+++ b/docs-bundle/docs/reference/architecture.md
@@ -70,7 +70,7 @@ One concern for each module. The table is the whole `benchpress/` package.
 |`permissions.py`|the role helpers and the six query conditions|
 |`overview.py`, `labs.py`, `lab_detail.py`, `run_history.py`|one screen each, assembled in a fixed number of queries|
 |`waitlist.py`, `signup.py`|the two doors open to a guest|
-|`diagnostics.py`|eleven read-only environment checks|
+|`diagnostics.py`|twelve read-only environment checks|
 |`notifications.py`|one desk alert and one email to a document owner|
 |`indexes.py`|composite indexes the DocType JSON cannot declare|
 |`request_cache.py`|a value memoised for one request, never in a module global|

--- a/docs-bundle/docs/reference/architecture.md
+++ b/docs-bundle/docs/reference/architecture.md
@@ -3,7 +3,7 @@ title: Architecture
 description: The moving parts of BenchPress — the control plane, the bench
   containers, the shared infrastructure, and which Python module owns each
   concern.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T08:05:07-04:00"
 lastAuthor: Venkatesh
 ---
 # Architecture

--- a/docs-bundle/docs/reference/networking.md
+++ b/docs-bundle/docs/reference/networking.md
@@ -14,10 +14,20 @@ Every address a bench answers on, and who can reach each one.
 one is addressed.
 
 **Before you start.** A bench has up to four addresses at once. They are not
-alternatives. Each one exists for a different caller, and three of the four are
-private.
+alternatives. Each one exists for a different caller, and two of the four are
+public.
 
 ## The four addresses
+
+**This section is the canonical statement of what a bench is reachable on.**
+The one sentence:
+
+> A bench answers on up to four addresses at once: two public HTTPS addresses
+> served by Traefik, which anyone on the internet can reach once `base_domain`
+> is set, and two tunnel addresses that only a device on the VPN can reach.
+
+The two `https://` addresses answer for anyone on the internet once
+`base_domain` is set, which is the documented install.
 
 `benchpress/addressing.py` builds all of them in one place, and the app renders
 what it returns rather than assembling a URL from a port it declared itself.
@@ -28,6 +38,19 @@ what it returns rather than assembling a URL from a port it declared itself.
 |Public IDE|`https://ide-<instance id>.<base domain>`|the internet, through Traefik|
 |Tunnel site|`http://<wg ip>:8000`|a device on the VPN|
 |Tunnel IDE|`http://<wg ip>:8080/`|a device on the VPN|
+
+`ingress.publish` writes routers on the `websecure` entry point: two for the
+site hostname, split so asset paths take their own rate limit, and one for the
+IDE hostname. `ingress.ensure_anchor` holds the wildcard certificate that
+terminates them. The IDE router is written only when the bench has an IDE, which
+is why the count is "up to four".
+
+Public means public. The only middlewares `publish` puts on a bench router are
+rate limits: a request cap on every router, and an in-flight cap on the site's
+render path when the instance size sets one. There is no authentication
+middleware at the edge. A browser anywhere resolves the name and gets the
+bench's own login page, and that login is the only thing between the internet
+and the site.
 
 The two ports are properties of the bench image, not settings. They are
 constants in `addressing.py`.
@@ -152,8 +175,12 @@ state.
 |Another bench on the same bridge|no|no|no|no|
 |A bench, reaching the shared MariaDB|—|—|—|the database only|
 
-No bench is on the public internet by port. The only public path is Traefik, and
-it terminates TLS on the wildcard.
+No bench is on the public internet by port. No bench container publishes a host
+port at all — the only public path is Traefik, and it terminates TLS on the
+wildcard.
+
+That is the whole of what the VPN gates. **SSH and the two `http://` tunnel
+addresses need the VPN. The two `https://` addresses do not.**
 
 ## Verify
 

--- a/docs-bundle/docs/reference/networking.md
+++ b/docs-bundle/docs/reference/networking.md
@@ -3,7 +3,7 @@ title: Networking
 description: The BenchPress address plan — bench bridges, WireGuard tunnel
   addresses, the two container ports, Traefik route files and the wildcard
   certificate anchor.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T08:05:07-04:00"
 lastAuthor: Venkatesh
 ---
 # Networking

--- a/docs-site/.well-known/agent-card.json
+++ b/docs-site/.well-known/agent-card.json
@@ -2,7 +2,7 @@
   "name": "BenchPress",
   "description": "Press a button. Get a Frappe bench.",
   "url": "https://docs.benchpress.cloud",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "documentationUrl": "https://docs.benchpress.cloud/docs",
   "capabilities": {
     "streaming": false,

--- a/docs-site/.well-known/llms-full.txt
+++ b/docs-site/.well-known/llms-full.txt
@@ -17,7 +17,7 @@
 - [Leases and credits](https://docs.benchpress.cloud/docs/user/leases-and-credits): The countdown on a running bench, the renew dialog and its plans, the credit meter, the ledger, and where a purchase hands off to the payment gateway.
 - [Troubleshooting](https://docs.benchpress.cloud/docs/user/troubleshooting): Every symptom a BenchPress user meets, its cause, and the page that fixes it — deploys, the VPN, SSH, code-server, logs and credits.
 - [Operator track](https://docs.benchpress.cloud/docs/operator): Run BenchPress on your own box — install, the VPN plane, settings, the shared database, images, upgrades, safety and diagnostics.
-- [Prerequisites](https://docs.benchpress.cloud/docs/operator/prerequisites): What a BenchPress host needs before you install — supported platforms, versions, Docker socket access, IP forwarding, sysbox, and the measured CPU sizing.
+- [Prerequisites](https://docs.benchpress.cloud/docs/operator/prerequisites): What a BenchPress host needs before you install — the four preconditions, supported platforms, versions, Docker socket access, and the measured CPU and disk sizing.
 - [Install](https://docs.benchpress.cloud/docs/operator/install): Install BenchPress into a Frappe v16 bench — get-app, setup.sh, the frontend build, the base domain, and the first screen.
 - [WireGuard and the VPN plane](https://docs.benchpress.cloud/docs/operator/wireguard-setup): How the vpn_management app owns the tunnel, what BenchPress consumes from it, the measured server and pool values, and why userns-remap matters.
 - [Settings reference](https://docs.benchpress.cloud/docs/operator/settings-reference): Every field on BenchPress Settings and Credit Settings, with the value measured on a live host, where each one is edited, and what changing it costs.
@@ -27,15 +27,15 @@
 - [Golden images](https://docs.benchpress.cloud/docs/operator/golden-images): A lab's finished site is baked into its own image as a database dump, so a deploy restores it instead of creating tables — the measured numbers, the two settings, and why a golden gets refused.
 - [The image cache](https://docs.benchpress.cloud/docs/operator/image-cache): One image per lab, tagged benchpress/<lab_id>:lab — what it costs on disk, how the weekly prewarm and sweep work, and what is safe to prune.
 - [Upgrading](https://docs.benchpress.cloud/docs/operator/upgrading): Move a BenchPress install to a newer release — the backup gate, the five steps, the scripted path, rollback, and why lab images are a separate opt-in.
-- [Production safety](https://docs.benchpress.cloud/docs/operator/production-safety): What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the endpoint-by-endpoint release checklist.
-- [Diagnostics](https://docs.benchpress.cloud/docs/operator/diagnostics): The eleven read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
+- [Production safety](https://docs.benchpress.cloud/docs/operator/production-safety): What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the release checklist that covers 25 of 52 whitelisted callables.
+- [Diagnostics](https://docs.benchpress.cloud/docs/operator/diagnostics): The twelve read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
 - [Credits and billing](https://docs.benchpress.cloud/docs/operator/credits-and-billing): Optional and off by default — the metering half of BenchPress, covering leases, balances, the ledger, admin adjustments, and the optional Razorpay handoff.
 - [Admission and limits](https://docs.benchpress.cloud/docs/operator/admission-and-limits): Optional and off by default — concurrency caps, size ceilings, device and build quotas, how a slot is claimed as a row, and the acceptance run that proves access still works.
 - [Self-serve signup](https://docs.benchpress.cloud/docs/operator/hosted-signup): Optional and off by default — retire the waitlist and let people sign themselves up, with GitHub and Google as the primary paths and the abuse controls that make a free grant safe.
 - [Reference track](https://docs.benchpress.cloud/docs/reference): The data model, the whitelisted API, the eleven deploy steps, the reconcilers, the address plan and the configuration split — for a contributor or an integrator.
 - [Architecture](https://docs.benchpress.cloud/docs/reference/architecture): The moving parts of BenchPress — the control plane, the bench containers, the shared infrastructure, and which Python module owns each concern.
 - [Data model](https://docs.benchpress.cloud/docs/reference/data-model): All 20 BenchPress DocTypes with their fields, links, naming and the permission rule that scopes each one — plus why there is no Device DocType.
-- [API](https://docs.benchpress.cloud/docs/reference/api): All 50 whitelisted BenchPress endpoints, with arguments, what each returns, and the permission check each one makes for itself.
+- [API](https://docs.benchpress.cloud/docs/reference/api): Every whitelisted BenchPress endpoint, with arguments, what each returns, and the permission check each one makes for itself.
 - [Deploy pipeline](https://docs.benchpress.cloud/docs/reference/deploy-pipeline): The eleven steps of a BenchPress deploy, in the order the code runs them, with the function behind each step and the log line it writes.
 - [Lifecycle and events](https://docs.benchpress.cloud/docs/reference/lifecycle-and-events): The bench states and their transitions, the Docker event listener, Bench Event incidents, the stats collector, and the eleven scheduled jobs that correct the database.
 - [Networking](https://docs.benchpress.cloud/docs/reference/networking): The BenchPress address plan — bench bridges, WireGuard tunnel addresses, the two container ports, Traefik route files and the wildcard certificate anchor.
@@ -1944,7 +1944,7 @@ elsewhere, and there is no second machine to keep in step.
 
 # Prerequisites
 URL: https://docs.benchpress.cloud/docs/operator/prerequisites
-What a BenchPress host needs before you install — supported platforms, versions, Docker socket access, IP forwarding, sysbox, and the measured CPU sizing.
+What a BenchPress host needs before you install — the four preconditions, supported platforms, versions, Docker socket access, and the measured CPU and disk sizing.
 
 What the machine must already have before [Install](/docs/operator/install)
 will work, and how much of it to buy.
@@ -1954,6 +1954,21 @@ will work, and how much of it to buy.
 **Before you start.** BenchPress installs into an existing Frappe bench and
 drives that host's Docker. It is not a standalone service, and it is Linux
 only — the setup script uses `apt` and `sysctl`.
+
+## The four preconditions
+
+Get these four before you read anything else on this page. Each one blocks the
+install or the first deploy, and none of them can be fixed from inside the app.
+
+|Precondition|Why it blocks|Set it in|
+|--|--|--|
+|`sysbox-runc` registered with Docker|`default_bench_runtime` is `sysbox`, so a deploy has no runtime without it. `runc` without `userns-remap` makes in-container root host root|[Step 5](#steps)|
+|`net.ipv4.ip_forward = 1`|The kernel drops tunnel traffic on its way to a bench, so a deploy fails on the network step|[Step 4](#steps)|
+|44556/UDP open, on `ufw` **and** on any cloud firewall|A WireGuard peer never handshakes, so nothing reaches a bench over the tunnel|[Step 7](#steps)|
+|A domain you control, for `base_domain`|`base_domain` is `reqd` on **BenchPress Settings**, so the settings form will not save without it. Sites are addressed as `<instance id>.<base domain>`|[Install, step 5](/docs/operator/install)|
+
+Size the host before you buy it as well. [Sizing](#sizing) holds the CPU floor
+and [Disk](#disk) the disk floor. Disk is the one that fails a default VPS.
 
 ## Steps
 
@@ -2072,7 +2087,7 @@ Three criteria, each with its own minimum:
 |Tier|Minimum CPU|Evidence at the minimum|
 |--|--:|--|
 |Boot and lifecycle|0.5|migration 13.22 s, login HTTP 200 in 192 ms, `/frontend` HTTP 200 in 27 ms|
-|Test suite|0.5|the 124-test suite passed in 11.59 s, with every endpoint timing budget met|
+|Test suite|0.5|the suite passed in 11.59 s, with every endpoint timing budget met. It held 124 tests that day. The suite has since grown by roughly an order of magnitude, so 11.59 s no longer describes a full run|
 |Concurrent reads|0.5|`get_labs` p95 127 ms, `get_benches` p95 48 ms, 0 of 60 requests failed|
 
 Concurrent reads at each candidate cap, 30 authenticated requests per endpoint
@@ -2095,10 +2110,50 @@ did not visibly degrade this workload, so the measurements do not support
 calling one core a minimum. Re-run the benchmark after the application grows,
 or when you change the host class.
 
-**RAM and disk are the real constraints, not CPU.** A lab image is 5.5 GB to
-19.7 GB, and one deploy costs roughly 0.2 GB to 1 GB more. See
-[The image cache](/docs/operator/image-cache) for what that grows into and how
-the sweep holds it down.
+**Of the two resources measured here, disk is the constraint, not CPU.** Size
+it before you buy the host. See [Disk](#disk).
+
+**RAM was not sized.** The benchmark capped CPU only, so the 7.8 GiB above
+describes the benchmark host and is not a floor. Watch `free -h` on your own
+host until someone measures it.
+
+## Disk
+
+**A 20 GB or 40 GB VPS root disk fails mid-build.** No setting in the app
+compensates for it, and the failure lands in the middle of an image build
+rather than at install.
+
+Measured on this host with `docker images` and `docker system df`, and listed
+per image in [The image cache](/docs/operator/image-cache):
+
+|Measurement|Value|
+|--|--:|
+|Smallest lab image|5.5 GB|
+|Largest lab image|19.7 GB|
+|Twelve lab images together|54.74 GB|
+|Reclaimable from that set|19.12 GB|
+
+Three costs sit on top of that image figure. A build holds the new image while
+its base layers are still on disk. Every bench has its own container layer and
+volumes — one deploy costs roughly 0.2 GB to 1 GB, measured in
+[The image cache](/docs/operator/image-cache). The shared MariaDB carries its
+data volume. The build headroom and the MariaDB volume are not measured.
+
+So provision against the catalog you will hold, not against one image:
+
+|The host will carry|Free disk to provision|Basis|
+|--|--:|--|
+|One lab image|100 GB|19.7 GB for the largest measured image, with room to rebuild it beside the copy in use|
+|A catalog the size of this host's|250 GB|54.74 GB measured for twelve images, plus the same rebuild headroom, plus bench volumes|
+
+Those two rows are recommendations derived from the measurements above. They
+are not themselves measured. Watch `df -h /` and `docker system df` on your own
+host, and raise them if either climbs.
+
+Building is also the slowest thing a fresh host does. Full builds on this host
+ran **4 to 26 minutes**, and the golden pass 5 to 11 — see
+[The image cache](/docs/operator/image-cache). The build job's own timeout is
+10,800 s, three hours, which is a ceiling and not an expected duration.
 
 ## Troubleshooting
 
@@ -2109,6 +2164,8 @@ the sweep holds it down.
 |Diagnostics reports `container_runtimes` as failed|`sysbox-runc` is not registered with Docker|Install sysbox, or set `default_bench_runtime` to `runc` and read [Production safety](/docs/operator/production-safety)|
 |Diagnostics reports `kernel_ceilings` as failed|The host ceilings are below what the fleet needs|`sudo scripts/tune-host.sh --benches <n>`, from the `benchpress_devops` checkout|
 |A peer never handshakes|UDP 44556 is closed|Step 7, and check the cloud firewall as well as `ufw`|
+|A build fails part-way with no space left|The host was sized for the OS, not for lab images|[Disk](#disk). Never run `docker image prune -a` on this host|
+|**BenchPress Settings** will not save|`base_domain` is required and empty|Point a domain you control at this host, then fill it in [Install, step 5](/docs/operator/install)|
 
 ## Reference
 
@@ -2120,6 +2177,9 @@ the sweep holds it down.
 |WireGuard port|44556/UDP|the `WireGuard Server` document in `vpn_management`|
 |Frappe version, host bench|v16|the bench itself|
 |CPU floor per bench|1 core|`Lab.cpu_cores`, an integer field|
+|Base domain|required, no default|`BenchPress Settings.base_domain`, `reqd`|
+|Free disk, one lab image|100 GB recommended|the host you buy|
+|Free disk, a full catalog|250 GB recommended|the host you buy|
 
 ## Related
 
@@ -2144,18 +2204,33 @@ Throughout, replace `<site>` with your real site name.
 
 ## Steps
 
-1. **Install the app into the bench.**
+1. **Install the apps into the bench.** There are two repositories, and you
+   clone both.
+
+   `benchpress` names `vpn_management` in `required_apps`, so
+   `install-app benchpress` installs `vpn_management` first — but only from a
+   copy already on the bench, listed in `sites/apps.txt`. Clone it yourself.
+   `bench get-app` resolves a bare
+   `required_apps` name under the `frappe` and `erpnext` GitHub accounts only,
+   and [vpn\_management](https://github.com/Venkateshvenki404224/vpn_management)
+   is under neither, so `--resolve-deps` does not find it either.
 
    ```bash
    cd /path/to/your/frappe-bench
+   bench get-app https://github.com/Venkateshvenki404224/vpn_management --branch version-16
    bench get-app https://github.com/Venkateshvenki404224/benchpress --branch version-16
    bench pip install docker
    bench --site <site> install-app benchpress
    bench --site <site> migrate
    ```
 
-   `benchpress` declares `vpn_management` as a required app, so Frappe
-   installs that first. It refuses to install without `vpn_endpoint_host` in
+   Skip the first `get-app` and `install-app` fails with
+   `frappe.exceptions.InvalidRemoteException`, raised with an empty message.
+   Frappe resolves the `required_apps` name the same way — against the `frappe`
+   and `erpnext` accounts — and gives up there, before it ever reports a
+   missing app.
+
+   `vpn_management` itself refuses to install without `vpn_endpoint_host` in
    `common_site_config.json` and without a reachable wg-agent socket. See
    [WireGuard and the VPN plane](/docs/operator/wireguard-setup).
 
@@ -2171,13 +2246,15 @@ Throughout, replace `<site>` with your real site name.
    |Step|What it does|Skipped when|
    |--|--|--|
    |1 of 4|Adds the bench user to the `docker` group|the user is already a member|
-   |2 of 4|Checks Docker `userns-remap` or rootless mode|never — it only warns|
+   |2 of 4|Checks the container-root privilege boundary: a registered `sysbox-runc` runtime, or Docker `userns-remap` (or rootless)|never — it warns, or exits under `--strict`|
    |3 of 4|Starts `benchpress-mariadb` and `benchpress-redis`, and creates the `benchpress` network and the data volume|the containers are already up|
    |4 of 4|Writes `net.ipv4.ip_forward = 1` under `/etc/sysctl.d`|forwarding is already on|
 
    Step 2 warns and continues by default. On a host that will carry anything
    you care about, run it as `bash apps/benchpress/setup.sh <site> --strict`
-   instead, which exits non-zero rather than warning. See
+   instead, which exits non-zero rather than warning. Either boundary
+   satisfies `--strict`. sysbox is checked first: it is the recommended one,
+   and a lab set to the `sysbox` runtime needs it registered anyway. See
    [Production safety](/docs/operator/production-safety).
 
 3. **Build the frontend.** The dashboard is a Vue single-page app and ships as
@@ -2222,7 +2299,7 @@ Throughout, replace `<site>` with your real site name.
 
    The first screen is the **Overview**: how many environments are running,
    stopped or broken, the average deploy time over the last seven days, and a
-   **Shared infrastructure** panel reporting eleven checks. Seven days is not
+   **Shared infrastructure** panel reporting twelve checks. Seven days is not
    a choice — deploy logs are cleared on that schedule, so no longer window
    has data behind it.
 
@@ -2270,11 +2347,11 @@ that image in seconds. See [The image cache](/docs/operator/image-cache).
 
 |Symptom|Cause|Fix|
 |--|--|--|
-|`install-app` fails naming `vpn_management`|The required app is missing or refuses to install|Install `vpn_management` first and set `vpn_endpoint_host`|
+|`install-app` fails with a bare `InvalidRemoteException`|The repository was never cloned into `apps/`|Run the first `get-app` in step 1, then re-run `install-app`|
 |The dashboard is blank or unstyled|The frontend was never built|Step 3, then `bench --site <site> clear-cache`|
 |Settings will not save|`base_domain` is empty, and it is required|Fill it. Sites are addressed under it|
 |Every deploy fails on a Docker call|The bench started before the group change took effect|Log out, log back in, restart the bench|
-|`setup.sh` warns about `userns-remap`|Container root maps to host root|See [Production safety](/docs/operator/production-safety) before running anything real|
+|`setup.sh` warns that there is no privilege boundary|Neither `sysbox-runc` nor `userns-remap` is present, so container root is host root|See [Production safety](/docs/operator/production-safety) before running anything real|
 |The Overview shows `Kernel ceilings Error`|Host-wide sysctl limits are below what a dense fleet needs|`sudo scripts/tune-host.sh`, from the `benchpress_devops` checkout|
 
 ## Reference
@@ -2282,6 +2359,8 @@ that image in seconds. See [The image cache](/docs/operator/image-cache).
 |Item|Value|
 |--|--|
 |App branch|`version-16`|
+|App repository|[Venkateshvenki404224/benchpress](https://github.com/Venkateshvenki404224/benchpress)|
+|Required app|[Venkateshvenki404224/vpn\_management](https://github.com/Venkateshvenki404224/vpn_management), branch `version-16`|
 |Setup script|`bash apps/benchpress/setup.sh <site> [--strict]`|
 |Shared containers|`benchpress-mariadb`, `benchpress-redis`|
 |Docker network|`benchpress`|
@@ -3802,7 +3881,7 @@ and never skip the step 0 gate.
 
 # Production safety
 URL: https://docs.benchpress.cloud/docs/operator/production-safety
-What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the endpoint-by-endpoint release checklist.
+What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the release checklist that covers 25 of 52 whitelisted callables.
 
 Whether BenchPress is safe to run on your host, and what has to be true first.
 
@@ -3832,6 +3911,10 @@ ERPNext environments. It is not built to host customer data. Concretely:
   up. See [Backup and restore](/docs/operator/backup-and-restore).
 * **Single-tenant assumption.** Quotas, rate limits and audit trails are still
   in progress. Run BenchPress for people you trust, on a host dedicated to it.
+* **The security review is partial.** It covers 25 of the app's 52 whitelisted
+  callables. The credit-purchase path and the per-bench credential endpoint are
+  among the 27 it never reached. See
+  [the release checklist](#the-release-checklist).
 
 Use it on a dedicated dev box, a VM, or a cloud instance you can rebuild. Not
 on your daily-driver workstation, and not on a shared production server.
@@ -3888,31 +3971,53 @@ All three must pass on a host carrying anything you would miss.
 
 ## The release checklist
 
-Last reviewed 2026-07-02, from the authorization suite, the contract and
-timing suite, a branch security review, and a sweep of every
-`ignore_permissions=True` and secret-handling path.
+Reviewed 2026-07-02, from the authorization suite, the contract and timing
+suite, a branch security review, and a sweep of every `ignore_permissions=True`
+and secret-handling path. Every row below was re-checked against the code on
+2026-08-30. Two findings had been fixed, one described an endpoint that never
+existed, and several guard descriptions were wrong.
 
-Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
+**What the audit covered.** The app exposes **52** whitelisted callables. This
+checklist covers **25** of them: 16 endpoints and 9 controller methods. It also
+carried a row for a `create_site` endpoint, which does not exist in the code —
+that row is gone. **27 whitelisted callables have never been reviewed**, and
+that is the largest gap on this page. They are:
+
+|Never reviewed|Where|
+|--|--|
+|`buy_credits`, `get_purchase_options`, `get_credit_summary`, `get_credit_statement`, `get_lease_plans`, `renew_bench`|the credit and lease path, including the one that takes money|
+|`get_bench_credentials`|decrypts SSH, admin and code-server passwords for one bench|
+|`launch_template`, `launch_lab`, `build_lab_golden`, `prewarm_catalog`|the one-click deploy and golden-build path|
+|`sign_up`, `join`, `notify_of_signup`, `approve`|`signup.py` and `waitlist.py`, the only self-service entry points|
+|`Credit Account.post_adjustment`, `post_refund`|controller methods that move a balance|
+|`server_time`, `get_lab_form_options`, `get_device_types`, `get_build_history`, `get_deploy_history`, `get_overview`, `get_vpn_status`, `run_connection_test`, `run_diagnostics`, `preflight_runtime`|the rest|
+
+Treat an unreviewed endpoint as unreviewed, not as safe.
+
+Read the verdicts as: **Ready**, **Ready with a follow-up**, **Not ready**.
 
 ### Whitelisted endpoints
 
+`require_app_user` admits `System Manager`, `BenchPress Admin` and
+`BenchPress User`. `require_admin` admits the first two. Both are
+`frappe.only_for`, so neither is satisfied by login alone.
+
 |Endpoint|Guard|Verdict|Note|
 |--|--|--|--|
-|`get_labs`|login only|Ready|A shared admin-curated catalog. No per-user data|
-|`get_lab`|login only|Ready|One catalog row|
-|`get_lab_templates`|login only|Ready|A static list|
+|`get_labs`|`require_app_user`|Ready|A shared admin-curated catalog. No per-user data|
+|`get_lab`|`require_app_user`|Ready|One catalog row|
+|`get_lab_templates`|`require_app_user`|Ready|A static list|
 |`create_lab_from_template`|`require_admin`|Ready|Admin-only, proven by test|
 |`build_lab_image`|`require_admin`|Ready|Admin-only, proven by test|
-|`get_benches`|owner filter|Follow-up|Returns decrypted SSH, admin and code-server passwords in the list payload. Owner-scoped, but secrets belong in an on-demand call|
-|`create_bench`|login, own deterministic id|Ready|The id embeds the caller, so a user can only create their own|
+|`get_benches`|`require_app_user`, owner filter|Ready|No longer returns any password. The field list holds no secret, and a test asserts their absence. Retrieval moved to `get_bench_credentials`|
+|`create_bench`|`require_app_user`, own deterministic id|Ready|The id embeds the caller, so a user can only create their own|
 |`bench_action`|`require_bench_access`, delete admin-only|Ready|Start, stop and restart are owner-scoped. Delete is admin-gated|
 |`get_deploy_logs`|`require_bench_access`|Ready|Cross-user access denied by test|
-|`add_device`|login, peer owned by caller|Ready|Creates only the caller's peer|
-|`remove_device`|owner or admin|Ready|Ownership enforced before delete|
-|`list_devices`|owner filter|Ready|Bench peers excluded|
-|`get_device_wg_config`|owner or admin|Follow-up|The guard exists. The cross-user negative test does not|
-|`create_site`|`require_bench_access` **only when `bench` is set**|Follow-up|A bench-less call skips the guard and creates an orphan `Bench Site`|
-|`get_user_context`|login, own session|Ready|Returns only the caller's identity and roles|
+|`add_device`|`require_app_user`, peer owned by caller|Ready|Writes `owner_user` as the session user, so it creates only the caller's peer|
+|`remove_device`|`require_app_user`, then an owned-peer lookup|Ready|Ownership resolved before the delete|
+|`list_devices`|`require_app_user`, `owner_user` filter|Ready|Bench peers excluded|
+|`get_device_wg_config`|`require_app_user`, then an owned-peer lookup|Follow-up|The guard exists. The cross-user negative test still does not|
+|`get_user_context`|login only|Ready|No role check, deliberately: the SPA calls it on boot. Returns the caller's own identity, roles and credit summary, and nothing about another user|
 |`get_code_server_credentials`|`require_bench_access`|Ready|Decrypted only after the ownership check|
 |`restart_code_server`|`require_bench_access`|Ready|Cross-user denied by test|
 
@@ -3924,7 +4029,7 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 |`Bench Instance.enqueue_redeploy`|same|Ready||
 |`Bench Instance.enqueue_stop`|same|Ready||
 |`Bench Instance.enqueue_start`|same|Ready||
-|`Database Server.setup_mariadb`|read permission, admin-only doctype|Follow-up|A state-changing operation should check `write`, and it has no authorization test|
+|`Database Server.setup_mariadb`|`frappe.has_permission` with no `ptype`, so `read`|Follow-up|A state-changing operation should check `write`, and it has no authorization test. The doctype grants `read` only to `System Manager` and `BenchPress Admin`, both of which also hold `write`, so the gap is hardening rather than an open door|
 |`Database Server.start_mariadb`|same|Follow-up|As above|
 |`Database Server.stop_mariadb`|same|Follow-up|As above|
 |`Database Server.retry_setup`|same|Follow-up|As above|
@@ -3935,8 +4040,8 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 |Component|Verdict|Note|
 |--|--|--|
 |Permission model|Ready|Guest, wrong role and cross-user are all rejected. `only_for` raises for non-administrators|
-|Secret handling|Ready|Decryption only behind an owner or admin guard. The database root password is never logged|
-|`ignore_permissions=True`, 39 uses|Ready|Confined to enqueued and system flows. Ownership is tracked on `owner` and `owner_user`|
+|Secret handling|Ready|Both decryptions a whitelisted endpoint can reach sit behind `require_bench_access`. The database root password is never logged. One of the two, `get_bench_credentials`, was never in this audit — see the coverage list above|
+|`ignore_permissions=True`, 53 uses outside tests|Ready|Confined to enqueued and system flows. Ownership is tracked on `owner` and `owner_user`. The count was 39 at the 2026-07-02 review|
 |SQL construction|Ready|Identifiers are hashed and SQL is base64-wrapped before shelling. Not injectable|
 |Container isolation|**Not ready without a precondition**|Non-privileged, but a lab user holds in-container root. Ship only on a host with sysbox, userns-remap or a rootless daemon|
 
@@ -3944,15 +4049,16 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 
 1. **The container privilege boundary.** Ship only on a host that closes it.
    This is a deployment precondition, not an app default.
-2. **`create_site` with no bench.** Make `bench` mandatory, or guard the empty
-   case, so the endpoint cannot create an orphan `Bench Site` that bypasses
-   the access check.
-3. **`Database Server` state-changing methods.** Move them to a `write`
-   permission check and add authorization tests.
-4. **`get_benches` secret exposure.** Move SSH, admin and code-server password
-   retrieval out of the bulk list payload into an on-demand per-bench call.
-5. **`get_device_wg_config` test gap.** Add an explicit cross-user negative
+2. **The 27 unreviewed endpoints.** Review them, starting with `buy_credits`,
+   which takes money, and `get_bench_credentials`, which decrypts passwords.
+3. **`Database Server` state-changing methods.** They call
+   `frappe.has_permission` with no `ptype`, which checks `read`. Move them to
+   `write` and add authorization tests.
+4. **`get_device_wg_config` test gap.** Add an explicit cross-user negative
    test. The guard exists. The coverage does not.
+
+Two items from the 2026-07-02 list are closed. `get_benches` no longer returns
+any password. The `create_site` item described an endpoint that does not exist.
 
 ## Troubleshooting
 
@@ -3973,7 +4079,10 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 |Default runtime|`sysbox`|
 |Backed up|the shared MariaDB, nightly, 7 dumps|
 |Not backed up|bench Docker volumes|
-|Checklist last reviewed|2026-07-02|
+|Checklist reviewed|2026-07-02, re-verified against the code 2026-08-30|
+|Whitelisted callables|52|
+|Covered by this checklist|25|
+|Never reviewed|27|
 
 ## Related
 
@@ -3984,7 +4093,7 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 
 # Diagnostics
 URL: https://docs.benchpress.cloud/docs/operator/diagnostics
-The eleven read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
+The twelve read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
 
 Eleven checks that read the host rather than the configuration, and what to do
 about each one that fails.
@@ -4010,7 +4119,7 @@ one you have already made worse.
 2. **Or read them in the app.** Open **Overview** as an admin and look at the
    **Shared infrastructure** panel, which renders the same eleven rows.
 
-   ![The Shared infrastructure panel on the BenchPress Overview, listing eleven checks with a status badge each. Docker socket, Docker network, Bridge capacity, MariaDB, Redis, Container runtimes, Event listener and WireGuard read Active. Kernel ceilings and Clock skew read Error, and Golden images reads Warning.](../images/operator/diagnostics/01-shared-infrastructure.png)
+   ![The Shared infrastructure panel on the BenchPress Overview, listing the shared-infrastructure checks with a status badge each. Docker socket, Docker network, Bridge capacity, MariaDB, Redis, Container runtimes, Event listener and WireGuard read Active. Kernel ceilings and Clock skew read Error, and Golden images reads Warning.](../images/operator/diagnostics/01-shared-infrastructure.png)
 
    On this host eight rows read **Active**, `kernel_ceilings` and `clock_skew`
    read **Error**, and `golden_images` reads **Warning**. A badge is the
@@ -4021,7 +4130,7 @@ one you have already made worse.
    checks again. Several rows fail together for one cause, and the first fix
    often clears three.
 
-## The eleven checks
+## The twelve checks
 
 |Check|On screen|What it asks|Severity of a failure|
 |--|--|--|--|
@@ -4035,6 +4144,7 @@ one you have already made worse.
 |`container_runtimes`|Container runtimes|`sysbox-runc` is registered with Docker|Error|
 |`golden_images`|Golden images|how many built labs carry a golden dump|Warning|
 |`docker_events`|Event listener|the listener's heartbeat is newer than 60 seconds|Error|
+|`route_directory`|Route directory|a worker has reported the Traefik route directory mounted, with the control-plane route and the wildcard anchor rendered|Error, or Warning when the report is stale or the anchor is merely late|
 |`vpn_server`|WireGuard|`vpn_management` is installed, `wg0` exists, and it has a public key|Error|
 
 ## Severity is not status
@@ -5012,7 +5122,7 @@ One concern for each module. The table is the whole `benchpress/` package.
 |`permissions.py`|the role helpers and the six query conditions|
 |`overview.py`, `labs.py`, `lab_detail.py`, `run_history.py`|one screen each, assembled in a fixed number of queries|
 |`waitlist.py`, `signup.py`|the two doors open to a guest|
-|`diagnostics.py`|eleven read-only environment checks|
+|`diagnostics.py`|twelve read-only environment checks|
 |`notifications.py`|one desk alert and one email to a document owner|
 |`indexes.py`|composite indexes the DocType JSON cannot declare|
 |`request_cache.py`|a value memoised for one request, never in a module global|
@@ -5438,7 +5548,7 @@ This is the only DocType a guest can cause to be written. See
 
 # API
 URL: https://docs.benchpress.cloud/docs/reference/api
-All 50 whitelisted BenchPress endpoints, with arguments, what each returns, and the permission check each one makes for itself.
+Every whitelisted BenchPress endpoint, with arguments, what each returns, and the permission check each one makes for itself.
 
 Every function this app publishes over HTTP, and what each one checks before it
 does anything.
@@ -5462,9 +5572,12 @@ curl -s https://<host>/api/method/benchpress.api.get_labs \
 Arguments go as query parameters on a `GET` or as form fields on a `POST`.
 Frappe decides the method from the function, not from a route table.
 
-Thirty-five of the fifty are in `benchpress.api`. Four more are module functions
-elsewhere. The remaining eleven are document methods, called through
-`run_doc_method` rather than by path. All three kinds are marked below.
+Endpoints come in three kinds. Most are module functions in `benchpress.api`. A
+few more are module functions elsewhere, in `benchpress.waitlist` and
+`benchpress.signup`. The rest are document methods on controllers, called
+through `run_doc_method` rather than by path. All three kinds are marked below.
+[The whole list, counted](#the-whole-list-counted) has the breakdown and the
+command that derives it.
 
 ## How an endpoint is guarded
 
@@ -5540,6 +5653,61 @@ MD5 of the two, so a second call redeploys rather than making a second bench.
 
 `server_time` exists so a countdown in the browser corrects against the server
 clock instead of the laptop's.
+
+## Launch
+
+`create_bench` deploys a lab whose image already exists. The two launch
+endpoints do not require one. They build the image first, when there is no
+image, and deploy from it in the same job.
+
+|Endpoint|Arguments|Returns|Checks|
+|--|--|--|--|
+|`launch_template`|`template`, `instance_size`, `site_name`|the launch response below|`require_app_user`, then `is_active` on the `Lab Template` row, then `requires_admission` inside `_launch`|
+|`launch_lab`|`data` (JSON, with at least `lab`)|the launch response below|`require_app_user`, then `requires_admission` inside `_launch`|
+
+Both live in `benchpress/api.py`. Both call the private
+`_launch`, which claims the instance and enqueues
+`benchpress.launch.run_launch` on `queue-long` under the deduplicated job id
+`launch:<bench name>`. The job timeout is the image build timeout plus the
+deploy timeout, because one job does both.
+
+**The admission gate is on `_launch`, not on the published function.** This
+looks like a missing decorator and is not. `requires_admission` binds its cost
+and cap arguments by name and needs a lab that exists, which is only true after
+`launch_template` has resolved a template to one. `launch_template` resolves or
+creates that lab first, so a caller the gate then refuses can leave a new `Lab`
+row behind. The gate still runs before any work is queued, which is the property
+that matters.
+
+`launch_template` checks `is_active` on the `Lab Template` itself.
+`lab_templates.get_template` checks only that the key exists, so without this
+check a user could materialise a template an admin had retired.
+
+`launch_template` reuses a lab before it makes one. It takes the newest lab
+built from that template whose recipe still matches the template's own, and
+creates a lab only when there is no match. A second developer launching the same
+template rides the image the first launch paid for. A lab an admin has edited
+away from the template is skipped, because deploying it would install apps the
+template never named.
+
+Both endpoints claim the bench through the same path `create_bench` uses, so the
+same pair of caller and lab is the same bench. A second launch redeploys.
+
+The launch response carries seven keys:
+
+|Key|Is|
+|--|--|
+|`name`|the bench id|
+|`bench`|the same string as `name`, so a caller still reading `name` keeps working|
+|`lab`|the lab this bench came from|
+|`lab_title`|that lab's title|
+|`lab_status`|that lab's status, read from the row|
+|`will_build`|`true` when `lab_status` is not `Ready`|
+|`eta_minutes`|`eta_minutes` from the `Lab Template` row, or `0`|
+
+`will_build` is that status read alone. It does not ask Docker whether the image
+is on the host. It is opening copy for the launch dialog, and the job decides
+what actually happens.
 
 ## History
 
@@ -5637,7 +5805,7 @@ not from now.
 
 |Endpoint|Arguments|Returns|Checks|
 |--|--|--|--|
-|`run_diagnostics`|—|eleven read-only environment checks|`require_admin`|
+|`run_diagnostics`|—|twelve read-only environment checks|`require_admin`|
 |`preflight_runtime`|`runtime`|whether that runtime can actually start a container|`require_admin`|
 
 `run_diagnostics` reads. `preflight_runtime` creates a container, which is why
@@ -5717,22 +5885,33 @@ Two more waitlist functions are admin-only and not guest-reachable.
 
 ## The whole list, counted
 
-Fifty `@frappe.whitelist()` functions. Every one is in a table above.
+**Count the code, not this page.** Run the command before you quote a number
+anywhere:
+
+```bash
+grep -rn "@frappe.whitelist" --include=*.py benchpress/ | wc -l
+```
+
+Per file:
+
+```bash
+grep -rc "@frappe.whitelist" --include=*.py benchpress/ | grep -v ':0$' | sort -t: -k2 -rn
+```
+
+What those two commands returned when this page was last checked:
 
 |Location|Count|
 |--|--|
-|`benchpress/api.py`|35|
+|`benchpress/api.py`|37|
 |`benchpress/benchpress/doctype/database_server/database_server.py`|5|
 |`benchpress/benchpress/doctype/bench_instance/bench_instance.py`|4|
 |`benchpress/waitlist.py`|3|
 |`benchpress/benchpress/doctype/credit_account/credit_account.py`|2|
 |`benchpress/signup.py`|1|
+|**Total**|**52**|
 
-Recount after a change:
-
-```bash
-grep -rn "@frappe.whitelist" --include=*.py benchpress/ | wc -l
-```
+Every one of those 52 has a row in a table above. That is the claim to keep
+true when you add an endpoint.
 
 ## Adding an endpoint
 
@@ -5742,6 +5921,8 @@ grep -rn "@frappe.whitelist" --include=*.py benchpress/ | wc -l
    `@frappe.whitelist()`.
 4. Query with `frappe.qb`. A raw `frappe.db.sql` string is a lint failure.
 5. Add the endpoint to the table on this page.
+6. Re-run the two commands in [The whole list, counted](#the-whole-list-counted)
+   and paste what they return over that table.
 
 The decorator order matters. `@frappe.whitelist()` goes on top, and
 `@requires_admission(...)` below it, so the gate runs inside the published
@@ -6242,10 +6423,20 @@ Every address a bench answers on, and who can reach each one.
 one is addressed.
 
 **Before you start.** A bench has up to four addresses at once. They are not
-alternatives. Each one exists for a different caller, and three of the four are
-private.
+alternatives. Each one exists for a different caller, and two of the four are
+public.
 
 ## The four addresses
+
+**This section is the canonical statement of what a bench is reachable on.**
+The one sentence:
+
+> A bench answers on up to four addresses at once: two public HTTPS addresses
+> served by Traefik, which anyone on the internet can reach once `base_domain`
+> is set, and two tunnel addresses that only a device on the VPN can reach.
+
+The two `https://` addresses answer for anyone on the internet once
+`base_domain` is set, which is the documented install.
 
 `benchpress/addressing.py` builds all of them in one place, and the app renders
 what it returns rather than assembling a URL from a port it declared itself.
@@ -6256,6 +6447,19 @@ what it returns rather than assembling a URL from a port it declared itself.
 |Public IDE|`https://ide-<instance id>.<base domain>`|the internet, through Traefik|
 |Tunnel site|`http://<wg ip>:8000`|a device on the VPN|
 |Tunnel IDE|`http://<wg ip>:8080/`|a device on the VPN|
+
+`ingress.publish` writes routers on the `websecure` entry point: two for the
+site hostname, split so asset paths take their own rate limit, and one for the
+IDE hostname. `ingress.ensure_anchor` holds the wildcard certificate that
+terminates them. The IDE router is written only when the bench has an IDE, which
+is why the count is "up to four".
+
+Public means public. The only middlewares `publish` puts on a bench router are
+rate limits: a request cap on every router, and an in-flight cap on the site's
+render path when the instance size sets one. There is no authentication
+middleware at the edge. A browser anywhere resolves the name and gets the
+bench's own login page, and that login is the only thing between the internet
+and the site.
 
 The two ports are properties of the bench image, not settings. They are
 constants in `addressing.py`.
@@ -6380,8 +6584,12 @@ state.
 |Another bench on the same bridge|no|no|no|no|
 |A bench, reaching the shared MariaDB|—|—|—|the database only|
 
-No bench is on the public internet by port. The only public path is Traefik, and
-it terminates TLS on the wildcard.
+No bench is on the public internet by port. No bench container publishes a host
+port at all — the only public path is Traefik, and it terminates TLS on the
+wildcard.
+
+That is the whole of what the VPN gates. **SSH and the two `http://` tunnel
+addresses need the VPN. The two `https://` addresses do not.**
 
 ## Verify
 
@@ -7154,8 +7362,12 @@ cached image, creates a site, and puts the container on a WireGuard network.
 You get a site address, an SSH login and a browser VS Code session. When the
 work is done, you destroy the environment. Spin up, use, tear down.
 
-No bench is on the public internet. Every site, SSH port and IDE session is
-reachable only from a device that joined the VPN.
+A bench answers on up to four addresses at once: two public HTTPS addresses
+served by Traefik, which anyone on the internet can reach once `base_domain` is
+set, and two tunnel addresses that only a device on the VPN can reach.
+`base_domain` is a required setting, so a bench is not VPN-only on the
+documented install. [Networking](/docs/reference/networking) states the address
+plan in full.
 
 ## Reference
 
@@ -7179,3 +7391,4 @@ the page is still complete.
 ## Related
 
 * [Quick tour](/docs/user/quick-tour) — the five screens, and what the dashboard reports.
+* [Networking](/docs/reference/networking) — the four addresses a bench answers on, and who can reach each one.

--- a/docs-site/.well-known/llms.txt
+++ b/docs-site/.well-known/llms.txt
@@ -37,7 +37,7 @@ is done.
 ## Operator Track
 
 - [Operator track](/docs/operator.md): Run BenchPress on your own box — install, the VPN plane, settings, the shared database, images, upgrades, safety and diagnostics.
-- [Prerequisites](/docs/operator/prerequisites.md): What a BenchPress host needs before you install — supported platforms, versions, Docker socket access, IP forwarding, sysbox, and the measured CPU sizing.
+- [Prerequisites](/docs/operator/prerequisites.md): What a BenchPress host needs before you install — the four preconditions, supported platforms, versions, Docker socket access, and the measured CPU and disk sizing.
 - [Install](/docs/operator/install.md): Install BenchPress into a Frappe v16 bench — get-app, setup.sh, the frontend build, the base domain, and the first screen.
 - [WireGuard and the VPN plane](/docs/operator/wireguard-setup.md): How the vpn_management app owns the tunnel, what BenchPress consumes from it, the measured server and pool values, and why userns-remap matters.
 - [Settings reference](/docs/operator/settings-reference.md): Every field on BenchPress Settings and Credit Settings, with the value measured on a live host, where each one is edited, and what changing it costs.
@@ -47,8 +47,8 @@ is done.
 - [The image cache](/docs/operator/image-cache.md): One image per lab, tagged benchpress/<lab_id>:lab — what it costs on disk, how the weekly prewarm and sweep work, and what is safe to prune.
 - [Users and roles](/docs/operator/users-and-roles.md): The two BenchPress roles, what each one may read and write, which screens are admin-only, and how ownership rather than a role decides who sees a bench.
 - [Upgrading](/docs/operator/upgrading.md): Move a BenchPress install to a newer release — the backup gate, the five steps, the scripted path, rollback, and why lab images are a separate opt-in.
-- [Production safety](/docs/operator/production-safety.md): What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the endpoint-by-endpoint release checklist.
-- [Diagnostics](/docs/operator/diagnostics.md): The eleven read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
+- [Production safety](/docs/operator/production-safety.md): What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the release checklist that covers 25 of 52 whitelisted callables.
+- [Diagnostics](/docs/operator/diagnostics.md): The twelve read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
 - [Credits and billing](/docs/operator/credits-and-billing.md): Optional and off by default — the metering half of BenchPress, covering leases, balances, the ledger, admin adjustments, and the optional Razorpay handoff.
 - [Admission and limits](/docs/operator/admission-and-limits.md): Optional and off by default — concurrency caps, size ceilings, device and build quotas, how a slot is claimed as a row, and the acceptance run that proves access still works.
 - [Self-serve signup](/docs/operator/hosted-signup.md): Optional and off by default — retire the waitlist and let people sign themselves up, with GitHub and Google as the primary paths and the abuse controls that make a free grant safe.
@@ -58,7 +58,7 @@ is done.
 - [Reference track](/docs/reference.md): The data model, the whitelisted API, the eleven deploy steps, the reconcilers, the address plan and the configuration split — for a contributor or an integrator.
 - [Architecture](/docs/reference/architecture.md): The moving parts of BenchPress — the control plane, the bench containers, the shared infrastructure, and which Python module owns each concern.
 - [Data model](/docs/reference/data-model.md): All 20 BenchPress DocTypes with their fields, links, naming and the permission rule that scopes each one — plus why there is no Device DocType.
-- [API](/docs/reference/api.md): All 50 whitelisted BenchPress endpoints, with arguments, what each returns, and the permission check each one makes for itself.
+- [API](/docs/reference/api.md): Every whitelisted BenchPress endpoint, with arguments, what each returns, and the permission check each one makes for itself.
 - [Deploy pipeline](/docs/reference/deploy-pipeline.md): The eleven steps of a BenchPress deploy, in the order the code runs them, with the function behind each step and the log line it writes.
 - [Lifecycle and events](/docs/reference/lifecycle-and-events.md): The bench states and their transitions, the Docker event listener, Bench Event incidents, the stats collector, and the eleven scheduled jobs that correct the database.
 - [Networking](/docs/reference/networking.md): The BenchPress address plan — bench bridges, WireGuard tunnel addresses, the two container ports, Traefik route files and the wildcard certificate anchor.

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -2,7 +2,7 @@
 title: BenchPress documentation
 description: Start here. Three tracks — use a bench, run the server that hosts
   one, or read the data model and the API.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T08:05:07-04:00"
 lastAuthor: Venkatesh
 ---
 # BenchPress documentation

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -34,8 +34,12 @@ cached image, creates a site, and puts the container on a WireGuard network.
 You get a site address, an SSH login and a browser VS Code session. When the
 work is done, you destroy the environment. Spin up, use, tear down.
 
-No bench is on the public internet. Every site, SSH port and IDE session is
-reachable only from a device that joined the VPN.
+A bench answers on up to four addresses at once: two public HTTPS addresses
+served by Traefik, which anyone on the internet can reach once `base_domain` is
+set, and two tunnel addresses that only a device on the VPN can reach.
+`base_domain` is a required setting, so a bench is not VPN-only on the
+documented install. [Networking](/docs/reference/networking) states the address
+plan in full.
 
 ## Reference
 
@@ -59,3 +63,4 @@ the page is still complete.
 ## Related
 
 * [Quick tour](/docs/user/quick-tour) — the five screens, and what the dashboard reports.
+* [Networking](/docs/reference/networking) — the four addresses a bench answers on, and who can reach each one.

--- a/docs-site/docs/llms.txt
+++ b/docs-site/docs/llms.txt
@@ -43,7 +43,7 @@ Read the summary links first. If the page links are not enough, use `/llms-full.
 
 ### Stand a host up
 
-- [Prerequisites](/docs/operator/prerequisites.md): What a BenchPress host needs before you install — supported platforms, versions, Docker socket access, IP forwarding, sysbox, and the measured CPU sizing.
+- [Prerequisites](/docs/operator/prerequisites.md): What a BenchPress host needs before you install — the four preconditions, supported platforms, versions, Docker socket access, and the measured CPU and disk sizing.
 - [Install](/docs/operator/install.md): Install BenchPress into a Frappe v16 bench — get-app, setup.sh, the frontend build, the base domain, and the first screen.
 - [WireGuard and the VPN plane](/docs/operator/wireguard-setup.md): How the vpn_management app owns the tunnel, what BenchPress consumes from it, the measured server and pool values, and why userns-remap matters.
 
@@ -62,8 +62,8 @@ Read the summary links first. If the page links are not enough, use `/llms-full.
 ### Keep it safe
 
 - [Upgrading](/docs/operator/upgrading.md): Move a BenchPress install to a newer release — the backup gate, the five steps, the scripted path, rollback, and why lab images are a separate opt-in.
-- [Production safety](/docs/operator/production-safety.md): What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the endpoint-by-endpoint release checklist.
-- [Diagnostics](/docs/operator/diagnostics.md): The eleven read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
+- [Production safety](/docs/operator/production-safety.md): What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the release checklist that covers 25 of 52 whitelisted callables.
+- [Diagnostics](/docs/operator/diagnostics.md): The twelve read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
 
 ### Optional — running it for a team
 
@@ -81,7 +81,7 @@ Read the summary links first. If the page links are not enough, use `/llms-full.
 
 - [Architecture](/docs/reference/architecture.md): The moving parts of BenchPress — the control plane, the bench containers, the shared infrastructure, and which Python module owns each concern.
 - [Data model](/docs/reference/data-model.md): All 20 BenchPress DocTypes with their fields, links, naming and the permission rule that scopes each one — plus why there is no Device DocType.
-- [API](/docs/reference/api.md): All 50 whitelisted BenchPress endpoints, with arguments, what each returns, and the permission check each one makes for itself.
+- [API](/docs/reference/api.md): Every whitelisted BenchPress endpoint, with arguments, what each returns, and the permission check each one makes for itself.
 
 ### What it does at runtime
 

--- a/docs-site/docs/operator/diagnostics.md
+++ b/docs-site/docs/operator/diagnostics.md
@@ -1,6 +1,6 @@
 ---
 title: Diagnostics
-description: The eleven read-only checks that ask Docker, MariaDB, Redis and the
+description: The twelve read-only checks that ask Docker, MariaDB, Redis and the
   kernel what is true — how to run them, what each failure means, and the four
   things they do not cover.
 lastModified: "2026-08-28T22:10:21+05:30"
@@ -32,7 +32,7 @@ one you have already made worse.
 2. **Or read them in the app.** Open **Overview** as an admin and look at the
    **Shared infrastructure** panel, which renders the same eleven rows.
 
-   ![The Shared infrastructure panel on the BenchPress Overview, listing eleven checks with a status badge each. Docker socket, Docker network, Bridge capacity, MariaDB, Redis, Container runtimes, Event listener and WireGuard read Active. Kernel ceilings and Clock skew read Error, and Golden images reads Warning.](../images/operator/diagnostics/01-shared-infrastructure.png)
+   ![The Shared infrastructure panel on the BenchPress Overview, listing the shared-infrastructure checks with a status badge each. Docker socket, Docker network, Bridge capacity, MariaDB, Redis, Container runtimes, Event listener and WireGuard read Active. Kernel ceilings and Clock skew read Error, and Golden images reads Warning.](../images/operator/diagnostics/01-shared-infrastructure.png)
 
    On this host eight rows read **Active**, `kernel_ceilings` and `clock_skew`
    read **Error**, and `golden_images` reads **Warning**. A badge is the
@@ -43,7 +43,7 @@ one you have already made worse.
    checks again. Several rows fail together for one cause, and the first fix
    often clears three.
 
-## The eleven checks
+## The twelve checks
 
 |Check|On screen|What it asks|Severity of a failure|
 |--|--|--|--|
@@ -57,6 +57,7 @@ one you have already made worse.
 |`container_runtimes`|Container runtimes|`sysbox-runc` is registered with Docker|Error|
 |`golden_images`|Golden images|how many built labs carry a golden dump|Warning|
 |`docker_events`|Event listener|the listener's heartbeat is newer than 60 seconds|Error|
+|`route_directory`|Route directory|a worker has reported the Traefik route directory mounted, with the control-plane route and the wildcard anchor rendered|Error, or Warning when the report is stale or the anchor is merely late|
 |`vpn_server`|WireGuard|`vpn_management` is installed, `wg0` exists, and it has a public key|Error|
 
 ## Severity is not status

--- a/docs-site/docs/operator/diagnostics.md
+++ b/docs-site/docs/operator/diagnostics.md
@@ -3,7 +3,7 @@ title: Diagnostics
 description: The twelve read-only checks that ask Docker, MariaDB, Redis and the
   kernel what is true — how to run them, what each failure means, and the four
   things they do not cover.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T08:05:07-04:00"
 lastAuthor: Venkatesh
 ---
 # Diagnostics

--- a/docs-site/docs/operator/install.md
+++ b/docs-site/docs/operator/install.md
@@ -2,7 +2,7 @@
 title: Install
 description: Install BenchPress into a Frappe v16 bench — get-app, setup.sh, the
   frontend build, the base domain, and the first screen.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T08:04:44-04:00"
 lastAuthor: Venkatesh
 ---
 # Install

--- a/docs-site/docs/operator/install.md
+++ b/docs-site/docs/operator/install.md
@@ -20,18 +20,33 @@ Throughout, replace `<site>` with your real site name.
 
 ## Steps
 
-1. **Install the app into the bench.**
+1. **Install the apps into the bench.** There are two repositories, and you
+   clone both.
+
+   `benchpress` names `vpn_management` in `required_apps`, so
+   `install-app benchpress` installs `vpn_management` first — but only from a
+   copy already on the bench, listed in `sites/apps.txt`. Clone it yourself.
+   `bench get-app` resolves a bare
+   `required_apps` name under the `frappe` and `erpnext` GitHub accounts only,
+   and [vpn\_management](https://github.com/Venkateshvenki404224/vpn_management)
+   is under neither, so `--resolve-deps` does not find it either.
 
    ```bash
    cd /path/to/your/frappe-bench
+   bench get-app https://github.com/Venkateshvenki404224/vpn_management --branch version-16
    bench get-app https://github.com/Venkateshvenki404224/benchpress --branch version-16
    bench pip install docker
    bench --site <site> install-app benchpress
    bench --site <site> migrate
    ```
 
-   `benchpress` declares `vpn_management` as a required app, so Frappe
-   installs that first. It refuses to install without `vpn_endpoint_host` in
+   Skip the first `get-app` and `install-app` fails with
+   `frappe.exceptions.InvalidRemoteException`, raised with an empty message.
+   Frappe resolves the `required_apps` name the same way — against the `frappe`
+   and `erpnext` accounts — and gives up there, before it ever reports a
+   missing app.
+
+   `vpn_management` itself refuses to install without `vpn_endpoint_host` in
    `common_site_config.json` and without a reachable wg-agent socket. See
    [WireGuard and the VPN plane](/docs/operator/wireguard-setup).
 
@@ -47,13 +62,15 @@ Throughout, replace `<site>` with your real site name.
    |Step|What it does|Skipped when|
    |--|--|--|
    |1 of 4|Adds the bench user to the `docker` group|the user is already a member|
-   |2 of 4|Checks Docker `userns-remap` or rootless mode|never — it only warns|
+   |2 of 4|Checks the container-root privilege boundary: a registered `sysbox-runc` runtime, or Docker `userns-remap` (or rootless)|never — it warns, or exits under `--strict`|
    |3 of 4|Starts `benchpress-mariadb` and `benchpress-redis`, and creates the `benchpress` network and the data volume|the containers are already up|
    |4 of 4|Writes `net.ipv4.ip_forward = 1` under `/etc/sysctl.d`|forwarding is already on|
 
    Step 2 warns and continues by default. On a host that will carry anything
    you care about, run it as `bash apps/benchpress/setup.sh <site> --strict`
-   instead, which exits non-zero rather than warning. See
+   instead, which exits non-zero rather than warning. Either boundary
+   satisfies `--strict`. sysbox is checked first: it is the recommended one,
+   and a lab set to the `sysbox` runtime needs it registered anyway. See
    [Production safety](/docs/operator/production-safety).
 
 3. **Build the frontend.** The dashboard is a Vue single-page app and ships as
@@ -98,7 +115,7 @@ Throughout, replace `<site>` with your real site name.
 
    The first screen is the **Overview**: how many environments are running,
    stopped or broken, the average deploy time over the last seven days, and a
-   **Shared infrastructure** panel reporting eleven checks. Seven days is not
+   **Shared infrastructure** panel reporting twelve checks. Seven days is not
    a choice — deploy logs are cleared on that schedule, so no longer window
    has data behind it.
 
@@ -146,11 +163,11 @@ that image in seconds. See [The image cache](/docs/operator/image-cache).
 
 |Symptom|Cause|Fix|
 |--|--|--|
-|`install-app` fails naming `vpn_management`|The required app is missing or refuses to install|Install `vpn_management` first and set `vpn_endpoint_host`|
+|`install-app` fails with a bare `InvalidRemoteException`|The repository was never cloned into `apps/`|Run the first `get-app` in step 1, then re-run `install-app`|
 |The dashboard is blank or unstyled|The frontend was never built|Step 3, then `bench --site <site> clear-cache`|
 |Settings will not save|`base_domain` is empty, and it is required|Fill it. Sites are addressed under it|
 |Every deploy fails on a Docker call|The bench started before the group change took effect|Log out, log back in, restart the bench|
-|`setup.sh` warns about `userns-remap`|Container root maps to host root|See [Production safety](/docs/operator/production-safety) before running anything real|
+|`setup.sh` warns that there is no privilege boundary|Neither `sysbox-runc` nor `userns-remap` is present, so container root is host root|See [Production safety](/docs/operator/production-safety) before running anything real|
 |The Overview shows `Kernel ceilings Error`|Host-wide sysctl limits are below what a dense fleet needs|`sudo scripts/tune-host.sh`, from the `benchpress_devops` checkout|
 
 ## Reference
@@ -158,6 +175,8 @@ that image in seconds. See [The image cache](/docs/operator/image-cache).
 |Item|Value|
 |--|--|
 |App branch|`version-16`|
+|App repository|[Venkateshvenki404224/benchpress](https://github.com/Venkateshvenki404224/benchpress)|
+|Required app|[Venkateshvenki404224/vpn\_management](https://github.com/Venkateshvenki404224/vpn_management), branch `version-16`|
 |Setup script|`bash apps/benchpress/setup.sh <site> [--strict]`|
 |Shared containers|`benchpress-mariadb`, `benchpress-redis`|
 |Docker network|`benchpress`|

--- a/docs-site/docs/operator/prerequisites.md
+++ b/docs-site/docs/operator/prerequisites.md
@@ -1,8 +1,8 @@
 ---
 title: Prerequisites
-description: What a BenchPress host needs before you install — supported
-  platforms, versions, Docker socket access, IP forwarding, sysbox, and the
-  measured CPU sizing.
+description: What a BenchPress host needs before you install — the four
+  preconditions, supported platforms, versions, Docker socket access, and the
+  measured CPU and disk sizing.
 lastModified: "2026-08-28T22:10:21+05:30"
 lastAuthor: Venkatesh
 ---
@@ -16,6 +16,21 @@ will work, and how much of it to buy.
 **Before you start.** BenchPress installs into an existing Frappe bench and
 drives that host's Docker. It is not a standalone service, and it is Linux
 only — the setup script uses `apt` and `sysctl`.
+
+## The four preconditions
+
+Get these four before you read anything else on this page. Each one blocks the
+install or the first deploy, and none of them can be fixed from inside the app.
+
+|Precondition|Why it blocks|Set it in|
+|--|--|--|
+|`sysbox-runc` registered with Docker|`default_bench_runtime` is `sysbox`, so a deploy has no runtime without it. `runc` without `userns-remap` makes in-container root host root|[Step 5](#steps)|
+|`net.ipv4.ip_forward = 1`|The kernel drops tunnel traffic on its way to a bench, so a deploy fails on the network step|[Step 4](#steps)|
+|44556/UDP open, on `ufw` **and** on any cloud firewall|A WireGuard peer never handshakes, so nothing reaches a bench over the tunnel|[Step 7](#steps)|
+|A domain you control, for `base_domain`|`base_domain` is `reqd` on **BenchPress Settings**, so the settings form will not save without it. Sites are addressed as `<instance id>.<base domain>`|[Install, step 5](/docs/operator/install)|
+
+Size the host before you buy it as well. [Sizing](#sizing) holds the CPU floor
+and [Disk](#disk) the disk floor. Disk is the one that fails a default VPS.
 
 ## Steps
 
@@ -134,7 +149,7 @@ Three criteria, each with its own minimum:
 |Tier|Minimum CPU|Evidence at the minimum|
 |--|--:|--|
 |Boot and lifecycle|0.5|migration 13.22 s, login HTTP 200 in 192 ms, `/frontend` HTTP 200 in 27 ms|
-|Test suite|0.5|the 124-test suite passed in 11.59 s, with every endpoint timing budget met|
+|Test suite|0.5|the suite passed in 11.59 s, with every endpoint timing budget met. It held 124 tests that day. The suite has since grown by roughly an order of magnitude, so 11.59 s no longer describes a full run|
 |Concurrent reads|0.5|`get_labs` p95 127 ms, `get_benches` p95 48 ms, 0 of 60 requests failed|
 
 Concurrent reads at each candidate cap, 30 authenticated requests per endpoint
@@ -157,10 +172,50 @@ did not visibly degrade this workload, so the measurements do not support
 calling one core a minimum. Re-run the benchmark after the application grows,
 or when you change the host class.
 
-**RAM and disk are the real constraints, not CPU.** A lab image is 5.5 GB to
-19.7 GB, and one deploy costs roughly 0.2 GB to 1 GB more. See
-[The image cache](/docs/operator/image-cache) for what that grows into and how
-the sweep holds it down.
+**Of the two resources measured here, disk is the constraint, not CPU.** Size
+it before you buy the host. See [Disk](#disk).
+
+**RAM was not sized.** The benchmark capped CPU only, so the 7.8 GiB above
+describes the benchmark host and is not a floor. Watch `free -h` on your own
+host until someone measures it.
+
+## Disk
+
+**A 20 GB or 40 GB VPS root disk fails mid-build.** No setting in the app
+compensates for it, and the failure lands in the middle of an image build
+rather than at install.
+
+Measured on this host with `docker images` and `docker system df`, and listed
+per image in [The image cache](/docs/operator/image-cache):
+
+|Measurement|Value|
+|--|--:|
+|Smallest lab image|5.5 GB|
+|Largest lab image|19.7 GB|
+|Twelve lab images together|54.74 GB|
+|Reclaimable from that set|19.12 GB|
+
+Three costs sit on top of that image figure. A build holds the new image while
+its base layers are still on disk. Every bench has its own container layer and
+volumes — one deploy costs roughly 0.2 GB to 1 GB, measured in
+[The image cache](/docs/operator/image-cache). The shared MariaDB carries its
+data volume. The build headroom and the MariaDB volume are not measured.
+
+So provision against the catalog you will hold, not against one image:
+
+|The host will carry|Free disk to provision|Basis|
+|--|--:|--|
+|One lab image|100 GB|19.7 GB for the largest measured image, with room to rebuild it beside the copy in use|
+|A catalog the size of this host's|250 GB|54.74 GB measured for twelve images, plus the same rebuild headroom, plus bench volumes|
+
+Those two rows are recommendations derived from the measurements above. They
+are not themselves measured. Watch `df -h /` and `docker system df` on your own
+host, and raise them if either climbs.
+
+Building is also the slowest thing a fresh host does. Full builds on this host
+ran **4 to 26 minutes**, and the golden pass 5 to 11 — see
+[The image cache](/docs/operator/image-cache). The build job's own timeout is
+10,800 s, three hours, which is a ceiling and not an expected duration.
 
 ## Troubleshooting
 
@@ -171,6 +226,8 @@ the sweep holds it down.
 |Diagnostics reports `container_runtimes` as failed|`sysbox-runc` is not registered with Docker|Install sysbox, or set `default_bench_runtime` to `runc` and read [Production safety](/docs/operator/production-safety)|
 |Diagnostics reports `kernel_ceilings` as failed|The host ceilings are below what the fleet needs|`sudo scripts/tune-host.sh --benches <n>`, from the `benchpress_devops` checkout|
 |A peer never handshakes|UDP 44556 is closed|Step 7, and check the cloud firewall as well as `ufw`|
+|A build fails part-way with no space left|The host was sized for the OS, not for lab images|[Disk](#disk). Never run `docker image prune -a` on this host|
+|**BenchPress Settings** will not save|`base_domain` is required and empty|Point a domain you control at this host, then fill it in [Install, step 5](/docs/operator/install)|
 
 ## Reference
 
@@ -182,6 +239,9 @@ the sweep holds it down.
 |WireGuard port|44556/UDP|the `WireGuard Server` document in `vpn_management`|
 |Frappe version, host bench|v16|the bench itself|
 |CPU floor per bench|1 core|`Lab.cpu_cores`, an integer field|
+|Base domain|required, no default|`BenchPress Settings.base_domain`, `reqd`|
+|Free disk, one lab image|100 GB recommended|the host you buy|
+|Free disk, a full catalog|250 GB recommended|the host you buy|
 
 ## Related
 

--- a/docs-site/docs/operator/prerequisites.md
+++ b/docs-site/docs/operator/prerequisites.md
@@ -3,7 +3,7 @@ title: Prerequisites
 description: What a BenchPress host needs before you install — the four
   preconditions, supported platforms, versions, Docker socket access, and the
   measured CPU and disk sizing.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T08:05:07-04:00"
 lastAuthor: Venkatesh
 ---
 # Prerequisites

--- a/docs-site/docs/operator/production-safety.md
+++ b/docs-site/docs/operator/production-safety.md
@@ -3,7 +3,7 @@ title: Production safety
 description: What BenchPress is and is not ready to carry — the alpha verdict,
   the container privilege boundary, what is backed up, and the release checklist
   that covers 25 of 52 whitelisted callables.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T08:05:07-04:00"
 lastAuthor: Venkatesh
 ---
 # Production safety

--- a/docs-site/docs/operator/production-safety.md
+++ b/docs-site/docs/operator/production-safety.md
@@ -1,8 +1,8 @@
 ---
 title: Production safety
 description: What BenchPress is and is not ready to carry — the alpha verdict,
-  the container privilege boundary, what is backed up, and the
-  endpoint-by-endpoint release checklist.
+  the container privilege boundary, what is backed up, and the release checklist
+  that covers 25 of 52 whitelisted callables.
 lastModified: "2026-08-28T22:10:21+05:30"
 lastAuthor: Venkatesh
 ---
@@ -36,6 +36,10 @@ ERPNext environments. It is not built to host customer data. Concretely:
   up. See [Backup and restore](/docs/operator/backup-and-restore).
 * **Single-tenant assumption.** Quotas, rate limits and audit trails are still
   in progress. Run BenchPress for people you trust, on a host dedicated to it.
+* **The security review is partial.** It covers 25 of the app's 52 whitelisted
+  callables. The credit-purchase path and the per-bench credential endpoint are
+  among the 27 it never reached. See
+  [the release checklist](#the-release-checklist).
 
 Use it on a dedicated dev box, a VM, or a cloud instance you can rebuild. Not
 on your daily-driver workstation, and not on a shared production server.
@@ -92,31 +96,53 @@ All three must pass on a host carrying anything you would miss.
 
 ## The release checklist
 
-Last reviewed 2026-07-02, from the authorization suite, the contract and
-timing suite, a branch security review, and a sweep of every
-`ignore_permissions=True` and secret-handling path.
+Reviewed 2026-07-02, from the authorization suite, the contract and timing
+suite, a branch security review, and a sweep of every `ignore_permissions=True`
+and secret-handling path. Every row below was re-checked against the code on
+2026-08-30. Two findings had been fixed, one described an endpoint that never
+existed, and several guard descriptions were wrong.
 
-Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
+**What the audit covered.** The app exposes **52** whitelisted callables. This
+checklist covers **25** of them: 16 endpoints and 9 controller methods. It also
+carried a row for a `create_site` endpoint, which does not exist in the code —
+that row is gone. **27 whitelisted callables have never been reviewed**, and
+that is the largest gap on this page. They are:
+
+|Never reviewed|Where|
+|--|--|
+|`buy_credits`, `get_purchase_options`, `get_credit_summary`, `get_credit_statement`, `get_lease_plans`, `renew_bench`|the credit and lease path, including the one that takes money|
+|`get_bench_credentials`|decrypts SSH, admin and code-server passwords for one bench|
+|`launch_template`, `launch_lab`, `build_lab_golden`, `prewarm_catalog`|the one-click deploy and golden-build path|
+|`sign_up`, `join`, `notify_of_signup`, `approve`|`signup.py` and `waitlist.py`, the only self-service entry points|
+|`Credit Account.post_adjustment`, `post_refund`|controller methods that move a balance|
+|`server_time`, `get_lab_form_options`, `get_device_types`, `get_build_history`, `get_deploy_history`, `get_overview`, `get_vpn_status`, `run_connection_test`, `run_diagnostics`, `preflight_runtime`|the rest|
+
+Treat an unreviewed endpoint as unreviewed, not as safe.
+
+Read the verdicts as: **Ready**, **Ready with a follow-up**, **Not ready**.
 
 ### Whitelisted endpoints
 
+`require_app_user` admits `System Manager`, `BenchPress Admin` and
+`BenchPress User`. `require_admin` admits the first two. Both are
+`frappe.only_for`, so neither is satisfied by login alone.
+
 |Endpoint|Guard|Verdict|Note|
 |--|--|--|--|
-|`get_labs`|login only|Ready|A shared admin-curated catalog. No per-user data|
-|`get_lab`|login only|Ready|One catalog row|
-|`get_lab_templates`|login only|Ready|A static list|
+|`get_labs`|`require_app_user`|Ready|A shared admin-curated catalog. No per-user data|
+|`get_lab`|`require_app_user`|Ready|One catalog row|
+|`get_lab_templates`|`require_app_user`|Ready|A static list|
 |`create_lab_from_template`|`require_admin`|Ready|Admin-only, proven by test|
 |`build_lab_image`|`require_admin`|Ready|Admin-only, proven by test|
-|`get_benches`|owner filter|Follow-up|Returns decrypted SSH, admin and code-server passwords in the list payload. Owner-scoped, but secrets belong in an on-demand call|
-|`create_bench`|login, own deterministic id|Ready|The id embeds the caller, so a user can only create their own|
+|`get_benches`|`require_app_user`, owner filter|Ready|No longer returns any password. The field list holds no secret, and a test asserts their absence. Retrieval moved to `get_bench_credentials`|
+|`create_bench`|`require_app_user`, own deterministic id|Ready|The id embeds the caller, so a user can only create their own|
 |`bench_action`|`require_bench_access`, delete admin-only|Ready|Start, stop and restart are owner-scoped. Delete is admin-gated|
 |`get_deploy_logs`|`require_bench_access`|Ready|Cross-user access denied by test|
-|`add_device`|login, peer owned by caller|Ready|Creates only the caller's peer|
-|`remove_device`|owner or admin|Ready|Ownership enforced before delete|
-|`list_devices`|owner filter|Ready|Bench peers excluded|
-|`get_device_wg_config`|owner or admin|Follow-up|The guard exists. The cross-user negative test does not|
-|`create_site`|`require_bench_access` **only when `bench` is set**|Follow-up|A bench-less call skips the guard and creates an orphan `Bench Site`|
-|`get_user_context`|login, own session|Ready|Returns only the caller's identity and roles|
+|`add_device`|`require_app_user`, peer owned by caller|Ready|Writes `owner_user` as the session user, so it creates only the caller's peer|
+|`remove_device`|`require_app_user`, then an owned-peer lookup|Ready|Ownership resolved before the delete|
+|`list_devices`|`require_app_user`, `owner_user` filter|Ready|Bench peers excluded|
+|`get_device_wg_config`|`require_app_user`, then an owned-peer lookup|Follow-up|The guard exists. The cross-user negative test still does not|
+|`get_user_context`|login only|Ready|No role check, deliberately: the SPA calls it on boot. Returns the caller's own identity, roles and credit summary, and nothing about another user|
 |`get_code_server_credentials`|`require_bench_access`|Ready|Decrypted only after the ownership check|
 |`restart_code_server`|`require_bench_access`|Ready|Cross-user denied by test|
 
@@ -128,7 +154,7 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 |`Bench Instance.enqueue_redeploy`|same|Ready||
 |`Bench Instance.enqueue_stop`|same|Ready||
 |`Bench Instance.enqueue_start`|same|Ready||
-|`Database Server.setup_mariadb`|read permission, admin-only doctype|Follow-up|A state-changing operation should check `write`, and it has no authorization test|
+|`Database Server.setup_mariadb`|`frappe.has_permission` with no `ptype`, so `read`|Follow-up|A state-changing operation should check `write`, and it has no authorization test. The doctype grants `read` only to `System Manager` and `BenchPress Admin`, both of which also hold `write`, so the gap is hardening rather than an open door|
 |`Database Server.start_mariadb`|same|Follow-up|As above|
 |`Database Server.stop_mariadb`|same|Follow-up|As above|
 |`Database Server.retry_setup`|same|Follow-up|As above|
@@ -139,8 +165,8 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 |Component|Verdict|Note|
 |--|--|--|
 |Permission model|Ready|Guest, wrong role and cross-user are all rejected. `only_for` raises for non-administrators|
-|Secret handling|Ready|Decryption only behind an owner or admin guard. The database root password is never logged|
-|`ignore_permissions=True`, 39 uses|Ready|Confined to enqueued and system flows. Ownership is tracked on `owner` and `owner_user`|
+|Secret handling|Ready|Both decryptions a whitelisted endpoint can reach sit behind `require_bench_access`. The database root password is never logged. One of the two, `get_bench_credentials`, was never in this audit — see the coverage list above|
+|`ignore_permissions=True`, 53 uses outside tests|Ready|Confined to enqueued and system flows. Ownership is tracked on `owner` and `owner_user`. The count was 39 at the 2026-07-02 review|
 |SQL construction|Ready|Identifiers are hashed and SQL is base64-wrapped before shelling. Not injectable|
 |Container isolation|**Not ready without a precondition**|Non-privileged, but a lab user holds in-container root. Ship only on a host with sysbox, userns-remap or a rootless daemon|
 
@@ -148,15 +174,16 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 
 1. **The container privilege boundary.** Ship only on a host that closes it.
    This is a deployment precondition, not an app default.
-2. **`create_site` with no bench.** Make `bench` mandatory, or guard the empty
-   case, so the endpoint cannot create an orphan `Bench Site` that bypasses
-   the access check.
-3. **`Database Server` state-changing methods.** Move them to a `write`
-   permission check and add authorization tests.
-4. **`get_benches` secret exposure.** Move SSH, admin and code-server password
-   retrieval out of the bulk list payload into an on-demand per-bench call.
-5. **`get_device_wg_config` test gap.** Add an explicit cross-user negative
+2. **The 27 unreviewed endpoints.** Review them, starting with `buy_credits`,
+   which takes money, and `get_bench_credentials`, which decrypts passwords.
+3. **`Database Server` state-changing methods.** They call
+   `frappe.has_permission` with no `ptype`, which checks `read`. Move them to
+   `write` and add authorization tests.
+4. **`get_device_wg_config` test gap.** Add an explicit cross-user negative
    test. The guard exists. The coverage does not.
+
+Two items from the 2026-07-02 list are closed. `get_benches` no longer returns
+any password. The `create_site` item described an endpoint that does not exist.
 
 ## Troubleshooting
 
@@ -177,7 +204,10 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 |Default runtime|`sysbox`|
 |Backed up|the shared MariaDB, nightly, 7 dumps|
 |Not backed up|bench Docker volumes|
-|Checklist last reviewed|2026-07-02|
+|Checklist reviewed|2026-07-02, re-verified against the code 2026-08-30|
+|Whitelisted callables|52|
+|Covered by this checklist|25|
+|Never reviewed|27|
 
 ## Related
 

--- a/docs-site/docs/reference/api.md
+++ b/docs-site/docs/reference/api.md
@@ -1,6 +1,6 @@
 ---
 title: API
-description: All 50 whitelisted BenchPress endpoints, with arguments, what each
+description: Every whitelisted BenchPress endpoint, with arguments, what each
   returns, and the permission check each one makes for itself.
 lastModified: "2026-08-28T22:10:21+05:30"
 lastAuthor: Venkatesh
@@ -29,9 +29,12 @@ curl -s https://<host>/api/method/benchpress.api.get_labs \
 Arguments go as query parameters on a `GET` or as form fields on a `POST`.
 Frappe decides the method from the function, not from a route table.
 
-Thirty-five of the fifty are in `benchpress.api`. Four more are module functions
-elsewhere. The remaining eleven are document methods, called through
-`run_doc_method` rather than by path. All three kinds are marked below.
+Endpoints come in three kinds. Most are module functions in `benchpress.api`. A
+few more are module functions elsewhere, in `benchpress.waitlist` and
+`benchpress.signup`. The rest are document methods on controllers, called
+through `run_doc_method` rather than by path. All three kinds are marked below.
+[The whole list, counted](#the-whole-list-counted) has the breakdown and the
+command that derives it.
 
 ## How an endpoint is guarded
 
@@ -107,6 +110,61 @@ MD5 of the two, so a second call redeploys rather than making a second bench.
 
 `server_time` exists so a countdown in the browser corrects against the server
 clock instead of the laptop's.
+
+## Launch
+
+`create_bench` deploys a lab whose image already exists. The two launch
+endpoints do not require one. They build the image first, when there is no
+image, and deploy from it in the same job.
+
+|Endpoint|Arguments|Returns|Checks|
+|--|--|--|--|
+|`launch_template`|`template`, `instance_size`, `site_name`|the launch response below|`require_app_user`, then `is_active` on the `Lab Template` row, then `requires_admission` inside `_launch`|
+|`launch_lab`|`data` (JSON, with at least `lab`)|the launch response below|`require_app_user`, then `requires_admission` inside `_launch`|
+
+Both live in `benchpress/api.py`. Both call the private
+`_launch`, which claims the instance and enqueues
+`benchpress.launch.run_launch` on `queue-long` under the deduplicated job id
+`launch:<bench name>`. The job timeout is the image build timeout plus the
+deploy timeout, because one job does both.
+
+**The admission gate is on `_launch`, not on the published function.** This
+looks like a missing decorator and is not. `requires_admission` binds its cost
+and cap arguments by name and needs a lab that exists, which is only true after
+`launch_template` has resolved a template to one. `launch_template` resolves or
+creates that lab first, so a caller the gate then refuses can leave a new `Lab`
+row behind. The gate still runs before any work is queued, which is the property
+that matters.
+
+`launch_template` checks `is_active` on the `Lab Template` itself.
+`lab_templates.get_template` checks only that the key exists, so without this
+check a user could materialise a template an admin had retired.
+
+`launch_template` reuses a lab before it makes one. It takes the newest lab
+built from that template whose recipe still matches the template's own, and
+creates a lab only when there is no match. A second developer launching the same
+template rides the image the first launch paid for. A lab an admin has edited
+away from the template is skipped, because deploying it would install apps the
+template never named.
+
+Both endpoints claim the bench through the same path `create_bench` uses, so the
+same pair of caller and lab is the same bench. A second launch redeploys.
+
+The launch response carries seven keys:
+
+|Key|Is|
+|--|--|
+|`name`|the bench id|
+|`bench`|the same string as `name`, so a caller still reading `name` keeps working|
+|`lab`|the lab this bench came from|
+|`lab_title`|that lab's title|
+|`lab_status`|that lab's status, read from the row|
+|`will_build`|`true` when `lab_status` is not `Ready`|
+|`eta_minutes`|`eta_minutes` from the `Lab Template` row, or `0`|
+
+`will_build` is that status read alone. It does not ask Docker whether the image
+is on the host. It is opening copy for the launch dialog, and the job decides
+what actually happens.
 
 ## History
 
@@ -204,7 +262,7 @@ not from now.
 
 |Endpoint|Arguments|Returns|Checks|
 |--|--|--|--|
-|`run_diagnostics`|—|eleven read-only environment checks|`require_admin`|
+|`run_diagnostics`|—|twelve read-only environment checks|`require_admin`|
 |`preflight_runtime`|`runtime`|whether that runtime can actually start a container|`require_admin`|
 
 `run_diagnostics` reads. `preflight_runtime` creates a container, which is why
@@ -284,22 +342,33 @@ Two more waitlist functions are admin-only and not guest-reachable.
 
 ## The whole list, counted
 
-Fifty `@frappe.whitelist()` functions. Every one is in a table above.
+**Count the code, not this page.** Run the command before you quote a number
+anywhere:
+
+```bash
+grep -rn "@frappe.whitelist" --include=*.py benchpress/ | wc -l
+```
+
+Per file:
+
+```bash
+grep -rc "@frappe.whitelist" --include=*.py benchpress/ | grep -v ':0$' | sort -t: -k2 -rn
+```
+
+What those two commands returned when this page was last checked:
 
 |Location|Count|
 |--|--|
-|`benchpress/api.py`|35|
+|`benchpress/api.py`|37|
 |`benchpress/benchpress/doctype/database_server/database_server.py`|5|
 |`benchpress/benchpress/doctype/bench_instance/bench_instance.py`|4|
 |`benchpress/waitlist.py`|3|
 |`benchpress/benchpress/doctype/credit_account/credit_account.py`|2|
 |`benchpress/signup.py`|1|
+|**Total**|**52**|
 
-Recount after a change:
-
-```bash
-grep -rn "@frappe.whitelist" --include=*.py benchpress/ | wc -l
-```
+Every one of those 52 has a row in a table above. That is the claim to keep
+true when you add an endpoint.
 
 ## Adding an endpoint
 
@@ -309,6 +378,8 @@ grep -rn "@frappe.whitelist" --include=*.py benchpress/ | wc -l
    `@frappe.whitelist()`.
 4. Query with `frappe.qb`. A raw `frappe.db.sql` string is a lint failure.
 5. Add the endpoint to the table on this page.
+6. Re-run the two commands in [The whole list, counted](#the-whole-list-counted)
+   and paste what they return over that table.
 
 The decorator order matters. `@frappe.whitelist()` goes on top, and
 `@requires_admission(...)` below it, so the gate runs inside the published

--- a/docs-site/docs/reference/api.md
+++ b/docs-site/docs/reference/api.md
@@ -2,7 +2,7 @@
 title: API
 description: Every whitelisted BenchPress endpoint, with arguments, what each
   returns, and the permission check each one makes for itself.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T08:05:07-04:00"
 lastAuthor: Venkatesh
 ---
 # API

--- a/docs-site/docs/reference/architecture.md
+++ b/docs-site/docs/reference/architecture.md
@@ -70,7 +70,7 @@ One concern for each module. The table is the whole `benchpress/` package.
 |`permissions.py`|the role helpers and the six query conditions|
 |`overview.py`, `labs.py`, `lab_detail.py`, `run_history.py`|one screen each, assembled in a fixed number of queries|
 |`waitlist.py`, `signup.py`|the two doors open to a guest|
-|`diagnostics.py`|eleven read-only environment checks|
+|`diagnostics.py`|twelve read-only environment checks|
 |`notifications.py`|one desk alert and one email to a document owner|
 |`indexes.py`|composite indexes the DocType JSON cannot declare|
 |`request_cache.py`|a value memoised for one request, never in a module global|

--- a/docs-site/docs/reference/architecture.md
+++ b/docs-site/docs/reference/architecture.md
@@ -3,7 +3,7 @@ title: Architecture
 description: The moving parts of BenchPress — the control plane, the bench
   containers, the shared infrastructure, and which Python module owns each
   concern.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T08:05:07-04:00"
 lastAuthor: Venkatesh
 ---
 # Architecture

--- a/docs-site/docs/reference/networking.md
+++ b/docs-site/docs/reference/networking.md
@@ -14,10 +14,20 @@ Every address a bench answers on, and who can reach each one.
 one is addressed.
 
 **Before you start.** A bench has up to four addresses at once. They are not
-alternatives. Each one exists for a different caller, and three of the four are
-private.
+alternatives. Each one exists for a different caller, and two of the four are
+public.
 
 ## The four addresses
+
+**This section is the canonical statement of what a bench is reachable on.**
+The one sentence:
+
+> A bench answers on up to four addresses at once: two public HTTPS addresses
+> served by Traefik, which anyone on the internet can reach once `base_domain`
+> is set, and two tunnel addresses that only a device on the VPN can reach.
+
+The two `https://` addresses answer for anyone on the internet once
+`base_domain` is set, which is the documented install.
 
 `benchpress/addressing.py` builds all of them in one place, and the app renders
 what it returns rather than assembling a URL from a port it declared itself.
@@ -28,6 +38,19 @@ what it returns rather than assembling a URL from a port it declared itself.
 |Public IDE|`https://ide-<instance id>.<base domain>`|the internet, through Traefik|
 |Tunnel site|`http://<wg ip>:8000`|a device on the VPN|
 |Tunnel IDE|`http://<wg ip>:8080/`|a device on the VPN|
+
+`ingress.publish` writes routers on the `websecure` entry point: two for the
+site hostname, split so asset paths take their own rate limit, and one for the
+IDE hostname. `ingress.ensure_anchor` holds the wildcard certificate that
+terminates them. The IDE router is written only when the bench has an IDE, which
+is why the count is "up to four".
+
+Public means public. The only middlewares `publish` puts on a bench router are
+rate limits: a request cap on every router, and an in-flight cap on the site's
+render path when the instance size sets one. There is no authentication
+middleware at the edge. A browser anywhere resolves the name and gets the
+bench's own login page, and that login is the only thing between the internet
+and the site.
 
 The two ports are properties of the bench image, not settings. They are
 constants in `addressing.py`.
@@ -152,8 +175,12 @@ state.
 |Another bench on the same bridge|no|no|no|no|
 |A bench, reaching the shared MariaDB|—|—|—|the database only|
 
-No bench is on the public internet by port. The only public path is Traefik, and
-it terminates TLS on the wildcard.
+No bench is on the public internet by port. No bench container publishes a host
+port at all — the only public path is Traefik, and it terminates TLS on the
+wildcard.
+
+That is the whole of what the VPN gates. **SSH and the two `http://` tunnel
+addresses need the VPN. The two `https://` addresses do not.**
 
 ## Verify
 

--- a/docs-site/docs/reference/networking.md
+++ b/docs-site/docs/reference/networking.md
@@ -3,7 +3,7 @@ title: Networking
 description: The BenchPress address plan — bench bridges, WireGuard tunnel
   addresses, the two container ports, Traefik route files and the wildcard
   certificate anchor.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T08:05:07-04:00"
 lastAuthor: Venkatesh
 ---
 # Networking

--- a/docs-site/llms-full.txt
+++ b/docs-site/llms-full.txt
@@ -17,7 +17,7 @@
 - [Leases and credits](https://docs.benchpress.cloud/docs/user/leases-and-credits): The countdown on a running bench, the renew dialog and its plans, the credit meter, the ledger, and where a purchase hands off to the payment gateway.
 - [Troubleshooting](https://docs.benchpress.cloud/docs/user/troubleshooting): Every symptom a BenchPress user meets, its cause, and the page that fixes it — deploys, the VPN, SSH, code-server, logs and credits.
 - [Operator track](https://docs.benchpress.cloud/docs/operator): Run BenchPress on your own box — install, the VPN plane, settings, the shared database, images, upgrades, safety and diagnostics.
-- [Prerequisites](https://docs.benchpress.cloud/docs/operator/prerequisites): What a BenchPress host needs before you install — supported platforms, versions, Docker socket access, IP forwarding, sysbox, and the measured CPU sizing.
+- [Prerequisites](https://docs.benchpress.cloud/docs/operator/prerequisites): What a BenchPress host needs before you install — the four preconditions, supported platforms, versions, Docker socket access, and the measured CPU and disk sizing.
 - [Install](https://docs.benchpress.cloud/docs/operator/install): Install BenchPress into a Frappe v16 bench — get-app, setup.sh, the frontend build, the base domain, and the first screen.
 - [WireGuard and the VPN plane](https://docs.benchpress.cloud/docs/operator/wireguard-setup): How the vpn_management app owns the tunnel, what BenchPress consumes from it, the measured server and pool values, and why userns-remap matters.
 - [Settings reference](https://docs.benchpress.cloud/docs/operator/settings-reference): Every field on BenchPress Settings and Credit Settings, with the value measured on a live host, where each one is edited, and what changing it costs.
@@ -27,15 +27,15 @@
 - [Golden images](https://docs.benchpress.cloud/docs/operator/golden-images): A lab's finished site is baked into its own image as a database dump, so a deploy restores it instead of creating tables — the measured numbers, the two settings, and why a golden gets refused.
 - [The image cache](https://docs.benchpress.cloud/docs/operator/image-cache): One image per lab, tagged benchpress/<lab_id>:lab — what it costs on disk, how the weekly prewarm and sweep work, and what is safe to prune.
 - [Upgrading](https://docs.benchpress.cloud/docs/operator/upgrading): Move a BenchPress install to a newer release — the backup gate, the five steps, the scripted path, rollback, and why lab images are a separate opt-in.
-- [Production safety](https://docs.benchpress.cloud/docs/operator/production-safety): What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the endpoint-by-endpoint release checklist.
-- [Diagnostics](https://docs.benchpress.cloud/docs/operator/diagnostics): The eleven read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
+- [Production safety](https://docs.benchpress.cloud/docs/operator/production-safety): What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the release checklist that covers 25 of 52 whitelisted callables.
+- [Diagnostics](https://docs.benchpress.cloud/docs/operator/diagnostics): The twelve read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
 - [Credits and billing](https://docs.benchpress.cloud/docs/operator/credits-and-billing): Optional and off by default — the metering half of BenchPress, covering leases, balances, the ledger, admin adjustments, and the optional Razorpay handoff.
 - [Admission and limits](https://docs.benchpress.cloud/docs/operator/admission-and-limits): Optional and off by default — concurrency caps, size ceilings, device and build quotas, how a slot is claimed as a row, and the acceptance run that proves access still works.
 - [Self-serve signup](https://docs.benchpress.cloud/docs/operator/hosted-signup): Optional and off by default — retire the waitlist and let people sign themselves up, with GitHub and Google as the primary paths and the abuse controls that make a free grant safe.
 - [Reference track](https://docs.benchpress.cloud/docs/reference): The data model, the whitelisted API, the eleven deploy steps, the reconcilers, the address plan and the configuration split — for a contributor or an integrator.
 - [Architecture](https://docs.benchpress.cloud/docs/reference/architecture): The moving parts of BenchPress — the control plane, the bench containers, the shared infrastructure, and which Python module owns each concern.
 - [Data model](https://docs.benchpress.cloud/docs/reference/data-model): All 20 BenchPress DocTypes with their fields, links, naming and the permission rule that scopes each one — plus why there is no Device DocType.
-- [API](https://docs.benchpress.cloud/docs/reference/api): All 50 whitelisted BenchPress endpoints, with arguments, what each returns, and the permission check each one makes for itself.
+- [API](https://docs.benchpress.cloud/docs/reference/api): Every whitelisted BenchPress endpoint, with arguments, what each returns, and the permission check each one makes for itself.
 - [Deploy pipeline](https://docs.benchpress.cloud/docs/reference/deploy-pipeline): The eleven steps of a BenchPress deploy, in the order the code runs them, with the function behind each step and the log line it writes.
 - [Lifecycle and events](https://docs.benchpress.cloud/docs/reference/lifecycle-and-events): The bench states and their transitions, the Docker event listener, Bench Event incidents, the stats collector, and the eleven scheduled jobs that correct the database.
 - [Networking](https://docs.benchpress.cloud/docs/reference/networking): The BenchPress address plan — bench bridges, WireGuard tunnel addresses, the two container ports, Traefik route files and the wildcard certificate anchor.
@@ -1944,7 +1944,7 @@ elsewhere, and there is no second machine to keep in step.
 
 # Prerequisites
 URL: https://docs.benchpress.cloud/docs/operator/prerequisites
-What a BenchPress host needs before you install — supported platforms, versions, Docker socket access, IP forwarding, sysbox, and the measured CPU sizing.
+What a BenchPress host needs before you install — the four preconditions, supported platforms, versions, Docker socket access, and the measured CPU and disk sizing.
 
 What the machine must already have before [Install](/docs/operator/install)
 will work, and how much of it to buy.
@@ -1954,6 +1954,21 @@ will work, and how much of it to buy.
 **Before you start.** BenchPress installs into an existing Frappe bench and
 drives that host's Docker. It is not a standalone service, and it is Linux
 only — the setup script uses `apt` and `sysctl`.
+
+## The four preconditions
+
+Get these four before you read anything else on this page. Each one blocks the
+install or the first deploy, and none of them can be fixed from inside the app.
+
+|Precondition|Why it blocks|Set it in|
+|--|--|--|
+|`sysbox-runc` registered with Docker|`default_bench_runtime` is `sysbox`, so a deploy has no runtime without it. `runc` without `userns-remap` makes in-container root host root|[Step 5](#steps)|
+|`net.ipv4.ip_forward = 1`|The kernel drops tunnel traffic on its way to a bench, so a deploy fails on the network step|[Step 4](#steps)|
+|44556/UDP open, on `ufw` **and** on any cloud firewall|A WireGuard peer never handshakes, so nothing reaches a bench over the tunnel|[Step 7](#steps)|
+|A domain you control, for `base_domain`|`base_domain` is `reqd` on **BenchPress Settings**, so the settings form will not save without it. Sites are addressed as `<instance id>.<base domain>`|[Install, step 5](/docs/operator/install)|
+
+Size the host before you buy it as well. [Sizing](#sizing) holds the CPU floor
+and [Disk](#disk) the disk floor. Disk is the one that fails a default VPS.
 
 ## Steps
 
@@ -2072,7 +2087,7 @@ Three criteria, each with its own minimum:
 |Tier|Minimum CPU|Evidence at the minimum|
 |--|--:|--|
 |Boot and lifecycle|0.5|migration 13.22 s, login HTTP 200 in 192 ms, `/frontend` HTTP 200 in 27 ms|
-|Test suite|0.5|the 124-test suite passed in 11.59 s, with every endpoint timing budget met|
+|Test suite|0.5|the suite passed in 11.59 s, with every endpoint timing budget met. It held 124 tests that day. The suite has since grown by roughly an order of magnitude, so 11.59 s no longer describes a full run|
 |Concurrent reads|0.5|`get_labs` p95 127 ms, `get_benches` p95 48 ms, 0 of 60 requests failed|
 
 Concurrent reads at each candidate cap, 30 authenticated requests per endpoint
@@ -2095,10 +2110,50 @@ did not visibly degrade this workload, so the measurements do not support
 calling one core a minimum. Re-run the benchmark after the application grows,
 or when you change the host class.
 
-**RAM and disk are the real constraints, not CPU.** A lab image is 5.5 GB to
-19.7 GB, and one deploy costs roughly 0.2 GB to 1 GB more. See
-[The image cache](/docs/operator/image-cache) for what that grows into and how
-the sweep holds it down.
+**Of the two resources measured here, disk is the constraint, not CPU.** Size
+it before you buy the host. See [Disk](#disk).
+
+**RAM was not sized.** The benchmark capped CPU only, so the 7.8 GiB above
+describes the benchmark host and is not a floor. Watch `free -h` on your own
+host until someone measures it.
+
+## Disk
+
+**A 20 GB or 40 GB VPS root disk fails mid-build.** No setting in the app
+compensates for it, and the failure lands in the middle of an image build
+rather than at install.
+
+Measured on this host with `docker images` and `docker system df`, and listed
+per image in [The image cache](/docs/operator/image-cache):
+
+|Measurement|Value|
+|--|--:|
+|Smallest lab image|5.5 GB|
+|Largest lab image|19.7 GB|
+|Twelve lab images together|54.74 GB|
+|Reclaimable from that set|19.12 GB|
+
+Three costs sit on top of that image figure. A build holds the new image while
+its base layers are still on disk. Every bench has its own container layer and
+volumes — one deploy costs roughly 0.2 GB to 1 GB, measured in
+[The image cache](/docs/operator/image-cache). The shared MariaDB carries its
+data volume. The build headroom and the MariaDB volume are not measured.
+
+So provision against the catalog you will hold, not against one image:
+
+|The host will carry|Free disk to provision|Basis|
+|--|--:|--|
+|One lab image|100 GB|19.7 GB for the largest measured image, with room to rebuild it beside the copy in use|
+|A catalog the size of this host's|250 GB|54.74 GB measured for twelve images, plus the same rebuild headroom, plus bench volumes|
+
+Those two rows are recommendations derived from the measurements above. They
+are not themselves measured. Watch `df -h /` and `docker system df` on your own
+host, and raise them if either climbs.
+
+Building is also the slowest thing a fresh host does. Full builds on this host
+ran **4 to 26 minutes**, and the golden pass 5 to 11 — see
+[The image cache](/docs/operator/image-cache). The build job's own timeout is
+10,800 s, three hours, which is a ceiling and not an expected duration.
 
 ## Troubleshooting
 
@@ -2109,6 +2164,8 @@ the sweep holds it down.
 |Diagnostics reports `container_runtimes` as failed|`sysbox-runc` is not registered with Docker|Install sysbox, or set `default_bench_runtime` to `runc` and read [Production safety](/docs/operator/production-safety)|
 |Diagnostics reports `kernel_ceilings` as failed|The host ceilings are below what the fleet needs|`sudo scripts/tune-host.sh --benches <n>`, from the `benchpress_devops` checkout|
 |A peer never handshakes|UDP 44556 is closed|Step 7, and check the cloud firewall as well as `ufw`|
+|A build fails part-way with no space left|The host was sized for the OS, not for lab images|[Disk](#disk). Never run `docker image prune -a` on this host|
+|**BenchPress Settings** will not save|`base_domain` is required and empty|Point a domain you control at this host, then fill it in [Install, step 5](/docs/operator/install)|
 
 ## Reference
 
@@ -2120,6 +2177,9 @@ the sweep holds it down.
 |WireGuard port|44556/UDP|the `WireGuard Server` document in `vpn_management`|
 |Frappe version, host bench|v16|the bench itself|
 |CPU floor per bench|1 core|`Lab.cpu_cores`, an integer field|
+|Base domain|required, no default|`BenchPress Settings.base_domain`, `reqd`|
+|Free disk, one lab image|100 GB recommended|the host you buy|
+|Free disk, a full catalog|250 GB recommended|the host you buy|
 
 ## Related
 
@@ -2144,18 +2204,33 @@ Throughout, replace `<site>` with your real site name.
 
 ## Steps
 
-1. **Install the app into the bench.**
+1. **Install the apps into the bench.** There are two repositories, and you
+   clone both.
+
+   `benchpress` names `vpn_management` in `required_apps`, so
+   `install-app benchpress` installs `vpn_management` first — but only from a
+   copy already on the bench, listed in `sites/apps.txt`. Clone it yourself.
+   `bench get-app` resolves a bare
+   `required_apps` name under the `frappe` and `erpnext` GitHub accounts only,
+   and [vpn\_management](https://github.com/Venkateshvenki404224/vpn_management)
+   is under neither, so `--resolve-deps` does not find it either.
 
    ```bash
    cd /path/to/your/frappe-bench
+   bench get-app https://github.com/Venkateshvenki404224/vpn_management --branch version-16
    bench get-app https://github.com/Venkateshvenki404224/benchpress --branch version-16
    bench pip install docker
    bench --site <site> install-app benchpress
    bench --site <site> migrate
    ```
 
-   `benchpress` declares `vpn_management` as a required app, so Frappe
-   installs that first. It refuses to install without `vpn_endpoint_host` in
+   Skip the first `get-app` and `install-app` fails with
+   `frappe.exceptions.InvalidRemoteException`, raised with an empty message.
+   Frappe resolves the `required_apps` name the same way — against the `frappe`
+   and `erpnext` accounts — and gives up there, before it ever reports a
+   missing app.
+
+   `vpn_management` itself refuses to install without `vpn_endpoint_host` in
    `common_site_config.json` and without a reachable wg-agent socket. See
    [WireGuard and the VPN plane](/docs/operator/wireguard-setup).
 
@@ -2171,13 +2246,15 @@ Throughout, replace `<site>` with your real site name.
    |Step|What it does|Skipped when|
    |--|--|--|
    |1 of 4|Adds the bench user to the `docker` group|the user is already a member|
-   |2 of 4|Checks Docker `userns-remap` or rootless mode|never — it only warns|
+   |2 of 4|Checks the container-root privilege boundary: a registered `sysbox-runc` runtime, or Docker `userns-remap` (or rootless)|never — it warns, or exits under `--strict`|
    |3 of 4|Starts `benchpress-mariadb` and `benchpress-redis`, and creates the `benchpress` network and the data volume|the containers are already up|
    |4 of 4|Writes `net.ipv4.ip_forward = 1` under `/etc/sysctl.d`|forwarding is already on|
 
    Step 2 warns and continues by default. On a host that will carry anything
    you care about, run it as `bash apps/benchpress/setup.sh <site> --strict`
-   instead, which exits non-zero rather than warning. See
+   instead, which exits non-zero rather than warning. Either boundary
+   satisfies `--strict`. sysbox is checked first: it is the recommended one,
+   and a lab set to the `sysbox` runtime needs it registered anyway. See
    [Production safety](/docs/operator/production-safety).
 
 3. **Build the frontend.** The dashboard is a Vue single-page app and ships as
@@ -2222,7 +2299,7 @@ Throughout, replace `<site>` with your real site name.
 
    The first screen is the **Overview**: how many environments are running,
    stopped or broken, the average deploy time over the last seven days, and a
-   **Shared infrastructure** panel reporting eleven checks. Seven days is not
+   **Shared infrastructure** panel reporting twelve checks. Seven days is not
    a choice — deploy logs are cleared on that schedule, so no longer window
    has data behind it.
 
@@ -2270,11 +2347,11 @@ that image in seconds. See [The image cache](/docs/operator/image-cache).
 
 |Symptom|Cause|Fix|
 |--|--|--|
-|`install-app` fails naming `vpn_management`|The required app is missing or refuses to install|Install `vpn_management` first and set `vpn_endpoint_host`|
+|`install-app` fails with a bare `InvalidRemoteException`|The repository was never cloned into `apps/`|Run the first `get-app` in step 1, then re-run `install-app`|
 |The dashboard is blank or unstyled|The frontend was never built|Step 3, then `bench --site <site> clear-cache`|
 |Settings will not save|`base_domain` is empty, and it is required|Fill it. Sites are addressed under it|
 |Every deploy fails on a Docker call|The bench started before the group change took effect|Log out, log back in, restart the bench|
-|`setup.sh` warns about `userns-remap`|Container root maps to host root|See [Production safety](/docs/operator/production-safety) before running anything real|
+|`setup.sh` warns that there is no privilege boundary|Neither `sysbox-runc` nor `userns-remap` is present, so container root is host root|See [Production safety](/docs/operator/production-safety) before running anything real|
 |The Overview shows `Kernel ceilings Error`|Host-wide sysctl limits are below what a dense fleet needs|`sudo scripts/tune-host.sh`, from the `benchpress_devops` checkout|
 
 ## Reference
@@ -2282,6 +2359,8 @@ that image in seconds. See [The image cache](/docs/operator/image-cache).
 |Item|Value|
 |--|--|
 |App branch|`version-16`|
+|App repository|[Venkateshvenki404224/benchpress](https://github.com/Venkateshvenki404224/benchpress)|
+|Required app|[Venkateshvenki404224/vpn\_management](https://github.com/Venkateshvenki404224/vpn_management), branch `version-16`|
 |Setup script|`bash apps/benchpress/setup.sh <site> [--strict]`|
 |Shared containers|`benchpress-mariadb`, `benchpress-redis`|
 |Docker network|`benchpress`|
@@ -3802,7 +3881,7 @@ and never skip the step 0 gate.
 
 # Production safety
 URL: https://docs.benchpress.cloud/docs/operator/production-safety
-What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the endpoint-by-endpoint release checklist.
+What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the release checklist that covers 25 of 52 whitelisted callables.
 
 Whether BenchPress is safe to run on your host, and what has to be true first.
 
@@ -3832,6 +3911,10 @@ ERPNext environments. It is not built to host customer data. Concretely:
   up. See [Backup and restore](/docs/operator/backup-and-restore).
 * **Single-tenant assumption.** Quotas, rate limits and audit trails are still
   in progress. Run BenchPress for people you trust, on a host dedicated to it.
+* **The security review is partial.** It covers 25 of the app's 52 whitelisted
+  callables. The credit-purchase path and the per-bench credential endpoint are
+  among the 27 it never reached. See
+  [the release checklist](#the-release-checklist).
 
 Use it on a dedicated dev box, a VM, or a cloud instance you can rebuild. Not
 on your daily-driver workstation, and not on a shared production server.
@@ -3888,31 +3971,53 @@ All three must pass on a host carrying anything you would miss.
 
 ## The release checklist
 
-Last reviewed 2026-07-02, from the authorization suite, the contract and
-timing suite, a branch security review, and a sweep of every
-`ignore_permissions=True` and secret-handling path.
+Reviewed 2026-07-02, from the authorization suite, the contract and timing
+suite, a branch security review, and a sweep of every `ignore_permissions=True`
+and secret-handling path. Every row below was re-checked against the code on
+2026-08-30. Two findings had been fixed, one described an endpoint that never
+existed, and several guard descriptions were wrong.
 
-Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
+**What the audit covered.** The app exposes **52** whitelisted callables. This
+checklist covers **25** of them: 16 endpoints and 9 controller methods. It also
+carried a row for a `create_site` endpoint, which does not exist in the code —
+that row is gone. **27 whitelisted callables have never been reviewed**, and
+that is the largest gap on this page. They are:
+
+|Never reviewed|Where|
+|--|--|
+|`buy_credits`, `get_purchase_options`, `get_credit_summary`, `get_credit_statement`, `get_lease_plans`, `renew_bench`|the credit and lease path, including the one that takes money|
+|`get_bench_credentials`|decrypts SSH, admin and code-server passwords for one bench|
+|`launch_template`, `launch_lab`, `build_lab_golden`, `prewarm_catalog`|the one-click deploy and golden-build path|
+|`sign_up`, `join`, `notify_of_signup`, `approve`|`signup.py` and `waitlist.py`, the only self-service entry points|
+|`Credit Account.post_adjustment`, `post_refund`|controller methods that move a balance|
+|`server_time`, `get_lab_form_options`, `get_device_types`, `get_build_history`, `get_deploy_history`, `get_overview`, `get_vpn_status`, `run_connection_test`, `run_diagnostics`, `preflight_runtime`|the rest|
+
+Treat an unreviewed endpoint as unreviewed, not as safe.
+
+Read the verdicts as: **Ready**, **Ready with a follow-up**, **Not ready**.
 
 ### Whitelisted endpoints
 
+`require_app_user` admits `System Manager`, `BenchPress Admin` and
+`BenchPress User`. `require_admin` admits the first two. Both are
+`frappe.only_for`, so neither is satisfied by login alone.
+
 |Endpoint|Guard|Verdict|Note|
 |--|--|--|--|
-|`get_labs`|login only|Ready|A shared admin-curated catalog. No per-user data|
-|`get_lab`|login only|Ready|One catalog row|
-|`get_lab_templates`|login only|Ready|A static list|
+|`get_labs`|`require_app_user`|Ready|A shared admin-curated catalog. No per-user data|
+|`get_lab`|`require_app_user`|Ready|One catalog row|
+|`get_lab_templates`|`require_app_user`|Ready|A static list|
 |`create_lab_from_template`|`require_admin`|Ready|Admin-only, proven by test|
 |`build_lab_image`|`require_admin`|Ready|Admin-only, proven by test|
-|`get_benches`|owner filter|Follow-up|Returns decrypted SSH, admin and code-server passwords in the list payload. Owner-scoped, but secrets belong in an on-demand call|
-|`create_bench`|login, own deterministic id|Ready|The id embeds the caller, so a user can only create their own|
+|`get_benches`|`require_app_user`, owner filter|Ready|No longer returns any password. The field list holds no secret, and a test asserts their absence. Retrieval moved to `get_bench_credentials`|
+|`create_bench`|`require_app_user`, own deterministic id|Ready|The id embeds the caller, so a user can only create their own|
 |`bench_action`|`require_bench_access`, delete admin-only|Ready|Start, stop and restart are owner-scoped. Delete is admin-gated|
 |`get_deploy_logs`|`require_bench_access`|Ready|Cross-user access denied by test|
-|`add_device`|login, peer owned by caller|Ready|Creates only the caller's peer|
-|`remove_device`|owner or admin|Ready|Ownership enforced before delete|
-|`list_devices`|owner filter|Ready|Bench peers excluded|
-|`get_device_wg_config`|owner or admin|Follow-up|The guard exists. The cross-user negative test does not|
-|`create_site`|`require_bench_access` **only when `bench` is set**|Follow-up|A bench-less call skips the guard and creates an orphan `Bench Site`|
-|`get_user_context`|login, own session|Ready|Returns only the caller's identity and roles|
+|`add_device`|`require_app_user`, peer owned by caller|Ready|Writes `owner_user` as the session user, so it creates only the caller's peer|
+|`remove_device`|`require_app_user`, then an owned-peer lookup|Ready|Ownership resolved before the delete|
+|`list_devices`|`require_app_user`, `owner_user` filter|Ready|Bench peers excluded|
+|`get_device_wg_config`|`require_app_user`, then an owned-peer lookup|Follow-up|The guard exists. The cross-user negative test still does not|
+|`get_user_context`|login only|Ready|No role check, deliberately: the SPA calls it on boot. Returns the caller's own identity, roles and credit summary, and nothing about another user|
 |`get_code_server_credentials`|`require_bench_access`|Ready|Decrypted only after the ownership check|
 |`restart_code_server`|`require_bench_access`|Ready|Cross-user denied by test|
 
@@ -3924,7 +4029,7 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 |`Bench Instance.enqueue_redeploy`|same|Ready||
 |`Bench Instance.enqueue_stop`|same|Ready||
 |`Bench Instance.enqueue_start`|same|Ready||
-|`Database Server.setup_mariadb`|read permission, admin-only doctype|Follow-up|A state-changing operation should check `write`, and it has no authorization test|
+|`Database Server.setup_mariadb`|`frappe.has_permission` with no `ptype`, so `read`|Follow-up|A state-changing operation should check `write`, and it has no authorization test. The doctype grants `read` only to `System Manager` and `BenchPress Admin`, both of which also hold `write`, so the gap is hardening rather than an open door|
 |`Database Server.start_mariadb`|same|Follow-up|As above|
 |`Database Server.stop_mariadb`|same|Follow-up|As above|
 |`Database Server.retry_setup`|same|Follow-up|As above|
@@ -3935,8 +4040,8 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 |Component|Verdict|Note|
 |--|--|--|
 |Permission model|Ready|Guest, wrong role and cross-user are all rejected. `only_for` raises for non-administrators|
-|Secret handling|Ready|Decryption only behind an owner or admin guard. The database root password is never logged|
-|`ignore_permissions=True`, 39 uses|Ready|Confined to enqueued and system flows. Ownership is tracked on `owner` and `owner_user`|
+|Secret handling|Ready|Both decryptions a whitelisted endpoint can reach sit behind `require_bench_access`. The database root password is never logged. One of the two, `get_bench_credentials`, was never in this audit — see the coverage list above|
+|`ignore_permissions=True`, 53 uses outside tests|Ready|Confined to enqueued and system flows. Ownership is tracked on `owner` and `owner_user`. The count was 39 at the 2026-07-02 review|
 |SQL construction|Ready|Identifiers are hashed and SQL is base64-wrapped before shelling. Not injectable|
 |Container isolation|**Not ready without a precondition**|Non-privileged, but a lab user holds in-container root. Ship only on a host with sysbox, userns-remap or a rootless daemon|
 
@@ -3944,15 +4049,16 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 
 1. **The container privilege boundary.** Ship only on a host that closes it.
    This is a deployment precondition, not an app default.
-2. **`create_site` with no bench.** Make `bench` mandatory, or guard the empty
-   case, so the endpoint cannot create an orphan `Bench Site` that bypasses
-   the access check.
-3. **`Database Server` state-changing methods.** Move them to a `write`
-   permission check and add authorization tests.
-4. **`get_benches` secret exposure.** Move SSH, admin and code-server password
-   retrieval out of the bulk list payload into an on-demand per-bench call.
-5. **`get_device_wg_config` test gap.** Add an explicit cross-user negative
+2. **The 27 unreviewed endpoints.** Review them, starting with `buy_credits`,
+   which takes money, and `get_bench_credentials`, which decrypts passwords.
+3. **`Database Server` state-changing methods.** They call
+   `frappe.has_permission` with no `ptype`, which checks `read`. Move them to
+   `write` and add authorization tests.
+4. **`get_device_wg_config` test gap.** Add an explicit cross-user negative
    test. The guard exists. The coverage does not.
+
+Two items from the 2026-07-02 list are closed. `get_benches` no longer returns
+any password. The `create_site` item described an endpoint that does not exist.
 
 ## Troubleshooting
 
@@ -3973,7 +4079,10 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 |Default runtime|`sysbox`|
 |Backed up|the shared MariaDB, nightly, 7 dumps|
 |Not backed up|bench Docker volumes|
-|Checklist last reviewed|2026-07-02|
+|Checklist reviewed|2026-07-02, re-verified against the code 2026-08-30|
+|Whitelisted callables|52|
+|Covered by this checklist|25|
+|Never reviewed|27|
 
 ## Related
 
@@ -3984,7 +4093,7 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 
 # Diagnostics
 URL: https://docs.benchpress.cloud/docs/operator/diagnostics
-The eleven read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
+The twelve read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
 
 Eleven checks that read the host rather than the configuration, and what to do
 about each one that fails.
@@ -4010,7 +4119,7 @@ one you have already made worse.
 2. **Or read them in the app.** Open **Overview** as an admin and look at the
    **Shared infrastructure** panel, which renders the same eleven rows.
 
-   ![The Shared infrastructure panel on the BenchPress Overview, listing eleven checks with a status badge each. Docker socket, Docker network, Bridge capacity, MariaDB, Redis, Container runtimes, Event listener and WireGuard read Active. Kernel ceilings and Clock skew read Error, and Golden images reads Warning.](../images/operator/diagnostics/01-shared-infrastructure.png)
+   ![The Shared infrastructure panel on the BenchPress Overview, listing the shared-infrastructure checks with a status badge each. Docker socket, Docker network, Bridge capacity, MariaDB, Redis, Container runtimes, Event listener and WireGuard read Active. Kernel ceilings and Clock skew read Error, and Golden images reads Warning.](../images/operator/diagnostics/01-shared-infrastructure.png)
 
    On this host eight rows read **Active**, `kernel_ceilings` and `clock_skew`
    read **Error**, and `golden_images` reads **Warning**. A badge is the
@@ -4021,7 +4130,7 @@ one you have already made worse.
    checks again. Several rows fail together for one cause, and the first fix
    often clears three.
 
-## The eleven checks
+## The twelve checks
 
 |Check|On screen|What it asks|Severity of a failure|
 |--|--|--|--|
@@ -4035,6 +4144,7 @@ one you have already made worse.
 |`container_runtimes`|Container runtimes|`sysbox-runc` is registered with Docker|Error|
 |`golden_images`|Golden images|how many built labs carry a golden dump|Warning|
 |`docker_events`|Event listener|the listener's heartbeat is newer than 60 seconds|Error|
+|`route_directory`|Route directory|a worker has reported the Traefik route directory mounted, with the control-plane route and the wildcard anchor rendered|Error, or Warning when the report is stale or the anchor is merely late|
 |`vpn_server`|WireGuard|`vpn_management` is installed, `wg0` exists, and it has a public key|Error|
 
 ## Severity is not status
@@ -5012,7 +5122,7 @@ One concern for each module. The table is the whole `benchpress/` package.
 |`permissions.py`|the role helpers and the six query conditions|
 |`overview.py`, `labs.py`, `lab_detail.py`, `run_history.py`|one screen each, assembled in a fixed number of queries|
 |`waitlist.py`, `signup.py`|the two doors open to a guest|
-|`diagnostics.py`|eleven read-only environment checks|
+|`diagnostics.py`|twelve read-only environment checks|
 |`notifications.py`|one desk alert and one email to a document owner|
 |`indexes.py`|composite indexes the DocType JSON cannot declare|
 |`request_cache.py`|a value memoised for one request, never in a module global|
@@ -5438,7 +5548,7 @@ This is the only DocType a guest can cause to be written. See
 
 # API
 URL: https://docs.benchpress.cloud/docs/reference/api
-All 50 whitelisted BenchPress endpoints, with arguments, what each returns, and the permission check each one makes for itself.
+Every whitelisted BenchPress endpoint, with arguments, what each returns, and the permission check each one makes for itself.
 
 Every function this app publishes over HTTP, and what each one checks before it
 does anything.
@@ -5462,9 +5572,12 @@ curl -s https://<host>/api/method/benchpress.api.get_labs \
 Arguments go as query parameters on a `GET` or as form fields on a `POST`.
 Frappe decides the method from the function, not from a route table.
 
-Thirty-five of the fifty are in `benchpress.api`. Four more are module functions
-elsewhere. The remaining eleven are document methods, called through
-`run_doc_method` rather than by path. All three kinds are marked below.
+Endpoints come in three kinds. Most are module functions in `benchpress.api`. A
+few more are module functions elsewhere, in `benchpress.waitlist` and
+`benchpress.signup`. The rest are document methods on controllers, called
+through `run_doc_method` rather than by path. All three kinds are marked below.
+[The whole list, counted](#the-whole-list-counted) has the breakdown and the
+command that derives it.
 
 ## How an endpoint is guarded
 
@@ -5540,6 +5653,61 @@ MD5 of the two, so a second call redeploys rather than making a second bench.
 
 `server_time` exists so a countdown in the browser corrects against the server
 clock instead of the laptop's.
+
+## Launch
+
+`create_bench` deploys a lab whose image already exists. The two launch
+endpoints do not require one. They build the image first, when there is no
+image, and deploy from it in the same job.
+
+|Endpoint|Arguments|Returns|Checks|
+|--|--|--|--|
+|`launch_template`|`template`, `instance_size`, `site_name`|the launch response below|`require_app_user`, then `is_active` on the `Lab Template` row, then `requires_admission` inside `_launch`|
+|`launch_lab`|`data` (JSON, with at least `lab`)|the launch response below|`require_app_user`, then `requires_admission` inside `_launch`|
+
+Both live in `benchpress/api.py`. Both call the private
+`_launch`, which claims the instance and enqueues
+`benchpress.launch.run_launch` on `queue-long` under the deduplicated job id
+`launch:<bench name>`. The job timeout is the image build timeout plus the
+deploy timeout, because one job does both.
+
+**The admission gate is on `_launch`, not on the published function.** This
+looks like a missing decorator and is not. `requires_admission` binds its cost
+and cap arguments by name and needs a lab that exists, which is only true after
+`launch_template` has resolved a template to one. `launch_template` resolves or
+creates that lab first, so a caller the gate then refuses can leave a new `Lab`
+row behind. The gate still runs before any work is queued, which is the property
+that matters.
+
+`launch_template` checks `is_active` on the `Lab Template` itself.
+`lab_templates.get_template` checks only that the key exists, so without this
+check a user could materialise a template an admin had retired.
+
+`launch_template` reuses a lab before it makes one. It takes the newest lab
+built from that template whose recipe still matches the template's own, and
+creates a lab only when there is no match. A second developer launching the same
+template rides the image the first launch paid for. A lab an admin has edited
+away from the template is skipped, because deploying it would install apps the
+template never named.
+
+Both endpoints claim the bench through the same path `create_bench` uses, so the
+same pair of caller and lab is the same bench. A second launch redeploys.
+
+The launch response carries seven keys:
+
+|Key|Is|
+|--|--|
+|`name`|the bench id|
+|`bench`|the same string as `name`, so a caller still reading `name` keeps working|
+|`lab`|the lab this bench came from|
+|`lab_title`|that lab's title|
+|`lab_status`|that lab's status, read from the row|
+|`will_build`|`true` when `lab_status` is not `Ready`|
+|`eta_minutes`|`eta_minutes` from the `Lab Template` row, or `0`|
+
+`will_build` is that status read alone. It does not ask Docker whether the image
+is on the host. It is opening copy for the launch dialog, and the job decides
+what actually happens.
 
 ## History
 
@@ -5637,7 +5805,7 @@ not from now.
 
 |Endpoint|Arguments|Returns|Checks|
 |--|--|--|--|
-|`run_diagnostics`|—|eleven read-only environment checks|`require_admin`|
+|`run_diagnostics`|—|twelve read-only environment checks|`require_admin`|
 |`preflight_runtime`|`runtime`|whether that runtime can actually start a container|`require_admin`|
 
 `run_diagnostics` reads. `preflight_runtime` creates a container, which is why
@@ -5717,22 +5885,33 @@ Two more waitlist functions are admin-only and not guest-reachable.
 
 ## The whole list, counted
 
-Fifty `@frappe.whitelist()` functions. Every one is in a table above.
+**Count the code, not this page.** Run the command before you quote a number
+anywhere:
+
+```bash
+grep -rn "@frappe.whitelist" --include=*.py benchpress/ | wc -l
+```
+
+Per file:
+
+```bash
+grep -rc "@frappe.whitelist" --include=*.py benchpress/ | grep -v ':0$' | sort -t: -k2 -rn
+```
+
+What those two commands returned when this page was last checked:
 
 |Location|Count|
 |--|--|
-|`benchpress/api.py`|35|
+|`benchpress/api.py`|37|
 |`benchpress/benchpress/doctype/database_server/database_server.py`|5|
 |`benchpress/benchpress/doctype/bench_instance/bench_instance.py`|4|
 |`benchpress/waitlist.py`|3|
 |`benchpress/benchpress/doctype/credit_account/credit_account.py`|2|
 |`benchpress/signup.py`|1|
+|**Total**|**52**|
 
-Recount after a change:
-
-```bash
-grep -rn "@frappe.whitelist" --include=*.py benchpress/ | wc -l
-```
+Every one of those 52 has a row in a table above. That is the claim to keep
+true when you add an endpoint.
 
 ## Adding an endpoint
 
@@ -5742,6 +5921,8 @@ grep -rn "@frappe.whitelist" --include=*.py benchpress/ | wc -l
    `@frappe.whitelist()`.
 4. Query with `frappe.qb`. A raw `frappe.db.sql` string is a lint failure.
 5. Add the endpoint to the table on this page.
+6. Re-run the two commands in [The whole list, counted](#the-whole-list-counted)
+   and paste what they return over that table.
 
 The decorator order matters. `@frappe.whitelist()` goes on top, and
 `@requires_admission(...)` below it, so the gate runs inside the published
@@ -6242,10 +6423,20 @@ Every address a bench answers on, and who can reach each one.
 one is addressed.
 
 **Before you start.** A bench has up to four addresses at once. They are not
-alternatives. Each one exists for a different caller, and three of the four are
-private.
+alternatives. Each one exists for a different caller, and two of the four are
+public.
 
 ## The four addresses
+
+**This section is the canonical statement of what a bench is reachable on.**
+The one sentence:
+
+> A bench answers on up to four addresses at once: two public HTTPS addresses
+> served by Traefik, which anyone on the internet can reach once `base_domain`
+> is set, and two tunnel addresses that only a device on the VPN can reach.
+
+The two `https://` addresses answer for anyone on the internet once
+`base_domain` is set, which is the documented install.
 
 `benchpress/addressing.py` builds all of them in one place, and the app renders
 what it returns rather than assembling a URL from a port it declared itself.
@@ -6256,6 +6447,19 @@ what it returns rather than assembling a URL from a port it declared itself.
 |Public IDE|`https://ide-<instance id>.<base domain>`|the internet, through Traefik|
 |Tunnel site|`http://<wg ip>:8000`|a device on the VPN|
 |Tunnel IDE|`http://<wg ip>:8080/`|a device on the VPN|
+
+`ingress.publish` writes routers on the `websecure` entry point: two for the
+site hostname, split so asset paths take their own rate limit, and one for the
+IDE hostname. `ingress.ensure_anchor` holds the wildcard certificate that
+terminates them. The IDE router is written only when the bench has an IDE, which
+is why the count is "up to four".
+
+Public means public. The only middlewares `publish` puts on a bench router are
+rate limits: a request cap on every router, and an in-flight cap on the site's
+render path when the instance size sets one. There is no authentication
+middleware at the edge. A browser anywhere resolves the name and gets the
+bench's own login page, and that login is the only thing between the internet
+and the site.
 
 The two ports are properties of the bench image, not settings. They are
 constants in `addressing.py`.
@@ -6380,8 +6584,12 @@ state.
 |Another bench on the same bridge|no|no|no|no|
 |A bench, reaching the shared MariaDB|—|—|—|the database only|
 
-No bench is on the public internet by port. The only public path is Traefik, and
-it terminates TLS on the wildcard.
+No bench is on the public internet by port. No bench container publishes a host
+port at all — the only public path is Traefik, and it terminates TLS on the
+wildcard.
+
+That is the whole of what the VPN gates. **SSH and the two `http://` tunnel
+addresses need the VPN. The two `https://` addresses do not.**
 
 ## Verify
 
@@ -7154,8 +7362,12 @@ cached image, creates a site, and puts the container on a WireGuard network.
 You get a site address, an SSH login and a browser VS Code session. When the
 work is done, you destroy the environment. Spin up, use, tear down.
 
-No bench is on the public internet. Every site, SSH port and IDE session is
-reachable only from a device that joined the VPN.
+A bench answers on up to four addresses at once: two public HTTPS addresses
+served by Traefik, which anyone on the internet can reach once `base_domain` is
+set, and two tunnel addresses that only a device on the VPN can reach.
+`base_domain` is a required setting, so a bench is not VPN-only on the
+documented install. [Networking](/docs/reference/networking) states the address
+plan in full.
 
 ## Reference
 
@@ -7179,3 +7391,4 @@ the page is still complete.
 ## Related
 
 * [Quick tour](/docs/user/quick-tour) — the five screens, and what the dashboard reports.
+* [Networking](/docs/reference/networking) — the four addresses a bench answers on, and who can reach each one.

--- a/docs-site/llms.txt
+++ b/docs-site/llms.txt
@@ -37,7 +37,7 @@ is done.
 ## Operator Track
 
 - [Operator track](/docs/operator.md): Run BenchPress on your own box — install, the VPN plane, settings, the shared database, images, upgrades, safety and diagnostics.
-- [Prerequisites](/docs/operator/prerequisites.md): What a BenchPress host needs before you install — supported platforms, versions, Docker socket access, IP forwarding, sysbox, and the measured CPU sizing.
+- [Prerequisites](/docs/operator/prerequisites.md): What a BenchPress host needs before you install — the four preconditions, supported platforms, versions, Docker socket access, and the measured CPU and disk sizing.
 - [Install](/docs/operator/install.md): Install BenchPress into a Frappe v16 bench — get-app, setup.sh, the frontend build, the base domain, and the first screen.
 - [WireGuard and the VPN plane](/docs/operator/wireguard-setup.md): How the vpn_management app owns the tunnel, what BenchPress consumes from it, the measured server and pool values, and why userns-remap matters.
 - [Settings reference](/docs/operator/settings-reference.md): Every field on BenchPress Settings and Credit Settings, with the value measured on a live host, where each one is edited, and what changing it costs.
@@ -47,8 +47,8 @@ is done.
 - [The image cache](/docs/operator/image-cache.md): One image per lab, tagged benchpress/<lab_id>:lab — what it costs on disk, how the weekly prewarm and sweep work, and what is safe to prune.
 - [Users and roles](/docs/operator/users-and-roles.md): The two BenchPress roles, what each one may read and write, which screens are admin-only, and how ownership rather than a role decides who sees a bench.
 - [Upgrading](/docs/operator/upgrading.md): Move a BenchPress install to a newer release — the backup gate, the five steps, the scripted path, rollback, and why lab images are a separate opt-in.
-- [Production safety](/docs/operator/production-safety.md): What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the endpoint-by-endpoint release checklist.
-- [Diagnostics](/docs/operator/diagnostics.md): The eleven read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
+- [Production safety](/docs/operator/production-safety.md): What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the release checklist that covers 25 of 52 whitelisted callables.
+- [Diagnostics](/docs/operator/diagnostics.md): The twelve read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
 - [Credits and billing](/docs/operator/credits-and-billing.md): Optional and off by default — the metering half of BenchPress, covering leases, balances, the ledger, admin adjustments, and the optional Razorpay handoff.
 - [Admission and limits](/docs/operator/admission-and-limits.md): Optional and off by default — concurrency caps, size ceilings, device and build quotas, how a slot is claimed as a row, and the acceptance run that proves access still works.
 - [Self-serve signup](/docs/operator/hosted-signup.md): Optional and off by default — retire the waitlist and let people sign themselves up, with GitHub and Google as the primary paths and the abuse controls that make a free grant safe.
@@ -58,7 +58,7 @@ is done.
 - [Reference track](/docs/reference.md): The data model, the whitelisted API, the eleven deploy steps, the reconcilers, the address plan and the configuration split — for a contributor or an integrator.
 - [Architecture](/docs/reference/architecture.md): The moving parts of BenchPress — the control plane, the bench containers, the shared infrastructure, and which Python module owns each concern.
 - [Data model](/docs/reference/data-model.md): All 20 BenchPress DocTypes with their fields, links, naming and the permission rule that scopes each one — plus why there is no Device DocType.
-- [API](/docs/reference/api.md): All 50 whitelisted BenchPress endpoints, with arguments, what each returns, and the permission check each one makes for itself.
+- [API](/docs/reference/api.md): Every whitelisted BenchPress endpoint, with arguments, what each returns, and the permission check each one makes for itself.
 - [Deploy pipeline](/docs/reference/deploy-pipeline.md): The eleven steps of a BenchPress deploy, in the order the code runs them, with the function behind each step and the log line it writes.
 - [Lifecycle and events](/docs/reference/lifecycle-and-events.md): The bench states and their transitions, the Docker event listener, Bench Event incidents, the stats collector, and the eleven scheduled jobs that correct the database.
 - [Networking](/docs/reference/networking.md): The BenchPress address plan — bench bridges, WireGuard tunnel addresses, the two container ports, Traefik route files and the wildcard certificate anchor.

--- a/docs-site/sitemap.md
+++ b/docs-site/sitemap.md
@@ -39,7 +39,7 @@ Structured documentation sitemap for BenchPress.
 
 ### Stand a host up
 
-- [Prerequisites](/docs/operator/prerequisites): What a BenchPress host needs before you install — supported platforms, versions, Docker socket access, IP forwarding, sysbox, and the measured CPU sizing.
+- [Prerequisites](/docs/operator/prerequisites): What a BenchPress host needs before you install — the four preconditions, supported platforms, versions, Docker socket access, and the measured CPU and disk sizing.
 - [Install](/docs/operator/install): Install BenchPress into a Frappe v16 bench — get-app, setup.sh, the frontend build, the base domain, and the first screen.
 - [WireGuard and the VPN plane](/docs/operator/wireguard-setup): How the vpn_management app owns the tunnel, what BenchPress consumes from it, the measured server and pool values, and why userns-remap matters.
 
@@ -58,8 +58,8 @@ Structured documentation sitemap for BenchPress.
 ### Keep it safe
 
 - [Upgrading](/docs/operator/upgrading): Move a BenchPress install to a newer release — the backup gate, the five steps, the scripted path, rollback, and why lab images are a separate opt-in.
-- [Production safety](/docs/operator/production-safety): What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the endpoint-by-endpoint release checklist.
-- [Diagnostics](/docs/operator/diagnostics): The eleven read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
+- [Production safety](/docs/operator/production-safety): What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the release checklist that covers 25 of 52 whitelisted callables.
+- [Diagnostics](/docs/operator/diagnostics): The twelve read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
 
 ### Optional — running it for a team
 
@@ -77,7 +77,7 @@ Structured documentation sitemap for BenchPress.
 
 - [Architecture](/docs/reference/architecture): The moving parts of BenchPress — the control plane, the bench containers, the shared infrastructure, and which Python module owns each concern.
 - [Data model](/docs/reference/data-model): All 20 BenchPress DocTypes with their fields, links, naming and the permission rule that scopes each one — plus why there is no Device DocType.
-- [API](/docs/reference/api): All 50 whitelisted BenchPress endpoints, with arguments, what each returns, and the permission check each one makes for itself.
+- [API](/docs/reference/api): Every whitelisted BenchPress endpoint, with arguments, what each returns, and the permission check each one makes for itself.
 
 ### What it does at runtime
 

--- a/docs-site/sitemap.xml
+++ b/docs-site/sitemap.xml
@@ -54,11 +54,11 @@
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/operator/prerequisites</loc>
-    <lastmod>2026-08-28T16:40:21.000Z</lastmod>
+    <lastmod>2026-08-30T12:05:07.000Z</lastmod>
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/operator/install</loc>
-    <lastmod>2026-08-28T16:40:21.000Z</lastmod>
+    <lastmod>2026-08-30T12:04:44.000Z</lastmod>
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/operator/wireguard-setup</loc>
@@ -94,11 +94,11 @@
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/operator/production-safety</loc>
-    <lastmod>2026-08-28T16:40:21.000Z</lastmod>
+    <lastmod>2026-08-30T12:05:07.000Z</lastmod>
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/operator/diagnostics</loc>
-    <lastmod>2026-08-28T16:40:21.000Z</lastmod>
+    <lastmod>2026-08-30T12:05:07.000Z</lastmod>
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/operator/credits-and-billing</loc>
@@ -118,7 +118,7 @@
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/reference/architecture</loc>
-    <lastmod>2026-08-28T16:40:21.000Z</lastmod>
+    <lastmod>2026-08-30T12:05:07.000Z</lastmod>
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/reference/data-model</loc>
@@ -126,7 +126,7 @@
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/reference/api</loc>
-    <lastmod>2026-08-28T16:40:21.000Z</lastmod>
+    <lastmod>2026-08-30T12:05:07.000Z</lastmod>
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/reference/deploy-pipeline</loc>
@@ -138,7 +138,7 @@
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/reference/networking</loc>
-    <lastmod>2026-08-28T16:40:21.000Z</lastmod>
+    <lastmod>2026-08-30T12:05:07.000Z</lastmod>
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/reference/realtime</loc>
@@ -158,6 +158,6 @@
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs</loc>
-    <lastmod>2026-08-28T16:40:21.000Z</lastmod>
+    <lastmod>2026-08-30T12:05:07.000Z</lastmod>
   </url>
 </urlset>

--- a/docs/docs.config.mjs
+++ b/docs/docs.config.mjs
@@ -1,9 +1,17 @@
+import { createRequire } from "node:module";
 import { defineDocsConfig } from "leadtype";
+
+// leadtype defaults the agent card to 1.0.0, which advertised a version this app has never
+// shipped. Read the real one instead, so the card cannot drift from the package again.
+const { version } = createRequire(import.meta.url)("../package.json");
 
 export default defineDocsConfig({
   product: {
     name: "BenchPress",
     tagline: "Press a button. Get a Frappe bench.",
+  },
+  agents: {
+    agentCard: { version },
   },
   llms: {
     sections: [

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -32,8 +32,12 @@ cached image, creates a site, and puts the container on a WireGuard network.
 You get a site address, an SSH login and a browser VS Code session. When the
 work is done, you destroy the environment. Spin up, use, tear down.
 
-No bench is on the public internet. Every site, SSH port and IDE session is
-reachable only from a device that joined the VPN.
+A bench answers on up to four addresses at once: two public HTTPS addresses
+served by Traefik, which anyone on the internet can reach once `base_domain` is
+set, and two tunnel addresses that only a device on the VPN can reach.
+`base_domain` is a required setting, so a bench is not VPN-only on the
+documented install. [Networking](/docs/reference/networking) states the address
+plan in full.
 
 ## Reference
 
@@ -57,3 +61,4 @@ the page is still complete.
 ## Related
 
 - [Quick tour](/docs/user/quick-tour) — the five screens, and what the dashboard reports.
+- [Networking](/docs/reference/networking) — the four addresses a bench answers on, and who can reach each one.

--- a/docs/operator/diagnostics.mdx
+++ b/docs/operator/diagnostics.mdx
@@ -1,6 +1,6 @@
 ---
 title: Diagnostics
-description: The eleven read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
+description: The twelve read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
 ---
 
 # Diagnostics
@@ -29,7 +29,7 @@ one you have already made worse.
 2. **Or read them in the app.** Open **Overview** as an admin and look at the
    **Shared infrastructure** panel, which renders the same eleven rows.
 
-   ![The Shared infrastructure panel on the BenchPress Overview, listing eleven checks with a status badge each. Docker socket, Docker network, Bridge capacity, MariaDB, Redis, Container runtimes, Event listener and WireGuard read Active. Kernel ceilings and Clock skew read Error, and Golden images reads Warning.](../images/operator/diagnostics/01-shared-infrastructure.png)
+   ![The Shared infrastructure panel on the BenchPress Overview, listing the shared-infrastructure checks with a status badge each. Docker socket, Docker network, Bridge capacity, MariaDB, Redis, Container runtimes, Event listener and WireGuard read Active. Kernel ceilings and Clock skew read Error, and Golden images reads Warning.](../images/operator/diagnostics/01-shared-infrastructure.png)
 
    On this host eight rows read **Active**, `kernel_ceilings` and `clock_skew`
    read **Error**, and `golden_images` reads **Warning**. A badge is the
@@ -40,7 +40,7 @@ one you have already made worse.
    checks again. Several rows fail together for one cause, and the first fix
    often clears three.
 
-## The eleven checks
+## The twelve checks
 
 | Check | On screen | What it asks | Severity of a failure |
 |---|---|---|---|
@@ -54,6 +54,7 @@ one you have already made worse.
 | `container_runtimes` | Container runtimes | `sysbox-runc` is registered with Docker | Error |
 | `golden_images` | Golden images | how many built labs carry a golden dump | Warning |
 | `docker_events` | Event listener | the listener's heartbeat is newer than 60 seconds | Error |
+| `route_directory` | Route directory | a worker has reported the Traefik route directory mounted, with the control-plane route and the wildcard anchor rendered | Error, or Warning when the report is stale or the anchor is merely late |
 | `vpn_server` | WireGuard | `vpn_management` is installed, `wg0` exists, and it has a public key | Error |
 
 ## Severity is not status

--- a/docs/operator/install.mdx
+++ b/docs/operator/install.mdx
@@ -18,18 +18,33 @@ Throughout, replace `<site>` with your real site name.
 
 ## Steps
 
-1. **Install the app into the bench.**
+1. **Install the apps into the bench.** There are two repositories, and you
+   clone both.
+
+   `benchpress` names `vpn_management` in `required_apps`, so
+   `install-app benchpress` installs `vpn_management` first — but only from a
+   copy already on the bench, listed in `sites/apps.txt`. Clone it yourself.
+   `bench get-app` resolves a bare
+   `required_apps` name under the `frappe` and `erpnext` GitHub accounts only,
+   and [vpn_management](https://github.com/Venkateshvenki404224/vpn_management)
+   is under neither, so `--resolve-deps` does not find it either.
 
    ```bash
    cd /path/to/your/frappe-bench
+   bench get-app https://github.com/Venkateshvenki404224/vpn_management --branch version-16
    bench get-app https://github.com/Venkateshvenki404224/benchpress --branch version-16
    bench pip install docker
    bench --site <site> install-app benchpress
    bench --site <site> migrate
    ```
 
-   `benchpress` declares `vpn_management` as a required app, so Frappe
-   installs that first. It refuses to install without `vpn_endpoint_host` in
+   Skip the first `get-app` and `install-app` fails with
+   `frappe.exceptions.InvalidRemoteException`, raised with an empty message.
+   Frappe resolves the `required_apps` name the same way — against the `frappe`
+   and `erpnext` accounts — and gives up there, before it ever reports a
+   missing app.
+
+   `vpn_management` itself refuses to install without `vpn_endpoint_host` in
    `common_site_config.json` and without a reachable wg-agent socket. See
    [WireGuard and the VPN plane](/docs/operator/wireguard-setup).
 
@@ -45,13 +60,15 @@ Throughout, replace `<site>` with your real site name.
    | Step | What it does | Skipped when |
    |---|---|---|
    | 1 of 4 | Adds the bench user to the `docker` group | the user is already a member |
-   | 2 of 4 | Checks Docker `userns-remap` or rootless mode | never — it only warns |
+   | 2 of 4 | Checks the container-root privilege boundary: a registered `sysbox-runc` runtime, or Docker `userns-remap` (or rootless) | never — it warns, or exits under `--strict` |
    | 3 of 4 | Starts `benchpress-mariadb` and `benchpress-redis`, and creates the `benchpress` network and the data volume | the containers are already up |
    | 4 of 4 | Writes `net.ipv4.ip_forward = 1` under `/etc/sysctl.d` | forwarding is already on |
 
    Step 2 warns and continues by default. On a host that will carry anything
    you care about, run it as `bash apps/benchpress/setup.sh <site> --strict`
-   instead, which exits non-zero rather than warning. See
+   instead, which exits non-zero rather than warning. Either boundary
+   satisfies `--strict`. sysbox is checked first: it is the recommended one,
+   and a lab set to the `sysbox` runtime needs it registered anyway. See
    [Production safety](/docs/operator/production-safety).
 
 3. **Build the frontend.** The dashboard is a Vue single-page app and ships as
@@ -96,7 +113,7 @@ Throughout, replace `<site>` with your real site name.
 
    The first screen is the **Overview**: how many environments are running,
    stopped or broken, the average deploy time over the last seven days, and a
-   **Shared infrastructure** panel reporting eleven checks. Seven days is not
+   **Shared infrastructure** panel reporting twelve checks. Seven days is not
    a choice — deploy logs are cleared on that schedule, so no longer window
    has data behind it.
 
@@ -144,11 +161,11 @@ that image in seconds. See [The image cache](/docs/operator/image-cache).
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `install-app` fails naming `vpn_management` | The required app is missing or refuses to install | Install `vpn_management` first and set `vpn_endpoint_host` |
+| `install-app` fails with a bare `InvalidRemoteException` | The repository was never cloned into `apps/` | Run the first `get-app` in step 1, then re-run `install-app` |
 | The dashboard is blank or unstyled | The frontend was never built | Step 3, then `bench --site <site> clear-cache` |
 | Settings will not save | `base_domain` is empty, and it is required | Fill it. Sites are addressed under it |
 | Every deploy fails on a Docker call | The bench started before the group change took effect | Log out, log back in, restart the bench |
-| `setup.sh` warns about `userns-remap` | Container root maps to host root | See [Production safety](/docs/operator/production-safety) before running anything real |
+| `setup.sh` warns that there is no privilege boundary | Neither `sysbox-runc` nor `userns-remap` is present, so container root is host root | See [Production safety](/docs/operator/production-safety) before running anything real |
 | The Overview shows `Kernel ceilings Error` | Host-wide sysctl limits are below what a dense fleet needs | `sudo scripts/tune-host.sh`, from the `benchpress_devops` checkout |
 
 ## Reference
@@ -156,6 +173,8 @@ that image in seconds. See [The image cache](/docs/operator/image-cache).
 | Item | Value |
 |---|---|
 | App branch | `version-16` |
+| App repository | [Venkateshvenki404224/benchpress](https://github.com/Venkateshvenki404224/benchpress) |
+| Required app | [Venkateshvenki404224/vpn_management](https://github.com/Venkateshvenki404224/vpn_management), branch `version-16` |
 | Setup script | `bash apps/benchpress/setup.sh <site> [--strict]` |
 | Shared containers | `benchpress-mariadb`, `benchpress-redis` |
 | Docker network | `benchpress` |

--- a/docs/operator/prerequisites.mdx
+++ b/docs/operator/prerequisites.mdx
@@ -1,6 +1,6 @@
 ---
 title: Prerequisites
-description: What a BenchPress host needs before you install — supported platforms, versions, Docker socket access, IP forwarding, sysbox, and the measured CPU sizing.
+description: What a BenchPress host needs before you install — the four preconditions, supported platforms, versions, Docker socket access, and the measured CPU and disk sizing.
 ---
 
 # Prerequisites
@@ -13,6 +13,21 @@ will work, and how much of it to buy.
 **Before you start.** BenchPress installs into an existing Frappe bench and
 drives that host's Docker. It is not a standalone service, and it is Linux
 only — the setup script uses `apt` and `sysctl`.
+
+## The four preconditions
+
+Get these four before you read anything else on this page. Each one blocks the
+install or the first deploy, and none of them can be fixed from inside the app.
+
+| Precondition | Why it blocks | Set it in |
+|---|---|---|
+| `sysbox-runc` registered with Docker | `default_bench_runtime` is `sysbox`, so a deploy has no runtime without it. `runc` without `userns-remap` makes in-container root host root | [Step 5](#steps) |
+| `net.ipv4.ip_forward = 1` | The kernel drops tunnel traffic on its way to a bench, so a deploy fails on the network step | [Step 4](#steps) |
+| 44556/UDP open, on `ufw` **and** on any cloud firewall | A WireGuard peer never handshakes, so nothing reaches a bench over the tunnel | [Step 7](#steps) |
+| A domain you control, for `base_domain` | `base_domain` is `reqd` on **BenchPress Settings**, so the settings form will not save without it. Sites are addressed as `<instance id>.<base domain>` | [Install, step 5](/docs/operator/install) |
+
+Size the host before you buy it as well. [Sizing](#sizing) holds the CPU floor
+and [Disk](#disk) the disk floor. Disk is the one that fails a default VPS.
 
 ## Steps
 
@@ -129,7 +144,7 @@ Three criteria, each with its own minimum:
 | Tier | Minimum CPU | Evidence at the minimum |
 |---|---:|---|
 | Boot and lifecycle | 0.5 | migration 13.22 s, login HTTP 200 in 192 ms, `/frontend` HTTP 200 in 27 ms |
-| Test suite | 0.5 | the 124-test suite passed in 11.59 s, with every endpoint timing budget met |
+| Test suite | 0.5 | the suite passed in 11.59 s, with every endpoint timing budget met. It held 124 tests that day. The suite has since grown by roughly an order of magnitude, so 11.59 s no longer describes a full run |
 | Concurrent reads | 0.5 | `get_labs` p95 127 ms, `get_benches` p95 48 ms, 0 of 60 requests failed |
 
 Concurrent reads at each candidate cap, 30 authenticated requests per endpoint
@@ -152,10 +167,50 @@ did not visibly degrade this workload, so the measurements do not support
 calling one core a minimum. Re-run the benchmark after the application grows,
 or when you change the host class.
 
-**RAM and disk are the real constraints, not CPU.** A lab image is 5.5 GB to
-19.7 GB, and one deploy costs roughly 0.2 GB to 1 GB more. See
-[The image cache](/docs/operator/image-cache) for what that grows into and how
-the sweep holds it down.
+**Of the two resources measured here, disk is the constraint, not CPU.** Size
+it before you buy the host. See [Disk](#disk).
+
+**RAM was not sized.** The benchmark capped CPU only, so the 7.8 GiB above
+describes the benchmark host and is not a floor. Watch `free -h` on your own
+host until someone measures it.
+
+## Disk
+
+**A 20 GB or 40 GB VPS root disk fails mid-build.** No setting in the app
+compensates for it, and the failure lands in the middle of an image build
+rather than at install.
+
+Measured on this host with `docker images` and `docker system df`, and listed
+per image in [The image cache](/docs/operator/image-cache):
+
+| Measurement | Value |
+|---|---:|
+| Smallest lab image | 5.5 GB |
+| Largest lab image | 19.7 GB |
+| Twelve lab images together | 54.74 GB |
+| Reclaimable from that set | 19.12 GB |
+
+Three costs sit on top of that image figure. A build holds the new image while
+its base layers are still on disk. Every bench has its own container layer and
+volumes — one deploy costs roughly 0.2 GB to 1 GB, measured in
+[The image cache](/docs/operator/image-cache). The shared MariaDB carries its
+data volume. The build headroom and the MariaDB volume are not measured.
+
+So provision against the catalog you will hold, not against one image:
+
+| The host will carry | Free disk to provision | Basis |
+|---|---:|---|
+| One lab image | 100 GB | 19.7 GB for the largest measured image, with room to rebuild it beside the copy in use |
+| A catalog the size of this host's | 250 GB | 54.74 GB measured for twelve images, plus the same rebuild headroom, plus bench volumes |
+
+Those two rows are recommendations derived from the measurements above. They
+are not themselves measured. Watch `df -h /` and `docker system df` on your own
+host, and raise them if either climbs.
+
+Building is also the slowest thing a fresh host does. Full builds on this host
+ran **4 to 26 minutes**, and the golden pass 5 to 11 — see
+[The image cache](/docs/operator/image-cache). The build job's own timeout is
+10,800 s, three hours, which is a ceiling and not an expected duration.
 
 ## Troubleshooting
 
@@ -166,6 +221,8 @@ the sweep holds it down.
 | Diagnostics reports `container_runtimes` as failed | `sysbox-runc` is not registered with Docker | Install sysbox, or set `default_bench_runtime` to `runc` and read [Production safety](/docs/operator/production-safety) |
 | Diagnostics reports `kernel_ceilings` as failed | The host ceilings are below what the fleet needs | `sudo scripts/tune-host.sh --benches <n>`, from the `benchpress_devops` checkout |
 | A peer never handshakes | UDP 44556 is closed | Step 7, and check the cloud firewall as well as `ufw` |
+| A build fails part-way with no space left | The host was sized for the OS, not for lab images | [Disk](#disk). Never run `docker image prune -a` on this host |
+| **BenchPress Settings** will not save | `base_domain` is required and empty | Point a domain you control at this host, then fill it in [Install, step 5](/docs/operator/install) |
 
 ## Reference
 
@@ -177,6 +234,9 @@ the sweep holds it down.
 | WireGuard port | 44556/UDP | the `WireGuard Server` document in `vpn_management` |
 | Frappe version, host bench | v16 | the bench itself |
 | CPU floor per bench | 1 core | `Lab.cpu_cores`, an integer field |
+| Base domain | required, no default | `BenchPress Settings.base_domain`, `reqd` |
+| Free disk, one lab image | 100 GB recommended | the host you buy |
+| Free disk, a full catalog | 250 GB recommended | the host you buy |
 
 ## Related
 

--- a/docs/operator/production-safety.mdx
+++ b/docs/operator/production-safety.mdx
@@ -1,6 +1,6 @@
 ---
 title: Production safety
-description: What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the endpoint-by-endpoint release checklist.
+description: What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the release checklist that covers 25 of 52 whitelisted callables.
 ---
 
 # Production safety
@@ -33,6 +33,10 @@ ERPNext environments. It is not built to host customer data. Concretely:
   up. See [Backup and restore](/docs/operator/backup-and-restore).
 - **Single-tenant assumption.** Quotas, rate limits and audit trails are still
   in progress. Run BenchPress for people you trust, on a host dedicated to it.
+- **The security review is partial.** It covers 25 of the app's 52 whitelisted
+  callables. The credit-purchase path and the per-bench credential endpoint are
+  among the 27 it never reached. See
+  [the release checklist](#the-release-checklist).
 
 Use it on a dedicated dev box, a VM, or a cloud instance you can rebuild. Not
 on your daily-driver workstation, and not on a shared production server.
@@ -89,31 +93,53 @@ All three must pass on a host carrying anything you would miss.
 
 ## The release checklist
 
-Last reviewed 2026-07-02, from the authorization suite, the contract and
-timing suite, a branch security review, and a sweep of every
-`ignore_permissions=True` and secret-handling path.
+Reviewed 2026-07-02, from the authorization suite, the contract and timing
+suite, a branch security review, and a sweep of every `ignore_permissions=True`
+and secret-handling path. Every row below was re-checked against the code on
+2026-08-30. Two findings had been fixed, one described an endpoint that never
+existed, and several guard descriptions were wrong.
 
-Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
+**What the audit covered.** The app exposes **52** whitelisted callables. This
+checklist covers **25** of them: 16 endpoints and 9 controller methods. It also
+carried a row for a `create_site` endpoint, which does not exist in the code —
+that row is gone. **27 whitelisted callables have never been reviewed**, and
+that is the largest gap on this page. They are:
+
+| Never reviewed | Where |
+|---|---|
+| `buy_credits`, `get_purchase_options`, `get_credit_summary`, `get_credit_statement`, `get_lease_plans`, `renew_bench` | the credit and lease path, including the one that takes money |
+| `get_bench_credentials` | decrypts SSH, admin and code-server passwords for one bench |
+| `launch_template`, `launch_lab`, `build_lab_golden`, `prewarm_catalog` | the one-click deploy and golden-build path |
+| `sign_up`, `join`, `notify_of_signup`, `approve` | `signup.py` and `waitlist.py`, the only self-service entry points |
+| `Credit Account.post_adjustment`, `post_refund` | controller methods that move a balance |
+| `server_time`, `get_lab_form_options`, `get_device_types`, `get_build_history`, `get_deploy_history`, `get_overview`, `get_vpn_status`, `run_connection_test`, `run_diagnostics`, `preflight_runtime` | the rest |
+
+Treat an unreviewed endpoint as unreviewed, not as safe.
+
+Read the verdicts as: **Ready**, **Ready with a follow-up**, **Not ready**.
 
 ### Whitelisted endpoints
 
+`require_app_user` admits `System Manager`, `BenchPress Admin` and
+`BenchPress User`. `require_admin` admits the first two. Both are
+`frappe.only_for`, so neither is satisfied by login alone.
+
 | Endpoint | Guard | Verdict | Note |
 |---|---|---|---|
-| `get_labs` | login only | Ready | A shared admin-curated catalog. No per-user data |
-| `get_lab` | login only | Ready | One catalog row |
-| `get_lab_templates` | login only | Ready | A static list |
+| `get_labs` | `require_app_user` | Ready | A shared admin-curated catalog. No per-user data |
+| `get_lab` | `require_app_user` | Ready | One catalog row |
+| `get_lab_templates` | `require_app_user` | Ready | A static list |
 | `create_lab_from_template` | `require_admin` | Ready | Admin-only, proven by test |
 | `build_lab_image` | `require_admin` | Ready | Admin-only, proven by test |
-| `get_benches` | owner filter | Follow-up | Returns decrypted SSH, admin and code-server passwords in the list payload. Owner-scoped, but secrets belong in an on-demand call |
-| `create_bench` | login, own deterministic id | Ready | The id embeds the caller, so a user can only create their own |
+| `get_benches` | `require_app_user`, owner filter | Ready | No longer returns any password. The field list holds no secret, and a test asserts their absence. Retrieval moved to `get_bench_credentials` |
+| `create_bench` | `require_app_user`, own deterministic id | Ready | The id embeds the caller, so a user can only create their own |
 | `bench_action` | `require_bench_access`, delete admin-only | Ready | Start, stop and restart are owner-scoped. Delete is admin-gated |
 | `get_deploy_logs` | `require_bench_access` | Ready | Cross-user access denied by test |
-| `add_device` | login, peer owned by caller | Ready | Creates only the caller's peer |
-| `remove_device` | owner or admin | Ready | Ownership enforced before delete |
-| `list_devices` | owner filter | Ready | Bench peers excluded |
-| `get_device_wg_config` | owner or admin | Follow-up | The guard exists. The cross-user negative test does not |
-| `create_site` | `require_bench_access` **only when `bench` is set** | Follow-up | A bench-less call skips the guard and creates an orphan `Bench Site` |
-| `get_user_context` | login, own session | Ready | Returns only the caller's identity and roles |
+| `add_device` | `require_app_user`, peer owned by caller | Ready | Writes `owner_user` as the session user, so it creates only the caller's peer |
+| `remove_device` | `require_app_user`, then an owned-peer lookup | Ready | Ownership resolved before the delete |
+| `list_devices` | `require_app_user`, `owner_user` filter | Ready | Bench peers excluded |
+| `get_device_wg_config` | `require_app_user`, then an owned-peer lookup | Follow-up | The guard exists. The cross-user negative test still does not |
+| `get_user_context` | login only | Ready | No role check, deliberately: the SPA calls it on boot. Returns the caller's own identity, roles and credit summary, and nothing about another user |
 | `get_code_server_credentials` | `require_bench_access` | Ready | Decrypted only after the ownership check |
 | `restart_code_server` | `require_bench_access` | Ready | Cross-user denied by test |
 
@@ -125,7 +151,7 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 | `Bench Instance.enqueue_redeploy` | same | Ready | |
 | `Bench Instance.enqueue_stop` | same | Ready | |
 | `Bench Instance.enqueue_start` | same | Ready | |
-| `Database Server.setup_mariadb` | read permission, admin-only doctype | Follow-up | A state-changing operation should check `write`, and it has no authorization test |
+| `Database Server.setup_mariadb` | `frappe.has_permission` with no `ptype`, so `read` | Follow-up | A state-changing operation should check `write`, and it has no authorization test. The doctype grants `read` only to `System Manager` and `BenchPress Admin`, both of which also hold `write`, so the gap is hardening rather than an open door |
 | `Database Server.start_mariadb` | same | Follow-up | As above |
 | `Database Server.stop_mariadb` | same | Follow-up | As above |
 | `Database Server.retry_setup` | same | Follow-up | As above |
@@ -136,8 +162,8 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 | Component | Verdict | Note |
 |---|---|---|
 | Permission model | Ready | Guest, wrong role and cross-user are all rejected. `only_for` raises for non-administrators |
-| Secret handling | Ready | Decryption only behind an owner or admin guard. The database root password is never logged |
-| `ignore_permissions=True`, 39 uses | Ready | Confined to enqueued and system flows. Ownership is tracked on `owner` and `owner_user` |
+| Secret handling | Ready | Both decryptions a whitelisted endpoint can reach sit behind `require_bench_access`. The database root password is never logged. One of the two, `get_bench_credentials`, was never in this audit — see the coverage list above |
+| `ignore_permissions=True`, 53 uses outside tests | Ready | Confined to enqueued and system flows. Ownership is tracked on `owner` and `owner_user`. The count was 39 at the 2026-07-02 review |
 | SQL construction | Ready | Identifiers are hashed and SQL is base64-wrapped before shelling. Not injectable |
 | Container isolation | **Not ready without a precondition** | Non-privileged, but a lab user holds in-container root. Ship only on a host with sysbox, userns-remap or a rootless daemon |
 
@@ -145,15 +171,16 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 
 1. **The container privilege boundary.** Ship only on a host that closes it.
    This is a deployment precondition, not an app default.
-2. **`create_site` with no bench.** Make `bench` mandatory, or guard the empty
-   case, so the endpoint cannot create an orphan `Bench Site` that bypasses
-   the access check.
-3. **`Database Server` state-changing methods.** Move them to a `write`
-   permission check and add authorization tests.
-4. **`get_benches` secret exposure.** Move SSH, admin and code-server password
-   retrieval out of the bulk list payload into an on-demand per-bench call.
-5. **`get_device_wg_config` test gap.** Add an explicit cross-user negative
+2. **The 27 unreviewed endpoints.** Review them, starting with `buy_credits`,
+   which takes money, and `get_bench_credentials`, which decrypts passwords.
+3. **`Database Server` state-changing methods.** They call
+   `frappe.has_permission` with no `ptype`, which checks `read`. Move them to
+   `write` and add authorization tests.
+4. **`get_device_wg_config` test gap.** Add an explicit cross-user negative
    test. The guard exists. The coverage does not.
+
+Two items from the 2026-07-02 list are closed. `get_benches` no longer returns
+any password. The `create_site` item described an endpoint that does not exist.
 
 ## Troubleshooting
 
@@ -174,7 +201,10 @@ Read as: **Ready**, **Ready with a follow-up**, **Not ready**.
 | Default runtime | `sysbox` |
 | Backed up | the shared MariaDB, nightly, 7 dumps |
 | Not backed up | bench Docker volumes |
-| Checklist last reviewed | 2026-07-02 |
+| Checklist reviewed | 2026-07-02, re-verified against the code 2026-08-30 |
+| Whitelisted callables | 52 |
+| Covered by this checklist | 25 |
+| Never reviewed | 27 |
 
 ## Related
 

--- a/docs/reference/api.mdx
+++ b/docs/reference/api.mdx
@@ -1,6 +1,6 @@
 ---
 title: API
-description: All 50 whitelisted BenchPress endpoints, with arguments, what each returns, and the permission check each one makes for itself.
+description: Every whitelisted BenchPress endpoint, with arguments, what each returns, and the permission check each one makes for itself.
 ---
 
 # API
@@ -27,9 +27,12 @@ curl -s https://<host>/api/method/benchpress.api.get_labs \
 Arguments go as query parameters on a `GET` or as form fields on a `POST`.
 Frappe decides the method from the function, not from a route table.
 
-Thirty-five of the fifty are in `benchpress.api`. Four more are module functions
-elsewhere. The remaining eleven are document methods, called through
-`run_doc_method` rather than by path. All three kinds are marked below.
+Endpoints come in three kinds. Most are module functions in `benchpress.api`. A
+few more are module functions elsewhere, in `benchpress.waitlist` and
+`benchpress.signup`. The rest are document methods on controllers, called
+through `run_doc_method` rather than by path. All three kinds are marked below.
+[The whole list, counted](#the-whole-list-counted) has the breakdown and the
+command that derives it.
 
 ## How an endpoint is guarded
 
@@ -105,6 +108,61 @@ MD5 of the two, so a second call redeploys rather than making a second bench.
 
 `server_time` exists so a countdown in the browser corrects against the server
 clock instead of the laptop's.
+
+## Launch
+
+`create_bench` deploys a lab whose image already exists. The two launch
+endpoints do not require one. They build the image first, when there is no
+image, and deploy from it in the same job.
+
+| Endpoint | Arguments | Returns | Checks |
+|---|---|---|---|
+| `launch_template` | `template`, `instance_size`, `site_name` | the launch response below | `require_app_user`, then `is_active` on the `Lab Template` row, then `requires_admission` inside `_launch` |
+| `launch_lab` | `data` (JSON, with at least `lab`) | the launch response below | `require_app_user`, then `requires_admission` inside `_launch` |
+
+Both live in `benchpress/api.py`. Both call the private
+`_launch`, which claims the instance and enqueues
+`benchpress.launch.run_launch` on `queue-long` under the deduplicated job id
+`launch:<bench name>`. The job timeout is the image build timeout plus the
+deploy timeout, because one job does both.
+
+**The admission gate is on `_launch`, not on the published function.** This
+looks like a missing decorator and is not. `requires_admission` binds its cost
+and cap arguments by name and needs a lab that exists, which is only true after
+`launch_template` has resolved a template to one. `launch_template` resolves or
+creates that lab first, so a caller the gate then refuses can leave a new `Lab`
+row behind. The gate still runs before any work is queued, which is the property
+that matters.
+
+`launch_template` checks `is_active` on the `Lab Template` itself.
+`lab_templates.get_template` checks only that the key exists, so without this
+check a user could materialise a template an admin had retired.
+
+`launch_template` reuses a lab before it makes one. It takes the newest lab
+built from that template whose recipe still matches the template's own, and
+creates a lab only when there is no match. A second developer launching the same
+template rides the image the first launch paid for. A lab an admin has edited
+away from the template is skipped, because deploying it would install apps the
+template never named.
+
+Both endpoints claim the bench through the same path `create_bench` uses, so the
+same pair of caller and lab is the same bench. A second launch redeploys.
+
+The launch response carries seven keys:
+
+| Key | Is |
+|---|---|
+| `name` | the bench id |
+| `bench` | the same string as `name`, so a caller still reading `name` keeps working |
+| `lab` | the lab this bench came from |
+| `lab_title` | that lab's title |
+| `lab_status` | that lab's status, read from the row |
+| `will_build` | `true` when `lab_status` is not `Ready` |
+| `eta_minutes` | `eta_minutes` from the `Lab Template` row, or `0` |
+
+`will_build` is that status read alone. It does not ask Docker whether the image
+is on the host. It is opening copy for the launch dialog, and the job decides
+what actually happens.
 
 ## History
 
@@ -202,7 +260,7 @@ not from now.
 
 | Endpoint | Arguments | Returns | Checks |
 |---|---|---|---|
-| `run_diagnostics` | — | eleven read-only environment checks | `require_admin` |
+| `run_diagnostics` | — | twelve read-only environment checks | `require_admin` |
 | `preflight_runtime` | `runtime` | whether that runtime can actually start a container | `require_admin` |
 
 `run_diagnostics` reads. `preflight_runtime` creates a container, which is why
@@ -282,22 +340,33 @@ Two more waitlist functions are admin-only and not guest-reachable.
 
 ## The whole list, counted
 
-Fifty `@frappe.whitelist()` functions. Every one is in a table above.
+**Count the code, not this page.** Run the command before you quote a number
+anywhere:
+
+```bash
+grep -rn "@frappe.whitelist" --include=*.py benchpress/ | wc -l
+```
+
+Per file:
+
+```bash
+grep -rc "@frappe.whitelist" --include=*.py benchpress/ | grep -v ':0$' | sort -t: -k2 -rn
+```
+
+What those two commands returned when this page was last checked:
 
 | Location | Count |
 |---|---|
-| `benchpress/api.py` | 35 |
+| `benchpress/api.py` | 37 |
 | `benchpress/benchpress/doctype/database_server/database_server.py` | 5 |
 | `benchpress/benchpress/doctype/bench_instance/bench_instance.py` | 4 |
 | `benchpress/waitlist.py` | 3 |
 | `benchpress/benchpress/doctype/credit_account/credit_account.py` | 2 |
 | `benchpress/signup.py` | 1 |
+| **Total** | **52** |
 
-Recount after a change:
-
-```bash
-grep -rn "@frappe.whitelist" --include=*.py benchpress/ | wc -l
-```
+Every one of those 52 has a row in a table above. That is the claim to keep
+true when you add an endpoint.
 
 ## Adding an endpoint
 
@@ -307,6 +376,8 @@ grep -rn "@frappe.whitelist" --include=*.py benchpress/ | wc -l
    `@frappe.whitelist()`.
 4. Query with `frappe.qb`. A raw `frappe.db.sql` string is a lint failure.
 5. Add the endpoint to the table on this page.
+6. Re-run the two commands in [The whole list, counted](#the-whole-list-counted)
+   and paste what they return over that table.
 
 The decorator order matters. `@frappe.whitelist()` goes on top, and
 `@requires_admission(...)` below it, so the gate runs inside the published

--- a/docs/reference/architecture.mdx
+++ b/docs/reference/architecture.mdx
@@ -67,7 +67,7 @@ One concern for each module. The table is the whole `benchpress/` package.
 | `permissions.py` | the role helpers and the six query conditions |
 | `overview.py`, `labs.py`, `lab_detail.py`, `run_history.py` | one screen each, assembled in a fixed number of queries |
 | `waitlist.py`, `signup.py` | the two doors open to a guest |
-| `diagnostics.py` | eleven read-only environment checks |
+| `diagnostics.py` | twelve read-only environment checks |
 | `notifications.py` | one desk alert and one email to a document owner |
 | `indexes.py` | composite indexes the DocType JSON cannot declare |
 | `request_cache.py` | a value memoised for one request, never in a module global |

--- a/docs/reference/networking.mdx
+++ b/docs/reference/networking.mdx
@@ -11,10 +11,20 @@ Every address a bench answers on, and who can reach each one.
 one is addressed.
 
 **Before you start.** A bench has up to four addresses at once. They are not
-alternatives. Each one exists for a different caller, and three of the four are
-private.
+alternatives. Each one exists for a different caller, and two of the four are
+public.
 
 ## The four addresses
+
+**This section is the canonical statement of what a bench is reachable on.**
+The one sentence:
+
+> A bench answers on up to four addresses at once: two public HTTPS addresses
+> served by Traefik, which anyone on the internet can reach once `base_domain`
+> is set, and two tunnel addresses that only a device on the VPN can reach.
+
+The two `https://` addresses answer for anyone on the internet once
+`base_domain` is set, which is the documented install.
 
 `benchpress/addressing.py` builds all of them in one place, and the app renders
 what it returns rather than assembling a URL from a port it declared itself.
@@ -25,6 +35,19 @@ what it returns rather than assembling a URL from a port it declared itself.
 | Public IDE | `https://ide-<instance id>.<base domain>` | the internet, through Traefik |
 | Tunnel site | `http://<wg ip>:8000` | a device on the VPN |
 | Tunnel IDE | `http://<wg ip>:8080/` | a device on the VPN |
+
+`ingress.publish` writes routers on the `websecure` entry point: two for the
+site hostname, split so asset paths take their own rate limit, and one for the
+IDE hostname. `ingress.ensure_anchor` holds the wildcard certificate that
+terminates them. The IDE router is written only when the bench has an IDE, which
+is why the count is "up to four".
+
+Public means public. The only middlewares `publish` puts on a bench router are
+rate limits: a request cap on every router, and an in-flight cap on the site's
+render path when the instance size sets one. There is no authentication
+middleware at the edge. A browser anywhere resolves the name and gets the
+bench's own login page, and that login is the only thing between the internet
+and the site.
 
 The two ports are properties of the bench image, not settings. They are
 constants in `addressing.py`.
@@ -149,8 +172,12 @@ state.
 | Another bench on the same bridge | no | no | no | no |
 | A bench, reaching the shared MariaDB | — | — | — | the database only |
 
-No bench is on the public internet by port. The only public path is Traefik, and
-it terminates TLS on the wildcard.
+No bench is on the public internet by port. No bench container publishes a host
+port at all — the only public path is Traefik, and it terminates TLS on the
+wildcard.
+
+That is the whole of what the VPN gates. **SSH and the two `http://` tunnel
+addresses need the VPN. The two `https://` addresses do not.**
 
 ## Verify
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "benchpress",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Press a button. Get a Frappe bench. Self-hosted, Docker-powered, VPN-secured.",
   "main": "index.js",
   "scripts": {

--- a/scripts/enable-sysbox.sh
+++ b/scripts/enable-sysbox.sh
@@ -1,0 +1,415 @@
+#!/usr/bin/env bash
+#
+# scripts/enable-sysbox.sh — register the Sysbox runtime with this host's Docker
+# daemon, so a bench container can have root that is not host root.
+#
+# A bench gives its user in-container root; sudo for bench work is the point of
+# the product. Under `runc` that root is host root wearing a namespace, so the
+# only thing between a bench and every other tenant's database is `runc` itself.
+# Sysbox runs a container in a user namespace: container root maps to an
+# unprivileged host UID. In-container root stays, the escape path closes.
+#
+# Nothing installs this for you. It restarts the Docker daemon, so it is a
+# decision an operator makes, not a step an installer takes.
+#
+#   sudo scripts/enable-sysbox.sh                    # confirm, then do it
+#   sudo scripts/enable-sysbox.sh --yes              # unattended
+#   sudo scripts/enable-sysbox.sh --skip-reclaim     # disk already has room
+#   sudo scripts/enable-sysbox.sh --version 0.6.7    # a different release
+#
+# `runc` stays the daemon's default-runtime, so nothing already running changes
+# behaviour. BenchPress names `sysbox-runc` explicitly on the containers it wants
+# isolated: set a Bench Instance's Runtime field to `sysbox`
+# (benchpress/docker_manager.py, CONTAINER_RUNTIMES).
+#
+# Re-runnable. On a host where Sysbox is already registered it re-runs the only
+# check that proves anything — creating a container — and reports that instead.
+#
+# Two things this script will not do, because both are worse than stopping:
+#
+#   * It never runs `docker system prune -a`. `-a` deletes every image not
+#     attached to a *running* container, which on a BenchPress host includes the
+#     lab images that Draft and Stopped benches point at. That damage passes every
+#     "the site loads" check and surfaces at the next redeploy, hours later.
+#   * It never removes a container. It records what was running, and starts those
+#     again after the daemon restart.
+
+set -euo pipefail
+
+# --- What an operator sets ----------------------------------------------------
+#
+# Every one of these has a default that is right for a stock BenchPress
+# deployment. Export a different value, or edit it here, if yours differs.
+
+# The container running the BenchPress site, used only to sweep unreferenced lab
+# images before the install. `<compose project>_backend` for a compose deployment;
+# the project defaults to `benchpress`.
+BENCH_BACKEND_CONTAINER="${BENCH_BACKEND_CONTAINER:-benchpress_backend}"
+
+# The BenchPress site name. `frontend` is the invariant this repo is built on.
+SITE_NAME="${SITE_NAME:-frontend}"
+
+SYSBOX_VERSION="0.7.1"
+SYSBOX_DEB_URL=""
+MIN_FREE_MB=2048
+ASSUME_YES=0
+SKIP_RECLAIM=0
+
+usage() {
+  cat <<'USAGE'
+Usage: sudo scripts/enable-sysbox.sh [options]
+
+  --version <x.y.z>  Sysbox CE release to install (default: 0.7.1)
+  --url <url>        Full .deb URL, overriding --version
+  --min-free <mb>    Refuse to install below this free space (default: 2048)
+  --yes              Do not ask before restarting the Docker daemon
+  --skip-reclaim     Skip the disk reclamation pass
+  -h, --help         This message
+
+Environment:
+  BENCH_BACKEND_CONTAINER  Container running the BenchPress site (default: benchpress_backend)
+  SITE_NAME                BenchPress site (default: frontend)
+  DOCKER_BIP               Address for docker0 (default: 172.17.0.1/16)
+  DOCKER_POOL_BASE         Pool new Docker networks are cut from (default: 172.20.0.0/14)
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)      SYSBOX_VERSION="${2:?--version needs a value}"; shift 2 ;;
+    --url)          SYSBOX_DEB_URL="${2:?--url needs a value}"; shift 2 ;;
+    --min-free)     MIN_FREE_MB="${2:?--min-free needs a value}"; shift 2 ;;
+    --yes)          ASSUME_YES=1; shift ;;
+    --skip-reclaim) SKIP_RECLAIM=1; shift ;;
+    -h|--help)      usage; exit 0 ;;
+    *)              usage; echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+log()  { printf '[%s] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*"; }
+die()  { printf '\nERROR: %s\n' "$*" >&2; exit 1; }
+
+DAEMON_JSON=/etc/docker/daemon.json
+BACKUP=""
+
+# --- The runtime gate ---------------------------------------------------------
+#
+# `systemctl is-active sysbox` and `docker info` listing sysbox-runc are both
+# true in the failure mode this whole exercise exists to catch: a registered
+# runtime that cannot create a single container. Creating one is the only check
+# that means anything, and the uid_map is the only proof of what it created --
+# HostConfig.Runtime records what was asked for.
+
+gate() {
+  local uid_map out
+  # Keep the output. Discarding it reports a failed `alpine` pull -- a rate limit, an
+  # air-gapped host -- as a Sysbox fault, and sends the operator to an AppArmor log that
+  # will show nothing.
+  out="$(docker run --rm --runtime=sysbox-runc alpine echo ok 2>&1)" \
+    || { printf '%s\n' "${out}" >&2; return 1; }
+  uid_map="$(docker run --rm --runtime=sysbox-runc alpine cat /proc/self/uid_map 2>/dev/null)" \
+    || return 1
+  log "uid_map inside a Sysbox container: ${uid_map}"
+  [[ "$(echo "${uid_map}" | awk 'NR==1 {print $1, $2}')" != "0 0" ]] \
+    || die "Sysbox ran the container but container root is still host root (identity map). Do not treat this host as isolated."
+  log "Sysbox works: container root maps to an unprivileged host UID."
+}
+
+# --- AppArmor -----------------------------------------------------------------
+#
+# Ubuntu's fusermount3 profile allow-lists mount DESTINATIONS -- $HOME, /mnt,
+# /media, /tmp, /run/user, a few flatpak caches. Sysbox mounts its per-container
+# FUSE filesystem under /var/lib/sysboxfs/<id>/, which is not among them, so the
+# kernel refuses every Sysbox container:
+#
+#   apparmor="DENIED" operation="mount" info="failed mntpnt match" error=-13
+#     profile="fusermount3" name="/var/lib/sysboxfs/<id>/" fstype="fuse"
+#
+# Docker reports that as "failed to pre-register with sysbox-fs: rpc error", which
+# names neither FUSE nor AppArmor. It is the registered-but-broken failure exactly:
+# sysbox-runc is in `docker info` and all three units are active.
+#
+# The profile ends with `include if exists <local/fusermount3>`, so a local file is
+# the supported extension point -- no complain mode, no disabled profile. Undo by
+# deleting it and re-running apparmor_parser -r.
+
+ensure_fusermount_apparmor() {
+  local profile=/etc/apparmor.d/fusermount3
+  local override=/etc/apparmor.d/local/fusermount3
+
+  [[ -f "${profile}" ]] || return 0
+  grep -q "include if exists <local/fusermount3>" "${profile}" || {
+    log "WARNING: ${profile} has no local include; if the gate fails, that is why"
+    return 0
+  }
+  if [[ -f "${override}" ]] && grep -q "/var/lib/sysboxfs" "${override}"; then
+    log "AppArmor override for /var/lib/sysboxfs already present"
+    return 0
+  fi
+
+  log "Allowing fusermount3 to mount under /var/lib/sysboxfs (AppArmor local override)"
+  mkdir -p "$(dirname "${override}")"
+  cat >>"${override}" <<'AAEOF'
+# Sysbox mounts a FUSE filesystem per container under /var/lib/sysboxfs/<id>/.
+# Flags match the kernel's denial exactly: rw, nosuid, nodev.
+mount fstype=fuse options=(nosuid,nodev,rw) {sysboxfs,/dev/fuse} -> /var/lib/sysboxfs/**/,
+umount /var/lib/sysboxfs/**/,
+AAEOF
+  apparmor_parser -r "${profile}" \
+    || die "could not reload ${profile}. Remove ${override} and reload it by hand."
+}
+
+# --- Restart, and put back what the restart stopped ---------------------------
+#
+# Bench containers carry no restart policy, so a daemon restart stops them and
+# nothing brings them back. This records what was running, restarts, waits for the
+# daemon, and starts those again. It never removes a container: a removed bench is
+# not recoverable by starting anything.
+
+restart_docker_and_restore() {
+  local running cid name
+  running="$(docker ps --format '{{.ID}}')"
+
+  log "Restarting the Docker daemon"
+  systemctl restart docker
+
+  for _ in $(seq 30); do
+    docker info >/dev/null 2>&1 && break
+    sleep 2
+  done
+  docker info >/dev/null 2>&1 \
+    || die "the daemon did not come back. Restore the config: cp ${BACKUP:-<no backup: ${DAEMON_JSON} did not exist>} ${DAEMON_JSON} && systemctl restart docker"
+
+  for cid in ${running}; do
+    if [[ "$(docker inspect -f '{{.State.Running}}' "${cid}" 2>/dev/null)" == "false" ]]; then
+      name="$(docker inspect -f '{{.Name}}' "${cid}" 2>/dev/null | sed 's|^/||')"
+      log "Starting ${cid} again (${name})"
+      docker start "${cid}" >/dev/null || log "WARNING: ${cid} (${name}) did not start; check it by hand"
+    fi
+  done
+}
+
+# --- Preflight ----------------------------------------------------------------
+
+[[ $EUID -eq 0 ]] || die "run this with sudo; it installs a package and restarts the Docker daemon"
+[[ -d /run/systemd/system ]] || die "no systemd on this host; Sysbox ships systemd units and has no other supervisor"
+command -v docker >/dev/null || die "docker is not installed"
+docker info >/dev/null 2>&1 || die "the Docker daemon is not responding"
+
+# shellcheck disable=SC1091
+. /etc/os-release
+case "${ID:-}" in
+  ubuntu|debian) ;;
+  *) die "unsupported distro '${ID:-unknown}'; Sysbox CE ships .deb packages only" ;;
+esac
+
+ARCH="$(dpkg --print-architecture)"
+case "${ARCH}" in
+  amd64|arm64) ;;
+  *) die "unsupported architecture '${ARCH}'; Sysbox CE builds amd64 and arm64 only" ;;
+esac
+
+log "Host: ${PRETTY_NAME:-${ID}} ${ARCH}, kernel $(uname -r), systemd $(systemctl --version | head -1 | awk '{print $2}')"
+log "Docker default-runtime: $(docker info --format '{{.DefaultRuntime}}'), storage driver: $(docker info --format '{{.Driver}}')"
+
+if docker info --format '{{json .Runtimes}}' | grep -q 'sysbox-runc'; then
+  log "sysbox-runc is already registered; re-running the container gate instead of installing."
+  # A host can be registered and still blocked by the AppArmor profile, which is
+  # the whole reason this branch does not just call gate().
+  ensure_fusermount_apparmor
+  gate || die "sysbox-runc is registered but cannot create a container.
+Read both, in this order -- the first names the cause, the second only the symptom:
+  dmesg -T | grep -i 'apparmor.*DENIED'
+  journalctl -u sysbox-mgr -u sysbox-fs -n 200"
+  exit 0
+fi
+
+# --- Disk ---------------------------------------------------------------------
+#
+# Sysbox needs room, and a daemon restart is a bad moment to discover the
+# partition is full. Enumerate before deleting, and stop rather than reach for
+# the destructive flag.
+
+if [[ ${SKIP_RECLAIM} -eq 0 ]]; then
+  log "Before reclamation:"
+  df -h /
+  docker system df
+  log "Dangling images:"
+  docker images -f dangling=true --format '  {{.ID}}  {{.Size}}  {{.Repository}}:{{.Tag}}' || true
+
+  # `prune -f` is documented as dangling-only. On the containerd image store that
+  # is not always what happens: it has removed TAGGED base images that Labs still
+  # build against. Recoverable -- they re-pull -- but not free, and invisible
+  # unless someone diffs the tags. So diff them.
+  tags_before="$(mktemp)"; tags_after="$(mktemp)"
+  docker images --format '{{.Repository}}:{{.Tag}}' | grep -v '^<none>:' | sort -u >"${tags_before}"
+
+  log "Pruning stopped containers, dangling images and unused networks"
+  docker system prune -f
+
+  docker images --format '{{.Repository}}:{{.Tag}}' | grep -v '^<none>:' | sort -u >"${tags_after}"
+  if ! comm -23 "${tags_before}" "${tags_after}" | grep -q .; then
+    log "No tagged image was removed by the prune"
+  else
+    log "WARNING: the prune removed these TAGGED images; re-pull any you still need:"
+    comm -23 "${tags_before}" "${tags_after}" | sed 's/^/  docker pull /'
+  fi
+  rm -f "${tags_before}" "${tags_after}"
+
+  # Lab images no Lab row still points at. The app knows which those are; docker
+  # does not, which is exactly why `prune -a` is the wrong tool here.
+  if docker inspect -f '{{.State.Running}}' "${BENCH_BACKEND_CONTAINER}" 2>/dev/null | grep -qx true; then
+    log "Sweeping unreferenced lab images through ${BENCH_BACKEND_CONTAINER}"
+    docker exec "${BENCH_BACKEND_CONTAINER}" \
+      bench --site "${SITE_NAME}" execute benchpress.image_cache.sweep_cached_images || true
+  else
+    log "${BENCH_BACKEND_CONTAINER} is not running; skipping the lab image sweep"
+  fi
+
+  log "After reclamation:"
+  df -h /
+fi
+
+FREE_MB="$(df -Pm / | awk 'NR==2 {print $4}')"
+if (( FREE_MB < MIN_FREE_MB )); then
+  cat >&2 <<EOF
+
+Only ${FREE_MB} MB free on /, below the ${MIN_FREE_MB} MB this script insists on.
+
+Images \`docker system prune -a\` would delete, which this script will not run:
+
+$(docker images --format '  {{.Repository}}:{{.Tag}}  {{.Size}}' | sort)
+
+Some of those are lab images that Draft and Stopped benches still point at.
+Decide against the Lab and Bench Instance tables first, delete by tag, then
+re-run. Unused volumes are left alone too: they may still hold bench data.
+EOF
+  exit 1
+fi
+
+# --- Download -----------------------------------------------------------------
+
+DEB_URL="${SYSBOX_DEB_URL:-https://downloads.nestybox.com/sysbox/releases/v${SYSBOX_VERSION}/sysbox-ce_${SYSBOX_VERSION}-0.linux_${ARCH}.deb}"
+
+if [[ ${ASSUME_YES} -eq 0 ]]; then
+  cat <<EOF
+
+About to install Sysbox CE from:
+  ${DEB_URL}
+
+and restart the Docker daemon. Containers without a restart policy stop when the
+daemon does; this script starts the ones that were running again afterwards, and
+removes nothing. The bench containers running right now:
+
+$(docker ps --filter label=benchpress.managed=true --format '  {{.Names}}  {{.Image}}  {{.Status}}')
+
+EOF
+  read -r -p "Proceed? [y/N] " reply
+  [[ "${reply}" =~ ^[Yy]$ ]] || die "aborted"
+fi
+
+TMPDIR_DEB="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR_DEB}"' EXIT
+DEB_PATH="${TMPDIR_DEB}/sysbox-ce.deb"
+
+log "Downloading ${DEB_URL}"
+curl -fsSL -o "${DEB_PATH}" "${DEB_URL}" \
+  || die "download failed. Check the release exists: https://github.com/nestybox/sysbox/releases"
+
+# --- Docker network pre-configuration -----------------------------------------
+#
+# The .deb's debconf `config` script REFUSES to install — exit 1, nothing done —
+# when Docker is running, has containers, and daemon.json lacks BOTH `bip` and
+# `default-address-pools`. It wants to restart the daemon to set them and will not
+# do that under live containers. Setting them here first means its
+# docker_restart_required() returns false, so `postinst` adds only the runtime and
+# reloads with SIGHUP instead of restarting: the bench containers are never
+# touched by the installer, and the one restart that happens is this script's.
+#
+# It greps rather than parses: `^[ ]+"bip": "[0-9.]+.*"`. The file must be written
+# indented — json.dumps(indent=2) satisfies it, compact JSON does not.
+#
+# CHECK THE POOL AGAINST YOUR OWN NETWORK BEFORE RUNNING THIS. Docker cuts every
+# network it creates from here on out of DOCKER_POOL_BASE, and a pool that
+# overlaps something the host must reach blackholes it. The defaults avoid:
+#   172.17.0.0/16   docker0 itself; `bip` only makes the existing value explicit
+#   172.30.0.0/24   the lab network (benchpress/docker_manager.py, ensure_network)
+# They do NOT know about your VPC, your LAN, your VPN, or the compose network of
+# whatever orchestrates this host. Compare with `ip route` first, and override
+# DOCKER_POOL_BASE if 172.20.0.0/14 (172.20.x - 172.23.x) collides.
+#
+# `features.time-namespaces: false` goes in the same write. Docker 29.5.0 made
+# private time namespaces the container default (moby/moby#52326) and sysbox-runc
+# does not implement that namespace, so without it every Sysbox container dies
+# with `namespace {"time" ""} does not exist`. Upgrading Sysbox does not help.
+#
+# `default-runtime` is only ever set if absent, and only to runc. Flipping it
+# would change every container on this host, not only BenchPress's.
+
+DOCKER_BIP="${DOCKER_BIP:-172.17.0.1/16}"
+DOCKER_POOL_BASE="${DOCKER_POOL_BASE:-172.20.0.0/14}"
+
+mkdir -p /etc/docker
+if [[ -f "${DAEMON_JSON}" ]]; then
+  BACKUP="${DAEMON_JSON}.$(date -u +%Y%m%dT%H%M%SZ).bak"
+  cp -a "${DAEMON_JSON}" "${BACKUP}"
+  log "Backed up ${DAEMON_JSON} to ${BACKUP}"
+fi
+
+log "Pre-configuring ${DAEMON_JSON} so the installer does not need its own restart"
+python3 - "${DAEMON_JSON}" "${DOCKER_BIP}" "${DOCKER_POOL_BASE}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path, bip, pool_base = Path(sys.argv[1]), sys.argv[2], sys.argv[3]
+config = json.loads(path.read_text()) if path.exists() else {}
+config.setdefault("bip", bip)
+config.setdefault("default-address-pools", [{"base": pool_base, "size": 24}])
+config.setdefault("default-runtime", "runc")
+config.setdefault("features", {})["time-namespaces"] = False
+path.write_text(json.dumps(config, indent=2) + "\n")
+print(json.dumps(config, indent=2))
+PY
+
+restart_docker_and_restore
+
+# --- Install ------------------------------------------------------------------
+
+log "Installing"
+DEBIAN_FRONTEND=noninteractive apt-get install -y "${DEB_PATH}"
+
+command -v sysbox-runc >/dev/null || die "the package installed but sysbox-runc is not on PATH"
+SYSBOX_BIN="$(command -v sysbox-runc)"
+log "sysbox-runc at ${SYSBOX_BIN}: $(sysbox-runc --version | head -1)"
+
+# postinst adds the runtime itself and SIGHUPs dockerd. Assert it rather than
+# assume it: a runtime the daemon has not picked up fails the gate below with a
+# message about the runtime, not about the reload.
+if ! docker info --format '{{json .Runtimes}}' | grep -q 'sysbox-runc'; then
+  log "the installer did not register sysbox-runc with the running daemon; adding it and restarting"
+  python3 - "${DAEMON_JSON}" "${SYSBOX_BIN}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path, sysbox_bin = Path(sys.argv[1]), sys.argv[2]
+config = json.loads(path.read_text())
+config.setdefault("runtimes", {})["sysbox-runc"] = {"path": sysbox_bin}
+path.write_text(json.dumps(config, indent=2) + "\n")
+PY
+  restart_docker_and_restore
+fi
+
+ensure_fusermount_apparmor
+
+# --- Verdict ------------------------------------------------------------------
+
+log "default-runtime is now: $(docker info --format '{{.DefaultRuntime}}')"
+gate || die "sysbox-runc is registered but cannot create a container -- the exact failure this gate exists for.
+Nothing else on the host changed; runc is still the default, and every container is untouched.
+Read both, in this order -- the first names the cause, the second only the symptom:
+  dmesg -T | grep -i 'apparmor.*DENIED'
+  journalctl -u sysbox-mgr -u sysbox-fs -n 200"
+
+log "Done. Set a Bench Instance's Runtime field to 'sysbox' to use it."

--- a/scripts/tune-host.sh
+++ b/scripts/tune-host.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+#
+# scripts/tune-host.sh — raise this host's kernel ceilings to what a dense bench
+# fleet needs, and prove afterwards that the raise took.
+#
+# Every ceiling a bench fleet runs into is host-wide: one pty pool, one pid space,
+# one neighbour table, one conntrack table. Left at whatever the machine image
+# shipped, the platform's real limit is a number nobody chose. This writes the
+# knobs measured below target into a single drop-in, states the arithmetic beside
+# each value, and leaves the rest to whatever set them.
+#
+# BenchPress cannot do this from inside its own container: /proc/sys belongs to
+# the host, and the three knobs the Diagnostics page reads are read-only there.
+# The `kernel_ceilings` row reports the gap; this script is what closes it.
+#
+#   sudo scripts/tune-host.sh                        # confirm, then do it
+#   sudo scripts/tune-host.sh --yes                  # unattended
+#   sudo scripts/tune-host.sh --benches 2000 --yes   # size for a bigger fleet
+#
+# Re-runnable. A second run with the same arguments renders the same file, applies
+# it again, and reports the same values.
+#
+# Undo: remove /etc/sysctl.d/99-benchpress-density.conf and run `sysctl --system`.
+# Every value returns to whatever the machine image set. Nothing else on the host
+# is touched — no daemon restarted, no unit installed, no container stopped.
+#
+# What this script will not do:
+#
+#   * It never writes kernel.threads-max. That is sized from RAM at boot, and
+#     raising it past what memory supports converts a clean refusal into an OOM
+#     kill. It is reported, with the bench count it implies, and left alone.
+#   * It never trusts the file it just wrote. `sysctl --system` exits 0 when the
+#     files parse, not when the values take: /etc/sysctl.d is read in lexical
+#     order and the last writer of a key wins, so any drop-in sorting after ours
+#     and naming one of these knobs silently overrides it. The gate below re-reads
+#     /proc/sys and names the file that won.
+
+set -euo pipefail
+
+SYSCTL_CONF=/etc/sysctl.d/99-benchpress-density.conf
+
+# Defaults, and where they come from. Both match `benchpress/placement.py`
+# (DEFAULT_SLOTS_PER_BRIDGE, DEFAULT_BRIDGE_COUNT), which is also what
+# `benchpress/diagnostics.py` sizes the `kernel_ceilings` row against. Change the
+# BenchPress Settings fields and this host's sizing disagrees with the report
+# until you pass the same number here.
+BENCHES=1000
+BRIDGES=16
+
+# The per-bench costs every target below is built from. Each one is a constant in
+# the app, not a guess:
+#   TERMINALS_PER_BENCH, PTY_ROOT_RESERVE, CONNTRACK_PER_BENCH  benchpress/diagnostics.py
+#   BENCH_PIDS_LIMIT (DEFAULT_PIDS_LIMIT)                       benchpress/docker_manager.py
+#   BRIDGE_DEVICE_PREFIX                                        benchpress/placement.py
+TERMINALS_PER_BENCH=8
+PTY_ROOT_RESERVE=1024
+BENCH_PIDS_LIMIT=500
+FILES_PER_BENCH=1024
+HOST_FILE_RESERVE=65536
+CONNTRACK_PER_BENCH=256
+SYN_BACKLOG_PER_BENCH=8
+BRIDGE_DEVICE_PREFIX=bpbr
+
+# A 64-bit kernel refuses anything larger, so the arithmetic stops here.
+PID_MAX_KERNEL_CEILING=4194304
+
+ASSUME_YES=0
+
+usage() {
+  cat <<USAGE
+Usage: sudo scripts/tune-host.sh [options]
+
+  --benches <n>  Bench count every value is sized against (default: ${BENCHES})
+  --bridges <n>  Bench bridges to enable proxy ARP on (default: ${BRIDGES})
+  --yes          Do not ask before writing ${SYSCTL_CONF}
+  -h, --help     This message
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --benches) BENCHES="${2:?--benches needs a value}"; shift 2 ;;
+    --bridges) BRIDGES="${2:?--bridges needs a value}"; shift 2 ;;
+    --yes)     ASSUME_YES=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *)         usage; echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+log() { printf '[%s] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*"; }
+die() { printf '\nERROR: %s\n' "$*" >&2; exit 1; }
+
+[[ "${BENCHES}" =~ ^[0-9]+$ && "${BENCHES}" -gt 0 ]] || die "--benches must be a positive integer"
+[[ "${BRIDGES}" =~ ^[0-9]+$ && "${BRIDGES}" -gt 0 ]] || die "--bridges must be a positive integer"
+[[ $EUID -eq 0 ]] || die "run this with sudo; it writes ${SYSCTL_CONF} and changes kernel limits for everything on this host"
+command -v sysctl >/dev/null || die "sysctl is not on PATH"
+
+# --- The knob table -----------------------------------------------------------
+#
+# One input — the bench count — decides every target, and the arithmetic behind
+# each one is written into the drop-in as the comment above the knob.
+
+KNOBS=(
+  kernel.pty.max
+  kernel.pid_max
+  fs.file-max
+  fs.nr_open
+  net.netfilter.nf_conntrack_max
+  net.ipv4.neigh.default.gc_thresh1
+  net.ipv4.neigh.default.gc_thresh2
+  net.ipv4.neigh.default.gc_thresh3
+  net.core.netdev_max_backlog
+  net.ipv4.tcp_max_syn_backlog
+)
+
+declare -A TARGET WHY
+
+build_knob_table() {
+  local pid_max gc2
+  pid_max=$(( BENCHES * BENCH_PIDS_LIMIT ))
+  (( pid_max > PID_MAX_KERNEL_CEILING )) && pid_max=${PID_MAX_KERNEL_CEILING}
+  gc2=$(( BENCHES * 2 )); (( gc2 < 8192 )) && gc2=8192
+
+  TARGET[kernel.pty.max]=$(( BENCHES * TERMINALS_PER_BENCH + PTY_ROOT_RESERVE ))
+  WHY[kernel.pty.max]="${TERMINALS_PER_BENCH} terminals per bench (code-server and ssh) x ${BENCHES} benches
+# + ${PTY_ROOT_RESERVE} held back for root by kernel.pty.reserve"
+
+  TARGET[kernel.pid_max]=${pid_max}
+  WHY[kernel.pid_max]="${BENCH_PIDS_LIMIT} pids per bench x ${BENCHES} benches, capped at the kernel's own
+# ${PID_MAX_KERNEL_CEILING}"
+
+  TARGET[fs.file-max]=$(( BENCHES * FILES_PER_BENCH + HOST_FILE_RESERVE ))
+  WHY[fs.file-max]="${FILES_PER_BENCH} open files per bench x ${BENCHES} benches
+# + ${HOST_FILE_RESERVE} for the host itself"
+
+  TARGET[fs.nr_open]=1048576
+  WHY[fs.nr_open]="Per process, so it does not scale with the bench count: it is the ceiling
+# fs.file-max is shared out under"
+
+  TARGET[net.netfilter.nf_conntrack_max]=$(( BENCHES * CONNTRACK_PER_BENCH ))
+  WHY[net.netfilter.nf_conntrack_max]="${CONNTRACK_PER_BENCH} tracked flows per bench x ${BENCHES} benches"
+
+  TARGET[net.ipv4.neigh.default.gc_thresh1]=4096
+  WHY[net.ipv4.neigh.default.gc_thresh1]="A floor, not a ceiling: below it the kernel never garbage-collects. Under the
+# working set it evicts entries it is about to need, which reads as intermittent
+# packet loss between containers"
+
+  TARGET[net.ipv4.neigh.default.gc_thresh2]=${gc2}
+  WHY[net.ipv4.neigh.default.gc_thresh2]="2 neighbour entries per bench (its own address and the gateway it holds)
+# x ${BENCHES} benches, floor 8192"
+
+  TARGET[net.ipv4.neigh.default.gc_thresh3]=$(( gc2 * 2 ))
+  WHY[net.ipv4.neigh.default.gc_thresh3]="Twice the soft threshold, so a burst has room before the kernel drops"
+
+  TARGET[net.core.netdev_max_backlog]=16384
+  WHY[net.core.netdev_max_backlog]="One broadcast on a full 1024-port bridge is 1024 packets, and the bridge count
+# rather than the bench count is what fills this queue. At the stock 1000 a single
+# ARP round overflows it"
+
+  TARGET[net.ipv4.tcp_max_syn_backlog]=$(( BENCHES * SYN_BACKLOG_PER_BENCH ))
+  (( TARGET[net.ipv4.tcp_max_syn_backlog] < 8192 )) && TARGET[net.ipv4.tcp_max_syn_backlog]=8192
+  WHY[net.ipv4.tcp_max_syn_backlog]="${SYN_BACKLOG_PER_BENCH} half-open connections per bench x ${BENCHES} benches
+# arriving at one proxy, floor 8192"
+}
+
+# A knob's running value straight from /proc/sys, or the empty string when this
+# kernel does not have it. Never read back from the file we wrote: a file under
+# /etc/sysctl.d is a request, not a value.
+read_knob() {
+  local path="/proc/sys/${1//.//}"
+  [[ -r "${path}" ]] || return 0
+  awk 'NR==1 {print $1}' "${path}" 2>/dev/null || true
+}
+
+proxy_arp_key() { printf 'net.ipv4.conf.%s%s.proxy_arp' "${BRIDGE_DEVICE_PREFIX}" "$1"; }
+
+# One line per knob: verdict, name, running value, target. Writes the names of the
+# knobs still below target to $1 so the caller can act on them.
+report() {
+  local low_file="${1:-/dev/null}" name running verdict threads ceiling
+  : >"${low_file}"
+
+  for name in "${KNOBS[@]}"; do
+    running="$(read_knob "${name}")"
+    if [[ -n "${running}" ]] && (( running >= TARGET[$name] )); then
+      verdict="ok "
+    else
+      verdict="LOW"
+      echo "${name}" >>"${low_file}"
+    fi
+    printf '  %s  %-38s%12s   target %s\n' \
+      "${verdict}" "${name}" "${running:--}" "${TARGET[$name]}"
+  done
+
+  local index
+  for (( index = 0; index < BRIDGES; index++ )); do
+    name="$(proxy_arp_key "${index}")"
+    running="$(read_knob "${name}")"
+    # The bridge does not exist yet, and the family is lazy on purpose.
+    [[ -n "${running}" ]] || continue
+    if [[ "${running}" == "1" ]]; then
+      verdict="ok "
+    else
+      verdict="LOW"
+      echo "${name}" >>"${low_file}"
+    fi
+    printf '  %s  %-38s%12s   target 1\n' "${verdict}" "${name}" "${running}"
+  done
+
+  # Reported, never raised. The quotient is the number an operator needs from it.
+  threads="$(read_knob kernel.threads-max)"
+  ceiling='-'
+  [[ -n "${threads}" ]] && ceiling=$(( threads / BENCH_PIDS_LIMIT ))
+  printf '      %-38s%12s   about %s benches at %s pids each, reported and never raised\n' \
+    "kernel.threads-max" "${threads:--}" "${ceiling}" "${BENCH_PIDS_LIMIT}"
+}
+
+# --- Before -------------------------------------------------------------------
+
+build_knob_table
+
+BEFORE_LOW="$(mktemp)"
+AFTER_LOW="$(mktemp)"
+trap 'rm -f "${BEFORE_LOW}" "${AFTER_LOW}"' EXIT
+
+log "Sizing for ${BENCHES} benches across ${BRIDGES} bridges. Running values now:"
+report "${BEFORE_LOW}"
+
+if [[ ${ASSUME_YES} -eq 0 ]]; then
+  cat <<EOF
+
+About to write ${SYSCTL_CONF} with the knobs above marked LOW, and apply it with
+\`sysctl --system\`. Nothing is restarted and no container is touched.
+
+Undo: rm ${SYSCTL_CONF} && sysctl --system
+
+EOF
+  read -r -p "Proceed? [y/N] " reply
+  [[ "${reply}" =~ ^[Yy]$ ]] || die "aborted"
+fi
+
+# --- Write --------------------------------------------------------------------
+#
+# Backed up unconditionally when it exists, so a re-run with different --benches
+# leaves the previous sizing recoverable by file rather than by memory.
+
+if [[ -f "${SYSCTL_CONF}" ]]; then
+  BACKUP="${SYSCTL_CONF}.$(date -u +%Y%m%dT%H%M%SZ).bak"
+  cp -a "${SYSCTL_CONF}" "${BACKUP}"
+  log "Backed up ${SYSCTL_CONF} to ${BACKUP}"
+fi
+
+log "Rendering ${SYSCTL_CONF}"
+mkdir -p "$(dirname "${SYSCTL_CONF}")"
+
+{
+  echo "# GENERATED by scripts/tune-host.sh for ${BENCHES} benches across ${BRIDGES} bridges."
+  echo "# Do not edit: re-run \`sudo scripts/tune-host.sh\` instead."
+  echo "#"
+  echo "# Only knobs measured below target are here. Anything absent was already at or"
+  echo "# above it and is left to whatever set it."
+  echo "#"
+  echo "# Undo: remove this file and run \`sysctl --system\`. Every value returns to"
+  echo "# whatever the machine image set."
+} >"${SYSCTL_CONF}"
+
+WRITTEN=0
+while read -r name; do
+  # A knob this kernel does not have is skipped rather than written: `sysctl
+  # --system` fails on an unknown key, and the gate below reports the absence.
+  [[ -n "$(read_knob "${name}")" ]] || continue
+  [[ -n "${TARGET[$name]:-}" ]] || continue
+  printf '\n# %s\n%s = %s\n' "${WHY[$name]}" "${name}" "${TARGET[$name]}" >>"${SYSCTL_CONF}"
+  WRITTEN=$(( WRITTEN + 1 ))
+done <"${BEFORE_LOW}"
+
+{
+  echo
+  echo "# Each bridge answers ARP for its own ports instead of flooding all of them, which is"
+  echo "# the O(N^2) storm a full bridge otherwise produces."
+  echo "#"
+  echo "# The \`-\` prefix means apply if the device exists and do not fail otherwise. Bench"
+  echo "# bridges are created lazily, so most of these do not exist at boot; udev's"
+  echo "# 99-systemd.rules re-runs systemd-sysctl against net.ipv4.conf.<name> when one is"
+  echo "# added, so a bridge created months from now still gets this."
+} >>"${SYSCTL_CONF}"
+
+for (( index = 0; index < BRIDGES; index++ )); do
+  echo "-$(proxy_arp_key "${index}") = 1" >>"${SYSCTL_CONF}"
+done
+
+log "  ${WRITTEN} sysctl knobs written, plus proxy ARP for ${BRIDGES} bridges"
+
+log "Applying"
+sysctl --system
+
+# --- The gate -----------------------------------------------------------------
+#
+# Re-read /proc/sys. The apply exiting 0 says the files parsed, not that the
+# values took.
+
+log "Running values after the apply:"
+report "${AFTER_LOW}"
+
+if [[ -s "${AFTER_LOW}" ]]; then
+  echo
+  echo "These knobs are still below target after a successful apply." >&2
+  echo "Other files under /etc/sysctl.d naming them, if any:" >&2
+  while read -r name; do
+    others="$(grep -l -F -- "${name}" /etc/sysctl.conf /etc/sysctl.d/*.conf 2>/dev/null \
+              | grep -vF "${SYSCTL_CONF}" || true)"
+    printf '  %s: %s\n' "${name}" "${others:-none — the kernel refused the value or the knob is not present}" >&2
+  done <"${AFTER_LOW}"
+  die "the host is not at target; nothing was rolled back, and ${SYSCTL_CONF} is safe to remove"
+fi
+
+log "Every knob is at or above target. Bench containers pick the new limits up on their next start."

--- a/setup.sh
+++ b/setup.sh
@@ -9,8 +9,9 @@
 # Example:
 #   bash apps/benchpress/setup.sh sponge.localhost
 #
-# --strict: exit non-zero if Docker userns-remap is absent or unverifiable
-# (production hosts); default is warn-and-continue (dev hosts).
+# --strict: exit non-zero if the container-root privilege boundary is absent or
+# unverifiable (production hosts); default is warn-and-continue (dev hosts).
+# The boundary is a registered sysbox-runc runtime, or Docker userns-remap.
 #
 # VPN note: tunnels, peers and IP allocation are owned by the vpn_management
 # app (wg-agent + VPN Peer / Network Pool DocTypes). This script only prepares
@@ -103,20 +104,33 @@ fi
 
 echo ""
 
-# --- Step 2: Docker user-namespace remap (container-root != host-root) ---
+# --- Step 2: Privilege boundary (container-root != host-root) ---
+#
+# Two configurations close it, and either one is enough. sysbox-runc gives each
+# container its own user namespace, so it needs no daemon-wide setting; that is
+# why it is checked first and why it is the recommended option. The runtime name
+# is the one benchpress/docker_manager.py registers in CONTAINER_RUNTIMES and
+# benchpress/diagnostics.py looks for in `docker info` — read it the same way.
 
-info "Step 2/4: Docker userns-remap"
+info "Step 2/4: Privilege boundary"
 if ! docker info &>/dev/null; then
-    MSG="Cannot verify userns-remap — docker socket not accessible (re-login, then re-run)"
+    MSG="Cannot verify the privilege boundary — docker socket not accessible (re-login, then re-run)"
     [ "$STRICT" -eq 1 ] && error "$MSG" || warn "$MSG"
+elif docker info --format '{{range $name, $runtime := .Runtimes}}{{println $name}}{{end}}' | grep -qx 'sysbox-runc'; then
+    success "sysbox-runc is registered with Docker — a bench on the sysbox runtime has its own user namespace"
+    if [ "$(docker info --format '{{.DefaultRuntime}}')" != "sysbox-runc" ]; then
+        warn "Registered, not default: a Bench Instance left on the 'runc' runtime still gets host root."
+        warn "The Runtime field has no default, so set it to 'sysbox' on every lab that matters."
+    fi
 elif docker info --format '{{join .SecurityOptions ","}}' | grep -qE 'name=(userns|rootless)'; then
     success "Docker userns-remap (or rootless) is enabled — container root is unprivileged on the host"
 else
-    warn "Docker userns-remap is NOT enabled — in-container root maps to HOST root"
-    warn "Lab users get container root; without remap that is one kernel bug from host root."
-    warn "Enable it: add {\"userns-remap\": \"default\"} to /etc/docker/daemon.json, restart docker."
+    warn "No privilege boundary — in-container root maps to HOST root"
+    warn "Lab users get container root; without sysbox or remap that is one kernel bug from host root."
+    warn "Install sysbox: sudo apps/benchpress/scripts/enable-sysbox.sh (upstream: https://github.com/nestybox/sysbox)"
+    warn "Or enable remap: add {\"userns-remap\": \"default\"} to /etc/docker/daemon.json, restart docker."
     warn "Details and migration caveats: apps/benchpress/docs/operator/wireguard-setup.mdx, section 'Container root is not host root'"
-    [ "$STRICT" -eq 1 ] && error "--strict: refusing to continue without userns-remap"
+    [ "$STRICT" -eq 1 ] && error "--strict: refusing to continue without sysbox-runc or userns-remap"
 fi
 
 echo ""


### PR DESCRIPTION
Closes the launch-readiness audit findings that are fixable in code and docs.

## What was broken

A stranger could not install BenchPress by following the documentation, and several
public surfaces described a product that does not exist.

- **The documented install failed on step 1.** `install.mdx` omitted `--resolve-deps`, so
  `vpn_management` was never cloned and `install-app` died with a bare
  `InvalidRemoteException`.
- **`setup.sh --strict` refused on the recommended runtime.** It tested only for
  userns-remap or rootless, never sysbox, and passed silently when sysbox was registered
  but not the default runtime — a lab user on `runc` still holds host root.
- **The Verify step could not pass.** It named a `docker-events` service and a
  `tune-host.sh` that lived only in a private orchestration repo.
- **Diagnostics passed on a host where no public URL could answer.** `base_domain` is
  required, so the documented install advertises a public hostname, then the publish path
  raises `TraefikRouteDirectoryMissing` inside the job. None of the eleven checks looked at
  the route directory.
- **The landing page advertised an API that does not exist** — `POST
  /api/method/benchpress.deploy`, scoped API keys with credit ceilings and TTLs, a registry
  image pull, and `bench build --production` during deploy, which `lifecycle.py:418-420`
  explicitly does not do. It claimed benches are reachable only over the VPN (false once
  `base_domain` is set) and rendered the hosted CTA, credit ledger and waitlist while
  `enable_credits` was 0.
- **Documents disagreed with the code and each other.** Four answers about the trunk
  branch; 50 endpoints documented against 52; a "124-test suite" against 1,231; three
  disagreeing version strings and a generated agent card advertising 1.0.0, a version this
  app has never shipped.

## What changed

Nine commits, grouped by concern. Notable beyond the list above:

- Workers now record the Traefik route directory state and a twelfth diagnostics check
  reads it. The check runs in `backend`, which never mounts that directory, so it reads a
  worker's report rather than the filesystem.
- `tune-host.sh` and `enable-sysbox.sh` are vendored with host- and account-specific values
  replaced by documented variables.
- `agentCard.version` is now read from `package.json`; leadtype defaults it to 1.0.0 and
  never read the package.
- vitest runs in CI, `linter.yml` gets a push trigger so the badge has a default-branch run,
  and the paths filter matches `.mdx` instead of `.md`.

## What was verified, and how

- `bench run-tests --app benchpress` — **938 tests**. Two failures in `test_waitlist`
  (`['Wiki User', 'BenchPress User'] != ['BenchPress User']`) are **pre-existing and
  environment-caused**: the `wiki` app is installed on this site and grants the extra role.
  Proven by stashing the whole branch and re-running on a clean `version-16` tree, where the
  same two fail identically. Neither file is in this diff.
- `vitest run` — 13 files, **191 passed**.
- `pre-commit run --all-files` — all hooks pass.
- `leadtype lint --max-warnings 0` — 41 files pass. `leadtype score --min 100` passes.
  Generated output regenerated and committed so the CI drift check is current.
- Every count now stated in prose was re-derived from the code before it was written.

## What remains open

These are not fixable in a PR and are listed so they are not mistaken for done:

- **Publishing the docs is manual and unwired.** `docs.benchpress.cloud` is live and serves
  the documentation through the Frappe `wiki` app, so the audit's "no published host" finding
  was wrong. But nothing syncs this repo's `docs/` to it: the live install page still lacks
  `--resolve-deps`, so none of the corrections in this PR reach a reader until someone
  republishes. No workflow does that.
- **There is still no trial path** — no hosted demo, no published image, no sandbox. A
  reader must provision a Linux host with an existing v16 bench.
- **The CLA has no bot.** Two documents promise one; adding a working action needs a
  maintainer-held secret, and a permanently-failing check would be worse than none.
- **The Playwright suite still does not run in CI.** It needs a live site, and it has a
  `test.fixme` and a self-skip on an empty host. CONTRIBUTING now says so rather than
  claiming otherwise.
- **`site/index.html`** shows `$ benchpress deploy crm-lab`, a CLI that does not exist, and
  badges BETA against the docs' alpha. Deliberately out of scope here; blocking only when
  that page is published.
- **The golden-image numbers have no committed run output.** The harness exists; no
  artifact does, and no second host has been measured.
- **The screenshot on `diagnostics.mdx` predates the twelfth check** and needs refreshing.
