### PR TITLE
fix(emails): put the BenchPress logo in the mail header

### DIFF
--- a/benchpress/emails.py
+++ b/benchpress/emails.py
@@ -10,7 +10,7 @@ from frappe.utils import cint, format_datetime, get_url, get_url_to_form
 from markupsafe import Markup, escape
 
 from benchpress import contact
-from benchpress.benchpress.site_content import REPO_URL
+from benchpress.benchpress.site_content import REPO_URL, asset_version
 from benchpress.credits import config
 from benchpress.permissions import ADMIN_ROLES
 
@@ -25,6 +25,9 @@ CONTACT_RECEIVED = "BenchPress Contact Message Received"
 CONTACT_FILED = "BenchPress Contact Message Filed"
 
 TEMPLATE_DIR = "benchpress/templates/emails"
+
+# The header lockup, in the one variant that reads on the dark bar the templates draw it on.
+LOGO_PATH = "/assets/benchpress/images/logo/wordmark-on-dark.png"
 
 # Template name -> (subject, body file). The file is both the fallback body and the Desk seed.
 DEFAULTS = {
@@ -217,6 +220,7 @@ def _urls() -> dict:
 	return {
 		"site_url": get_url(),
 		"login_url": get_url("/login"),
+		"logo_url": f"{get_url(LOGO_PATH)}?v={asset_version()}",
 		"docs_url": "https://benchpress.cloud/docs",
 		"repo_url": REPO_URL,
 	}

--- a/benchpress/patches.txt
+++ b/benchpress/patches.txt
@@ -32,3 +32,4 @@ benchpress.patches.default_traefik_health
 benchpress.patches.seed_route_rate_limits
 benchpress.patches.seed_public_site
 benchpress.patches.drop_page_content_doctypes
+benchpress.patches.relogo_email_templates

--- a/benchpress/patches/relogo_email_templates.py
+++ b/benchpress/patches/relogo_email_templates.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+from benchpress.public_site.seed import relogo_email_templates
+
+
+def execute():
+	relogo_email_templates()

--- a/benchpress/public_site/seed.py
+++ b/benchpress/public_site/seed.py
@@ -4,6 +4,7 @@
 import re
 
 import frappe
+from frappe import _
 
 from benchpress import emails
 from benchpress.public_site import public_site_enabled
@@ -65,5 +66,5 @@ def _shipped_logo_block() -> str:
 	# Taken from the shipped body so the markup lives in the templates and nowhere else.
 	found = LOGO_BLOCK.search(emails.default_body(emails.ACCESS_APPROVED))
 	if not found:
-		frappe.throw("The shipped email header no longer carries the logo block")
+		frappe.throw(_("The shipped email header no longer carries the logo block"))
 	return found.group(0)

--- a/benchpress/public_site/seed.py
+++ b/benchpress/public_site/seed.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2026, Venkatesh and contributors
 # For license information, please see license.txt
 
+import re
+
 import frappe
 
 from benchpress import emails
@@ -11,6 +13,14 @@ EMAIL_TEMPLATE = "Email Template"
 
 # The landing page's former route; a site still pointing at it is re-pointed, not left.
 FORMER_HOME_PAGE = "home"
+
+# The brand bar the first seeded rows carried: a blue square beside the word BENCHPRESS.
+FAUX_LOGO = re.compile(
+	r'<table role="presentation" cellpadding="0" cellspacing="0" border="0">\s*<tr>\s*'
+	r'<td width="10" bgcolor="#4E8BFB".*?</td>\s*<td [^>]*>BENCHPRESS</td>\s*</tr>\s*</table>',
+	re.DOTALL,
+)
+LOGO_BLOCK = re.compile(r'<a href="\{\{ site_url \| e \}\}"[^>]*><img [^>]*alt="BenchPress"[^>]*></a>')
 
 
 def seed_public_site() -> None:
@@ -37,3 +47,23 @@ def claim_home_page() -> None:
 	frappe.db.set_single_value(WEBSITE_SETTINGS, "home_page", LANDING_PAGE)
 	# Written straight to the row, so the controller that would have dropped this key never ran.
 	frappe.cache.delete_value("home_page")
+
+
+def relogo_email_templates() -> None:
+	block = _shipped_logo_block()
+	for name in emails.DEFAULTS:
+		body = frappe.db.get_value(EMAIL_TEMPLATE, name, "response_html")
+		if not body:
+			continue
+		swapped, count = FAUX_LOGO.subn(lambda _match: block, body, count=1)
+		if count:
+			frappe.db.set_value(EMAIL_TEMPLATE, name, "response_html", swapped)
+	frappe.clear_cache(doctype=EMAIL_TEMPLATE)
+
+
+def _shipped_logo_block() -> str:
+	# Taken from the shipped body so the markup lives in the templates and nowhere else.
+	found = LOGO_BLOCK.search(emails.default_body(emails.ACCESS_APPROVED))
+	if not found:
+		frappe.throw("The shipped email header no longer carries the logo block")
+	return found.group(0)

--- a/benchpress/templates/emails/access_approved.html
+++ b/benchpress/templates/emails/access_approved.html
@@ -12,12 +12,7 @@
 
 				<tr>
 					<td style="padding:20px 28px;background-color:#0A1024;border-radius:13px 13px 0 0;">
-						<table role="presentation" cellpadding="0" cellspacing="0" border="0">
-							<tr>
-								<td width="10" bgcolor="#4E8BFB" style="width:10px;height:10px;border-radius:3px;font-size:0;line-height:10px;">&nbsp;</td>
-								<td style="padding-left:12px;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;">BENCHPRESS</td>
-							</tr>
-						</table>
+						<a href="{{ site_url | e }}" style="display:inline-block;text-decoration:none;"><img src="{{ logo_url | e }}" width="140" height="36" alt="BenchPress" style="display:block;width:140px;height:36px;border:0;outline:none;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;text-decoration:none;"></a>
 					</td>
 				</tr>
 

--- a/benchpress/templates/emails/access_declined.html
+++ b/benchpress/templates/emails/access_declined.html
@@ -11,12 +11,7 @@
 
 				<tr>
 					<td style="padding:20px 28px;background-color:#0A1024;border-radius:13px 13px 0 0;">
-						<table role="presentation" cellpadding="0" cellspacing="0" border="0">
-							<tr>
-								<td width="10" bgcolor="#4E8BFB" style="width:10px;height:10px;border-radius:3px;font-size:0;line-height:10px;">&nbsp;</td>
-								<td style="padding-left:12px;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;">BENCHPRESS</td>
-							</tr>
-						</table>
+						<a href="{{ site_url | e }}" style="display:inline-block;text-decoration:none;"><img src="{{ logo_url | e }}" width="140" height="36" alt="BenchPress" style="display:block;width:140px;height:36px;border:0;outline:none;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;text-decoration:none;"></a>
 					</td>
 				</tr>
 

--- a/benchpress/templates/emails/access_request_filed.html
+++ b/benchpress/templates/emails/access_request_filed.html
@@ -11,12 +11,7 @@
 
 				<tr>
 					<td style="padding:20px 28px;background-color:#0A1024;border-radius:13px 13px 0 0;">
-						<table role="presentation" cellpadding="0" cellspacing="0" border="0">
-							<tr>
-								<td width="10" bgcolor="#4E8BFB" style="width:10px;height:10px;border-radius:3px;font-size:0;line-height:10px;">&nbsp;</td>
-								<td style="padding-left:12px;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;">BENCHPRESS</td>
-							</tr>
-						</table>
+						<a href="{{ site_url | e }}" style="display:inline-block;text-decoration:none;"><img src="{{ logo_url | e }}" width="140" height="36" alt="BenchPress" style="display:block;width:140px;height:36px;border:0;outline:none;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;text-decoration:none;"></a>
 					</td>
 				</tr>
 

--- a/benchpress/templates/emails/access_request_received.html
+++ b/benchpress/templates/emails/access_request_received.html
@@ -12,12 +12,7 @@
 
 				<tr>
 					<td style="padding:20px 28px;background-color:#0A1024;border-radius:13px 13px 0 0;">
-						<table role="presentation" cellpadding="0" cellspacing="0" border="0">
-							<tr>
-								<td width="10" bgcolor="#4E8BFB" style="width:10px;height:10px;border-radius:3px;font-size:0;line-height:10px;">&nbsp;</td>
-								<td style="padding-left:12px;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;">BENCHPRESS</td>
-							</tr>
-						</table>
+						<a href="{{ site_url | e }}" style="display:inline-block;text-decoration:none;"><img src="{{ logo_url | e }}" width="140" height="36" alt="BenchPress" style="display:block;width:140px;height:36px;border:0;outline:none;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;text-decoration:none;"></a>
 					</td>
 				</tr>
 

--- a/benchpress/templates/emails/contact_filed.html
+++ b/benchpress/templates/emails/contact_filed.html
@@ -11,12 +11,7 @@
 
 				<tr>
 					<td style="padding:20px 28px;background-color:#0A1024;border-radius:13px 13px 0 0;">
-						<table role="presentation" cellpadding="0" cellspacing="0" border="0">
-							<tr>
-								<td width="10" bgcolor="#4E8BFB" style="width:10px;height:10px;border-radius:3px;font-size:0;line-height:10px;">&nbsp;</td>
-								<td style="padding-left:12px;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;">BENCHPRESS</td>
-							</tr>
-						</table>
+						<a href="{{ site_url | e }}" style="display:inline-block;text-decoration:none;"><img src="{{ logo_url | e }}" width="140" height="36" alt="BenchPress" style="display:block;width:140px;height:36px;border:0;outline:none;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;text-decoration:none;"></a>
 					</td>
 				</tr>
 

--- a/benchpress/templates/emails/contact_received.html
+++ b/benchpress/templates/emails/contact_received.html
@@ -11,12 +11,7 @@
 
 				<tr>
 					<td style="padding:20px 28px;background-color:#0A1024;border-radius:13px 13px 0 0;">
-						<table role="presentation" cellpadding="0" cellspacing="0" border="0">
-							<tr>
-								<td width="10" bgcolor="#4E8BFB" style="width:10px;height:10px;border-radius:3px;font-size:0;line-height:10px;">&nbsp;</td>
-								<td style="padding-left:12px;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;">BENCHPRESS</td>
-							</tr>
-						</table>
+						<a href="{{ site_url | e }}" style="display:inline-block;text-decoration:none;"><img src="{{ logo_url | e }}" width="140" height="36" alt="BenchPress" style="display:block;width:140px;height:36px;border:0;outline:none;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;text-decoration:none;"></a>
 					</td>
 				</tr>
 

--- a/benchpress/tests/test_emails.py
+++ b/benchpress/tests/test_emails.py
@@ -5,8 +5,10 @@ from unittest.mock import patch
 
 import frappe
 from frappe.tests import IntegrationTestCase
+from frappe.utils import get_url
 
 from benchpress import contact, emails
+from benchpress.public_site.seed import relogo_email_templates
 
 REQUESTER = "emails-requester@example.com"
 SENDER = "emails-sender@example.com"
@@ -15,6 +17,17 @@ ADMIN_ROLE = "BenchPress Admin"
 
 # `_message()` files under "Sales"; routing it at the admin pins who the notice reaches.
 ROUTED_TO_ADMIN = ({"label": "Sales", "route_to_email": ADMIN},)
+
+# A row as the seed planted it before the logo existed, with a line of operator copy under it.
+FAUX_LOGO_BODY = """<td style="padding:20px 28px;background-color:#0A1024;border-radius:13px 13px 0 0;">
+	<table role="presentation" cellpadding="0" cellspacing="0" border="0">
+		<tr>
+			<td width="10" bgcolor="#4E8BFB" style="width:10px;height:10px;">&nbsp;</td>
+			<td style="font-size:17px;color:#FFFFFF;">BENCHPRESS</td>
+		</tr>
+	</table>
+</td>
+<p>Hosted access is invite-only.</p>"""
 
 
 def _entry(**overrides) -> frappe._dict:
@@ -148,8 +161,21 @@ class TestEmails(IntegrationTestCase):
 			emails.send_access_request_received(_entry())
 
 		self.assertEqual(self.sent["subject"], "Your BenchPress access request — REQ-A1B2-C3D4")
-		self.assertIn("BENCH", self.sent["message"], "the shipped body did not render")
+		self.assertIn(emails.LOGO_PATH, self.sent["message"], "the shipped body did not render")
 		self.assertNotIn("{{", self.sent["message"], "an interpolation was left unrendered")
+
+	def test_every_shipped_body_carries_the_logo_over_an_absolute_url(self):
+		"""A mail client resolves nothing relative, so the header src must arrive absolute."""
+		patch.object(emails, "admin_recipients", return_value=[ADMIN]).start()
+		patch.object(contact, "TOPICS", ROUTED_TO_ADMIN).start()
+
+		with patch.object(frappe.db, "exists", return_value=False):
+			for send, row in self._every_send():
+				self.mailer.reset_mock()
+				send(row)
+				with self.subTest(send=send.__name__):
+					self.assertIn(f'src="{get_url(emails.LOGO_PATH)}?v=', self.sent["message"])
+					self.assertIn('alt="BenchPress"', self.sent["message"])
 
 	def test_an_operator_edit_in_desk_wins_over_the_shipped_body(self):
 		self._install_template(
@@ -175,6 +201,26 @@ class TestEmails(IntegrationTestCase):
 				self.mailer.reset_mock()
 				send(bare)
 				self.assertTrue(self.sent["message"].strip())
+
+	def test_a_row_seeded_before_the_logo_is_re_branded_in_place(self):
+		self._install_template(emails.ACCESS_APPROVED, subject="x", body=FAUX_LOGO_BODY)
+
+		relogo_email_templates()
+
+		body = frappe.db.get_value("Email Template", emails.ACCESS_APPROVED, "response_html")
+		self.assertNotIn("BENCHPRESS", body)
+		self.assertIn('alt="BenchPress"', body)
+		self.assertIn("<p>Hosted access is invite-only.</p>", body, "the operator's copy was lost")
+
+	def test_re_branding_a_row_that_already_carries_the_logo_changes_nothing(self):
+		self._install_template(emails.ACCESS_APPROVED, subject="x", body=FAUX_LOGO_BODY)
+		relogo_email_templates()
+		once = frappe.db.get_value("Email Template", emails.ACCESS_APPROVED, "response_html")
+
+		relogo_email_templates()
+
+		twice = frappe.db.get_value("Email Template", emails.ACCESS_APPROVED, "response_html")
+		self.assertEqual(once, twice)
 
 	# failure containment
 
@@ -224,6 +270,18 @@ class TestEmails(IntegrationTestCase):
 		self.assertNotIn(ADMIN, emails.admin_recipients())
 
 	# helpers
+
+	def _every_send(self) -> tuple:
+		"""One call per shipped body: the four that reach a person and the two that reach the admins."""
+		entry, message = _entry(), _message()
+		return (
+			(emails.send_access_request_received, entry),
+			(emails.notify_admins_of_access_request, entry),
+			(emails.send_access_request_approved, entry),
+			(emails.send_access_request_rejected, entry),
+			(emails.send_contact_received, message),
+			(emails.notify_admins_of_contact, message),
+		)
 
 	def _install_template(self, name: str, subject: str, body: str) -> None:
 		if frappe.db.exists("Email Template", name):


### PR DESCRIPTION
## What

All six transactional emails drew their own brand bar — a blue square beside the word `BENCHPRESS` in bold — instead of the BenchPress logo. Every body now carries `wordmark-on-dark.png`, the same lockup the site header and footer use, at 140x36 and linked to the site.

Templates changed: `access_approved`, `access_declined`, `access_request_filed`, `access_request_received`, `contact_filed`, `contact_received`.

## How

- `emails.LOGO_PATH` names the asset; `_urls()` adds a `logo_url` key built with `get_url()` plus the `asset_version()` token the site already uses on its unhashed assets. A mail client resolves nothing relative, so the `src` has to arrive absolute.
- The `<img>` carries the font, weight, letter spacing and colour the old text carried, so a client that blocks remote images degrades to a readable white **BenchPress** on the dark bar rather than to nothing.
- Rows seeded before this change still hold the old markup, and the seeder only inserts what is missing. `relogo_email_templates` swaps just the brand block in each stored `response_html` and leaves the rest of the body — including operator edits — untouched. Wired as `benchpress.patches.relogo_email_templates`, and idempotent.

## Tests

`bench --site frontend run-tests --module benchpress.tests.test_emails` — 22 pass, three of them new:

- every one of the six sends puts an absolute logo `src` and `alt="BenchPress"` in the body
- a row seeded before the logo is re-branded in place, with the operator's copy intact
- running the patch twice changes nothing

`test_public_site_flag` (12) and `test_landing` (15) also pass. `pre-commit` is clean.

## Checked

Rendered the approval mail and opened it in a browser, with images on and with the image blocked.