### PR TITLE
docs: make benchpress.cloud/docs the canonical documentation home

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -11,5 +11,5 @@ contact_links:
     url: https://github.com/Venkateshvenki404224/benchpress/discussions
     about: Ask how to do something, or propose an idea before opening an issue.
   - name: Documentation
-    url: https://docs.benchpress.cloud/docs
+    url: https://benchpress.cloud/docs
     about: Install, deploy and configure BenchPress.

--- a/docs-bundle/AGENTS.md
+++ b/docs-bundle/AGENTS.md
@@ -12,7 +12,7 @@ works in it over SSH or a browser VS Code session, and destroys it when the task
 is done.
 
 - Self-hosted. One box, Docker, no external control plane.
-- Every bench reachable only over WireGuard.
+- No bench port is published on the host; benches answer on WireGuard, plus an HTTPS name when a base domain is set.
 - Built on the Frappe framework, with a Vue 3 single-page app on the front.
 
 ## Best Starting Points

--- a/docs-bundle/docs/operator/diagnostics.md
+++ b/docs-bundle/docs/operator/diagnostics.md
@@ -3,7 +3,7 @@ title: Diagnostics
 description: The twelve read-only checks that ask Docker, MariaDB, Redis and the
   kernel what is true — how to run them, what each failure means, and the four
   things they do not cover.
-lastModified: "2026-08-30T08:51:56-04:00"
+lastModified: "2026-08-30T18:40:05+05:30"
 lastAuthor: Venkatesh
 ---
 # Diagnostics

--- a/docs-bundle/docs/user/deploy-from-template.md
+++ b/docs-bundle/docs/user/deploy-from-template.md
@@ -2,7 +2,7 @@
 title: Deploy from a template
 description: Turn a catalog template into a running bench, and read the eleven
   pipeline steps while they run.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T10:28:35-04:00"
 lastAuthor: Venkatesh
 ---
 # Deploy from a template

--- a/docs-bundle/docs/user/deploy-from-template.md
+++ b/docs-bundle/docs/user/deploy-from-template.md
@@ -113,7 +113,7 @@ The deploy worked when all four are true.
 |The log stops at `Waiting for the worker to pick the deploy up…`|No worker is running, so nothing has started|Ask the operator to check `queue-long`|
 |Step 7 runs for minutes|The image has no golden dump, so the site is built from scratch|Nothing to fix. Read step 2, which reports the same thing|
 |The run ends **Error**|The step that failed names the reason|Open **Raw log** under the steps and read the last lines|
-|**Open site** opens nothing|Bench sites resolve only over the VPN|Connect the VPN, then press it again|
+|**Open site** opens nothing|The site has no public name, so it answers only on the VPN|Connect the VPN, then press it again|
 
 ## Reference
 

--- a/docs-bundle/docs/user/lab-detail.md
+++ b/docs-bundle/docs/user/lab-detail.md
@@ -2,7 +2,7 @@
 title: Read a lab page
 description: Every field on the lab page, and why container status and container
   health can disagree.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T10:28:35-04:00"
 lastAuthor: Venkatesh
 ---
 # Read a lab page

--- a/docs-bundle/docs/user/lab-detail.md
+++ b/docs-bundle/docs/user/lab-detail.md
@@ -111,7 +111,7 @@ You are reading the page correctly when all four are true.
 |CPU and memory read `—`|The container is not running|Start the bench|
 |The header has no **Build log** tab|Build logs are admin-only|Ask an admin for the build output|
 |A stopped bench shows a countdown|Stopped benches are deleted after a set number of days|Start it, or accept that it goes|
-|**Open site** does nothing|Bench sites resolve only over the VPN|Connect the VPN and press it again|
+|**Open site** does nothing|The site has no public name, so it answers only on the VPN|Connect the VPN and press it again|
 
 ## Reference
 

--- a/docs-bundle/docs/user/quick-tour.md
+++ b/docs-bundle/docs/user/quick-tour.md
@@ -84,7 +84,7 @@ You have read the tour correctly when all four are true.
 |--|--|--|
 |`/frontend` returns to the login page|You have no session, or it expired|Sign in at `/login`, then open `/frontend` again|
 |The VPN chip is amber and reads VPN off|This device has no WireGuard tunnel|Open **Devices**, register the device, install the config it gives you|
-|**Open site** opens nothing|Bench sites resolve only over the VPN|Connect the VPN, then click again|
+|**Open site** opens nothing|The site has no public name, so it answers only on the VPN|Connect the VPN, then click again|
 |**Templates** is missing from the sidebar|Templates is admin-only|Ask an admin, or start a bench from **Labs**|
 |**Needs attention** is above zero|A bench errored or stopped answering|Open **Instances**, open the bench, read its deploy log|
 |**Credits** is missing everywhere|Credits are off on this server|Nothing to fix. A self-hosted server runs without them|

--- a/docs-bundle/docs/user/quick-tour.md
+++ b/docs-bundle/docs/user/quick-tour.md
@@ -2,7 +2,7 @@
 title: Quick tour
 description: The five screens in the BenchPress sidebar, and every number the
   Overview dashboard reports.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T10:28:35-04:00"
 lastAuthor: Venkatesh
 ---
 # Quick tour

--- a/docs-site/.well-known/agent-card.json
+++ b/docs-site/.well-known/agent-card.json
@@ -1,9 +1,9 @@
 {
   "name": "BenchPress",
   "description": "Press a button. Get a Frappe bench.",
-  "url": "https://docs.benchpress.cloud",
+  "url": "https://benchpress.cloud",
   "version": "0.1.0",
-  "documentationUrl": "https://docs.benchpress.cloud/docs",
+  "documentationUrl": "https://benchpress.cloud/docs",
   "capabilities": {
     "streaming": false,
     "pushNotifications": false

--- a/docs-site/.well-known/api-catalog
+++ b/docs-site/.well-known/api-catalog
@@ -1,28 +1,28 @@
 {
   "linkset": [
     {
-      "anchor": "https://docs.benchpress.cloud/",
+      "anchor": "https://benchpress.cloud/",
       "api-catalog": [
         {
-          "href": "https://docs.benchpress.cloud/.well-known/api-catalog",
+          "href": "https://benchpress.cloud/.well-known/api-catalog",
           "type": "application/linkset+json"
         }
       ],
       "service-doc": [
         {
-          "href": "https://docs.benchpress.cloud/docs/llms.txt",
+          "href": "https://benchpress.cloud/docs/llms.txt",
           "type": "text/plain"
         }
       ],
       "service-desc": [
         {
-          "href": "https://docs.benchpress.cloud/docs/agent-readability.json",
+          "href": "https://benchpress.cloud/docs/agent-readability.json",
           "type": "application/json"
         }
       ],
       "describedby": [
         {
-          "href": "https://docs.benchpress.cloud/sitemap.xml",
+          "href": "https://benchpress.cloud/sitemap.xml",
           "type": "application/xml"
         }
       ]

--- a/docs-site/.well-known/llms-full.txt
+++ b/docs-site/.well-known/llms-full.txt
@@ -4,51 +4,51 @@
 
 ## Included Pages
 
-- [Quick tour](https://docs.benchpress.cloud/docs/user/quick-tour): The five screens in the BenchPress sidebar, and every number the Overview dashboard reports.
-- [Deploy from a template](https://docs.benchpress.cloud/docs/user/deploy-from-template): Turn a catalog template into a running bench, and read the eleven pipeline steps while they run.
-- [Create a lab](https://docs.benchpress.cloud/docs/user/create-a-lab): Fill in the New lab form when no catalog template matches the app list you need.
-- [Read a lab page](https://docs.benchpress.cloud/docs/user/lab-detail): Every field on the lab page, and why container status and container health can disagree.
-- [Start, stop and redeploy](https://docs.benchpress.cloud/docs/user/lifecycle): The five actions on a running bench, which of them destroy work, and which are admin-only.
-- [Register a VPN device](https://docs.benchpress.cloud/docs/user/vpn-devices): Put a laptop or a phone on the WireGuard network, import the config, read the device status, and run the connection test when a site will not open.
-- [Open the bench site](https://docs.benchpress.cloud/docs/user/open-your-site): The Sites card, the three states of its Open button, and logging in to the Frappe site a deploy created.
-- [Connect over SSH and the VPN](https://docs.benchpress.cloud/docs/user/connect-ssh-vpn): The connection card on a lab page — two addresses, the SSH command, the three passwords, and which of them work without the tunnel.
-- [Use code-server](https://docs.benchpress.cloud/docs/user/code-server): Open the browser VS Code session on a bench, find its password, hand the session to a teammate, and restart it when it stops answering.
-- [Read logs and container stats](https://docs.benchpress.cloud/docs/user/logs-and-monitoring): The deploy stepper, the raw log and its step markers, the build log, and the CPU and memory bars on a running bench.
-- [Leases and credits](https://docs.benchpress.cloud/docs/user/leases-and-credits): The countdown on a running bench, the renew dialog and its plans, the credit meter, the ledger, and where a purchase hands off to the payment gateway.
-- [Troubleshooting](https://docs.benchpress.cloud/docs/user/troubleshooting): Every symptom a BenchPress user meets, its cause, and the page that fixes it — deploys, the VPN, SSH, code-server, logs and credits.
-- [Operator track](https://docs.benchpress.cloud/docs/operator): Run BenchPress on your own box — install, the VPN plane, settings, the shared database, images, upgrades, safety and diagnostics.
-- [Prerequisites](https://docs.benchpress.cloud/docs/operator/prerequisites): What a BenchPress host needs before you install — the four preconditions, supported platforms, versions, Docker socket access, and the measured CPU and disk sizing.
-- [Install](https://docs.benchpress.cloud/docs/operator/install): Install BenchPress into a Frappe v16 bench — get-app, setup.sh, the frontend build, the base domain, and the first screen.
-- [WireGuard and the VPN plane](https://docs.benchpress.cloud/docs/operator/wireguard-setup): How the vpn_management app owns the tunnel, what BenchPress consumes from it, the measured server and pool values, and why userns-remap matters.
-- [Settings reference](https://docs.benchpress.cloud/docs/operator/settings-reference): Every field on BenchPress Settings and Credit Settings, with the value measured on a live host, where each one is edited, and what changing it costs.
-- [The shared database server](https://docs.benchpress.cloud/docs/operator/database-server): One MariaDB holds every bench site's database — where it lives, how BenchPress drives it, what drift detection watches, and the four actions on the record.
-- [Backup and restore](https://docs.benchpress.cloud/docs/operator/backup-and-restore): Where the nightly MariaDB dumps land, how long they are kept, and the two restore paths — a scratch container for verification, and managed recovery from bench console.
-- [Users and roles](https://docs.benchpress.cloud/docs/operator/users-and-roles): The two BenchPress roles, what each one may read and write, which screens are admin-only, and how ownership rather than a role decides who sees a bench.
-- [Golden images](https://docs.benchpress.cloud/docs/operator/golden-images): A lab's finished site is baked into its own image as a database dump, so a deploy restores it instead of creating tables — the measured numbers, the two settings, and why a golden gets refused.
-- [The image cache](https://docs.benchpress.cloud/docs/operator/image-cache): One image per lab, tagged benchpress/<lab_id>:lab — what it costs on disk, how the weekly prewarm and sweep work, and what is safe to prune.
-- [Upgrading](https://docs.benchpress.cloud/docs/operator/upgrading): Move a BenchPress install to a newer release — the backup gate, the five steps, the scripted path, rollback, and why lab images are a separate opt-in.
-- [Production safety](https://docs.benchpress.cloud/docs/operator/production-safety): What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the release checklist that covers 25 of 52 whitelisted callables.
-- [Diagnostics](https://docs.benchpress.cloud/docs/operator/diagnostics): The twelve read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
-- [Credits and billing](https://docs.benchpress.cloud/docs/operator/credits-and-billing): Optional and off by default — the metering half of BenchPress, covering leases, balances, the ledger, admin adjustments, and the optional Razorpay handoff.
-- [Admission and limits](https://docs.benchpress.cloud/docs/operator/admission-and-limits): Optional and off by default — concurrency caps, size ceilings, device and build quotas, how a slot is claimed as a row, and the acceptance run that proves access still works.
-- [Self-serve signup](https://docs.benchpress.cloud/docs/operator/hosted-signup): Optional and off by default — retire the waitlist and let people sign themselves up, with GitHub and Google as the primary paths and the abuse controls that make a free grant safe.
-- [Reference track](https://docs.benchpress.cloud/docs/reference): The data model, the whitelisted API, the eleven deploy steps, the reconcilers, the address plan and the configuration split — for a contributor or an integrator.
-- [Architecture](https://docs.benchpress.cloud/docs/reference/architecture): The moving parts of BenchPress — the control plane, the bench containers, the shared infrastructure, and which Python module owns each concern.
-- [Data model](https://docs.benchpress.cloud/docs/reference/data-model): All 20 BenchPress DocTypes with their fields, links, naming and the permission rule that scopes each one — plus why there is no Device DocType.
-- [API](https://docs.benchpress.cloud/docs/reference/api): Every whitelisted BenchPress endpoint, with arguments, what each returns, and the permission check each one makes for itself.
-- [Deploy pipeline](https://docs.benchpress.cloud/docs/reference/deploy-pipeline): The eleven steps of a BenchPress deploy, in the order the code runs them, with the function behind each step and the log line it writes.
-- [Lifecycle and events](https://docs.benchpress.cloud/docs/reference/lifecycle-and-events): The bench states and their transitions, the Docker event listener, Bench Event incidents, the stats collector, and the eleven scheduled jobs that correct the database.
-- [Networking](https://docs.benchpress.cloud/docs/reference/networking): The BenchPress address plan — bench bridges, WireGuard tunnel addresses, the two container ports, Traefik route files and the wildcard certificate anchor.
-- [Realtime](https://docs.benchpress.cloud/docs/reference/realtime): The six realtime events BenchPress publishes over socket.io, their payloads, who receives each one, and why the deploy log commits every line.
-- [Configuration](https://docs.benchpress.cloud/docs/reference/configuration): Where each BenchPress setting lives — build arguments that need a rebuild, runtime environment that needs a restart, and DocType fields that apply on save.
-- [CLI and scripts](https://docs.benchpress.cloud/docs/reference/cli-and-scripts): Every command that drives BenchPress from a shell — entry.py, the bench commands, setup.sh and upgrade.sh, the four repository scripts and the documentation pipeline.
-- [Glossary](https://docs.benchpress.cloud/docs/reference/glossary): What each BenchPress term means here — lab, bench, site, lease, admission, golden image, peer — including the words that mean something else elsewhere.
-- [BenchPress documentation](https://docs.benchpress.cloud/docs): Start here. Three tracks — use a bench, run the server that hosts one, or read the data model and the API.
+- [Quick tour](https://benchpress.cloud/docs/user/quick-tour): The five screens in the BenchPress sidebar, and every number the Overview dashboard reports.
+- [Deploy from a template](https://benchpress.cloud/docs/user/deploy-from-template): Turn a catalog template into a running bench, and read the eleven pipeline steps while they run.
+- [Create a lab](https://benchpress.cloud/docs/user/create-a-lab): Fill in the New lab form when no catalog template matches the app list you need.
+- [Read a lab page](https://benchpress.cloud/docs/user/lab-detail): Every field on the lab page, and why container status and container health can disagree.
+- [Start, stop and redeploy](https://benchpress.cloud/docs/user/lifecycle): The five actions on a running bench, which of them destroy work, and which are admin-only.
+- [Register a VPN device](https://benchpress.cloud/docs/user/vpn-devices): Put a laptop or a phone on the WireGuard network, import the config, read the device status, and run the connection test when a site will not open.
+- [Open the bench site](https://benchpress.cloud/docs/user/open-your-site): The Sites card, the three states of its Open button, and logging in to the Frappe site a deploy created.
+- [Connect over SSH and the VPN](https://benchpress.cloud/docs/user/connect-ssh-vpn): The connection card on a lab page — two addresses, the SSH command, the three passwords, and which of them work without the tunnel.
+- [Use code-server](https://benchpress.cloud/docs/user/code-server): Open the browser VS Code session on a bench, find its password, hand the session to a teammate, and restart it when it stops answering.
+- [Read logs and container stats](https://benchpress.cloud/docs/user/logs-and-monitoring): The deploy stepper, the raw log and its step markers, the build log, and the CPU and memory bars on a running bench.
+- [Leases and credits](https://benchpress.cloud/docs/user/leases-and-credits): The countdown on a running bench, the renew dialog and its plans, the credit meter, the ledger, and where a purchase hands off to the payment gateway.
+- [Troubleshooting](https://benchpress.cloud/docs/user/troubleshooting): Every symptom a BenchPress user meets, its cause, and the page that fixes it — deploys, the VPN, SSH, code-server, logs and credits.
+- [Operator track](https://benchpress.cloud/docs/operator): Run BenchPress on your own box — install, the VPN plane, settings, the shared database, images, upgrades, safety and diagnostics.
+- [Prerequisites](https://benchpress.cloud/docs/operator/prerequisites): What a BenchPress host needs before you install — the four preconditions, supported platforms, versions, Docker socket access, and the measured CPU and disk sizing.
+- [Install](https://benchpress.cloud/docs/operator/install): Install BenchPress into a Frappe v16 bench — get-app, setup.sh, the frontend build, the base domain, and the first screen.
+- [WireGuard and the VPN plane](https://benchpress.cloud/docs/operator/wireguard-setup): How the vpn_management app owns the tunnel, what BenchPress consumes from it, the measured server and pool values, and why userns-remap matters.
+- [Settings reference](https://benchpress.cloud/docs/operator/settings-reference): Every field on BenchPress Settings and Credit Settings, with the value measured on a live host, where each one is edited, and what changing it costs.
+- [The shared database server](https://benchpress.cloud/docs/operator/database-server): One MariaDB holds every bench site's database — where it lives, how BenchPress drives it, what drift detection watches, and the four actions on the record.
+- [Backup and restore](https://benchpress.cloud/docs/operator/backup-and-restore): Where the nightly MariaDB dumps land, how long they are kept, and the two restore paths — a scratch container for verification, and managed recovery from bench console.
+- [Users and roles](https://benchpress.cloud/docs/operator/users-and-roles): The two BenchPress roles, what each one may read and write, which screens are admin-only, and how ownership rather than a role decides who sees a bench.
+- [Golden images](https://benchpress.cloud/docs/operator/golden-images): A lab's finished site is baked into its own image as a database dump, so a deploy restores it instead of creating tables — the measured numbers, the two settings, and why a golden gets refused.
+- [The image cache](https://benchpress.cloud/docs/operator/image-cache): One image per lab, tagged benchpress/<lab_id>:lab — what it costs on disk, how the weekly prewarm and sweep work, and what is safe to prune.
+- [Upgrading](https://benchpress.cloud/docs/operator/upgrading): Move a BenchPress install to a newer release — the backup gate, the five steps, the scripted path, rollback, and why lab images are a separate opt-in.
+- [Production safety](https://benchpress.cloud/docs/operator/production-safety): What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the release checklist that covers 25 of 52 whitelisted callables.
+- [Diagnostics](https://benchpress.cloud/docs/operator/diagnostics): The twelve read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
+- [Credits and billing](https://benchpress.cloud/docs/operator/credits-and-billing): Optional and off by default — the metering half of BenchPress, covering leases, balances, the ledger, admin adjustments, and the optional Razorpay handoff.
+- [Admission and limits](https://benchpress.cloud/docs/operator/admission-and-limits): Optional and off by default — concurrency caps, size ceilings, device and build quotas, how a slot is claimed as a row, and the acceptance run that proves access still works.
+- [Self-serve signup](https://benchpress.cloud/docs/operator/hosted-signup): Optional and off by default — retire the waitlist and let people sign themselves up, with GitHub and Google as the primary paths and the abuse controls that make a free grant safe.
+- [Reference track](https://benchpress.cloud/docs/reference): The data model, the whitelisted API, the eleven deploy steps, the reconcilers, the address plan and the configuration split — for a contributor or an integrator.
+- [Architecture](https://benchpress.cloud/docs/reference/architecture): The moving parts of BenchPress — the control plane, the bench containers, the shared infrastructure, and which Python module owns each concern.
+- [Data model](https://benchpress.cloud/docs/reference/data-model): All 20 BenchPress DocTypes with their fields, links, naming and the permission rule that scopes each one — plus why there is no Device DocType.
+- [API](https://benchpress.cloud/docs/reference/api): Every whitelisted BenchPress endpoint, with arguments, what each returns, and the permission check each one makes for itself.
+- [Deploy pipeline](https://benchpress.cloud/docs/reference/deploy-pipeline): The eleven steps of a BenchPress deploy, in the order the code runs them, with the function behind each step and the log line it writes.
+- [Lifecycle and events](https://benchpress.cloud/docs/reference/lifecycle-and-events): The bench states and their transitions, the Docker event listener, Bench Event incidents, the stats collector, and the eleven scheduled jobs that correct the database.
+- [Networking](https://benchpress.cloud/docs/reference/networking): The BenchPress address plan — bench bridges, WireGuard tunnel addresses, the two container ports, Traefik route files and the wildcard certificate anchor.
+- [Realtime](https://benchpress.cloud/docs/reference/realtime): The six realtime events BenchPress publishes over socket.io, their payloads, who receives each one, and why the deploy log commits every line.
+- [Configuration](https://benchpress.cloud/docs/reference/configuration): Where each BenchPress setting lives — build arguments that need a rebuild, runtime environment that needs a restart, and DocType fields that apply on save.
+- [CLI and scripts](https://benchpress.cloud/docs/reference/cli-and-scripts): Every command that drives BenchPress from a shell — entry.py, the bench commands, setup.sh and upgrade.sh, the four repository scripts and the documentation pipeline.
+- [Glossary](https://benchpress.cloud/docs/reference/glossary): What each BenchPress term means here — lab, bench, site, lease, admission, golden image, peer — including the words that mean something else elsewhere.
+- [BenchPress documentation](https://benchpress.cloud/docs): Start here. Three tracks — use a bench, run the server that hosts one, or read the data model and the API.
 
 ## Content
 
 # Quick tour
-URL: https://docs.benchpress.cloud/docs/user/quick-tour
+URL: https://benchpress.cloud/docs/user/quick-tour
 The five screens in the BenchPress sidebar, and every number the Overview dashboard reports.
 
 This page names every screen in BenchPress and reads the first one out loud.
@@ -128,7 +128,7 @@ You have read the tour correctly when all four are true.
 |--|--|--|
 |`/frontend` returns to the login page|You have no session, or it expired|Sign in at `/login`, then open `/frontend` again|
 |The VPN chip is amber and reads VPN off|This device has no WireGuard tunnel|Open **Devices**, register the device, install the config it gives you|
-|**Open site** opens nothing|Bench sites resolve only over the VPN|Connect the VPN, then click again|
+|**Open site** opens nothing|The site has no public name, so it answers only on the VPN|Connect the VPN, then click again|
 |**Templates** is missing from the sidebar|Templates is admin-only|Ask an admin, or start a bench from **Labs**|
 |**Needs attention** is above zero|A bench errored or stopped answering|Open **Instances**, open the bench, read its deploy log|
 |**Credits** is missing everywhere|Credits are off on this server|Nothing to fix. A self-hosted server runs without them|
@@ -175,7 +175,7 @@ server.
 * [BenchPress documentation](/docs) — the three tracks, and what each one covers.
 
 # Deploy from a template
-URL: https://docs.benchpress.cloud/docs/user/deploy-from-template
+URL: https://benchpress.cloud/docs/user/deploy-from-template
 Turn a catalog template into a running bench, and read the eleven pipeline steps while they run.
 
 A template is a recipe someone already wrote. This page takes you from the
@@ -284,7 +284,7 @@ The deploy worked when all four are true.
 |The log stops at `Waiting for the worker to pick the deploy up…`|No worker is running, so nothing has started|Ask the operator to check `queue-long`|
 |Step 7 runs for minutes|The image has no golden dump, so the site is built from scratch|Nothing to fix. Read step 2, which reports the same thing|
 |The run ends **Error**|The step that failed names the reason|Open **Raw log** under the steps and read the last lines|
-|**Open site** opens nothing|Bench sites resolve only over the VPN|Connect the VPN, then press it again|
+|**Open site** opens nothing|The site has no public name, so it answers only on the VPN|Connect the VPN, then press it again|
 
 ## Reference
 
@@ -321,7 +321,7 @@ The deploy worked when all four are true.
 * [Start, stop and redeploy](/docs/user/lifecycle) — what to do after it is running.
 
 # Create a lab
-URL: https://docs.benchpress.cloud/docs/user/create-a-lab
+URL: https://benchpress.cloud/docs/user/create-a-lab
 Fill in the New lab form when no catalog template matches the app list you need.
 
 A lab is a recipe: a Frappe version, a list of apps and a set of container
@@ -440,7 +440,7 @@ The **What gets built** panel says so: `Docker image shared with every lab that 
 * [Start, stop and redeploy](/docs/user/lifecycle) — running the bench afterwards.
 
 # Read a lab page
-URL: https://docs.benchpress.cloud/docs/user/lab-detail
+URL: https://benchpress.cloud/docs/user/lab-detail
 Every field on the lab page, and why container status and container health can disagree.
 
 The lab page is one screen with two clocks on it. This page reads every field,
@@ -547,7 +547,7 @@ You are reading the page correctly when all four are true.
 |CPU and memory read `—`|The container is not running|Start the bench|
 |The header has no **Build log** tab|Build logs are admin-only|Ask an admin for the build output|
 |A stopped bench shows a countdown|Stopped benches are deleted after a set number of days|Start it, or accept that it goes|
-|**Open site** does nothing|Bench sites resolve only over the VPN|Connect the VPN and press it again|
+|**Open site** does nothing|The site has no public name, so it answers only on the VPN|Connect the VPN and press it again|
 
 ## Reference
 
@@ -592,7 +592,7 @@ The window is `reap_after_days` in Credit Settings, which is **7 days** here.
 * [Create a lab](/docs/user/create-a-lab) — where the header chips come from.
 
 # Start, stop and redeploy
-URL: https://docs.benchpress.cloud/docs/user/lifecycle
+URL: https://benchpress.cloud/docs/user/lifecycle
 The five actions on a running bench, which of them destroy work, and which are admin-only.
 
 A running bench has five actions. Two are safe, one is destructive, one is
@@ -724,7 +724,7 @@ before, so nothing disappears without notice. `0` turns the deletion off.
 * [Create a lab](/docs/user/create-a-lab) — what a rebuild rebuilds.
 
 # Register a VPN device
-URL: https://docs.benchpress.cloud/docs/user/vpn-devices
+URL: https://benchpress.cloud/docs/user/vpn-devices
 Put a laptop or a phone on the WireGuard network, import the config, read the device status, and run the connection test when a site will not open.
 
 No bench is published to the internet on a tunnel-only address. Register the
@@ -904,7 +904,7 @@ not go through BenchPress while the tunnel is on.
 * [Troubleshooting](/docs/user/troubleshooting) — symptoms across the whole app.
 
 # Open the bench site
-URL: https://docs.benchpress.cloud/docs/user/open-your-site
+URL: https://benchpress.cloud/docs/user/open-your-site
 The Sites card, the three states of its Open button, and logging in to the Frappe site a deploy created.
 
 A deploy ends with a working Frappe site. This page opens it and logs in, and
@@ -1033,7 +1033,7 @@ redeploy.
 * [Read a lab page](/docs/user/lab-detail) — the rest of the lab screen.
 
 # Connect over SSH and the VPN
-URL: https://docs.benchpress.cloud/docs/user/connect-ssh-vpn
+URL: https://benchpress.cloud/docs/user/connect-ssh-vpn
 The connection card on a lab page — two addresses, the SSH command, the three passwords, and which of them work without the tunnel.
 
 A running bench publishes one card with everything needed to reach it. This
@@ -1182,7 +1182,7 @@ benches. An admin sees every bench on the server.
 * [Read a lab page](/docs/user/lab-detail) — the rest of the screen this card sits on.
 
 # Use code-server
-URL: https://docs.benchpress.cloud/docs/user/code-server
+URL: https://benchpress.cloud/docs/user/code-server
 Open the browser VS Code session on a bench, find its password, hand the session to a teammate, and restart it when it stops answering.
 
 Every bench whose lab enables it runs code-server, which is VS Code in a
@@ -1311,7 +1311,7 @@ benches.
 * [Read a lab page](/docs/user/lab-detail) — the chips that say whether a lab has an IDE.
 
 # Read logs and container stats
-URL: https://docs.benchpress.cloud/docs/user/logs-and-monitoring
+URL: https://benchpress.cloud/docs/user/logs-and-monitoring
 The deploy stepper, the raw log and its step markers, the build log, and the CPU and memory bars on a running bench.
 
 Every deploy and every image build writes a log you can read while it runs and
@@ -1497,7 +1497,7 @@ card, and the deploy log says which of them changed.
 * [Troubleshooting](/docs/user/troubleshooting) — symptoms across the whole app.
 
 # Leases and credits
-URL: https://docs.benchpress.cloud/docs/user/leases-and-credits
+URL: https://benchpress.cloud/docs/user/leases-and-credits
 The countdown on a running bench, the renew dialog and its plans, the credit meter, the ledger, and where a purchase hands off to the payment gateway.
 
 On a server with credits switched on, a deploy buys a fixed window of time and
@@ -1746,7 +1746,7 @@ They can still be refused for credits.
 * [Troubleshooting](/docs/user/troubleshooting) — symptoms across the whole app.
 
 # Troubleshooting
-URL: https://docs.benchpress.cloud/docs/user/troubleshooting
+URL: https://benchpress.cloud/docs/user/troubleshooting
 Every symptom a BenchPress user meets, its cause, and the page that fixes it — deploys, the VPN, SSH, code-server, logs and credits.
 
 One index of symptoms across the whole app. Find the line that matches what
@@ -1869,7 +1869,7 @@ address and its password instead of retyping the error.
 * [Connect over SSH and the VPN](/docs/user/connect-ssh-vpn) — the card behind most access problems.
 
 # Operator track
-URL: https://docs.benchpress.cloud/docs/operator
+URL: https://benchpress.cloud/docs/operator
 Run BenchPress on your own box — install, the VPN plane, settings, the shared database, images, upgrades, safety and diagnostics.
 
 Everything about the machine BenchPress runs on, rather than the benches it
@@ -1943,7 +1943,7 @@ elsewhere, and there is no second machine to keep in step.
 * [Troubleshooting](/docs/user/troubleshooting) — the symptom index a user reads before calling you.
 
 # Prerequisites
-URL: https://docs.benchpress.cloud/docs/operator/prerequisites
+URL: https://benchpress.cloud/docs/operator/prerequisites
 What a BenchPress host needs before you install — the four preconditions, supported platforms, versions, Docker socket access, and the measured CPU and disk sizing.
 
 What the machine must already have before [Install](/docs/operator/install)
@@ -2188,7 +2188,7 @@ ran **4 to 26 minutes**, and the golden pass 5 to 11 — see
 * [Diagnostics](/docs/operator/diagnostics) — the same checks, run by the app against the live host.
 
 # Install
-URL: https://docs.benchpress.cloud/docs/operator/install
+URL: https://benchpress.cloud/docs/operator/install
 Install BenchPress into a Frappe v16 bench — get-app, setup.sh, the frontend build, the base domain, and the first screen.
 
 From a prepared host to the BenchPress Overview, in six steps.
@@ -2377,7 +2377,7 @@ that image in seconds. See [The image cache](/docs/operator/image-cache).
 * [Quick tour](/docs/user/quick-tour) — the screens you just installed.
 
 # WireGuard and the VPN plane
-URL: https://docs.benchpress.cloud/docs/operator/wireguard-setup
+URL: https://benchpress.cloud/docs/operator/wireguard-setup
 How the vpn_management app owns the tunnel, what BenchPress consumes from it, the measured server and pool values, and why userns-remap matters.
 
 BenchPress does not manage WireGuard. This page says who does, what BenchPress
@@ -2566,7 +2566,7 @@ documentation. It owns every one of these values.
 * [Diagnostics](/docs/operator/diagnostics) — the `vpn_server` check and what it does not cover.
 
 # Settings reference
-URL: https://docs.benchpress.cloud/docs/operator/settings-reference
+URL: https://benchpress.cloud/docs/operator/settings-reference
 Every field on BenchPress Settings and Credit Settings, with the value measured on a live host, where each one is edited, and what changing it costs.
 
 Every field on the two settings documents, what it controls, and what it reads
@@ -2822,7 +2822,7 @@ wrap it in a single `exec()` call.
 * [Golden images](/docs/operator/golden-images) — the two settings that decide deploy speed.
 
 # The shared database server
-URL: https://docs.benchpress.cloud/docs/operator/database-server
+URL: https://benchpress.cloud/docs/operator/database-server
 One MariaDB holds every bench site's database — where it lives, how BenchPress drives it, what drift detection watches, and the four actions on the record.
 
 Every bench site's database lives in one shared MariaDB container. This page
@@ -2990,7 +2990,7 @@ Status values are `Pending`, `Active`, `Stopped` and `Error`.
 * [Production safety](/docs/operator/production-safety) — what is and is not backed up.
 
 # Backup and restore
-URL: https://docs.benchpress.cloud/docs/operator/backup-and-restore
+URL: https://benchpress.cloud/docs/operator/backup-and-restore
 Where the nightly MariaDB dumps land, how long they are kept, and the two restore paths — a scratch container for verification, and managed recovery from bench console.
 
 Where BenchPress's automatic MariaDB dumps live, and how to turn one back into
@@ -3158,7 +3158,7 @@ older than that, the scheduled job is not running — see
 * [Production safety](/docs/operator/production-safety) — the full list of what is not backed up.
 
 # Users and roles
-URL: https://docs.benchpress.cloud/docs/operator/users-and-roles
+URL: https://benchpress.cloud/docs/operator/users-and-roles
 The two BenchPress roles, what each one may read and write, which screens are admin-only, and how ownership rather than a role decides who sees a bench.
 
 Two roles, and one rule that matters more than either: a user sees their own
@@ -3329,7 +3329,7 @@ that would let a new endpoint ship unguarded by omission.
 * [Quick tour](/docs/user/quick-tour) — the sidebar as a user sees it.
 
 # Golden images
-URL: https://docs.benchpress.cloud/docs/operator/golden-images
+URL: https://benchpress.cloud/docs/operator/golden-images
 A lab's finished site is baked into its own image as a database dump, so a deploy restores it instead of creating tables — the measured numbers, the two settings, and why a golden gets refused.
 
 Why a deploy takes 13 seconds instead of 43, what turns it off, and how to
@@ -3504,7 +3504,7 @@ it is the field the deploy compares.
 * [Read logs and container stats](/docs/user/logs-and-monitoring) — where the site step's wording appears.
 
 # The image cache
-URL: https://docs.benchpress.cloud/docs/operator/image-cache
+URL: https://benchpress.cloud/docs/operator/image-cache
 One image per lab, tagged benchpress/<lab_id>:lab — what it costs on disk, how the weekly prewarm and sweep work, and what is safe to prune.
 
 Lab images are the largest thing on a BenchPress host. This page says how they
@@ -3678,7 +3678,7 @@ These are safe:
 * [Create a lab](/docs/user/create-a-lab) — the screen that orders a build.
 
 # Upgrading
-URL: https://docs.benchpress.cloud/docs/operator/upgrading
+URL: https://benchpress.cloud/docs/operator/upgrading
 Move a BenchPress install to a newer release — the backup gate, the five steps, the scripted path, rollback, and why lab images are a separate opt-in.
 
 App code, database schema and frontend assets, with a backup gate in front and
@@ -3880,7 +3880,7 @@ and never skip the step 0 gate.
 * [Diagnostics](/docs/operator/diagnostics) — the post-upgrade health check in full.
 
 # Production safety
-URL: https://docs.benchpress.cloud/docs/operator/production-safety
+URL: https://benchpress.cloud/docs/operator/production-safety
 What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the release checklist that covers 25 of 52 whitelisted callables.
 
 Whether BenchPress is safe to run on your host, and what has to be true first.
@@ -4092,7 +4092,7 @@ any password. The `create_site` item described an endpoint that does not exist.
 * [Diagnostics](/docs/operator/diagnostics) — the checks that read the host.
 
 # Diagnostics
-URL: https://docs.benchpress.cloud/docs/operator/diagnostics
+URL: https://benchpress.cloud/docs/operator/diagnostics
 The twelve read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
 
 Twelve checks that read the host rather than the configuration, and what to do
@@ -4404,7 +4404,7 @@ router in one action. See
 * [Production safety](/docs/operator/production-safety) — the checks that a human runs, not the app.
 
 # Credits and billing
-URL: https://docs.benchpress.cloud/docs/operator/credits-and-billing
+URL: https://benchpress.cloud/docs/operator/credits-and-billing
 Optional and off by default — the metering half of BenchPress, covering leases, balances, the ledger, admin adjustments, and the optional Razorpay handoff.
 
 **Optional, and off by default.** `enable_credits` ships as `0`, and nothing
@@ -4617,7 +4617,7 @@ Measured on this host.
 * [Settings reference](/docs/operator/settings-reference) — every field above, in one table.
 
 # Admission and limits
-URL: https://docs.benchpress.cloud/docs/operator/admission-and-limits
+URL: https://benchpress.cloud/docs/operator/admission-and-limits
 Optional and off by default — concurrency caps, size ceilings, device and build quotas, how a slot is claimed as a row, and the acceptance run that proves access still works.
 
 **Optional, and off by default.** The caps on this page only bind while
@@ -4860,7 +4860,7 @@ cannot close that cycle.
 * [Troubleshooting](/docs/user/troubleshooting) — the same refusals, indexed for the user who hit one.
 
 # Self-serve signup
-URL: https://docs.benchpress.cloud/docs/operator/hosted-signup
+URL: https://benchpress.cloud/docs/operator/hosted-signup
 Optional and off by default — retire the waitlist and let people sign themselves up, with GitHub and Google as the primary paths and the abuse controls that make a free grant safe.
 
 **Optional, and off by default.** This applies to a **hosted** BenchPress,
@@ -5014,7 +5014,7 @@ keep their role, their balance and their instances.
 * [Users and roles](/docs/operator/users-and-roles) — the role every signup lands with.
 
 # Reference track
-URL: https://docs.benchpress.cloud/docs/reference
+URL: https://benchpress.cloud/docs/reference
 The data model, the whitelisted API, the eleven deploy steps, the reconcilers, the address plan and the configuration split — for a contributor or an integrator.
 
 What BenchPress is made of, rather than how to use it or how to run it.
@@ -5086,7 +5086,7 @@ it before you assume a save does the plain thing.
 * [Settings reference](/docs/operator/settings-reference) — every field on the two settings documents.
 
 # Architecture
-URL: https://docs.benchpress.cloud/docs/reference/architecture
+URL: https://benchpress.cloud/docs/reference/architecture
 The moving parts of BenchPress — the control plane, the bench containers, the shared infrastructure, and which Python module owns each concern.
 
 What the system is made of, and which module you open when a question is about
@@ -5247,7 +5247,7 @@ The counts a change should keep true.
 * [Operator track](/docs/operator) — the same system, as tasks on a host.
 
 # Data model
-URL: https://docs.benchpress.cloud/docs/reference/data-model
+URL: https://benchpress.cloud/docs/reference/data-model
 All 20 BenchPress DocTypes with their fields, links, naming and the permission rule that scopes each one — plus why there is no Device DocType.
 
 Every DocType the BenchPress module defines, what it holds, and who is allowed
@@ -5576,7 +5576,7 @@ This is the only DocType a guest can cause to be written. See
 * [Users and roles](/docs/operator/users-and-roles) — the three roles named above.
 
 # API
-URL: https://docs.benchpress.cloud/docs/reference/api
+URL: https://benchpress.cloud/docs/reference/api
 Every whitelisted BenchPress endpoint, with arguments, what each returns, and the permission check each one makes for itself.
 
 Every function this app publishes over HTTP, and what each one checks before it
@@ -5985,7 +5985,7 @@ bench --site <site> run-tests --app benchpress --module benchpress.tests.test_ap
 * [Realtime](/docs/reference/realtime) — how a screen hears about the result.
 
 # Deploy pipeline
-URL: https://docs.benchpress.cloud/docs/reference/deploy-pipeline
+URL: https://benchpress.cloud/docs/reference/deploy-pipeline
 The eleven steps of a BenchPress deploy, in the order the code runs them, with the function behind each step and the log line it writes.
 
 What happens between a click on **Deploy** and a site that answers.
@@ -6212,7 +6212,7 @@ A successful run shows eleven ticked steps on the Lab detail screen. See
 * [Logs and monitoring](/docs/user/logs-and-monitoring) — reading a run as it happens.
 
 # Lifecycle and events
-URL: https://docs.benchpress.cloud/docs/reference/lifecycle-and-events
+URL: https://benchpress.cloud/docs/reference/lifecycle-and-events
 The bench states and their transitions, the Docker event listener, Bench Event incidents, the stats collector, and the eleven scheduled jobs that correct the database.
 
 What changes a bench without anybody clicking anything.
@@ -6443,7 +6443,7 @@ bench --site <site> execute frappe.client.get_list \
 * [Settings reference](/docs/operator/settings-reference) — every number named above.
 
 # Networking
-URL: https://docs.benchpress.cloud/docs/reference/networking
+URL: https://benchpress.cloud/docs/reference/networking
 The BenchPress address plan — bench bridges, WireGuard tunnel addresses, the two container ports, Traefik route files and the wildcard certificate anchor.
 
 Every address a bench answers on, and who can reach each one.
@@ -6674,7 +6674,7 @@ docker network ls --filter name=benchpress-
 * [Data model](/docs/reference/data-model#devices-are-vpn-peers) — why there is no Device DocType.
 
 # Realtime
-URL: https://docs.benchpress.cloud/docs/reference/realtime
+URL: https://benchpress.cloud/docs/reference/realtime
 The six realtime events BenchPress publishes over socket.io, their payloads, who receives each one, and why the deploy log commits every line.
 
 How a screen changes without a page reload, and what it is listening to.
@@ -6841,7 +6841,7 @@ Then deploy a bench. See
 * [Data model](/docs/reference/data-model#deploy-log) — the row every line is written to.
 
 # Configuration
-URL: https://docs.benchpress.cloud/docs/reference/configuration
+URL: https://benchpress.cloud/docs/reference/configuration
 Where each BenchPress setting lives — build arguments that need a rebuild, runtime environment that needs a restart, and DocType fields that apply on save.
 
 Which knob lives where, and what changing it costs.
@@ -7010,7 +7010,7 @@ flag on.
 * [CLI and scripts](/docs/reference/cli-and-scripts) — the commands named above.
 
 # CLI and scripts
-URL: https://docs.benchpress.cloud/docs/reference/cli-and-scripts
+URL: https://benchpress.cloud/docs/reference/cli-and-scripts
 Every command that drives BenchPress from a shell — entry.py, the bench commands, setup.sh and upgrade.sh, the four repository scripts and the documentation pipeline.
 
 What you can run from a terminal, and what each one changes.
@@ -7237,7 +7237,7 @@ npm run docs:build && npm run docs:lint && npm run docs:score; echo "exit=$?"
 * [Golden images](/docs/operator/golden-images) — what the golden drill measures.
 
 # Glossary
-URL: https://docs.benchpress.cloud/docs/reference/glossary
+URL: https://benchpress.cloud/docs/reference/glossary
 What each BenchPress term means here — lab, bench, site, lease, admission, golden image, peer — including the words that mean something else elsewhere.
 
 One name for one thing. This page is the list of names.
@@ -7361,7 +7361,7 @@ An admin sees every row. Both admin roles short-circuit every scoping rule. See
 * [Credits and billing](/docs/operator/credits-and-billing) — the whole optional half.
 
 # BenchPress documentation
-URL: https://docs.benchpress.cloud/docs
+URL: https://benchpress.cloud/docs
 Start here. Three tracks — use a bench, run the server that hosts one, or read the data model and the API.
 
 BenchPress deploys a Frappe bench from a template. An operator describes the

--- a/docs-site/.well-known/llms.txt
+++ b/docs-site/.well-known/llms.txt
@@ -10,7 +10,7 @@ works in it over SSH or a browser VS Code session, and destroys it when the task
 is done.
 
 - Self-hosted. One box, Docker, no external control plane.
-- Every bench reachable only over WireGuard.
+- No bench port is published on the host; benches answer on WireGuard, plus an HTTPS name when a base domain is set.
 - Built on the Frappe framework, with a Vue 3 single-page app on the front.
 
 ## Best Starting Points

--- a/docs-site/docs/operator/diagnostics.md
+++ b/docs-site/docs/operator/diagnostics.md
@@ -3,7 +3,7 @@ title: Diagnostics
 description: The twelve read-only checks that ask Docker, MariaDB, Redis and the
   kernel what is true — how to run them, what each failure means, and the four
   things they do not cover.
-lastModified: "2026-08-30T08:51:56-04:00"
+lastModified: "2026-08-30T18:40:05+05:30"
 lastAuthor: Venkatesh
 ---
 # Diagnostics

--- a/docs-site/docs/user/deploy-from-template.md
+++ b/docs-site/docs/user/deploy-from-template.md
@@ -2,7 +2,7 @@
 title: Deploy from a template
 description: Turn a catalog template into a running bench, and read the eleven
   pipeline steps while they run.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T10:28:35-04:00"
 lastAuthor: Venkatesh
 ---
 # Deploy from a template

--- a/docs-site/docs/user/deploy-from-template.md
+++ b/docs-site/docs/user/deploy-from-template.md
@@ -113,7 +113,7 @@ The deploy worked when all four are true.
 |The log stops at `Waiting for the worker to pick the deploy up…`|No worker is running, so nothing has started|Ask the operator to check `queue-long`|
 |Step 7 runs for minutes|The image has no golden dump, so the site is built from scratch|Nothing to fix. Read step 2, which reports the same thing|
 |The run ends **Error**|The step that failed names the reason|Open **Raw log** under the steps and read the last lines|
-|**Open site** opens nothing|Bench sites resolve only over the VPN|Connect the VPN, then press it again|
+|**Open site** opens nothing|The site has no public name, so it answers only on the VPN|Connect the VPN, then press it again|
 
 ## Reference
 

--- a/docs-site/docs/user/lab-detail.md
+++ b/docs-site/docs/user/lab-detail.md
@@ -2,7 +2,7 @@
 title: Read a lab page
 description: Every field on the lab page, and why container status and container
   health can disagree.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T10:28:35-04:00"
 lastAuthor: Venkatesh
 ---
 # Read a lab page

--- a/docs-site/docs/user/lab-detail.md
+++ b/docs-site/docs/user/lab-detail.md
@@ -111,7 +111,7 @@ You are reading the page correctly when all four are true.
 |CPU and memory read `—`|The container is not running|Start the bench|
 |The header has no **Build log** tab|Build logs are admin-only|Ask an admin for the build output|
 |A stopped bench shows a countdown|Stopped benches are deleted after a set number of days|Start it, or accept that it goes|
-|**Open site** does nothing|Bench sites resolve only over the VPN|Connect the VPN and press it again|
+|**Open site** does nothing|The site has no public name, so it answers only on the VPN|Connect the VPN and press it again|
 
 ## Reference
 

--- a/docs-site/docs/user/quick-tour.md
+++ b/docs-site/docs/user/quick-tour.md
@@ -84,7 +84,7 @@ You have read the tour correctly when all four are true.
 |--|--|--|
 |`/frontend` returns to the login page|You have no session, or it expired|Sign in at `/login`, then open `/frontend` again|
 |The VPN chip is amber and reads VPN off|This device has no WireGuard tunnel|Open **Devices**, register the device, install the config it gives you|
-|**Open site** opens nothing|Bench sites resolve only over the VPN|Connect the VPN, then click again|
+|**Open site** opens nothing|The site has no public name, so it answers only on the VPN|Connect the VPN, then click again|
 |**Templates** is missing from the sidebar|Templates is admin-only|Ask an admin, or start a bench from **Labs**|
 |**Needs attention** is above zero|A bench errored or stopped answering|Open **Instances**, open the bench, read its deploy log|
 |**Credits** is missing everywhere|Credits are off on this server|Nothing to fix. A self-hosted server runs without them|

--- a/docs-site/docs/user/quick-tour.md
+++ b/docs-site/docs/user/quick-tour.md
@@ -2,7 +2,7 @@
 title: Quick tour
 description: The five screens in the BenchPress sidebar, and every number the
   Overview dashboard reports.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-08-30T10:28:35-04:00"
 lastAuthor: Venkatesh
 ---
 # Quick tour

--- a/docs-site/llms-full.txt
+++ b/docs-site/llms-full.txt
@@ -4,51 +4,51 @@
 
 ## Included Pages
 
-- [Quick tour](https://docs.benchpress.cloud/docs/user/quick-tour): The five screens in the BenchPress sidebar, and every number the Overview dashboard reports.
-- [Deploy from a template](https://docs.benchpress.cloud/docs/user/deploy-from-template): Turn a catalog template into a running bench, and read the eleven pipeline steps while they run.
-- [Create a lab](https://docs.benchpress.cloud/docs/user/create-a-lab): Fill in the New lab form when no catalog template matches the app list you need.
-- [Read a lab page](https://docs.benchpress.cloud/docs/user/lab-detail): Every field on the lab page, and why container status and container health can disagree.
-- [Start, stop and redeploy](https://docs.benchpress.cloud/docs/user/lifecycle): The five actions on a running bench, which of them destroy work, and which are admin-only.
-- [Register a VPN device](https://docs.benchpress.cloud/docs/user/vpn-devices): Put a laptop or a phone on the WireGuard network, import the config, read the device status, and run the connection test when a site will not open.
-- [Open the bench site](https://docs.benchpress.cloud/docs/user/open-your-site): The Sites card, the three states of its Open button, and logging in to the Frappe site a deploy created.
-- [Connect over SSH and the VPN](https://docs.benchpress.cloud/docs/user/connect-ssh-vpn): The connection card on a lab page — two addresses, the SSH command, the three passwords, and which of them work without the tunnel.
-- [Use code-server](https://docs.benchpress.cloud/docs/user/code-server): Open the browser VS Code session on a bench, find its password, hand the session to a teammate, and restart it when it stops answering.
-- [Read logs and container stats](https://docs.benchpress.cloud/docs/user/logs-and-monitoring): The deploy stepper, the raw log and its step markers, the build log, and the CPU and memory bars on a running bench.
-- [Leases and credits](https://docs.benchpress.cloud/docs/user/leases-and-credits): The countdown on a running bench, the renew dialog and its plans, the credit meter, the ledger, and where a purchase hands off to the payment gateway.
-- [Troubleshooting](https://docs.benchpress.cloud/docs/user/troubleshooting): Every symptom a BenchPress user meets, its cause, and the page that fixes it — deploys, the VPN, SSH, code-server, logs and credits.
-- [Operator track](https://docs.benchpress.cloud/docs/operator): Run BenchPress on your own box — install, the VPN plane, settings, the shared database, images, upgrades, safety and diagnostics.
-- [Prerequisites](https://docs.benchpress.cloud/docs/operator/prerequisites): What a BenchPress host needs before you install — the four preconditions, supported platforms, versions, Docker socket access, and the measured CPU and disk sizing.
-- [Install](https://docs.benchpress.cloud/docs/operator/install): Install BenchPress into a Frappe v16 bench — get-app, setup.sh, the frontend build, the base domain, and the first screen.
-- [WireGuard and the VPN plane](https://docs.benchpress.cloud/docs/operator/wireguard-setup): How the vpn_management app owns the tunnel, what BenchPress consumes from it, the measured server and pool values, and why userns-remap matters.
-- [Settings reference](https://docs.benchpress.cloud/docs/operator/settings-reference): Every field on BenchPress Settings and Credit Settings, with the value measured on a live host, where each one is edited, and what changing it costs.
-- [The shared database server](https://docs.benchpress.cloud/docs/operator/database-server): One MariaDB holds every bench site's database — where it lives, how BenchPress drives it, what drift detection watches, and the four actions on the record.
-- [Backup and restore](https://docs.benchpress.cloud/docs/operator/backup-and-restore): Where the nightly MariaDB dumps land, how long they are kept, and the two restore paths — a scratch container for verification, and managed recovery from bench console.
-- [Users and roles](https://docs.benchpress.cloud/docs/operator/users-and-roles): The two BenchPress roles, what each one may read and write, which screens are admin-only, and how ownership rather than a role decides who sees a bench.
-- [Golden images](https://docs.benchpress.cloud/docs/operator/golden-images): A lab's finished site is baked into its own image as a database dump, so a deploy restores it instead of creating tables — the measured numbers, the two settings, and why a golden gets refused.
-- [The image cache](https://docs.benchpress.cloud/docs/operator/image-cache): One image per lab, tagged benchpress/<lab_id>:lab — what it costs on disk, how the weekly prewarm and sweep work, and what is safe to prune.
-- [Upgrading](https://docs.benchpress.cloud/docs/operator/upgrading): Move a BenchPress install to a newer release — the backup gate, the five steps, the scripted path, rollback, and why lab images are a separate opt-in.
-- [Production safety](https://docs.benchpress.cloud/docs/operator/production-safety): What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the release checklist that covers 25 of 52 whitelisted callables.
-- [Diagnostics](https://docs.benchpress.cloud/docs/operator/diagnostics): The twelve read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
-- [Credits and billing](https://docs.benchpress.cloud/docs/operator/credits-and-billing): Optional and off by default — the metering half of BenchPress, covering leases, balances, the ledger, admin adjustments, and the optional Razorpay handoff.
-- [Admission and limits](https://docs.benchpress.cloud/docs/operator/admission-and-limits): Optional and off by default — concurrency caps, size ceilings, device and build quotas, how a slot is claimed as a row, and the acceptance run that proves access still works.
-- [Self-serve signup](https://docs.benchpress.cloud/docs/operator/hosted-signup): Optional and off by default — retire the waitlist and let people sign themselves up, with GitHub and Google as the primary paths and the abuse controls that make a free grant safe.
-- [Reference track](https://docs.benchpress.cloud/docs/reference): The data model, the whitelisted API, the eleven deploy steps, the reconcilers, the address plan and the configuration split — for a contributor or an integrator.
-- [Architecture](https://docs.benchpress.cloud/docs/reference/architecture): The moving parts of BenchPress — the control plane, the bench containers, the shared infrastructure, and which Python module owns each concern.
-- [Data model](https://docs.benchpress.cloud/docs/reference/data-model): All 20 BenchPress DocTypes with their fields, links, naming and the permission rule that scopes each one — plus why there is no Device DocType.
-- [API](https://docs.benchpress.cloud/docs/reference/api): Every whitelisted BenchPress endpoint, with arguments, what each returns, and the permission check each one makes for itself.
-- [Deploy pipeline](https://docs.benchpress.cloud/docs/reference/deploy-pipeline): The eleven steps of a BenchPress deploy, in the order the code runs them, with the function behind each step and the log line it writes.
-- [Lifecycle and events](https://docs.benchpress.cloud/docs/reference/lifecycle-and-events): The bench states and their transitions, the Docker event listener, Bench Event incidents, the stats collector, and the eleven scheduled jobs that correct the database.
-- [Networking](https://docs.benchpress.cloud/docs/reference/networking): The BenchPress address plan — bench bridges, WireGuard tunnel addresses, the two container ports, Traefik route files and the wildcard certificate anchor.
-- [Realtime](https://docs.benchpress.cloud/docs/reference/realtime): The six realtime events BenchPress publishes over socket.io, their payloads, who receives each one, and why the deploy log commits every line.
-- [Configuration](https://docs.benchpress.cloud/docs/reference/configuration): Where each BenchPress setting lives — build arguments that need a rebuild, runtime environment that needs a restart, and DocType fields that apply on save.
-- [CLI and scripts](https://docs.benchpress.cloud/docs/reference/cli-and-scripts): Every command that drives BenchPress from a shell — entry.py, the bench commands, setup.sh and upgrade.sh, the four repository scripts and the documentation pipeline.
-- [Glossary](https://docs.benchpress.cloud/docs/reference/glossary): What each BenchPress term means here — lab, bench, site, lease, admission, golden image, peer — including the words that mean something else elsewhere.
-- [BenchPress documentation](https://docs.benchpress.cloud/docs): Start here. Three tracks — use a bench, run the server that hosts one, or read the data model and the API.
+- [Quick tour](https://benchpress.cloud/docs/user/quick-tour): The five screens in the BenchPress sidebar, and every number the Overview dashboard reports.
+- [Deploy from a template](https://benchpress.cloud/docs/user/deploy-from-template): Turn a catalog template into a running bench, and read the eleven pipeline steps while they run.
+- [Create a lab](https://benchpress.cloud/docs/user/create-a-lab): Fill in the New lab form when no catalog template matches the app list you need.
+- [Read a lab page](https://benchpress.cloud/docs/user/lab-detail): Every field on the lab page, and why container status and container health can disagree.
+- [Start, stop and redeploy](https://benchpress.cloud/docs/user/lifecycle): The five actions on a running bench, which of them destroy work, and which are admin-only.
+- [Register a VPN device](https://benchpress.cloud/docs/user/vpn-devices): Put a laptop or a phone on the WireGuard network, import the config, read the device status, and run the connection test when a site will not open.
+- [Open the bench site](https://benchpress.cloud/docs/user/open-your-site): The Sites card, the three states of its Open button, and logging in to the Frappe site a deploy created.
+- [Connect over SSH and the VPN](https://benchpress.cloud/docs/user/connect-ssh-vpn): The connection card on a lab page — two addresses, the SSH command, the three passwords, and which of them work without the tunnel.
+- [Use code-server](https://benchpress.cloud/docs/user/code-server): Open the browser VS Code session on a bench, find its password, hand the session to a teammate, and restart it when it stops answering.
+- [Read logs and container stats](https://benchpress.cloud/docs/user/logs-and-monitoring): The deploy stepper, the raw log and its step markers, the build log, and the CPU and memory bars on a running bench.
+- [Leases and credits](https://benchpress.cloud/docs/user/leases-and-credits): The countdown on a running bench, the renew dialog and its plans, the credit meter, the ledger, and where a purchase hands off to the payment gateway.
+- [Troubleshooting](https://benchpress.cloud/docs/user/troubleshooting): Every symptom a BenchPress user meets, its cause, and the page that fixes it — deploys, the VPN, SSH, code-server, logs and credits.
+- [Operator track](https://benchpress.cloud/docs/operator): Run BenchPress on your own box — install, the VPN plane, settings, the shared database, images, upgrades, safety and diagnostics.
+- [Prerequisites](https://benchpress.cloud/docs/operator/prerequisites): What a BenchPress host needs before you install — the four preconditions, supported platforms, versions, Docker socket access, and the measured CPU and disk sizing.
+- [Install](https://benchpress.cloud/docs/operator/install): Install BenchPress into a Frappe v16 bench — get-app, setup.sh, the frontend build, the base domain, and the first screen.
+- [WireGuard and the VPN plane](https://benchpress.cloud/docs/operator/wireguard-setup): How the vpn_management app owns the tunnel, what BenchPress consumes from it, the measured server and pool values, and why userns-remap matters.
+- [Settings reference](https://benchpress.cloud/docs/operator/settings-reference): Every field on BenchPress Settings and Credit Settings, with the value measured on a live host, where each one is edited, and what changing it costs.
+- [The shared database server](https://benchpress.cloud/docs/operator/database-server): One MariaDB holds every bench site's database — where it lives, how BenchPress drives it, what drift detection watches, and the four actions on the record.
+- [Backup and restore](https://benchpress.cloud/docs/operator/backup-and-restore): Where the nightly MariaDB dumps land, how long they are kept, and the two restore paths — a scratch container for verification, and managed recovery from bench console.
+- [Users and roles](https://benchpress.cloud/docs/operator/users-and-roles): The two BenchPress roles, what each one may read and write, which screens are admin-only, and how ownership rather than a role decides who sees a bench.
+- [Golden images](https://benchpress.cloud/docs/operator/golden-images): A lab's finished site is baked into its own image as a database dump, so a deploy restores it instead of creating tables — the measured numbers, the two settings, and why a golden gets refused.
+- [The image cache](https://benchpress.cloud/docs/operator/image-cache): One image per lab, tagged benchpress/<lab_id>:lab — what it costs on disk, how the weekly prewarm and sweep work, and what is safe to prune.
+- [Upgrading](https://benchpress.cloud/docs/operator/upgrading): Move a BenchPress install to a newer release — the backup gate, the five steps, the scripted path, rollback, and why lab images are a separate opt-in.
+- [Production safety](https://benchpress.cloud/docs/operator/production-safety): What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the release checklist that covers 25 of 52 whitelisted callables.
+- [Diagnostics](https://benchpress.cloud/docs/operator/diagnostics): The twelve read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
+- [Credits and billing](https://benchpress.cloud/docs/operator/credits-and-billing): Optional and off by default — the metering half of BenchPress, covering leases, balances, the ledger, admin adjustments, and the optional Razorpay handoff.
+- [Admission and limits](https://benchpress.cloud/docs/operator/admission-and-limits): Optional and off by default — concurrency caps, size ceilings, device and build quotas, how a slot is claimed as a row, and the acceptance run that proves access still works.
+- [Self-serve signup](https://benchpress.cloud/docs/operator/hosted-signup): Optional and off by default — retire the waitlist and let people sign themselves up, with GitHub and Google as the primary paths and the abuse controls that make a free grant safe.
+- [Reference track](https://benchpress.cloud/docs/reference): The data model, the whitelisted API, the eleven deploy steps, the reconcilers, the address plan and the configuration split — for a contributor or an integrator.
+- [Architecture](https://benchpress.cloud/docs/reference/architecture): The moving parts of BenchPress — the control plane, the bench containers, the shared infrastructure, and which Python module owns each concern.
+- [Data model](https://benchpress.cloud/docs/reference/data-model): All 20 BenchPress DocTypes with their fields, links, naming and the permission rule that scopes each one — plus why there is no Device DocType.
+- [API](https://benchpress.cloud/docs/reference/api): Every whitelisted BenchPress endpoint, with arguments, what each returns, and the permission check each one makes for itself.
+- [Deploy pipeline](https://benchpress.cloud/docs/reference/deploy-pipeline): The eleven steps of a BenchPress deploy, in the order the code runs them, with the function behind each step and the log line it writes.
+- [Lifecycle and events](https://benchpress.cloud/docs/reference/lifecycle-and-events): The bench states and their transitions, the Docker event listener, Bench Event incidents, the stats collector, and the eleven scheduled jobs that correct the database.
+- [Networking](https://benchpress.cloud/docs/reference/networking): The BenchPress address plan — bench bridges, WireGuard tunnel addresses, the two container ports, Traefik route files and the wildcard certificate anchor.
+- [Realtime](https://benchpress.cloud/docs/reference/realtime): The six realtime events BenchPress publishes over socket.io, their payloads, who receives each one, and why the deploy log commits every line.
+- [Configuration](https://benchpress.cloud/docs/reference/configuration): Where each BenchPress setting lives — build arguments that need a rebuild, runtime environment that needs a restart, and DocType fields that apply on save.
+- [CLI and scripts](https://benchpress.cloud/docs/reference/cli-and-scripts): Every command that drives BenchPress from a shell — entry.py, the bench commands, setup.sh and upgrade.sh, the four repository scripts and the documentation pipeline.
+- [Glossary](https://benchpress.cloud/docs/reference/glossary): What each BenchPress term means here — lab, bench, site, lease, admission, golden image, peer — including the words that mean something else elsewhere.
+- [BenchPress documentation](https://benchpress.cloud/docs): Start here. Three tracks — use a bench, run the server that hosts one, or read the data model and the API.
 
 ## Content
 
 # Quick tour
-URL: https://docs.benchpress.cloud/docs/user/quick-tour
+URL: https://benchpress.cloud/docs/user/quick-tour
 The five screens in the BenchPress sidebar, and every number the Overview dashboard reports.
 
 This page names every screen in BenchPress and reads the first one out loud.
@@ -128,7 +128,7 @@ You have read the tour correctly when all four are true.
 |--|--|--|
 |`/frontend` returns to the login page|You have no session, or it expired|Sign in at `/login`, then open `/frontend` again|
 |The VPN chip is amber and reads VPN off|This device has no WireGuard tunnel|Open **Devices**, register the device, install the config it gives you|
-|**Open site** opens nothing|Bench sites resolve only over the VPN|Connect the VPN, then click again|
+|**Open site** opens nothing|The site has no public name, so it answers only on the VPN|Connect the VPN, then click again|
 |**Templates** is missing from the sidebar|Templates is admin-only|Ask an admin, or start a bench from **Labs**|
 |**Needs attention** is above zero|A bench errored or stopped answering|Open **Instances**, open the bench, read its deploy log|
 |**Credits** is missing everywhere|Credits are off on this server|Nothing to fix. A self-hosted server runs without them|
@@ -175,7 +175,7 @@ server.
 * [BenchPress documentation](/docs) — the three tracks, and what each one covers.
 
 # Deploy from a template
-URL: https://docs.benchpress.cloud/docs/user/deploy-from-template
+URL: https://benchpress.cloud/docs/user/deploy-from-template
 Turn a catalog template into a running bench, and read the eleven pipeline steps while they run.
 
 A template is a recipe someone already wrote. This page takes you from the
@@ -284,7 +284,7 @@ The deploy worked when all four are true.
 |The log stops at `Waiting for the worker to pick the deploy up…`|No worker is running, so nothing has started|Ask the operator to check `queue-long`|
 |Step 7 runs for minutes|The image has no golden dump, so the site is built from scratch|Nothing to fix. Read step 2, which reports the same thing|
 |The run ends **Error**|The step that failed names the reason|Open **Raw log** under the steps and read the last lines|
-|**Open site** opens nothing|Bench sites resolve only over the VPN|Connect the VPN, then press it again|
+|**Open site** opens nothing|The site has no public name, so it answers only on the VPN|Connect the VPN, then press it again|
 
 ## Reference
 
@@ -321,7 +321,7 @@ The deploy worked when all four are true.
 * [Start, stop and redeploy](/docs/user/lifecycle) — what to do after it is running.
 
 # Create a lab
-URL: https://docs.benchpress.cloud/docs/user/create-a-lab
+URL: https://benchpress.cloud/docs/user/create-a-lab
 Fill in the New lab form when no catalog template matches the app list you need.
 
 A lab is a recipe: a Frappe version, a list of apps and a set of container
@@ -440,7 +440,7 @@ The **What gets built** panel says so: `Docker image shared with every lab that 
 * [Start, stop and redeploy](/docs/user/lifecycle) — running the bench afterwards.
 
 # Read a lab page
-URL: https://docs.benchpress.cloud/docs/user/lab-detail
+URL: https://benchpress.cloud/docs/user/lab-detail
 Every field on the lab page, and why container status and container health can disagree.
 
 The lab page is one screen with two clocks on it. This page reads every field,
@@ -547,7 +547,7 @@ You are reading the page correctly when all four are true.
 |CPU and memory read `—`|The container is not running|Start the bench|
 |The header has no **Build log** tab|Build logs are admin-only|Ask an admin for the build output|
 |A stopped bench shows a countdown|Stopped benches are deleted after a set number of days|Start it, or accept that it goes|
-|**Open site** does nothing|Bench sites resolve only over the VPN|Connect the VPN and press it again|
+|**Open site** does nothing|The site has no public name, so it answers only on the VPN|Connect the VPN and press it again|
 
 ## Reference
 
@@ -592,7 +592,7 @@ The window is `reap_after_days` in Credit Settings, which is **7 days** here.
 * [Create a lab](/docs/user/create-a-lab) — where the header chips come from.
 
 # Start, stop and redeploy
-URL: https://docs.benchpress.cloud/docs/user/lifecycle
+URL: https://benchpress.cloud/docs/user/lifecycle
 The five actions on a running bench, which of them destroy work, and which are admin-only.
 
 A running bench has five actions. Two are safe, one is destructive, one is
@@ -724,7 +724,7 @@ before, so nothing disappears without notice. `0` turns the deletion off.
 * [Create a lab](/docs/user/create-a-lab) — what a rebuild rebuilds.
 
 # Register a VPN device
-URL: https://docs.benchpress.cloud/docs/user/vpn-devices
+URL: https://benchpress.cloud/docs/user/vpn-devices
 Put a laptop or a phone on the WireGuard network, import the config, read the device status, and run the connection test when a site will not open.
 
 No bench is published to the internet on a tunnel-only address. Register the
@@ -904,7 +904,7 @@ not go through BenchPress while the tunnel is on.
 * [Troubleshooting](/docs/user/troubleshooting) — symptoms across the whole app.
 
 # Open the bench site
-URL: https://docs.benchpress.cloud/docs/user/open-your-site
+URL: https://benchpress.cloud/docs/user/open-your-site
 The Sites card, the three states of its Open button, and logging in to the Frappe site a deploy created.
 
 A deploy ends with a working Frappe site. This page opens it and logs in, and
@@ -1033,7 +1033,7 @@ redeploy.
 * [Read a lab page](/docs/user/lab-detail) — the rest of the lab screen.
 
 # Connect over SSH and the VPN
-URL: https://docs.benchpress.cloud/docs/user/connect-ssh-vpn
+URL: https://benchpress.cloud/docs/user/connect-ssh-vpn
 The connection card on a lab page — two addresses, the SSH command, the three passwords, and which of them work without the tunnel.
 
 A running bench publishes one card with everything needed to reach it. This
@@ -1182,7 +1182,7 @@ benches. An admin sees every bench on the server.
 * [Read a lab page](/docs/user/lab-detail) — the rest of the screen this card sits on.
 
 # Use code-server
-URL: https://docs.benchpress.cloud/docs/user/code-server
+URL: https://benchpress.cloud/docs/user/code-server
 Open the browser VS Code session on a bench, find its password, hand the session to a teammate, and restart it when it stops answering.
 
 Every bench whose lab enables it runs code-server, which is VS Code in a
@@ -1311,7 +1311,7 @@ benches.
 * [Read a lab page](/docs/user/lab-detail) — the chips that say whether a lab has an IDE.
 
 # Read logs and container stats
-URL: https://docs.benchpress.cloud/docs/user/logs-and-monitoring
+URL: https://benchpress.cloud/docs/user/logs-and-monitoring
 The deploy stepper, the raw log and its step markers, the build log, and the CPU and memory bars on a running bench.
 
 Every deploy and every image build writes a log you can read while it runs and
@@ -1497,7 +1497,7 @@ card, and the deploy log says which of them changed.
 * [Troubleshooting](/docs/user/troubleshooting) — symptoms across the whole app.
 
 # Leases and credits
-URL: https://docs.benchpress.cloud/docs/user/leases-and-credits
+URL: https://benchpress.cloud/docs/user/leases-and-credits
 The countdown on a running bench, the renew dialog and its plans, the credit meter, the ledger, and where a purchase hands off to the payment gateway.
 
 On a server with credits switched on, a deploy buys a fixed window of time and
@@ -1746,7 +1746,7 @@ They can still be refused for credits.
 * [Troubleshooting](/docs/user/troubleshooting) — symptoms across the whole app.
 
 # Troubleshooting
-URL: https://docs.benchpress.cloud/docs/user/troubleshooting
+URL: https://benchpress.cloud/docs/user/troubleshooting
 Every symptom a BenchPress user meets, its cause, and the page that fixes it — deploys, the VPN, SSH, code-server, logs and credits.
 
 One index of symptoms across the whole app. Find the line that matches what
@@ -1869,7 +1869,7 @@ address and its password instead of retyping the error.
 * [Connect over SSH and the VPN](/docs/user/connect-ssh-vpn) — the card behind most access problems.
 
 # Operator track
-URL: https://docs.benchpress.cloud/docs/operator
+URL: https://benchpress.cloud/docs/operator
 Run BenchPress on your own box — install, the VPN plane, settings, the shared database, images, upgrades, safety and diagnostics.
 
 Everything about the machine BenchPress runs on, rather than the benches it
@@ -1943,7 +1943,7 @@ elsewhere, and there is no second machine to keep in step.
 * [Troubleshooting](/docs/user/troubleshooting) — the symptom index a user reads before calling you.
 
 # Prerequisites
-URL: https://docs.benchpress.cloud/docs/operator/prerequisites
+URL: https://benchpress.cloud/docs/operator/prerequisites
 What a BenchPress host needs before you install — the four preconditions, supported platforms, versions, Docker socket access, and the measured CPU and disk sizing.
 
 What the machine must already have before [Install](/docs/operator/install)
@@ -2188,7 +2188,7 @@ ran **4 to 26 minutes**, and the golden pass 5 to 11 — see
 * [Diagnostics](/docs/operator/diagnostics) — the same checks, run by the app against the live host.
 
 # Install
-URL: https://docs.benchpress.cloud/docs/operator/install
+URL: https://benchpress.cloud/docs/operator/install
 Install BenchPress into a Frappe v16 bench — get-app, setup.sh, the frontend build, the base domain, and the first screen.
 
 From a prepared host to the BenchPress Overview, in six steps.
@@ -2377,7 +2377,7 @@ that image in seconds. See [The image cache](/docs/operator/image-cache).
 * [Quick tour](/docs/user/quick-tour) — the screens you just installed.
 
 # WireGuard and the VPN plane
-URL: https://docs.benchpress.cloud/docs/operator/wireguard-setup
+URL: https://benchpress.cloud/docs/operator/wireguard-setup
 How the vpn_management app owns the tunnel, what BenchPress consumes from it, the measured server and pool values, and why userns-remap matters.
 
 BenchPress does not manage WireGuard. This page says who does, what BenchPress
@@ -2566,7 +2566,7 @@ documentation. It owns every one of these values.
 * [Diagnostics](/docs/operator/diagnostics) — the `vpn_server` check and what it does not cover.
 
 # Settings reference
-URL: https://docs.benchpress.cloud/docs/operator/settings-reference
+URL: https://benchpress.cloud/docs/operator/settings-reference
 Every field on BenchPress Settings and Credit Settings, with the value measured on a live host, where each one is edited, and what changing it costs.
 
 Every field on the two settings documents, what it controls, and what it reads
@@ -2822,7 +2822,7 @@ wrap it in a single `exec()` call.
 * [Golden images](/docs/operator/golden-images) — the two settings that decide deploy speed.
 
 # The shared database server
-URL: https://docs.benchpress.cloud/docs/operator/database-server
+URL: https://benchpress.cloud/docs/operator/database-server
 One MariaDB holds every bench site's database — where it lives, how BenchPress drives it, what drift detection watches, and the four actions on the record.
 
 Every bench site's database lives in one shared MariaDB container. This page
@@ -2990,7 +2990,7 @@ Status values are `Pending`, `Active`, `Stopped` and `Error`.
 * [Production safety](/docs/operator/production-safety) — what is and is not backed up.
 
 # Backup and restore
-URL: https://docs.benchpress.cloud/docs/operator/backup-and-restore
+URL: https://benchpress.cloud/docs/operator/backup-and-restore
 Where the nightly MariaDB dumps land, how long they are kept, and the two restore paths — a scratch container for verification, and managed recovery from bench console.
 
 Where BenchPress's automatic MariaDB dumps live, and how to turn one back into
@@ -3158,7 +3158,7 @@ older than that, the scheduled job is not running — see
 * [Production safety](/docs/operator/production-safety) — the full list of what is not backed up.
 
 # Users and roles
-URL: https://docs.benchpress.cloud/docs/operator/users-and-roles
+URL: https://benchpress.cloud/docs/operator/users-and-roles
 The two BenchPress roles, what each one may read and write, which screens are admin-only, and how ownership rather than a role decides who sees a bench.
 
 Two roles, and one rule that matters more than either: a user sees their own
@@ -3329,7 +3329,7 @@ that would let a new endpoint ship unguarded by omission.
 * [Quick tour](/docs/user/quick-tour) — the sidebar as a user sees it.
 
 # Golden images
-URL: https://docs.benchpress.cloud/docs/operator/golden-images
+URL: https://benchpress.cloud/docs/operator/golden-images
 A lab's finished site is baked into its own image as a database dump, so a deploy restores it instead of creating tables — the measured numbers, the two settings, and why a golden gets refused.
 
 Why a deploy takes 13 seconds instead of 43, what turns it off, and how to
@@ -3504,7 +3504,7 @@ it is the field the deploy compares.
 * [Read logs and container stats](/docs/user/logs-and-monitoring) — where the site step's wording appears.
 
 # The image cache
-URL: https://docs.benchpress.cloud/docs/operator/image-cache
+URL: https://benchpress.cloud/docs/operator/image-cache
 One image per lab, tagged benchpress/<lab_id>:lab — what it costs on disk, how the weekly prewarm and sweep work, and what is safe to prune.
 
 Lab images are the largest thing on a BenchPress host. This page says how they
@@ -3678,7 +3678,7 @@ These are safe:
 * [Create a lab](/docs/user/create-a-lab) — the screen that orders a build.
 
 # Upgrading
-URL: https://docs.benchpress.cloud/docs/operator/upgrading
+URL: https://benchpress.cloud/docs/operator/upgrading
 Move a BenchPress install to a newer release — the backup gate, the five steps, the scripted path, rollback, and why lab images are a separate opt-in.
 
 App code, database schema and frontend assets, with a backup gate in front and
@@ -3880,7 +3880,7 @@ and never skip the step 0 gate.
 * [Diagnostics](/docs/operator/diagnostics) — the post-upgrade health check in full.
 
 # Production safety
-URL: https://docs.benchpress.cloud/docs/operator/production-safety
+URL: https://benchpress.cloud/docs/operator/production-safety
 What BenchPress is and is not ready to carry — the alpha verdict, the container privilege boundary, what is backed up, and the release checklist that covers 25 of 52 whitelisted callables.
 
 Whether BenchPress is safe to run on your host, and what has to be true first.
@@ -4092,7 +4092,7 @@ any password. The `create_site` item described an endpoint that does not exist.
 * [Diagnostics](/docs/operator/diagnostics) — the checks that read the host.
 
 # Diagnostics
-URL: https://docs.benchpress.cloud/docs/operator/diagnostics
+URL: https://benchpress.cloud/docs/operator/diagnostics
 The twelve read-only checks that ask Docker, MariaDB, Redis and the kernel what is true — how to run them, what each failure means, and the four things they do not cover.
 
 Twelve checks that read the host rather than the configuration, and what to do
@@ -4404,7 +4404,7 @@ router in one action. See
 * [Production safety](/docs/operator/production-safety) — the checks that a human runs, not the app.
 
 # Credits and billing
-URL: https://docs.benchpress.cloud/docs/operator/credits-and-billing
+URL: https://benchpress.cloud/docs/operator/credits-and-billing
 Optional and off by default — the metering half of BenchPress, covering leases, balances, the ledger, admin adjustments, and the optional Razorpay handoff.
 
 **Optional, and off by default.** `enable_credits` ships as `0`, and nothing
@@ -4617,7 +4617,7 @@ Measured on this host.
 * [Settings reference](/docs/operator/settings-reference) — every field above, in one table.
 
 # Admission and limits
-URL: https://docs.benchpress.cloud/docs/operator/admission-and-limits
+URL: https://benchpress.cloud/docs/operator/admission-and-limits
 Optional and off by default — concurrency caps, size ceilings, device and build quotas, how a slot is claimed as a row, and the acceptance run that proves access still works.
 
 **Optional, and off by default.** The caps on this page only bind while
@@ -4860,7 +4860,7 @@ cannot close that cycle.
 * [Troubleshooting](/docs/user/troubleshooting) — the same refusals, indexed for the user who hit one.
 
 # Self-serve signup
-URL: https://docs.benchpress.cloud/docs/operator/hosted-signup
+URL: https://benchpress.cloud/docs/operator/hosted-signup
 Optional and off by default — retire the waitlist and let people sign themselves up, with GitHub and Google as the primary paths and the abuse controls that make a free grant safe.
 
 **Optional, and off by default.** This applies to a **hosted** BenchPress,
@@ -5014,7 +5014,7 @@ keep their role, their balance and their instances.
 * [Users and roles](/docs/operator/users-and-roles) — the role every signup lands with.
 
 # Reference track
-URL: https://docs.benchpress.cloud/docs/reference
+URL: https://benchpress.cloud/docs/reference
 The data model, the whitelisted API, the eleven deploy steps, the reconcilers, the address plan and the configuration split — for a contributor or an integrator.
 
 What BenchPress is made of, rather than how to use it or how to run it.
@@ -5086,7 +5086,7 @@ it before you assume a save does the plain thing.
 * [Settings reference](/docs/operator/settings-reference) — every field on the two settings documents.
 
 # Architecture
-URL: https://docs.benchpress.cloud/docs/reference/architecture
+URL: https://benchpress.cloud/docs/reference/architecture
 The moving parts of BenchPress — the control plane, the bench containers, the shared infrastructure, and which Python module owns each concern.
 
 What the system is made of, and which module you open when a question is about
@@ -5247,7 +5247,7 @@ The counts a change should keep true.
 * [Operator track](/docs/operator) — the same system, as tasks on a host.
 
 # Data model
-URL: https://docs.benchpress.cloud/docs/reference/data-model
+URL: https://benchpress.cloud/docs/reference/data-model
 All 20 BenchPress DocTypes with their fields, links, naming and the permission rule that scopes each one — plus why there is no Device DocType.
 
 Every DocType the BenchPress module defines, what it holds, and who is allowed
@@ -5576,7 +5576,7 @@ This is the only DocType a guest can cause to be written. See
 * [Users and roles](/docs/operator/users-and-roles) — the three roles named above.
 
 # API
-URL: https://docs.benchpress.cloud/docs/reference/api
+URL: https://benchpress.cloud/docs/reference/api
 Every whitelisted BenchPress endpoint, with arguments, what each returns, and the permission check each one makes for itself.
 
 Every function this app publishes over HTTP, and what each one checks before it
@@ -5985,7 +5985,7 @@ bench --site <site> run-tests --app benchpress --module benchpress.tests.test_ap
 * [Realtime](/docs/reference/realtime) — how a screen hears about the result.
 
 # Deploy pipeline
-URL: https://docs.benchpress.cloud/docs/reference/deploy-pipeline
+URL: https://benchpress.cloud/docs/reference/deploy-pipeline
 The eleven steps of a BenchPress deploy, in the order the code runs them, with the function behind each step and the log line it writes.
 
 What happens between a click on **Deploy** and a site that answers.
@@ -6212,7 +6212,7 @@ A successful run shows eleven ticked steps on the Lab detail screen. See
 * [Logs and monitoring](/docs/user/logs-and-monitoring) — reading a run as it happens.
 
 # Lifecycle and events
-URL: https://docs.benchpress.cloud/docs/reference/lifecycle-and-events
+URL: https://benchpress.cloud/docs/reference/lifecycle-and-events
 The bench states and their transitions, the Docker event listener, Bench Event incidents, the stats collector, and the eleven scheduled jobs that correct the database.
 
 What changes a bench without anybody clicking anything.
@@ -6443,7 +6443,7 @@ bench --site <site> execute frappe.client.get_list \
 * [Settings reference](/docs/operator/settings-reference) — every number named above.
 
 # Networking
-URL: https://docs.benchpress.cloud/docs/reference/networking
+URL: https://benchpress.cloud/docs/reference/networking
 The BenchPress address plan — bench bridges, WireGuard tunnel addresses, the two container ports, Traefik route files and the wildcard certificate anchor.
 
 Every address a bench answers on, and who can reach each one.
@@ -6674,7 +6674,7 @@ docker network ls --filter name=benchpress-
 * [Data model](/docs/reference/data-model#devices-are-vpn-peers) — why there is no Device DocType.
 
 # Realtime
-URL: https://docs.benchpress.cloud/docs/reference/realtime
+URL: https://benchpress.cloud/docs/reference/realtime
 The six realtime events BenchPress publishes over socket.io, their payloads, who receives each one, and why the deploy log commits every line.
 
 How a screen changes without a page reload, and what it is listening to.
@@ -6841,7 +6841,7 @@ Then deploy a bench. See
 * [Data model](/docs/reference/data-model#deploy-log) — the row every line is written to.
 
 # Configuration
-URL: https://docs.benchpress.cloud/docs/reference/configuration
+URL: https://benchpress.cloud/docs/reference/configuration
 Where each BenchPress setting lives — build arguments that need a rebuild, runtime environment that needs a restart, and DocType fields that apply on save.
 
 Which knob lives where, and what changing it costs.
@@ -7010,7 +7010,7 @@ flag on.
 * [CLI and scripts](/docs/reference/cli-and-scripts) — the commands named above.
 
 # CLI and scripts
-URL: https://docs.benchpress.cloud/docs/reference/cli-and-scripts
+URL: https://benchpress.cloud/docs/reference/cli-and-scripts
 Every command that drives BenchPress from a shell — entry.py, the bench commands, setup.sh and upgrade.sh, the four repository scripts and the documentation pipeline.
 
 What you can run from a terminal, and what each one changes.
@@ -7237,7 +7237,7 @@ npm run docs:build && npm run docs:lint && npm run docs:score; echo "exit=$?"
 * [Golden images](/docs/operator/golden-images) — what the golden drill measures.
 
 # Glossary
-URL: https://docs.benchpress.cloud/docs/reference/glossary
+URL: https://benchpress.cloud/docs/reference/glossary
 What each BenchPress term means here — lab, bench, site, lease, admission, golden image, peer — including the words that mean something else elsewhere.
 
 One name for one thing. This page is the list of names.
@@ -7361,7 +7361,7 @@ An admin sees every row. Both admin roles short-circuit every scoping rule. See
 * [Credits and billing](/docs/operator/credits-and-billing) — the whole optional half.
 
 # BenchPress documentation
-URL: https://docs.benchpress.cloud/docs
+URL: https://benchpress.cloud/docs
 Start here. Three tracks — use a bench, run the server that hosts one, or read the data model and the API.
 
 BenchPress deploys a Frappe bench from a template. An operator describes the

--- a/docs-site/llms.txt
+++ b/docs-site/llms.txt
@@ -10,7 +10,7 @@ works in it over SSH or a browser VS Code session, and destroys it when the task
 is done.
 
 - Self-hosted. One box, Docker, no external control plane.
-- Every bench reachable only over WireGuard.
+- No bench port is published on the host; benches answer on WireGuard, plus an HTTPS name when a base domain is set.
 - Built on the Frappe framework, with a Vue 3 single-page app on the front.
 
 ## Best Starting Points

--- a/docs-site/robots.txt
+++ b/docs-site/robots.txt
@@ -207,4 +207,4 @@ Allow: /docs/llms.txt
 Allow: /sitemap.xml
 Allow: /sitemap.md
 
-Sitemap: https://docs.benchpress.cloud/sitemap.xml
+Sitemap: https://benchpress.cloud/sitemap.xml

--- a/docs-site/sitemap.xml
+++ b/docs-site/sitemap.xml
@@ -2,11 +2,11 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://benchpress.cloud/docs/user/quick-tour</loc>
-    <lastmod>2026-08-28T16:40:21.000Z</lastmod>
+    <lastmod>2026-08-30T14:28:35.000Z</lastmod>
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/user/deploy-from-template</loc>
-    <lastmod>2026-08-28T16:40:21.000Z</lastmod>
+    <lastmod>2026-08-30T14:28:35.000Z</lastmod>
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/user/create-a-lab</loc>
@@ -14,7 +14,7 @@
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/user/lab-detail</loc>
-    <lastmod>2026-08-28T16:40:21.000Z</lastmod>
+    <lastmod>2026-08-30T14:28:35.000Z</lastmod>
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/user/lifecycle</loc>

--- a/docs-site/sitemap.xml
+++ b/docs-site/sitemap.xml
@@ -1,163 +1,163 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://docs.benchpress.cloud/docs/user/quick-tour</loc>
+    <loc>https://benchpress.cloud/docs/user/quick-tour</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/user/deploy-from-template</loc>
+    <loc>https://benchpress.cloud/docs/user/deploy-from-template</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/user/create-a-lab</loc>
+    <loc>https://benchpress.cloud/docs/user/create-a-lab</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/user/lab-detail</loc>
+    <loc>https://benchpress.cloud/docs/user/lab-detail</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/user/lifecycle</loc>
+    <loc>https://benchpress.cloud/docs/user/lifecycle</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/user/vpn-devices</loc>
+    <loc>https://benchpress.cloud/docs/user/vpn-devices</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/user/open-your-site</loc>
+    <loc>https://benchpress.cloud/docs/user/open-your-site</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/user/connect-ssh-vpn</loc>
+    <loc>https://benchpress.cloud/docs/user/connect-ssh-vpn</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/user/code-server</loc>
+    <loc>https://benchpress.cloud/docs/user/code-server</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/user/logs-and-monitoring</loc>
+    <loc>https://benchpress.cloud/docs/user/logs-and-monitoring</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/user/leases-and-credits</loc>
+    <loc>https://benchpress.cloud/docs/user/leases-and-credits</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/user/troubleshooting</loc>
+    <loc>https://benchpress.cloud/docs/user/troubleshooting</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/operator</loc>
+    <loc>https://benchpress.cloud/docs/operator</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/operator/prerequisites</loc>
+    <loc>https://benchpress.cloud/docs/operator/prerequisites</loc>
     <lastmod>2026-08-30T12:18:34.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/operator/install</loc>
+    <loc>https://benchpress.cloud/docs/operator/install</loc>
     <lastmod>2026-08-30T12:18:34.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/operator/wireguard-setup</loc>
+    <loc>https://benchpress.cloud/docs/operator/wireguard-setup</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/operator/settings-reference</loc>
+    <loc>https://benchpress.cloud/docs/operator/settings-reference</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/operator/database-server</loc>
+    <loc>https://benchpress.cloud/docs/operator/database-server</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/operator/backup-and-restore</loc>
+    <loc>https://benchpress.cloud/docs/operator/backup-and-restore</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/operator/users-and-roles</loc>
+    <loc>https://benchpress.cloud/docs/operator/users-and-roles</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/operator/golden-images</loc>
+    <loc>https://benchpress.cloud/docs/operator/golden-images</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/operator/image-cache</loc>
+    <loc>https://benchpress.cloud/docs/operator/image-cache</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/operator/upgrading</loc>
+    <loc>https://benchpress.cloud/docs/operator/upgrading</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/operator/production-safety</loc>
+    <loc>https://benchpress.cloud/docs/operator/production-safety</loc>
     <lastmod>2026-08-30T12:18:34.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/operator/diagnostics</loc>
+    <loc>https://benchpress.cloud/docs/operator/diagnostics</loc>
     <lastmod>2026-08-30T13:10:05.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/operator/credits-and-billing</loc>
+    <loc>https://benchpress.cloud/docs/operator/credits-and-billing</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/operator/admission-and-limits</loc>
+    <loc>https://benchpress.cloud/docs/operator/admission-and-limits</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/operator/hosted-signup</loc>
+    <loc>https://benchpress.cloud/docs/operator/hosted-signup</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/reference</loc>
+    <loc>https://benchpress.cloud/docs/reference</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/reference/architecture</loc>
+    <loc>https://benchpress.cloud/docs/reference/architecture</loc>
     <lastmod>2026-08-30T12:18:34.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/reference/data-model</loc>
+    <loc>https://benchpress.cloud/docs/reference/data-model</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/reference/api</loc>
+    <loc>https://benchpress.cloud/docs/reference/api</loc>
     <lastmod>2026-08-30T12:18:34.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/reference/deploy-pipeline</loc>
+    <loc>https://benchpress.cloud/docs/reference/deploy-pipeline</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/reference/lifecycle-and-events</loc>
+    <loc>https://benchpress.cloud/docs/reference/lifecycle-and-events</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/reference/networking</loc>
+    <loc>https://benchpress.cloud/docs/reference/networking</loc>
     <lastmod>2026-08-30T12:18:34.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/reference/realtime</loc>
+    <loc>https://benchpress.cloud/docs/reference/realtime</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/reference/configuration</loc>
+    <loc>https://benchpress.cloud/docs/reference/configuration</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/reference/cli-and-scripts</loc>
+    <loc>https://benchpress.cloud/docs/reference/cli-and-scripts</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs/reference/glossary</loc>
+    <loc>https://benchpress.cloud/docs/reference/glossary</loc>
     <lastmod>2026-08-28T16:40:21.000Z</lastmod>
   </url>
   <url>
-    <loc>https://docs.benchpress.cloud/docs</loc>
+    <loc>https://benchpress.cloud/docs</loc>
     <lastmod>2026-08-30T12:18:34.000Z</lastmod>
   </url>
 </urlset>

--- a/docs-site/sitemap.xml
+++ b/docs-site/sitemap.xml
@@ -98,7 +98,7 @@
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/operator/diagnostics</loc>
-    <lastmod>2026-08-30T12:51:56.000Z</lastmod>
+    <lastmod>2026-08-30T13:10:05.000Z</lastmod>
   </url>
   <url>
     <loc>https://docs.benchpress.cloud/docs/operator/credits-and-billing</loc>

--- a/docs/docs.config.mjs
+++ b/docs/docs.config.mjs
@@ -25,7 +25,7 @@ export default defineDocsConfig({
           "is done.",
           "",
           "- Self-hosted. One box, Docker, no external control plane.",
-          "- Every bench reachable only over WireGuard.",
+          "- No bench port is published on the host; benches answer on WireGuard, plus an HTTPS name when a base domain is set.",
           "- Built on the Frappe framework, with a Vue 3 single-page app on the front.",
         ].join("\n"),
       },

--- a/docs/user/deploy-from-template.mdx
+++ b/docs/user/deploy-from-template.mdx
@@ -111,7 +111,7 @@ The deploy worked when all four are true.
 | The log stops at `Waiting for the worker to pick the deploy up…` | No worker is running, so nothing has started | Ask the operator to check `queue-long` |
 | Step 7 runs for minutes | The image has no golden dump, so the site is built from scratch | Nothing to fix. Read step 2, which reports the same thing |
 | The run ends **Error** | The step that failed names the reason | Open **Raw log** under the steps and read the last lines |
-| **Open site** opens nothing | Bench sites resolve only over the VPN | Connect the VPN, then press it again |
+| **Open site** opens nothing | The site has no public name, so it answers only on the VPN | Connect the VPN, then press it again |
 
 ## Reference
 

--- a/docs/user/lab-detail.mdx
+++ b/docs/user/lab-detail.mdx
@@ -109,7 +109,7 @@ You are reading the page correctly when all four are true.
 | CPU and memory read `—` | The container is not running | Start the bench |
 | The header has no **Build log** tab | Build logs are admin-only | Ask an admin for the build output |
 | A stopped bench shows a countdown | Stopped benches are deleted after a set number of days | Start it, or accept that it goes |
-| **Open site** does nothing | Bench sites resolve only over the VPN | Connect the VPN and press it again |
+| **Open site** does nothing | The site has no public name, so it answers only on the VPN | Connect the VPN and press it again |
 
 ## Reference
 

--- a/docs/user/quick-tour.mdx
+++ b/docs/user/quick-tour.mdx
@@ -82,7 +82,7 @@ You have read the tour correctly when all four are true.
 |---|---|---|
 | `/frontend` returns to the login page | You have no session, or it expired | Sign in at `/login`, then open `/frontend` again |
 | The VPN chip is amber and reads VPN off | This device has no WireGuard tunnel | Open **Devices**, register the device, install the config it gives you |
-| **Open site** opens nothing | Bench sites resolve only over the VPN | Connect the VPN, then click again |
+| **Open site** opens nothing | The site has no public name, so it answers only on the VPN | Connect the VPN, then click again |
 | **Templates** is missing from the sidebar | Templates is admin-only | Ask an admin, or start a bench from **Labs** |
 | **Needs attention** is above zero | A bench errored or stopped answering | Open **Instances**, open the bench, read its deploy log |
 | **Credits** is missing everywhere | Credits are off on this server | Nothing to fix. A self-hosted server runs without them |

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "postinstall": "cd frontend && yarn install",
     "dev": "cd frontend && yarn dev",
     "build": "cd frontend && yarn build",
-    "docs:site": "leadtype generate --src . --out docs-site --base-url https://docs.benchpress.cloud",
+    "docs:site": "leadtype generate --src . --out docs-site --base-url https://benchpress.cloud",
     "docs:bundle": "leadtype generate --src . --out docs-bundle --bundle --name benchpress --summary \"Self-hosted Frappe dev environments, deployed from a template.\"",
     "docs:build": "npm run docs:site && npm run docs:bundle",
     "docs:lint": "leadtype lint docs --max-warnings 0",

--- a/scripts/publish_docs.py
+++ b/scripts/publish_docs.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Push `docs/*.mdx` into the Wiki Pages that serve benchpress.cloud/docs.
+
+The repo is the source of truth; the wiki is a render target that has drifted from it.
+"""
+
+# Why this exists: the documentation has had two sources of truth. `docs/*.mdx` is gated in CI
+# (lint at zero warnings, a score floor, and a drift check on the generated output), while the
+# published site is the `wiki` app, whose pages live in the database rather than in git.
+# Nothing connected them, so fixes merged here never reached a reader at benchpress.cloud/docs.
+# This script is the connection. `llms.txt` needs none of it: the app serves that straight
+# from the committed `docs-site/` tree (benchpress/docs_assets.py).
+#
+# Three mappings, all verified against the live site rather than assumed:
+#   route    `docs/operator/install.mdx`      -> `docs/operator/install`
+#            `docs/operator/index.mdx`        -> `docs/operator`
+#   images   `](../images/user/x/01.png)`     -> `](/files/docs-images/user/x/01.png)`
+#   links    already site-absolute (`/docs/...`) and need no rewrite.
+#
+# It never deletes. A page on the site with no `.mdx` behind it is reported and left alone,
+# because this repo is not the only thing that may have put it there.
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+DOCS_DIR = Path(__file__).resolve().parent.parent / "docs"
+DEFAULT_URL = "https://benchpress.cloud"
+IMAGE_PREFIX = "/files/docs-images/"
+TIMEOUT = 30
+
+# The public name is behind Cloudflare, which answers a machine client with error 1010 rather
+# than with the endpoint. `--url` takes the origin directly when that happens.
+CLOUDFLARE_BLOCK = "1010"
+# Cloudflare 403s the default `Python-urllib/3.x` agent outright, before the site is reached.
+# Every request carries a real one, or nothing here works against the public name.
+USER_AGENT = "Mozilla/5.0 (compatible; benchpress-publish-docs)"
+
+
+class PublishError(RuntimeError):
+	pass
+
+
+def parse_front_matter(text: str) -> tuple[dict, str]:
+	"""Split leading `---` YAML from the body. Only flat `key: value` pairs are used."""
+	if not text.startswith("---"):
+		return {}, text
+	end = text.find("\n---", 3)
+	if end == -1:
+		return {}, text
+	raw, body = text[3:end], text[end + 4 :]
+	meta = {}
+	for line in raw.splitlines():
+		key, sep, value = line.partition(":")
+		if sep and not key.startswith((" ", "\t", "#")):
+			meta[key.strip()] = value.strip().strip("\"'")
+	return meta, body.lstrip("\n")
+
+
+def route_for(path: Path) -> str:
+	"""The wiki route an `.mdx` file publishes to."""
+	rel = path.relative_to(DOCS_DIR).with_suffix("")
+	parts = list(rel.parts)
+	if parts[-1] == "index":
+		parts.pop()
+	return "/".join(["docs", *parts])
+
+
+def rewrite_images(body: str) -> tuple[str, set[str]]:
+	"""Point relative image paths at the site's file store, and report what they resolve to."""
+	seen: set[str] = set()
+
+	def replace(match: re.Match) -> str:
+		target = IMAGE_PREFIX + match.group("path")
+		seen.add(target)
+		return f"]({target})"
+
+	# `../images/x.png` from a nested page and `./images/x.png` from the root index both land in
+	# the same store; the leading dots are what differ, never the tail.
+	pattern = re.compile(r"\]\((?:\.\./|\./)+images/(?P<path>[^)]+)\)")
+	return pattern.sub(replace, body), seen
+
+
+def page_payload(path: Path) -> dict:
+	meta, body = parse_front_matter(path.read_text(encoding="utf-8"))
+	content, images = rewrite_images(body)
+	title = meta.get("title")
+	if not title:
+		raise PublishError(f"{path}: no `title` in front matter, so the wiki page would be unnamed")
+	return {
+		"route": route_for(path),
+		"title": title,
+		"meta_description": meta.get("description", ""),
+		"content": content,
+		"published": 1,
+		"allow_guest": 1,
+		"_images": sorted(images),
+		"_source": str(path),
+	}
+
+
+class Site:
+	def __init__(self, url: str, key: str, secret: str):
+		self.url = url.rstrip("/")
+		self.auth = f"token {key}:{secret}"
+
+	def _request(self, method: str, path: str, payload: dict | None = None) -> dict:
+		data = json.dumps(payload).encode() if payload is not None else None
+		request = urllib.request.Request(f"{self.url}{path}", data=data, method=method)
+		request.add_header("Authorization", self.auth)
+		request.add_header("Accept", "application/json")
+		request.add_header("User-Agent", USER_AGENT)
+		if data:
+			request.add_header("Content-Type", "application/json")
+		try:
+			with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
+				return json.loads(response.read() or b"{}")
+		except urllib.error.HTTPError as error:
+			body = error.read().decode(errors="replace")[:400]
+			if CLOUDFLARE_BLOCK in body:
+				raise PublishError(
+					"Cloudflare answered instead of the site (error 1010). Pass the origin "
+					"with --url, the way scripts/golden_drill.py documents for the same reason."
+				) from error
+			raise PublishError(f"{method} {path} -> {error.code}: {body}") from error
+
+	def existing(self) -> dict[str, dict]:
+		"""Every Wiki Page on the site, by route."""
+		fields = urllib.parse.quote(json.dumps(["name", "route", "title", "content"]))
+		out = self._request("GET", f"/api/resource/Wiki Page?fields={fields}&limit_page_length=0")
+		return {row["route"]: row for row in out.get("data", [])}
+
+	def create(self, page: dict) -> None:
+		self._request("POST", "/api/resource/Wiki Page", page)
+
+	def update(self, name: str, page: dict) -> None:
+		self._request("PUT", f"/api/resource/Wiki Page/{urllib.parse.quote(name)}", page)
+
+	def has_file(self, path: str) -> bool:
+		request = urllib.request.Request(
+			f"{self.url}{urllib.parse.quote(path)}", method="HEAD", headers={"User-Agent": USER_AGENT}
+		)
+		try:
+			with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
+				return response.status == 200
+		except urllib.error.HTTPError as error:
+			if error.code == 403:
+				raise PublishError(
+					f"the edge refused {path} (403) — the file store was never reached"
+				) from error
+			return False
+		except OSError:
+			return False
+
+
+def main() -> int:
+	parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+	parser.add_argument("--url", default=os.environ.get("DOCS_URL", DEFAULT_URL))
+	parser.add_argument("--publish", action="store_true", help="write; without it this is a dry run")
+	parser.add_argument("--check-images", action="store_true", help="HEAD every referenced image")
+	parser.add_argument("--only", help="publish one route substring, for a single-page fix")
+	args = parser.parse_args()
+
+	key, secret = os.environ.get("DOCS_API_KEY"), os.environ.get("DOCS_API_SECRET")
+	if not key or not secret:
+		print("DOCS_API_KEY and DOCS_API_SECRET must be set (a docs-site key with Wiki Page write).")
+		return 2
+
+	pages = [page_payload(p) for p in sorted(DOCS_DIR.rglob("*.mdx"))]
+	if args.only:
+		pages = [p for p in pages if args.only in p["route"]]
+		if not pages:
+			print(f"No page matched --only {args.only!r}")
+			return 1
+
+	site = Site(args.url, key, secret)
+	live = site.existing()
+	print(f"{len(pages)} local pages, {len(live)} live pages on {site.url}\n")
+
+	if args.check_images:
+		# A referenced image that is not in the store publishes a broken page. Say so before
+		# writing, not after: the store is on the docs site and is not fed by this repo.
+		referenced = sorted({image for page in pages for image in page["_images"]})
+		missing = [image for image in referenced if not site.has_file(image)]
+		print(f"images referenced: {len(referenced)}, missing from the store: {len(missing)}")
+		for image in missing:
+			print(f"  MISSING  {image}")
+		print()
+
+	created = updated = unchanged = 0
+	for page in sorted(pages, key=lambda p: p["route"]):
+		route, source = page["route"], page.pop("_source")
+		page.pop("_images")
+		current = live.get(route)
+		if current is None:
+			created += 1
+			print(f"  CREATE   {route}")
+			if args.publish:
+				site.create(page)
+		elif (current.get("content") or "") != page["content"] or current.get("title") != page["title"]:
+			updated += 1
+			print(f"  UPDATE   {route}  ({source})")
+			if args.publish:
+				site.update(current["name"], page)
+		else:
+			unchanged += 1
+
+	orphans = sorted(set(live) - {p["route"] for p in pages})
+	print(f"\ncreated {created}, updated {updated}, unchanged {unchanged}")
+	if orphans and not args.only:
+		# Never deleted: this repo may not be the only thing that put a page there.
+		print(f"{len(orphans)} live page(s) have no .mdx behind them, left alone:")
+		for route in orphans:
+			print(f"  ORPHAN   {route}")
+	if not args.publish:
+		print("\nDry run. Nothing was written. Re-run with --publish.")
+	return 0
+
+
+if __name__ == "__main__":
+	try:
+		sys.exit(main())
+	except PublishError as error:
+		print(f"error: {error}", file=sys.stderr)
+		sys.exit(1)


### PR DESCRIPTION
`docs.benchpress.cloud` was a second documentation site nobody maintained. It is gone from
the repo. The documentation has one home:

- **Readers** — `benchpress.cloud/docs`, served by the wiki app.
- **Agents** — `benchpress.cloud/llms.txt` and `/llms-full.txt`, served straight from the
  committed `docs-site/` tree by `benchpress/docs_assets.py`.

## Only two references were hand-maintained

`package.json`'s `--base-url` and the issue chooser's docs link. Everything else —
`sitemap.xml`, `robots.txt`, the agent card, the api-catalog, every generated page — derives
from that base url and followed automatically on regeneration. `grep -rl docs.benchpress.cloud`
now returns nothing outside `.git`.

## A claim two earlier passes missed

`llms.txt` line 13 read **"Every bench reachable only over WireGuard."** It was live and
readable on `benchpress.cloud/llms.txt`, and it is the same falsehood #266 removed from the
landing page and `docs/index.mdx` — in a third wording that neither sweep matched, because
both greps searched for phrasings ("only over your private VPN", "Nothing is published to
the internet") rather than for the claim.

Its source is `docs/docs.config.mjs:28`, which feeds the generated `llms.txt`. Three
troubleshooting tables carried the same cause, stated as "Bench sites resolve only over the
VPN". A bench answers on an HTTPS name too once `base_domain` is set, and `base_domain` is
required. All four now say what is true.

## A publisher for the wiki

`scripts/publish_docs.py` closes the gap that let the wiki drift: the repo is gated in CI,
the wiki is not, and only about a quarter of a sampled page still matched its source.

Every mapping was verified against the live site rather than assumed:

- **Routes** derive to all 40, matching the live sitemap exactly, no orphans either direction.
- **Images** rewrite `../images/X` to `/files/docs-images/X`; all 51 confirmed to resolve.
- **Links** are already site-absolute and need no rewrite.

It is a dry run unless `--publish`, it never deletes, it reports pages with no `.mdx` behind
them, and `--check-images` HEADs every reference before writing so a broken page is caught
before it ships. One trap it handles: Cloudflare 403s the default `Python-urllib` agent
before the site is reached, which presents as "all 51 images are missing".

It has not been run against the site — that needs an API key with Wiki Page write.

## Verification

`leadtype lint` 41/41, score 100/100, `pre-commit` clean, generated output regenerated from a
clean tree and confirmed against the CI drift gate.
