### PR TITLE
fix(ingress): report the missing route mount, and stop advertising a dead URL

### DIFF
--- a/benchpress/diagnostics.py
+++ b/benchpress/diagnostics.py
@@ -31,12 +31,17 @@ from benchpress.mariadb_manager import (
 from benchpress.vpn_adapter import DEFAULT_INTERFACE
 
 DRIFT_FIX = "Recreate the shared pair: docker compose up -d in benchpress/config"
-# What refreshes the route-directory report. Named in every row that has none to read, because a
-# row that says only "no report" leaves the reader with nothing to start it.
-ROUTE_STATE_FIX = "the scheduler and queue-long refresh it every reconcile pass, so check both"
+# What writes the route-directory report. Named in every row that has none to read, because a row
+# that says only "no report" leaves the reader with nothing to start it. Only the paths that reach
+# routing write it, and a reconcile pass on a host with no route mount is not one of them:
+# `reconcile._converge_routes` returns before `ingress.ensure_anchor`, the call that records.
+ROUTE_STATE_WRITERS = (
+	"every deploy and every bench start or stop records it, as does each reconcile pass that "
+	"finds the directory mounted"
+)
 ROUTE_STATE_UNREPORTED = (
-	"No worker has reported on the Traefik route directory yet. The first deploy records it, and "
-	f"so does every reconcile pass — until one does, no public URL is verified: {ROUTE_STATE_FIX}"
+	"No worker has reported on the Traefik route directory yet, so no public URL is verified: "
+	f"{ROUTE_STATE_WRITERS}"
 )
 # A row that says a listener is dead without naming what restarts it costs the reader a search.
 LISTENER_FIX = "start it with docker compose up -d docker-events"
@@ -361,7 +366,7 @@ def _check_route_directory() -> dict:
 				"route_directory",
 				False,
 				f"The route directory was last reported on {state['age']}s ago, past the "
-				f"{ingress.ROUTE_STATE_STALE_SECONDS}s it is given — {ROUTE_STATE_FIX}",
+				f"{ingress.ROUTE_STATE_STALE_SECONDS}s it is given — {ROUTE_STATE_WRITERS}",
 				severity="Warning",
 			)
 
@@ -391,12 +396,14 @@ def _check_route_directory() -> dict:
 			return check_row(
 				"route_directory",
 				True,
-				"Route directory mounted and rendered, no bench route published yet — the first "
-				f"deploy writes {ingress.WILDCARD_ANCHOR_FILE}",
+				"Route directory mounted and rendered, no bench route published yet — the next "
+				f"deploy or reconcile pass writes {ingress.WILDCARD_ANCHOR_FILE}",
 			)
-		# Warning, not Error: every deploy and every reconcile pass writes the anchor, so this is a
-		# state that heals itself. Still worth a row, because until it does each of those published
-		# hostnames answers on a certificate the browser refuses.
+		# Warning, not Error: this branch needs `mounted`, and on a mounted host every deploy and
+		# every reconcile pass writes the anchor, so the state heals itself. `ensure_anchor`
+		# records before it writes, so an anchor-missing report is normally one pass behind a
+		# directory that already has one. Still worth a row, because until it heals each of those
+		# published hostnames answers on a certificate the browser refuses.
 		return check_row(
 			"route_directory",
 			False,

--- a/benchpress/ingress.py
+++ b/benchpress/ingress.py
@@ -93,8 +93,10 @@ INFLIGHT_CEILING = 24
 # in a web request, cannot stat it and reads what a worker last saw instead. Same shape as the
 # heartbeat `docker_events` publishes for a listener the web process cannot see either.
 ROUTE_STATE_KEY = "benchpress:route_directory"
-# The reconcile pass (hooks.py, `*/5`) refreshes this, so three missed passes are what it takes to
-# stop believing it. It outlives that so a stale record can still name its own age.
+# Written by every deploy, every bench start or stop, and every reconcile pass (hooks.py, `*/5`)
+# that finds the directory mounted. The scheduler tick is four minutes, so a `*/5` entry fires
+# every four to eight and 15 minutes is two missed passes on a host that reconciles. The key
+# outlives that so a stale record can still name its own age.
 ROUTE_STATE_STALE_SECONDS = 15 * 60
 ROUTE_STATE_EXPIRY = ROUTE_STATE_STALE_SECONDS * 2
 
@@ -384,7 +386,9 @@ def record_directory_state() -> dict:
 
 def directory_state() -> dict | None:
 	"""What the last worker to reach routing saw, plus its `age`, or None when none has."""
-	state = frappe.cache().get_value(ROUTE_STATE_KEY)
+	# `expires=True`: core memoises a non-expiring read into `frappe.local.cache`, misses
+	# included, and this key has a TTL the memo would outlive in a long-lived process.
+	state = frappe.cache().get_value(ROUTE_STATE_KEY, expires=True)
 	if not state:
 		return None
 	return {**state, "age": int(time.time()) - cint(state.get("ts"))}
@@ -401,8 +405,10 @@ def ensure_anchor(base_domain: str | None) -> bool:
 
 	# Same gate as `publish`, and for the same reason: this runs at the first step of every
 	# deploy, so a raise here fails the run before any bench work starts. Recorded rather than
-	# only tested, because this is the one call every deploy makes and the reconcile pass makes
-	# every five minutes — it is what keeps the `route_directory` diagnostics row current.
+	# only tested, because this is the one call every deploy makes, and the one the reconcile
+	# pass makes on a host that mounts the directory — it is what keeps the `route_directory`
+	# diagnostics row current there. A host with no mount is reported by a deploy or a lifecycle
+	# transition only: `_converge_routes` returns before this call.
 	if not record_directory_state()["mounted"]:
 		return False
 

--- a/benchpress/lifecycle.py
+++ b/benchpress/lifecycle.py
@@ -377,8 +377,12 @@ def _deploy_bench(bench_name: str, size_name: str | None = None, deploy_log: str
 		bench.save(ignore_permissions=True)
 		frappe.db.commit()  # nosemgrep -- the address the route file is written from
 
-		bench.public_url = addressing.public_site_url(bench.name, settings.base_domain)
-		ingress.publish(bench.name, settings.base_domain)
+		# Only claim the public address once a route file backs it. `publish` returns whether it
+		# wrote one; discarding that persisted an https URL on every deploy, including on a worker
+		# with no route mount, where nothing can ever answer it. `launch` and the Lab screen both
+		# prefer `public_url` over the tunnel address, so a dead one suppresses a working one.
+		if ingress.publish(bench.name, settings.base_domain):
+			bench.public_url = addressing.public_site_url(bench.name, settings.base_domain)
 		ingress.log_certificate_state(bench.name, settings.base_domain, pipeline)
 
 		_setup_container_vpn(bench, container_id, pipeline)

--- a/benchpress/reconcile.py
+++ b/benchpress/reconcile.py
@@ -106,9 +106,13 @@ def _converge_routes() -> dict:
 		# A dev checkout has no route directory and must stay byte-for-byte unaffected.
 		return {"anchored": False, "written": 0, "deleted": 0, "kept": 0}
 
-	if not ingress.directory_mounted():
-		# Only ever a by-hand run outside queue-long. None rather than 0, because the directory
-		# was never read and zero counts would read as a converged pass.
+	# Record before the gate, not after it. `ensure_anchor` below is the only other recurring
+	# caller of `record_directory_state`, so returning here without recording left the one host
+	# this reports on — a bench whose worker has no route mount — with no report at all, and the
+	# diagnostics row blaming a healthy scheduler instead of the missing mount.
+	if not ingress.record_directory_state()["mounted"]:
+		# None rather than 0, because the directory was never read and zero counts would read as
+		# a converged pass.
 		return {"anchored": None, "written": None, "deleted": None, "kept": None}
 
 	anchored = ingress.ensure_anchor(base_domain)

--- a/benchpress/tests/test_api.py
+++ b/benchpress/tests/test_api.py
@@ -46,7 +46,7 @@ BUDGETS_MS = {
 	"get_deploy_history": 600,
 }
 
-# The eleven rows benchpress.diagnostics always returns; the real checks talk to
+# The twelve rows benchpress.diagnostics always returns; the real checks talk to
 # Docker and MariaDB, so the Overview timing test never runs them.
 DIAGNOSTICS_ROWS = [
 	{"check": "docker_socket", "status": "pass", "hint": "Docker daemon reachable"},
@@ -62,7 +62,7 @@ DIAGNOSTICS_ROWS = [
 	{
 		"check": "route_directory",
 		"status": "pass",
-		"hint": "2 bench routes published beside benchpress.yml, *.example.test anchored",
+		"hint": "2 bench routes published beside dynamic.yml, *.example.test anchored",
 	},
 	{"check": "vpn_server", "status": "pass", "hint": "WireGuard server 'wg0' configured"},
 ]

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -840,6 +840,17 @@ class TestDeployStepMarkers(IntegrationTestCase):
 
 		self.assertEqual(self._bench_field(bench, "public_url"), f"https://{bench.name}.benchpress.cloud")
 
+	def test_public_url_stays_unset_when_no_route_was_written(self):
+		"""The worker deploying may hold no route mount, and then nothing can answer the public
+		name. `launch` and the Lab screen prefer it over the tunnel URL, so a dead one hides a live one."""
+		bench = self._bench()
+		self._set_base_domain("benchpress.cloud")
+
+		with patch.object(lifecycle.ingress, "publish", return_value=False):
+			self._run_deploy(bench)
+
+		self.assertFalse(self._bench_field(bench, "public_url"))
+
 	def test_public_url_stays_unset_with_localhost_base_domain(self):
 		bench = self._bench()
 		self._set_base_domain("localhost")

--- a/benchpress/tests/test_diagnostics.py
+++ b/benchpress/tests/test_diagnostics.py
@@ -374,6 +374,13 @@ class TestDiagnostics(unittest.TestCase):
 		self.assertEqual([row["check"] for row in DIAGNOSTICS_ROWS], CHECK_ORDER)
 		self.assertIn(COUNT_WORDS[len(CHECK_ORDER)], inspect.getdoc(_infrastructure))
 
+	def test_every_check_has_a_screen_label(self):
+		"""`_infrastructure` falls back to the raw check key, so a label nobody adds ships as
+		snake_case on an operator's screen instead of failing here."""
+		from benchpress.overview import INFRASTRUCTURE_LABELS
+
+		self.assertEqual(sorted(INFRASTRUCTURE_LABELS), sorted(CHECK_ORDER))
+
 	def test_the_mariadb_row_always_reports_the_buffer_pool_hit_rate(self):
 		"""The 128M pool rests on one measurement, so the number stays in front of the operator."""
 		by_check, _rows = self._run()
@@ -438,7 +445,7 @@ class TestDiagnostics(unittest.TestCase):
 		self.assertEqual(row["hint"], ROUTE_STATE_UNREPORTED)
 
 	def test_a_stale_report_is_named_by_its_age_and_not_believed(self):
-		"""The reconcile pass refreshes it, so a report this old means the pass stopped running."""
+		"""Nothing that reaches routing has reported in 15 minutes, so the report is not evidence."""
 		age = ingress.ROUTE_STATE_STALE_SECONDS + 60
 		with patch.object(ingress, "ROUTE_STATE_KEY", TEST_ROUTE_STATE_KEY):
 			frappe.cache().set_value(
@@ -473,7 +480,7 @@ class TestDiagnostics(unittest.TestCase):
 		self.assertIn(f"*.{BASE_DOMAIN} anchored", row["hint"])
 
 	def test_an_install_that_has_never_deployed_is_not_a_failure(self):
-		"""The anchor is written by the first deploy, so its absence before one is normal."""
+		"""The next deploy or reconcile pass writes the anchor, so its absence before one is normal."""
 		by_check, _rows = self._run(route_files=(ingress.CONTROL_PLANE_ROUTE_FILE,))
 
 		row = by_check["route_directory"]

--- a/benchpress/tests/test_reconcile.py
+++ b/benchpress/tests/test_reconcile.py
@@ -628,6 +628,23 @@ class TestConvergeRoutes(IntegrationTestCase):
 		# None, not 0: nothing was read, and zero counts are what a converged pass reports.
 		self.assertEqual(routes, {"anchored": None, "written": None, "deleted": None, "kept": None})
 
+	def test_the_unmounted_pass_records_what_it_saw(self):
+		"""The recurring pass is the only writer on a host that never deploys, so returning
+		without recording left the diagnostics row blaming the scheduler for a missing mount."""
+		frappe.cache().delete_value(ingress.ROUTE_STATE_KEY)
+		self.addCleanup(frappe.cache().delete_value, ingress.ROUTE_STATE_KEY)
+
+		with tempfile.TemporaryDirectory() as tmp:
+			with (
+				patch.object(ingress, "TRAEFIK_DYNAMIC_DIR", Path(tmp) / "dynamic"),
+				patch("frappe.get_cached_doc", return_value=frappe._dict(base_domain="benchpress.cloud")),
+			):
+				reconcile._converge_routes()
+
+		state = ingress.directory_state()
+		self.assertIsNotNone(state, "the pass returned without reporting what it saw")
+		self.assertFalse(state["mounted"])
+
 	def test_a_dev_checkout_is_left_byte_for_byte_alone(self):
 		"""No public domain means no route directory this pass understands, so it writes nothing
 		and reaps nothing."""

--- a/docs-bundle/docs/index.md
+++ b/docs-bundle/docs/index.md
@@ -2,7 +2,7 @@
 title: BenchPress documentation
 description: Start here. Three tracks — use a bench, run the server that hosts
   one, or read the data model and the API.
-lastModified: "2026-08-30T08:05:07-04:00"
+lastModified: "2026-08-30T17:48:34+05:30"
 lastAuthor: Venkatesh
 ---
 # BenchPress documentation

--- a/docs-bundle/docs/operator/diagnostics.md
+++ b/docs-bundle/docs/operator/diagnostics.md
@@ -3,12 +3,12 @@ title: Diagnostics
 description: The twelve read-only checks that ask Docker, MariaDB, Redis and the
   kernel what is true — how to run them, what each failure means, and the four
   things they do not cover.
-lastModified: "2026-08-30T08:05:07-04:00"
+lastModified: "2026-08-30T17:48:34+05:30"
 lastAuthor: Venkatesh
 ---
 # Diagnostics
 
-Eleven checks that read the host rather than the configuration, and what to do
+Twelve checks that read the host rather than the configuration, and what to do
 about each one that fails.
 
 **Who this is for.** Whoever is holding a broken host and does not yet know
@@ -30,14 +30,14 @@ one you have already made worse.
    Each row is `{check, status, hint, severity}`. The hint names the fix.
 
 2. **Or read them in the app.** Open **Overview** as an admin and look at the
-   **Shared infrastructure** panel, which renders the same eleven rows.
+   **Shared infrastructure** panel, which renders the same twelve rows.
 
    ![The Shared infrastructure panel on the BenchPress Overview, listing the shared-infrastructure checks with a status badge each. Docker socket, Docker network, Bridge capacity, MariaDB, Redis, Container runtimes, Event listener and WireGuard read Active. Kernel ceilings and Clock skew read Error, and Golden images reads Warning.](../images/operator/diagnostics/01-shared-infrastructure.png)
 
    On this host eight rows read **Active**, `kernel_ceilings` and `clock_skew`
-   read **Error**, and `golden_images` reads **Warning**. A badge is the
-   check's severity, not a second verdict — see
-   [Severity](#severity-is-not-status).
+   read **Error**, and `golden_images` reads **Warning**. The capture predates
+   the `route_directory` row, so it shows eleven. A badge is the check's
+   severity, not a second verdict — see [Severity](#severity-is-not-status).
 
 3. **Fix the failing rows in the order the table below gives**, then run the
    checks again. Several rows fail together for one cause, and the first fix
@@ -57,12 +57,12 @@ one you have already made worse.
 |`container_runtimes`|Container runtimes|`sysbox-runc` is registered with Docker|Error|
 |`golden_images`|Golden images|how many built labs carry a golden dump|Warning|
 |`docker_events`|Event listener|the listener's heartbeat is newer than 60 seconds|Error|
-|`route_directory`|Route directory|a worker has reported the Traefik route directory mounted, with the control-plane route and the wildcard anchor rendered|Error, or Warning when the report is stale or the anchor is merely late|
+|`route_directory`|Route directory|a worker has reported the Traefik route directory mounted, with the control-plane route and the wildcard anchor rendered|Error, or Warning when the report is missing or stale, or the anchor is merely late|
 |`vpn_server`|WireGuard|`vpn_management` is installed, `wg0` exists, and it has a public key|Error|
 
 ## Severity is not status
 
-Two rows fail in ways that are not the same kind of problem, so they carry
+Three rows fail in ways that are not the same kind of problem, so they carry
 their own severity.
 
 * **`golden_images` is always a Warning.** A lab with no golden dump deploys
@@ -71,6 +71,10 @@ their own severity.
 * **Config drift on `mariadb` or `redis` is a Warning.** The cache still
   serves every bench, and it stays drifted until a human recreates the pair.
   A server that does not answer at all is an Error.
+* **`route_directory` is a Warning when it cannot tell.** A report that is
+  missing or older than 15 minutes says the host is unverified, not broken,
+  and a missing wildcard anchor is written by the next deploy or reconcile
+  pass. A directory that is not mounted, or is mounted and empty, is an Error.
 
 Everything else is an Error, because a bench cannot deploy through it.
 
@@ -192,6 +196,30 @@ which is why the heartbeat exists at all. Restart it:
 docker compose up -d docker-events
 ```
 
+### `route_directory` — the public URL has nothing behind it
+
+**Base Domain** is required, so every install advertises
+`https://<bench>.<domain>` for each bench. Only `docker-compose.prod.yml`
+mounts `/etc/traefik/dynamic`, and only a checkout brought up with
+`./entry.py --domain <fqdn>` loads that overlay — so on any other host no
+route is ever written and none of those URLs answer.
+
+The row reads a report a worker leaves in the cache, because this screen
+renders in `backend`, which never mounts that directory. What the hints mean:
+
+|The hint says|What is true|What to do|
+|--|--|--|
+|`/etc/traefik/dynamic is not mounted in queue-long`|The host runs without the production overlay|Bring the host up with `./entry.py --domain <fqdn>`, or set **Base Domain** to `localhost` to advertise no public URL|
+|`holds no dynamic.yml … never rendered`|Docker turned a bind source that does not exist into an empty directory, which passes every check that only asks whether the path is there|Render the Traefik config on the host: `./entry.py --domain <fqdn>`|
+|`no wildcard-anchor.yml holds *.<domain>`|Traefik holds no certificate for the bench zone, so every published hostname fails TLS|Nothing, normally: the next deploy or reconcile pass writes it. If it stays, read `queue-long`'s log|
+|`No worker has reported …`, or `last reported on <n>s ago`|Nothing that writes the report has run recently|Read the workers, then deploy or start a bench, which forces a report|
+
+**A host with no route mount reports nothing on its own.** The reconcile pass
+returns before the call that records, so on exactly the host this row exists
+for, the first report comes from a deploy or from starting a bench. Until one
+does, the row reads the missing-report Warning rather than the Error that
+names the mount.
+
 ### `vpn_server` — not configured
 
 Either `vpn_management` is not installed, or `wg0` does not exist, or it
@@ -246,7 +274,7 @@ bench --site <site> execute frappe.client.get_list \
 ## Verify
 
 A pass is not a claim that the host is healthy. It is a claim that these
-eleven questions have good answers. Confirm the rest by deploying a bench and
+twelve questions have good answers. Confirm the rest by deploying a bench and
 opening it, which exercises Docker, the bridge, the VPN, the database and the
 router in one action. See
 [Deploy from a template](/docs/user/deploy-from-template).
@@ -274,6 +302,7 @@ router in one action. See
 |Severities|`Error`, `Warning`|
 |Clock tolerance|2 seconds|
 |Heartbeat patience|60 seconds|
+|Route report patience|15 minutes|
 |Terminals per bench, for `kernel.pty.max`|8, plus 1,024 reserved|
 |PIDs per bench, for `kernel.pid_max`|500|
 |Conntrack per bench|256|

--- a/docs-bundle/docs/operator/diagnostics.md
+++ b/docs-bundle/docs/operator/diagnostics.md
@@ -3,7 +3,7 @@ title: Diagnostics
 description: The twelve read-only checks that ask Docker, MariaDB, Redis and the
   kernel what is true — how to run them, what each failure means, and the four
   things they do not cover.
-lastModified: "2026-08-30T17:48:34+05:30"
+lastModified: "2026-08-30T08:51:56-04:00"
 lastAuthor: Venkatesh
 ---
 # Diagnostics

--- a/docs-bundle/docs/operator/install.md
+++ b/docs-bundle/docs/operator/install.md
@@ -2,7 +2,7 @@
 title: Install
 description: Install BenchPress into a Frappe v16 bench — get-app, setup.sh, the
   frontend build, the base domain, and the first screen.
-lastModified: "2026-08-30T08:04:44-04:00"
+lastModified: "2026-08-30T17:48:34+05:30"
 lastAuthor: Venkatesh
 ---
 # Install

--- a/docs-bundle/docs/operator/prerequisites.md
+++ b/docs-bundle/docs/operator/prerequisites.md
@@ -3,7 +3,7 @@ title: Prerequisites
 description: What a BenchPress host needs before you install — the four
   preconditions, supported platforms, versions, Docker socket access, and the
   measured CPU and disk sizing.
-lastModified: "2026-08-30T08:05:07-04:00"
+lastModified: "2026-08-30T17:48:34+05:30"
 lastAuthor: Venkatesh
 ---
 # Prerequisites

--- a/docs-bundle/docs/operator/production-safety.md
+++ b/docs-bundle/docs/operator/production-safety.md
@@ -3,7 +3,7 @@ title: Production safety
 description: What BenchPress is and is not ready to carry — the alpha verdict,
   the container privilege boundary, what is backed up, and the release checklist
   that covers 25 of 52 whitelisted callables.
-lastModified: "2026-08-30T08:05:07-04:00"
+lastModified: "2026-08-30T17:48:34+05:30"
 lastAuthor: Venkatesh
 ---
 # Production safety

--- a/docs-bundle/docs/reference/api.md
+++ b/docs-bundle/docs/reference/api.md
@@ -2,7 +2,7 @@
 title: API
 description: Every whitelisted BenchPress endpoint, with arguments, what each
   returns, and the permission check each one makes for itself.
-lastModified: "2026-08-30T08:05:07-04:00"
+lastModified: "2026-08-30T17:48:34+05:30"
 lastAuthor: Venkatesh
 ---
 # API

--- a/docs-bundle/docs/reference/architecture.md
+++ b/docs-bundle/docs/reference/architecture.md
@@ -3,7 +3,7 @@ title: Architecture
 description: The moving parts of BenchPress — the control plane, the bench
   containers, the shared infrastructure, and which Python module owns each
   concern.
-lastModified: "2026-08-30T08:05:07-04:00"
+lastModified: "2026-08-30T17:48:34+05:30"
 lastAuthor: Venkatesh
 ---
 # Architecture

--- a/docs-bundle/docs/reference/networking.md
+++ b/docs-bundle/docs/reference/networking.md
@@ -3,7 +3,7 @@ title: Networking
 description: The BenchPress address plan — bench bridges, WireGuard tunnel
   addresses, the two container ports, Traefik route files and the wildcard
   certificate anchor.
-lastModified: "2026-08-30T08:05:07-04:00"
+lastModified: "2026-08-30T17:48:34+05:30"
 lastAuthor: Venkatesh
 ---
 # Networking

--- a/docs-site/.well-known/llms-full.txt
+++ b/docs-site/.well-known/llms-full.txt
@@ -4095,7 +4095,7 @@ any password. The `create_site` item described an endpoint that does not exist.
 URL: https://docs.benchpress.cloud/docs/operator/diagnostics
 The twelve read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
 
-Eleven checks that read the host rather than the configuration, and what to do
+Twelve checks that read the host rather than the configuration, and what to do
 about each one that fails.
 
 **Who this is for.** Whoever is holding a broken host and does not yet know
@@ -4117,14 +4117,14 @@ one you have already made worse.
    Each row is `{check, status, hint, severity}`. The hint names the fix.
 
 2. **Or read them in the app.** Open **Overview** as an admin and look at the
-   **Shared infrastructure** panel, which renders the same eleven rows.
+   **Shared infrastructure** panel, which renders the same twelve rows.
 
    ![The Shared infrastructure panel on the BenchPress Overview, listing the shared-infrastructure checks with a status badge each. Docker socket, Docker network, Bridge capacity, MariaDB, Redis, Container runtimes, Event listener and WireGuard read Active. Kernel ceilings and Clock skew read Error, and Golden images reads Warning.](../images/operator/diagnostics/01-shared-infrastructure.png)
 
    On this host eight rows read **Active**, `kernel_ceilings` and `clock_skew`
-   read **Error**, and `golden_images` reads **Warning**. A badge is the
-   check's severity, not a second verdict — see
-   [Severity](#severity-is-not-status).
+   read **Error**, and `golden_images` reads **Warning**. The capture predates
+   the `route_directory` row, so it shows eleven. A badge is the check's
+   severity, not a second verdict — see [Severity](#severity-is-not-status).
 
 3. **Fix the failing rows in the order the table below gives**, then run the
    checks again. Several rows fail together for one cause, and the first fix
@@ -4144,12 +4144,12 @@ one you have already made worse.
 |`container_runtimes`|Container runtimes|`sysbox-runc` is registered with Docker|Error|
 |`golden_images`|Golden images|how many built labs carry a golden dump|Warning|
 |`docker_events`|Event listener|the listener's heartbeat is newer than 60 seconds|Error|
-|`route_directory`|Route directory|a worker has reported the Traefik route directory mounted, with the control-plane route and the wildcard anchor rendered|Error, or Warning when the report is stale or the anchor is merely late|
+|`route_directory`|Route directory|a worker has reported the Traefik route directory mounted, with the control-plane route and the wildcard anchor rendered|Error, or Warning when the report is missing or stale, or the anchor is merely late|
 |`vpn_server`|WireGuard|`vpn_management` is installed, `wg0` exists, and it has a public key|Error|
 
 ## Severity is not status
 
-Two rows fail in ways that are not the same kind of problem, so they carry
+Three rows fail in ways that are not the same kind of problem, so they carry
 their own severity.
 
 * **`golden_images` is always a Warning.** A lab with no golden dump deploys
@@ -4158,6 +4158,10 @@ their own severity.
 * **Config drift on `mariadb` or `redis` is a Warning.** The cache still
   serves every bench, and it stays drifted until a human recreates the pair.
   A server that does not answer at all is an Error.
+* **`route_directory` is a Warning when it cannot tell.** A report that is
+  missing or older than 15 minutes says the host is unverified, not broken,
+  and a missing wildcard anchor is written by the next deploy or reconcile
+  pass. A directory that is not mounted, or is mounted and empty, is an Error.
 
 Everything else is an Error, because a bench cannot deploy through it.
 
@@ -4279,6 +4283,30 @@ which is why the heartbeat exists at all. Restart it:
 docker compose up -d docker-events
 ```
 
+### `route_directory` — the public URL has nothing behind it
+
+**Base Domain** is required, so every install advertises
+`https://<bench>.<domain>` for each bench. Only `docker-compose.prod.yml`
+mounts `/etc/traefik/dynamic`, and only a checkout brought up with
+`./entry.py --domain <fqdn>` loads that overlay — so on any other host no
+route is ever written and none of those URLs answer.
+
+The row reads a report a worker leaves in the cache, because this screen
+renders in `backend`, which never mounts that directory. What the hints mean:
+
+|The hint says|What is true|What to do|
+|--|--|--|
+|`/etc/traefik/dynamic is not mounted in queue-long`|The host runs without the production overlay|Bring the host up with `./entry.py --domain <fqdn>`, or set **Base Domain** to `localhost` to advertise no public URL|
+|`holds no dynamic.yml … never rendered`|Docker turned a bind source that does not exist into an empty directory, which passes every check that only asks whether the path is there|Render the Traefik config on the host: `./entry.py --domain <fqdn>`|
+|`no wildcard-anchor.yml holds *.<domain>`|Traefik holds no certificate for the bench zone, so every published hostname fails TLS|Nothing, normally: the next deploy or reconcile pass writes it. If it stays, read `queue-long`'s log|
+|`No worker has reported …`, or `last reported on <n>s ago`|Nothing that writes the report has run recently|Read the workers, then deploy or start a bench, which forces a report|
+
+**A host with no route mount reports nothing on its own.** The reconcile pass
+returns before the call that records, so on exactly the host this row exists
+for, the first report comes from a deploy or from starting a bench. Until one
+does, the row reads the missing-report Warning rather than the Error that
+names the mount.
+
 ### `vpn_server` — not configured
 
 Either `vpn_management` is not installed, or `wg0` does not exist, or it
@@ -4333,7 +4361,7 @@ bench --site <site> execute frappe.client.get_list \
 ## Verify
 
 A pass is not a claim that the host is healthy. It is a claim that these
-eleven questions have good answers. Confirm the rest by deploying a bench and
+twelve questions have good answers. Confirm the rest by deploying a bench and
 opening it, which exercises Docker, the bridge, the VPN, the database and the
 router in one action. See
 [Deploy from a template](/docs/user/deploy-from-template).
@@ -4361,6 +4389,7 @@ router in one action. See
 |Severities|`Error`, `Warning`|
 |Clock tolerance|2 seconds|
 |Heartbeat patience|60 seconds|
+|Route report patience|15 minutes|
 |Terminals per bench, for `kernel.pty.max`|8, plus 1,024 reserved|
 |PIDs per bench, for `kernel.pid_max`|500|
 |Conntrack per bench|256|

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -2,7 +2,7 @@
 title: BenchPress documentation
 description: Start here. Three tracks — use a bench, run the server that hosts
   one, or read the data model and the API.
-lastModified: "2026-08-30T08:05:07-04:00"
+lastModified: "2026-08-30T17:48:34+05:30"
 lastAuthor: Venkatesh
 ---
 # BenchPress documentation

--- a/docs-site/docs/operator/diagnostics.md
+++ b/docs-site/docs/operator/diagnostics.md
@@ -3,12 +3,12 @@ title: Diagnostics
 description: The twelve read-only checks that ask Docker, MariaDB, Redis and the
   kernel what is true — how to run them, what each failure means, and the four
   things they do not cover.
-lastModified: "2026-08-30T08:05:07-04:00"
+lastModified: "2026-08-30T17:48:34+05:30"
 lastAuthor: Venkatesh
 ---
 # Diagnostics
 
-Eleven checks that read the host rather than the configuration, and what to do
+Twelve checks that read the host rather than the configuration, and what to do
 about each one that fails.
 
 **Who this is for.** Whoever is holding a broken host and does not yet know
@@ -30,14 +30,14 @@ one you have already made worse.
    Each row is `{check, status, hint, severity}`. The hint names the fix.
 
 2. **Or read them in the app.** Open **Overview** as an admin and look at the
-   **Shared infrastructure** panel, which renders the same eleven rows.
+   **Shared infrastructure** panel, which renders the same twelve rows.
 
    ![The Shared infrastructure panel on the BenchPress Overview, listing the shared-infrastructure checks with a status badge each. Docker socket, Docker network, Bridge capacity, MariaDB, Redis, Container runtimes, Event listener and WireGuard read Active. Kernel ceilings and Clock skew read Error, and Golden images reads Warning.](../images/operator/diagnostics/01-shared-infrastructure.png)
 
    On this host eight rows read **Active**, `kernel_ceilings` and `clock_skew`
-   read **Error**, and `golden_images` reads **Warning**. A badge is the
-   check's severity, not a second verdict — see
-   [Severity](#severity-is-not-status).
+   read **Error**, and `golden_images` reads **Warning**. The capture predates
+   the `route_directory` row, so it shows eleven. A badge is the check's
+   severity, not a second verdict — see [Severity](#severity-is-not-status).
 
 3. **Fix the failing rows in the order the table below gives**, then run the
    checks again. Several rows fail together for one cause, and the first fix
@@ -57,12 +57,12 @@ one you have already made worse.
 |`container_runtimes`|Container runtimes|`sysbox-runc` is registered with Docker|Error|
 |`golden_images`|Golden images|how many built labs carry a golden dump|Warning|
 |`docker_events`|Event listener|the listener's heartbeat is newer than 60 seconds|Error|
-|`route_directory`|Route directory|a worker has reported the Traefik route directory mounted, with the control-plane route and the wildcard anchor rendered|Error, or Warning when the report is stale or the anchor is merely late|
+|`route_directory`|Route directory|a worker has reported the Traefik route directory mounted, with the control-plane route and the wildcard anchor rendered|Error, or Warning when the report is missing or stale, or the anchor is merely late|
 |`vpn_server`|WireGuard|`vpn_management` is installed, `wg0` exists, and it has a public key|Error|
 
 ## Severity is not status
 
-Two rows fail in ways that are not the same kind of problem, so they carry
+Three rows fail in ways that are not the same kind of problem, so they carry
 their own severity.
 
 * **`golden_images` is always a Warning.** A lab with no golden dump deploys
@@ -71,6 +71,10 @@ their own severity.
 * **Config drift on `mariadb` or `redis` is a Warning.** The cache still
   serves every bench, and it stays drifted until a human recreates the pair.
   A server that does not answer at all is an Error.
+* **`route_directory` is a Warning when it cannot tell.** A report that is
+  missing or older than 15 minutes says the host is unverified, not broken,
+  and a missing wildcard anchor is written by the next deploy or reconcile
+  pass. A directory that is not mounted, or is mounted and empty, is an Error.
 
 Everything else is an Error, because a bench cannot deploy through it.
 
@@ -192,6 +196,30 @@ which is why the heartbeat exists at all. Restart it:
 docker compose up -d docker-events
 ```
 
+### `route_directory` — the public URL has nothing behind it
+
+**Base Domain** is required, so every install advertises
+`https://<bench>.<domain>` for each bench. Only `docker-compose.prod.yml`
+mounts `/etc/traefik/dynamic`, and only a checkout brought up with
+`./entry.py --domain <fqdn>` loads that overlay — so on any other host no
+route is ever written and none of those URLs answer.
+
+The row reads a report a worker leaves in the cache, because this screen
+renders in `backend`, which never mounts that directory. What the hints mean:
+
+|The hint says|What is true|What to do|
+|--|--|--|
+|`/etc/traefik/dynamic is not mounted in queue-long`|The host runs without the production overlay|Bring the host up with `./entry.py --domain <fqdn>`, or set **Base Domain** to `localhost` to advertise no public URL|
+|`holds no dynamic.yml … never rendered`|Docker turned a bind source that does not exist into an empty directory, which passes every check that only asks whether the path is there|Render the Traefik config on the host: `./entry.py --domain <fqdn>`|
+|`no wildcard-anchor.yml holds *.<domain>`|Traefik holds no certificate for the bench zone, so every published hostname fails TLS|Nothing, normally: the next deploy or reconcile pass writes it. If it stays, read `queue-long`'s log|
+|`No worker has reported …`, or `last reported on <n>s ago`|Nothing that writes the report has run recently|Read the workers, then deploy or start a bench, which forces a report|
+
+**A host with no route mount reports nothing on its own.** The reconcile pass
+returns before the call that records, so on exactly the host this row exists
+for, the first report comes from a deploy or from starting a bench. Until one
+does, the row reads the missing-report Warning rather than the Error that
+names the mount.
+
 ### `vpn_server` — not configured
 
 Either `vpn_management` is not installed, or `wg0` does not exist, or it
@@ -246,7 +274,7 @@ bench --site <site> execute frappe.client.get_list \
 ## Verify
 
 A pass is not a claim that the host is healthy. It is a claim that these
-eleven questions have good answers. Confirm the rest by deploying a bench and
+twelve questions have good answers. Confirm the rest by deploying a bench and
 opening it, which exercises Docker, the bridge, the VPN, the database and the
 router in one action. See
 [Deploy from a template](/docs/user/deploy-from-template).
@@ -274,6 +302,7 @@ router in one action. See
 |Severities|`Error`, `Warning`|
 |Clock tolerance|2 seconds|
 |Heartbeat patience|60 seconds|
+|Route report patience|15 minutes|
 |Terminals per bench, for `kernel.pty.max`|8, plus 1,024 reserved|
 |PIDs per bench, for `kernel.pid_max`|500|
 |Conntrack per bench|256|

--- a/docs-site/docs/operator/diagnostics.md
+++ b/docs-site/docs/operator/diagnostics.md
@@ -3,7 +3,7 @@ title: Diagnostics
 description: The twelve read-only checks that ask Docker, MariaDB, Redis and the
   kernel what is true — how to run them, what each failure means, and the four
   things they do not cover.
-lastModified: "2026-08-30T17:48:34+05:30"
+lastModified: "2026-08-30T08:51:56-04:00"
 lastAuthor: Venkatesh
 ---
 # Diagnostics

--- a/docs-site/docs/operator/install.md
+++ b/docs-site/docs/operator/install.md
@@ -2,7 +2,7 @@
 title: Install
 description: Install BenchPress into a Frappe v16 bench — get-app, setup.sh, the
   frontend build, the base domain, and the first screen.
-lastModified: "2026-08-30T08:04:44-04:00"
+lastModified: "2026-08-30T17:48:34+05:30"
 lastAuthor: Venkatesh
 ---
 # Install

--- a/docs-site/docs/operator/prerequisites.md
+++ b/docs-site/docs/operator/prerequisites.md
@@ -3,7 +3,7 @@ title: Prerequisites
 description: What a BenchPress host needs before you install — the four
   preconditions, supported platforms, versions, Docker socket access, and the
   measured CPU and disk sizing.
-lastModified: "2026-08-30T08:05:07-04:00"
+lastModified: "2026-08-30T17:48:34+05:30"
 lastAuthor: Venkatesh
 ---
 # Prerequisites

--- a/docs-site/docs/operator/production-safety.md
+++ b/docs-site/docs/operator/production-safety.md
@@ -3,7 +3,7 @@ title: Production safety
 description: What BenchPress is and is not ready to carry — the alpha verdict,
   the container privilege boundary, what is backed up, and the release checklist
   that covers 25 of 52 whitelisted callables.
-lastModified: "2026-08-30T08:05:07-04:00"
+lastModified: "2026-08-30T17:48:34+05:30"
 lastAuthor: Venkatesh
 ---
 # Production safety

--- a/docs-site/docs/reference/api.md
+++ b/docs-site/docs/reference/api.md
@@ -2,7 +2,7 @@
 title: API
 description: Every whitelisted BenchPress endpoint, with arguments, what each
   returns, and the permission check each one makes for itself.
-lastModified: "2026-08-30T08:05:07-04:00"
+lastModified: "2026-08-30T17:48:34+05:30"
 lastAuthor: Venkatesh
 ---
 # API

--- a/docs-site/docs/reference/architecture.md
+++ b/docs-site/docs/reference/architecture.md
@@ -3,7 +3,7 @@ title: Architecture
 description: The moving parts of BenchPress — the control plane, the bench
   containers, the shared infrastructure, and which Python module owns each
   concern.
-lastModified: "2026-08-30T08:05:07-04:00"
+lastModified: "2026-08-30T17:48:34+05:30"
 lastAuthor: Venkatesh
 ---
 # Architecture

--- a/docs-site/docs/reference/networking.md
+++ b/docs-site/docs/reference/networking.md
@@ -3,7 +3,7 @@ title: Networking
 description: The BenchPress address plan — bench bridges, WireGuard tunnel
   addresses, the two container ports, Traefik route files and the wildcard
   certificate anchor.
-lastModified: "2026-08-30T08:05:07-04:00"
+lastModified: "2026-08-30T17:48:34+05:30"
 lastAuthor: Venkatesh
 ---
 # Networking

--- a/docs-site/llms-full.txt
+++ b/docs-site/llms-full.txt
@@ -4095,7 +4095,7 @@ any password. The `create_site` item described an endpoint that does not exist.
 URL: https://docs.benchpress.cloud/docs/operator/diagnostics
 The twelve read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
 
-Eleven checks that read the host rather than the configuration, and what to do
+Twelve checks that read the host rather than the configuration, and what to do
 about each one that fails.
 
 **Who this is for.** Whoever is holding a broken host and does not yet know
@@ -4117,14 +4117,14 @@ one you have already made worse.
    Each row is `{check, status, hint, severity}`. The hint names the fix.
 
 2. **Or read them in the app.** Open **Overview** as an admin and look at the
-   **Shared infrastructure** panel, which renders the same eleven rows.
+   **Shared infrastructure** panel, which renders the same twelve rows.
 
    ![The Shared infrastructure panel on the BenchPress Overview, listing the shared-infrastructure checks with a status badge each. Docker socket, Docker network, Bridge capacity, MariaDB, Redis, Container runtimes, Event listener and WireGuard read Active. Kernel ceilings and Clock skew read Error, and Golden images reads Warning.](../images/operator/diagnostics/01-shared-infrastructure.png)
 
    On this host eight rows read **Active**, `kernel_ceilings` and `clock_skew`
-   read **Error**, and `golden_images` reads **Warning**. A badge is the
-   check's severity, not a second verdict — see
-   [Severity](#severity-is-not-status).
+   read **Error**, and `golden_images` reads **Warning**. The capture predates
+   the `route_directory` row, so it shows eleven. A badge is the check's
+   severity, not a second verdict — see [Severity](#severity-is-not-status).
 
 3. **Fix the failing rows in the order the table below gives**, then run the
    checks again. Several rows fail together for one cause, and the first fix
@@ -4144,12 +4144,12 @@ one you have already made worse.
 |`container_runtimes`|Container runtimes|`sysbox-runc` is registered with Docker|Error|
 |`golden_images`|Golden images|how many built labs carry a golden dump|Warning|
 |`docker_events`|Event listener|the listener's heartbeat is newer than 60 seconds|Error|
-|`route_directory`|Route directory|a worker has reported the Traefik route directory mounted, with the control-plane route and the wildcard anchor rendered|Error, or Warning when the report is stale or the anchor is merely late|
+|`route_directory`|Route directory|a worker has reported the Traefik route directory mounted, with the control-plane route and the wildcard anchor rendered|Error, or Warning when the report is missing or stale, or the anchor is merely late|
 |`vpn_server`|WireGuard|`vpn_management` is installed, `wg0` exists, and it has a public key|Error|
 
 ## Severity is not status
 
-Two rows fail in ways that are not the same kind of problem, so they carry
+Three rows fail in ways that are not the same kind of problem, so they carry
 their own severity.
 
 * **`golden_images` is always a Warning.** A lab with no golden dump deploys
@@ -4158,6 +4158,10 @@ their own severity.
 * **Config drift on `mariadb` or `redis` is a Warning.** The cache still
   serves every bench, and it stays drifted until a human recreates the pair.
   A server that does not answer at all is an Error.
+* **`route_directory` is a Warning when it cannot tell.** A report that is
+  missing or older than 15 minutes says the host is unverified, not broken,
+  and a missing wildcard anchor is written by the next deploy or reconcile
+  pass. A directory that is not mounted, or is mounted and empty, is an Error.
 
 Everything else is an Error, because a bench cannot deploy through it.
 
@@ -4279,6 +4283,30 @@ which is why the heartbeat exists at all. Restart it:
 docker compose up -d docker-events
 ```
 
+### `route_directory` — the public URL has nothing behind it
+
+**Base Domain** is required, so every install advertises
+`https://<bench>.<domain>` for each bench. Only `docker-compose.prod.yml`
+mounts `/etc/traefik/dynamic`, and only a checkout brought up with
+`./entry.py --domain <fqdn>` loads that overlay — so on any other host no
+route is ever written and none of those URLs answer.
+
+The row reads a report a worker leaves in the cache, because this screen
+renders in `backend`, which never mounts that directory. What the hints mean:
+
+|The hint says|What is true|What to do|
+|--|--|--|
+|`/etc/traefik/dynamic is not mounted in queue-long`|The host runs without the production overlay|Bring the host up with `./entry.py --domain <fqdn>`, or set **Base Domain** to `localhost` to advertise no public URL|
+|`holds no dynamic.yml … never rendered`|Docker turned a bind source that does not exist into an empty directory, which passes every check that only asks whether the path is there|Render the Traefik config on the host: `./entry.py --domain <fqdn>`|
+|`no wildcard-anchor.yml holds *.<domain>`|Traefik holds no certificate for the bench zone, so every published hostname fails TLS|Nothing, normally: the next deploy or reconcile pass writes it. If it stays, read `queue-long`'s log|
+|`No worker has reported …`, or `last reported on <n>s ago`|Nothing that writes the report has run recently|Read the workers, then deploy or start a bench, which forces a report|
+
+**A host with no route mount reports nothing on its own.** The reconcile pass
+returns before the call that records, so on exactly the host this row exists
+for, the first report comes from a deploy or from starting a bench. Until one
+does, the row reads the missing-report Warning rather than the Error that
+names the mount.
+
 ### `vpn_server` — not configured
 
 Either `vpn_management` is not installed, or `wg0` does not exist, or it
@@ -4333,7 +4361,7 @@ bench --site <site> execute frappe.client.get_list \
 ## Verify
 
 A pass is not a claim that the host is healthy. It is a claim that these
-eleven questions have good answers. Confirm the rest by deploying a bench and
+twelve questions have good answers. Confirm the rest by deploying a bench and
 opening it, which exercises Docker, the bridge, the VPN, the database and the
 router in one action. See
 [Deploy from a template](/docs/user/deploy-from-template).
@@ -4361,6 +4389,7 @@ router in one action. See
 |Severities|`Error`, `Warning`|
 |Clock tolerance|2 seconds|
 |Heartbeat patience|60 seconds|
+|Route report patience|15 minutes|
 |Terminals per bench, for `kernel.pty.max`|8, plus 1,024 reserved|
 |PIDs per bench, for `kernel.pid_max`|500|
 |Conntrack per bench|256|

--- a/docs-site/sitemap.xml
+++ b/docs-site/sitemap.xml
@@ -54,11 +54,11 @@
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/operator/prerequisites</loc>
-    <lastmod>2026-08-30T12:05:07.000Z</lastmod>
+    <lastmod>2026-08-30T12:18:34.000Z</lastmod>
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/operator/install</loc>
-    <lastmod>2026-08-30T12:04:44.000Z</lastmod>
+    <lastmod>2026-08-30T12:18:34.000Z</lastmod>
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/operator/wireguard-setup</loc>
@@ -94,11 +94,11 @@
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/operator/production-safety</loc>
-    <lastmod>2026-08-30T12:05:07.000Z</lastmod>
+    <lastmod>2026-08-30T12:18:34.000Z</lastmod>
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/operator/diagnostics</loc>
-    <lastmod>2026-08-30T12:05:07.000Z</lastmod>
+    <lastmod>2026-08-30T12:18:34.000Z</lastmod>
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/operator/credits-and-billing</loc>
@@ -118,7 +118,7 @@
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/reference/architecture</loc>
-    <lastmod>2026-08-30T12:05:07.000Z</lastmod>
+    <lastmod>2026-08-30T12:18:34.000Z</lastmod>
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/reference/data-model</loc>
@@ -126,7 +126,7 @@
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/reference/api</loc>
-    <lastmod>2026-08-30T12:05:07.000Z</lastmod>
+    <lastmod>2026-08-30T12:18:34.000Z</lastmod>
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/reference/deploy-pipeline</loc>
@@ -138,7 +138,7 @@
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/reference/networking</loc>
-    <lastmod>2026-08-30T12:05:07.000Z</lastmod>
+    <lastmod>2026-08-30T12:18:34.000Z</lastmod>
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/reference/realtime</loc>
@@ -158,6 +158,6 @@
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs</loc>
-    <lastmod>2026-08-30T12:05:07.000Z</lastmod>
+    <lastmod>2026-08-30T12:18:34.000Z</lastmod>
   </url>
 </urlset>

--- a/docs-site/sitemap.xml
+++ b/docs-site/sitemap.xml
@@ -98,7 +98,7 @@
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/operator/diagnostics</loc>
-    <lastmod>2026-08-30T12:18:34.000Z</lastmod>
+    <lastmod>2026-08-30T12:51:56.000Z</lastmod>
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/operator/credits-and-billing</loc>

--- a/docs/operator/diagnostics.mdx
+++ b/docs/operator/diagnostics.mdx
@@ -5,7 +5,7 @@ description: The twelve read-only checks that ask Docker, MariaDB, Redis and the
 
 # Diagnostics
 
-Eleven checks that read the host rather than the configuration, and what to do
+Twelve checks that read the host rather than the configuration, and what to do
 about each one that fails.
 
 **Who this is for.** Whoever is holding a broken host and does not yet know
@@ -27,14 +27,14 @@ one you have already made worse.
    Each row is `{check, status, hint, severity}`. The hint names the fix.
 
 2. **Or read them in the app.** Open **Overview** as an admin and look at the
-   **Shared infrastructure** panel, which renders the same eleven rows.
+   **Shared infrastructure** panel, which renders the same twelve rows.
 
    ![The Shared infrastructure panel on the BenchPress Overview, listing the shared-infrastructure checks with a status badge each. Docker socket, Docker network, Bridge capacity, MariaDB, Redis, Container runtimes, Event listener and WireGuard read Active. Kernel ceilings and Clock skew read Error, and Golden images reads Warning.](../images/operator/diagnostics/01-shared-infrastructure.png)
 
    On this host eight rows read **Active**, `kernel_ceilings` and `clock_skew`
-   read **Error**, and `golden_images` reads **Warning**. A badge is the
-   check's severity, not a second verdict — see
-   [Severity](#severity-is-not-status).
+   read **Error**, and `golden_images` reads **Warning**. The capture predates
+   the `route_directory` row, so it shows eleven. A badge is the check's
+   severity, not a second verdict — see [Severity](#severity-is-not-status).
 
 3. **Fix the failing rows in the order the table below gives**, then run the
    checks again. Several rows fail together for one cause, and the first fix
@@ -54,12 +54,12 @@ one you have already made worse.
 | `container_runtimes` | Container runtimes | `sysbox-runc` is registered with Docker | Error |
 | `golden_images` | Golden images | how many built labs carry a golden dump | Warning |
 | `docker_events` | Event listener | the listener's heartbeat is newer than 60 seconds | Error |
-| `route_directory` | Route directory | a worker has reported the Traefik route directory mounted, with the control-plane route and the wildcard anchor rendered | Error, or Warning when the report is stale or the anchor is merely late |
+| `route_directory` | Route directory | a worker has reported the Traefik route directory mounted, with the control-plane route and the wildcard anchor rendered | Error, or Warning when the report is missing or stale, or the anchor is merely late |
 | `vpn_server` | WireGuard | `vpn_management` is installed, `wg0` exists, and it has a public key | Error |
 
 ## Severity is not status
 
-Two rows fail in ways that are not the same kind of problem, so they carry
+Three rows fail in ways that are not the same kind of problem, so they carry
 their own severity.
 
 - **`golden_images` is always a Warning.** A lab with no golden dump deploys
@@ -68,6 +68,10 @@ their own severity.
 - **Config drift on `mariadb` or `redis` is a Warning.** The cache still
   serves every bench, and it stays drifted until a human recreates the pair.
   A server that does not answer at all is an Error.
+- **`route_directory` is a Warning when it cannot tell.** A report that is
+  missing or older than 15 minutes says the host is unverified, not broken,
+  and a missing wildcard anchor is written by the next deploy or reconcile
+  pass. A directory that is not mounted, or is mounted and empty, is an Error.
 
 Everything else is an Error, because a bench cannot deploy through it.
 
@@ -190,6 +194,30 @@ which is why the heartbeat exists at all. Restart it:
 docker compose up -d docker-events
 ```
 
+### `route_directory` — the public URL has nothing behind it
+
+**Base Domain** is required, so every install advertises
+`https://<bench>.<domain>` for each bench. Only `docker-compose.prod.yml`
+mounts `/etc/traefik/dynamic`, and only a checkout brought up with
+`./entry.py --domain <fqdn>` loads that overlay — so on any other host no
+route is ever written and none of those URLs answer.
+
+The row reads a report a worker leaves in the cache, because this screen
+renders in `backend`, which never mounts that directory. What the hints mean:
+
+| The hint says | What is true | What to do |
+|---|---|---|
+| `/etc/traefik/dynamic is not mounted in queue-long` | The host runs without the production overlay | Bring the host up with `./entry.py --domain <fqdn>`, or set **Base Domain** to `localhost` to advertise no public URL |
+| `holds no dynamic.yml … never rendered` | Docker turned a bind source that does not exist into an empty directory, which passes every check that only asks whether the path is there | Render the Traefik config on the host: `./entry.py --domain <fqdn>` |
+| `no wildcard-anchor.yml holds *.<domain>` | Traefik holds no certificate for the bench zone, so every published hostname fails TLS | Nothing, normally: the next deploy or reconcile pass writes it. If it stays, read `queue-long`'s log |
+| `No worker has reported …`, or `last reported on <n>s ago` | Nothing that writes the report has run recently | Read the workers, then deploy or start a bench, which forces a report |
+
+**A host with no route mount reports nothing on its own.** The reconcile pass
+returns before the call that records, so on exactly the host this row exists
+for, the first report comes from a deploy or from starting a bench. Until one
+does, the row reads the missing-report Warning rather than the Error that
+names the mount.
+
 ### `vpn_server` — not configured
 
 Either `vpn_management` is not installed, or `wg0` does not exist, or it
@@ -244,7 +272,7 @@ bench --site <site> execute frappe.client.get_list \
 ## Verify
 
 A pass is not a claim that the host is healthy. It is a claim that these
-eleven questions have good answers. Confirm the rest by deploying a bench and
+twelve questions have good answers. Confirm the rest by deploying a bench and
 opening it, which exercises Docker, the bridge, the VPN, the database and the
 router in one action. See
 [Deploy from a template](/docs/user/deploy-from-template).
@@ -272,6 +300,7 @@ router in one action. See
 | Severities | `Error`, `Warning` |
 | Clock tolerance | 2 seconds |
 | Heartbeat patience | 60 seconds |
+| Route report patience | 15 minutes |
 | Terminals per bench, for `kernel.pty.max` | 8, plus 1,024 reserved |
 | PIDs per bench, for `kernel.pid_max` | 500 |
 | Conntrack per bench | 256 |


### PR DESCRIPTION
Follow-up to #266. That PR added a twelfth diagnostics check for the Traefik route
directory, but its bundle was the one whose independent triage died on a session limit,
so it merged without that gate. This is the gate, arriving late, and it found two real
defects. Two adversarial reviews — one on Frappe convention, one on operational
correctness — converged on both independently.

## The check could not report the failure it was written for

`_converge_routes` returned at `if not ingress.directory_mounted():` **before**
`ingress.ensure_anchor(base_domain)`, and `ensure_anchor` is the only recurring caller of
`record_directory_state()`. So on the documented install — `base_domain` required and
filled, no prod overlay, `queue-long` with no route mount — the `*/5` pass recorded
nothing, forever.

The row could therefore only ever show the vague "no worker has reported yet" Warning,
which blames a healthy scheduler and a healthy `queue-long`, and never the precise Error
naming the missing mount. Worse, a working prod host that *lost* its route mount degraded
`pass` → Warning-stale → Warning-unreported and could never reach Error, because nothing
ever recorded `mounted: False`.

That is the same false clean bill of health #266 set out to remove, delayed by half an hour.

The fix records before the gate, the shape `ensure_anchor` and `sync_instance_route`
already use. The stale comment claiming the unmounted path is "only ever a by-hand run
outside queue-long" is gone — that assumption is what the bundle existed to refute.

## The deploy advertised a URL nothing could answer

#266 changed `publish()` to return whether it wrote a route file, then discarded the
result at the one call site where it decides something a user sees. `lifecycle.py:380`
assigned `bench.public_url` unconditionally, so a worker with no route mount finished the
deploy green and persisted an `https://` URL with no route behind it. `launch.py:84` and
the Lab screen both prefer `public_url` over the tunnel address, so the dead URL
suppressed the working WireGuard one, and `_announce` emailed it.

`public_url` is now assigned only when `publish()` reports a route on disk.

## Also

- `directory_state()` reads with `expires=True`. A non-expiring read memoises into
  `frappe.local.cache`, misses included, so a TTL'd key can outlive its own TTL. Core reads
  expiring keys this way (`frappe/www/login.py:121`).
- **A guard test for `INFRASTRUCTURE_LABELS`.** The suite already guarded check order and
  the docstring count word; the label map was the third member of that trio with no guard,
  which is exactly why a missing label reached a human eyeball instead of CI.
- The hints and comments that promised "every reconcile pass refreshes it" now say what
  actually writes the report.
- Three more "eleven"s in `diagnostics.mdx` that the earlier count sweep missed, a
  contradicted "Everything else is an Error" paragraph, and a fixture hint that said
  `benchpress.yml` where the constant is `dynamic.yml`.

## Verification

- **940 backend tests.** Both new tests were confirmed to fail without their fix and pass
  with it — reverting just the two source files fails exactly those two.
- `vitest`, `pre-commit`, `leadtype lint` 41/41, score 100/100, generated docs current.
- Pre-existing and unrelated: two `test_waitlist` failures locally, caused by the `wiki`
  app granting an extra role on this site (proven in #266 against a clean tree; CI passes
  them). `test_lease.test_a_renewal_locks_the_row_the_stop_job_locks` errored once in a
  full run and passes in isolation — an order-dependent row-lock test, worth a look
  separately.

## Deliberately not done

Four review findings were **refused** with evidence rather than applied:

- Comparing the reported route count against `len(ingress.routable())` and erroring on a
  mismatch. Both recorders write the report *before* the write they gate, so the count is
  systematically one behind at exactly the moments it changes — this would trade a false
  pass for a false Error.
- Escalating the published-routes-without-anchor branch from Warning to Error, for the same
  reason: it is normally one pass behind a directory that already healed.
- Migrating `frappe.cache()` to core's `frappe.cache` property form. Behaviourally a no-op,
  the repo is split 16/6, and this check deliberately mirrors `docker_events.heartbeat_value`.
  A repo-wide form migration is its own change.
- Asserting the count word appears in the docs. "twelve" was already present in the heading
  while the intro said eleven, so a presence assertion would have passed.
