### PR TITLE
chore(docs): regenerate the diagnostics timestamp against its own commit

### DIFF
--- a/docs-bundle/docs/operator/diagnostics.md
+++ b/docs-bundle/docs/operator/diagnostics.md
@@ -3,7 +3,7 @@ title: Diagnostics
 description: The twelve read-only checks that ask Docker, MariaDB, Redis and the
   kernel what is true — how to run them, what each failure means, and the four
   things they do not cover.
-lastModified: "2026-08-30T08:51:56-04:00"
+lastModified: "2026-08-30T18:40:05+05:30"
 lastAuthor: Venkatesh
 ---
 # Diagnostics

--- a/docs-site/docs/operator/diagnostics.md
+++ b/docs-site/docs/operator/diagnostics.md
@@ -3,7 +3,7 @@ title: Diagnostics
 description: The twelve read-only checks that ask Docker, MariaDB, Redis and the
   kernel what is true — how to run them, what each failure means, and the four
   things they do not cover.
-lastModified: "2026-08-30T08:51:56-04:00"
+lastModified: "2026-08-30T18:40:05+05:30"
 lastAuthor: Venkatesh
 ---
 # Diagnostics

--- a/docs-site/sitemap.xml
+++ b/docs-site/sitemap.xml
@@ -98,7 +98,7 @@
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/operator/diagnostics</loc>
-    <lastmod>2026-08-30T12:51:56.000Z</lastmod>
+    <lastmod>2026-08-30T13:10:05.000Z</lastmod>
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/operator/credits-and-billing</loc>


### PR DESCRIPTION
## Summary

The `Docs` job failed on `version-16` and on all 13 open dependabot pull requests. One timestamp caused it.

`docs/operator/diagnostics.mdx` was last edited by 42e994a. Its generated copies carried `lastModified: "2026-08-30T08:51:56-04:00"`, but every run since produces `"2026-08-30T18:40:05+05:30"` — which is 42e994a's own commit date.

42e994a edited the `.mdx` and regenerated the docs trees in the same commit. `leadtype generate` stamps each page with the commit date that last touched it, and git enrichment skips when git metadata is unavailable. The edit had no commit yet, so it fell back to the file mtime and that value was committed. Once 42e994a landed the file had a commit date, so every later run disagreed. Regenerating inside the same commit could never settle this.

This commit regenerates now that 42e994a exists. Three files, three lines.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional change)
- [x] Documentation update
- [ ] Performance improvement

## Test Plan

Regenerated from a clean `rm -rf docs-site docs-bundle`, because incremental runs skip files they consider unchanged. The rebuild reproduced CI's three files exactly, with no additions or deletions, so the committed output was faithful apart from the stamp.

- [x] Clean rebuild reproduces exactly the three files CI reported
- [x] Second clean rebuild on top of this fix reports zero drift — the output is idempotent, not just green once
- [x] `npm run docs:lint` — all 41 files pass
- [x] `npm run docs:score` — every scored row passes
- [x] `uvx pre-commit@4.3.0` passes on the changed files
- [ ] Tested locally with `bench start` — not applicable, no app code changes
- [ ] Frontend builds without errors — not applicable, no frontend changes

## Checklist

- [x] Commit messages follow conventional commits format
- [x] No `frappe.db.sql` in new code (use `frappe.qb`)
- [x] No `console.log` left in JS
- [x] Permission checks on new whitelisted endpoints — no new endpoints
- [x] No hardcoded credentials or API keys

## Follow-up

This recurs on any future commit that edits a `.mdx` and regenerates in one go. The durable fix is to stop committing generated output and let CI build it, or to split docs changes into a source commit followed by a regeneration commit. Not in scope here.