### PR TITLE
chore(docs): regenerate the user page timestamps against their own commit

### DIFF
--- a/docs-bundle/docs/user/deploy-from-template.md
+++ b/docs-bundle/docs/user/deploy-from-template.md
@@ -2,7 +2,7 @@
 title: Deploy from a template
 description: Turn a catalog template into a running bench, and read the eleven
   pipeline steps while they run.
-lastModified: "2026-08-30T10:28:35-04:00"
+lastModified: "2026-08-30T20:13:11+05:30"
 lastAuthor: Venkatesh
 ---
 # Deploy from a template

--- a/docs-bundle/docs/user/lab-detail.md
+++ b/docs-bundle/docs/user/lab-detail.md
@@ -2,7 +2,7 @@
 title: Read a lab page
 description: Every field on the lab page, and why container status and container
   health can disagree.
-lastModified: "2026-08-30T10:28:35-04:00"
+lastModified: "2026-08-30T20:13:11+05:30"
 lastAuthor: Venkatesh
 ---
 # Read a lab page

--- a/docs-bundle/docs/user/quick-tour.md
+++ b/docs-bundle/docs/user/quick-tour.md
@@ -2,7 +2,7 @@
 title: Quick tour
 description: The five screens in the BenchPress sidebar, and every number the
   Overview dashboard reports.
-lastModified: "2026-08-30T10:28:35-04:00"
+lastModified: "2026-08-30T20:13:11+05:30"
 lastAuthor: Venkatesh
 ---
 # Quick tour

--- a/docs-site/docs/user/deploy-from-template.md
+++ b/docs-site/docs/user/deploy-from-template.md
@@ -2,7 +2,7 @@
 title: Deploy from a template
 description: Turn a catalog template into a running bench, and read the eleven
   pipeline steps while they run.
-lastModified: "2026-08-30T10:28:35-04:00"
+lastModified: "2026-08-30T20:13:11+05:30"
 lastAuthor: Venkatesh
 ---
 # Deploy from a template

--- a/docs-site/docs/user/lab-detail.md
+++ b/docs-site/docs/user/lab-detail.md
@@ -2,7 +2,7 @@
 title: Read a lab page
 description: Every field on the lab page, and why container status and container
   health can disagree.
-lastModified: "2026-08-30T10:28:35-04:00"
+lastModified: "2026-08-30T20:13:11+05:30"
 lastAuthor: Venkatesh
 ---
 # Read a lab page

--- a/docs-site/docs/user/quick-tour.md
+++ b/docs-site/docs/user/quick-tour.md
@@ -2,7 +2,7 @@
 title: Quick tour
 description: The five screens in the BenchPress sidebar, and every number the
   Overview dashboard reports.
-lastModified: "2026-08-30T10:28:35-04:00"
+lastModified: "2026-08-30T20:13:11+05:30"
 lastAuthor: Venkatesh
 ---
 # Quick tour

--- a/docs-site/sitemap.xml
+++ b/docs-site/sitemap.xml
@@ -2,11 +2,11 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://benchpress.cloud/docs/user/quick-tour</loc>
-    <lastmod>2026-08-30T14:28:35.000Z</lastmod>
+    <lastmod>2026-08-30T14:43:11.000Z</lastmod>
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/user/deploy-from-template</loc>
-    <lastmod>2026-08-30T14:28:35.000Z</lastmod>
+    <lastmod>2026-08-30T14:43:11.000Z</lastmod>
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/user/create-a-lab</loc>
@@ -14,7 +14,7 @@
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/user/lab-detail</loc>
-    <lastmod>2026-08-30T14:28:35.000Z</lastmod>
+    <lastmod>2026-08-30T14:43:11.000Z</lastmod>
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/user/lifecycle</loc>


### PR DESCRIPTION
## Summary

The same fault #281 fixed has returned, in three different files.

Commit dc41f58 (#282) edited `docs/user/deploy-from-template.mdx`, `docs/user/lab-detail.mdx` and `docs/user/quick-tour.mdx`, and regenerated the docs trees in the same commit. At generation time those edits had no commit, so leadtype skipped git enrichment and stamped `lastModified` from the filesystem. Once dc41f58 landed the files had a commit date, so every later run disagrees:

```
-lastModified: "2026-08-30T10:28:35-04:00"   committed
+lastModified: "2026-08-30T20:13:11+05:30"   dc41f58's own commit date
```

This regenerates now that dc41f58 exists. Seven files, nine lines, all timestamps.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional change)
- [x] Documentation update
- [ ] Performance improvement

## Test Plan

- [x] Clean rebuild (`rm -rf docs-site docs-bundle && npm run docs:build`) reproduces exactly the seven files CI reported, with no additions or deletions
- [x] A second clean rebuild on top of this fix reports zero drift
- [x] `npm run docs:lint` — all 41 files pass
- [x] `npm run docs:score` — every scored row passes
- [ ] Tested locally with `bench start` — not applicable, no app code changes
- [ ] Frontend builds without errors — not applicable, no frontend changes

## Checklist

- [x] Commit messages follow conventional commits format
- [x] No `frappe.db.sql` in new code (use `frappe.qb`)
- [x] No `console.log` left in JS
- [x] Permission checks on new whitelisted endpoints — no new endpoints
- [x] No hardcoded credentials or API keys

## This will keep happening

Twice in one day. Any commit that edits a `.mdx` and regenerates in the same commit reintroduces it, and each recurrence turns every open pull request red, because the drift check runs on every one. The pipeline should not let a commit generate output for its own uncommitted sources. Worth fixing structurally rather than regenerating after the fact each time.