### PR TITLE
ci(docs): stop the drift check failing on git-derived timestamps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,14 +257,33 @@ jobs:
       - name: Score
         run: npm run docs:score
 
-      # `git status --porcelain` rather than `git diff`: diff alone misses a
-      # generated file that was added but never committed.
+      # Two checks, because neither alone is enough. `git ls-files -o` catches a
+      # generated file that was added but never committed, which `git diff`
+      # cannot see. `git diff` catches edits and deletions.
+      #
+      # The -I rules exclude the three git-derived timestamps. leadtype sets
+      # `lastModified` from the commit date of the commit that last touched the
+      # source file, so a commit that changes a source and regenerates the
+      # output in one go can never be self-consistent: the date does not exist
+      # until the commit does. That fixed point turned every open pull request
+      # red twice on 2026-08-30 (#281, #283) for output that was otherwise
+      # correct. -I ignores a hunk only when every changed line in it matches,
+      # so a real content edit beside a timestamp still fails.
       - name: Generated docs are committed and current
         run: |
-          if [ -n "$(git status --porcelain -- docs-site docs-bundle)" ]; then
+          untracked="$(git ls-files --others --exclude-standard -- docs-site docs-bundle)"
+          if [ -n "$untracked" ]; then
+            echo "Generated files exist but were never committed:"
+            echo "$untracked"
+            echo "Run: npm run docs:build && git add docs-site docs-bundle"
+            exit 1
+          fi
+          if ! git diff --exit-code \
+                 -I '^lastModified:' \
+                 -I '^lastAuthor:' \
+                 -I '^[[:space:]]*<lastmod>' \
+                 -- docs-site docs-bundle; then
             echo "docs-site/ or docs-bundle/ is stale or hand-edited."
             echo "Run: npm run docs:build && git add docs-site docs-bundle"
-            git status --porcelain -- docs-site docs-bundle
-            git diff -- docs-site docs-bundle
             exit 1
           fi


### PR DESCRIPTION
## Summary

The `Docs` drift check fails on output that is correct, and it did so twice today. #281 and #283 each fixed the symptom. This fixes the cause.

leadtype sets `lastModified` from the commit date of the commit that last touched the source file. A commit that edits a source **and** regenerates the output together can never satisfy that check, because the date does not exist until the commit does. It is a fixed point, not an ordering mistake someone can be careful about. The check is ungated, so every recurrence turns every open pull request red at once — with 13 dependabot pull requests open, one docs commit cost 13 red checks and a round of rebases.

Suppressing the field is not reachable. `--enrich-git` is deprecated and on by default with no counterpart (`dist/cli.js:476`), and `enrichFrontmatterFromGit` is programmatic-only on `convertAllMdx` (`dist/convert/index.d.ts:39`). Turning it off would fall back to file mtime, which leadtype's own docs note changes on every fresh checkout — guaranteed drift instead of occasional drift.

So the dependency is removed from the check rather than the output. `git diff -I` drops a hunk only when **every** changed line in it matches, so this is not a blanket exemption for those files.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional change)
- [ ] Documentation update
- [ ] Performance improvement

## Test Plan

The step was extracted and run verbatim against six cases on a real tree:

| # | Scenario | Expected | Result |
|---|---|---|---|
| 1 | Clean tree | pass | pass |
| 2 | The timestamp drift currently on `version-16` (7 files) | pass | pass |
| 3 | Body text edited | fail | fail |
| 3b | Body text edited **and** a timestamp changed in the same file | fail | fail |
| 4 | Untracked generated file added | fail | fail |
| 5 | Generated file deleted | fail | fail |

Case 3b is the one that matters: it proves `-I` opens no blind spot when a real edit sits beside a timestamp change.

- [x] `python3 -c "yaml.safe_load(...)"` — workflow parses
- [x] `uvx pre-commit@4.3.0` passes on the changed file
- [ ] Tested locally with `bench start` — not applicable, CI configuration only
- [ ] Frontend builds without errors — not applicable, CI configuration only

## Checklist

- [x] Commit messages follow conventional commits format
- [x] No `frappe.db.sql` in new code (use `frappe.qb`)
- [x] No `console.log` left in JS
- [x] Permission checks on new whitelisted endpoints — no new endpoints
- [x] No hardcoded credentials or API keys

## Interaction with #283

Independent, and either order works. #283 corrects the committed timestamps so they match reality. This makes CI stop caring when they do not. #283 is still worth merging on its own terms.

## Known tradeoff

The committed `sitemap.xml` `lastmod` values can now go stale without CI noticing. If that matters for search indexing later, the fix is a scheduled job that regenerates and commits, not a stricter check here.