### PR TITLE
fix(emails): four transactional-mail bugs from testing round 1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Eleven facts that are easy to break:
   `TOPICS` (first row is the default), `RESPONSE_TIMES` and `ACKNOWLEDGE_SENDER`.
   Only the forwarding address is per-deployment — the `benchpress_contact_email`
   site-config key, falling back to `CONTACT_EMAIL`.
-- The six `Email Template` rows are the one thing `benchpress.public_site.seed`
+- The seven `Email Template` rows are the one thing `benchpress.public_site.seed`
   still plants, and they are deliberately not a `fixtures` entry: `sync_fixtures`
   imports with `force=True` on every `bench migrate`, which no flag can gate and
   which overwrites an edited body.

--- a/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.py
+++ b/benchpress/benchpress/doctype/benchpress_settings/benchpress_settings.py
@@ -2,7 +2,11 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe.installer import update_site_config
 from frappe.model.document import Document
+from frappe.utils import cstr
+
+HOST_NAME_KEY = "host_name"
 
 
 class BenchPressSettings(Document):
@@ -17,6 +21,8 @@ class BenchPressSettings(Document):
 		The guard keeps an unrelated settings save — a toggle, a timeout — from queueing a
 		directory sweep.
 		"""
+		claim_host_name(self.base_domain)
+
 		if not self.has_value_changed("base_domain"):
 			return
 
@@ -29,3 +35,16 @@ class BenchPressSettings(Document):
 			# the new value is committed. Same mistake `6e25962` fixed for deploys.
 			enqueue_after_commit=True,
 		)
+
+
+def claim_host_name(base_domain: str | None) -> None:
+	"""`frappe.utils.get_url()` falls back to the site name, so every mailed link needs this key."""
+	domain = cstr(base_domain).strip()
+	if not domain or domain == "localhost":
+		return
+	url = f"https://{domain}"
+	if frappe.conf.get(HOST_NAME_KEY) == url:
+		return
+	update_site_config(HOST_NAME_KEY, url)
+	# The file as well as the live conf: `get_url` reads the copy loaded at request start.
+	frappe.conf[HOST_NAME_KEY] = url

--- a/benchpress/benchpress/doctype/benchpress_settings/test_benchpress_settings.py
+++ b/benchpress/benchpress/doctype/benchpress_settings/test_benchpress_settings.py
@@ -10,8 +10,15 @@ is invisible to anyone testing as Administrator, which is why it is asserted
 here rather than left to manual checking.
 """
 
+from unittest.mock import patch
+
 import frappe
 from frappe.tests import IntegrationTestCase
+
+from benchpress.benchpress.doctype.benchpress_settings.benchpress_settings import (
+	HOST_NAME_KEY,
+	claim_host_name,
+)
 
 EXTRA_TEST_RECORD_DEPENDENCIES = []
 IGNORE_TEST_RECORD_DEPENDENCIES = []
@@ -93,3 +100,40 @@ class IntegrationTestBenchPressSettings(IntegrationTestCase):
 		settings.save(ignore_permissions=True)
 		# Restores a singleton the test committed through the real save path.
 		frappe.db.commit()  # nosemgrep
+
+
+class IntegrationTestHostName(IntegrationTestCase):
+	"""`host_name` is what keeps a mailed link off `http://frontend/`."""
+
+	def setUp(self):
+		self.written = patch(
+			"benchpress.benchpress.doctype.benchpress_settings.benchpress_settings.update_site_config"
+		).start()
+		self.addCleanup(patch.stopall)
+		# Patched, not written: the real key belongs to the site, not to a test run.
+		patch.dict(frappe.conf, {HOST_NAME_KEY: None}).start()
+
+	def test_a_bench_zone_becomes_the_site_url(self):
+		claim_host_name("benchpress.cloud")
+
+		self.written.assert_called_once_with(HOST_NAME_KEY, "https://benchpress.cloud")
+		self.assertEqual(frappe.conf.get(HOST_NAME_KEY), "https://benchpress.cloud")
+
+	def test_an_empty_bench_zone_writes_nothing(self):
+		claim_host_name("")
+		claim_host_name(None)
+		claim_host_name("   ")
+
+		self.written.assert_not_called()
+
+	def test_localhost_writes_nothing(self):
+		claim_host_name("localhost")
+
+		self.written.assert_not_called()
+
+	def test_the_key_is_not_rewritten_when_it_already_agrees(self):
+		frappe.conf[HOST_NAME_KEY] = "https://benchpress.cloud"
+
+		claim_host_name("benchpress.cloud")
+
+		self.written.assert_not_called()

--- a/benchpress/benchpress/doctype/waitlist_entry/waitlist_entry.py
+++ b/benchpress/benchpress/doctype/waitlist_entry/waitlist_entry.py
@@ -47,9 +47,14 @@ class WaitlistEntry(Document):
 		if decided_now:
 			self.status = "Approved"
 			self.save(ignore_permissions=True)
+		created_now = not frappe.db.exists("User", self.email)
 		user = self.invite_user()
 		if decided_now:
-			send_notice("send_access_request_approved", self)
+			send_notice(
+				"send_access_request_approved",
+				self,
+				set_password_url=set_password_url(user) if created_now else "",
+			)
 		return user
 
 	def reject(self, reason: str = "") -> None:
@@ -75,7 +80,9 @@ class WaitlistEntry(Document):
 		user = frappe.new_doc("User")
 		user.email = self.email
 		user.first_name = self.full_name or self.email.split("@")[0]
-		user.send_welcome_email = 1
+		# The approval mail carries the set-password link itself, so Frappe's welcome mail would
+		# be a second mail saying the same thing — and a second key, invalidating the first.
+		user.send_welcome_email = 0
 		user.append("roles", {"role": ACCESS_ROLE})
 		user.insert(ignore_permissions=True)
 		# After the insert, not before: `User.set_system_user` re-derives the type from role desk
@@ -93,12 +100,21 @@ def derive_reference(email: str) -> str:
 	return f"{REFERENCE_PREFIX}-{digest[:4].upper()}-{digest[4:8].upper()}"
 
 
-def send_notice(sender: str, entry) -> None:
+def set_password_url(user: str) -> str:
+	"""Frappe's own one-time key, so the approval mail carries the way in. Never raises."""
+	try:
+		return frappe.get_doc("User", user)._reset_password()
+	except Exception:
+		frappe.log_error(title="BenchPress set-password link failed", message=frappe.get_traceback())
+		return ""
+
+
+def send_notice(sender: str, entry, **context) -> None:
 	"""Fire one `benchpress.emails` sender. Never raises — mail must not undo a decision."""
 	try:
 		from benchpress import emails
 
-		getattr(emails, sender)(entry)
+		getattr(emails, sender)(entry, **context)
 	except Exception:
 		frappe.log_error(
 			title=f"BenchPress access request email failed: {sender}",

--- a/benchpress/emails.py
+++ b/benchpress/emails.py
@@ -70,10 +70,11 @@ def notify_admins_of_access_request(entry) -> None:
 
 
 @best_effort
-def send_access_request_approved(entry) -> None:
-	"""The decision, never a credential — Frappe's welcome mail carries the password link."""
+def send_access_request_approved(entry, set_password_url: str = "") -> None:
+	"""The decision and the way in, in one mail — a second mail can be undone by a stalled queue."""
 	context = _request_context(entry)
 	context["free_credits"] = cint(config.settings().signup_grant_credits)
+	context["set_password_url"] = set_password_url
 	_send(ACCESS_APPROVED, [entry.name], context, WAITLIST, entry.name)
 
 

--- a/benchpress/emails.py
+++ b/benchpress/emails.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Venkatesh and contributors
 # For license information, please see license.txt
 
-"""Transactional mail for the public site — six operator-editable `Email Template` rows."""
+"""Transactional mail — seven operator-editable `Email Template` rows."""
 
 import functools
 
@@ -10,7 +10,7 @@ from frappe.utils import cint, format_datetime, get_url, get_url_to_form
 from markupsafe import Markup, escape
 
 from benchpress import contact
-from benchpress.benchpress.site_content import REPO_URL
+from benchpress.benchpress.site_content import REPO_URL, asset_version
 from benchpress.credits import config
 from benchpress.permissions import ADMIN_ROLES
 
@@ -23,8 +23,12 @@ ACCESS_APPROVED = "BenchPress Access Approved"
 ACCESS_DECLINED = "BenchPress Access Declined"
 CONTACT_RECEIVED = "BenchPress Contact Message Received"
 CONTACT_FILED = "BenchPress Contact Message Filed"
+PASSWORD_RESET = "BenchPress Password Reset"
 
 TEMPLATE_DIR = "benchpress/templates/emails"
+
+# The header lockup, in the one variant that reads on the dark bar the templates draw it on.
+LOGO_PATH = "/assets/benchpress/images/logo/wordmark-on-dark.png"
 
 # Template name -> (subject, body file). The file is both the fallback body and the Desk seed.
 DEFAULTS = {
@@ -34,6 +38,7 @@ DEFAULTS = {
 	ACCESS_DECLINED: ("About your BenchPress access request", "access_declined.html"),
 	CONTACT_RECEIVED: ("We got your message", "contact_received.html"),
 	CONTACT_FILED: ("[{{ topic }}] {{ sender_name }}", "contact_filed.html"),
+	PASSWORD_RESET: ("Reset your BenchPress password", "password_reset.html"),
 }
 
 NO_COMPANY = "no company"
@@ -106,6 +111,21 @@ def notify_admins_of_contact(message) -> None:
 	_send(CONTACT_FILED, recipients, context, CONTACT, message.name, reply_to=message.email)
 
 
+def send_password_reset(user, link: str) -> None:
+	"""Frappe's own reset mail, in BenchPress's chrome. Raises so the caller can report a failure."""
+	body = _render(
+		PASSWORD_RESET,
+		{"full_name": user.get_fullname() or user.name, "email": user.name, "reset_url": link, **_urls()},
+	)
+	frappe.sendmail(
+		recipients=[user.name],
+		subject=body["subject"],
+		message=body["message"],
+		now=True,
+		redact_message_after_send=True,
+	)
+
+
 def admin_recipients() -> list[str]:
 	"""Enabled system users holding an admin role; the contact address when there are none."""
 	has_role = frappe.qb.DocType("Has Role")
@@ -127,7 +147,7 @@ def admin_recipients() -> list[str]:
 
 
 def seed_rows() -> list[dict]:
-	"""The six `Email Template` records as the seed hook should insert them."""
+	"""The seven `Email Template` records as the seed hook should insert them."""
 	# `use_html`, or the Text Editor would rewrite these hand-built tables on the first save.
 	return [
 		{
@@ -218,6 +238,7 @@ def _urls() -> dict:
 	return {
 		"site_url": get_url(),
 		"login_url": get_url("/login"),
+		"logo_url": f"{get_url(LOGO_PATH)}?v={asset_version()}",
 		"docs_url": "https://benchpress.cloud/docs",
 		"repo_url": REPO_URL,
 	}

--- a/benchpress/emails.py
+++ b/benchpress/emails.py
@@ -12,7 +12,6 @@ from markupsafe import Markup, escape
 from benchpress import contact
 from benchpress.benchpress.site_content import REPO_URL, asset_version
 from benchpress.credits import config
-from benchpress.permissions import ADMIN_ROLES
 
 WAITLIST = "Waitlist Entry"
 CONTACT = "Contact Message"
@@ -67,11 +66,11 @@ def send_access_request_received(entry) -> None:
 
 @best_effort
 def notify_admins_of_access_request(entry) -> None:
-	"""Tell the admins a request is waiting, with every field they need to decide."""
+	"""Tell the operator a request is waiting, with every field they need to decide."""
 	context = _request_context(entry)
 	context["desk_url"] = get_url_to_form(WAITLIST, entry.name)
 	context["submitted_on"] = _timestamp(entry.get("creation"))
-	_send(ACCESS_FILED, admin_recipients(), context, WAITLIST, entry.name)
+	_send(ACCESS_FILED, [contact.notify_email()], context, WAITLIST, entry.name)
 
 
 @best_effort
@@ -124,26 +123,6 @@ def send_password_reset(user, link: str) -> None:
 		now=True,
 		redact_message_after_send=True,
 	)
-
-
-def admin_recipients() -> list[str]:
-	"""Enabled system users holding an admin role; the contact address when there are none."""
-	has_role = frappe.qb.DocType("Has Role")
-	user = frappe.qb.DocType("User")
-	addresses = (
-		frappe.qb.from_(has_role)
-		.join(user)
-		.on(has_role.parent == user.name)
-		.select(user.email)
-		.distinct()
-		.where(has_role.parenttype == "User")
-		.where(has_role.role.isin(list(ADMIN_ROLES)))
-		.where(user.enabled == 1)
-		.where(user.user_type == "System User")
-		.where(user.email.notnull())
-		.where(user.email != "")
-	).run(pluck=True)
-	return sorted(set(addresses)) or [contact.notify_email()]
 
 
 def seed_rows() -> list[dict]:

--- a/benchpress/hooks.py
+++ b/benchpress/hooks.py
@@ -159,11 +159,17 @@ has_permission = {
 
 # DocType Class
 # ---------------
-# Override standard doctype classes
+# Extend standard doctype classes with a mixin
 
-# override_doctype_class = {
-# 	"ToDo": "custom_app.overrides.CustomToDo"
-# }
+# One method: the password reset mail. `User.send_login_mail` forces `with_container`, so the
+# framework's white masthead cannot be turned off from a template — and shadowing
+# `templates/emails/password_reset.html` alone would leave the mail with two brand bars.
+#
+# A mixin rather than `override_doctype_class`: that replaces the controller class, so only one
+# app can own a DocType, and the frappe semgrep rules block it.
+extend_doctype_class = {
+	"User": "benchpress.user.BenchPressPasswordResetMixin",
+}
 
 # Document Events
 # ---------------

--- a/benchpress/patches.txt
+++ b/benchpress/patches.txt
@@ -32,3 +32,4 @@ benchpress.patches.default_traefik_health
 benchpress.patches.seed_route_rate_limits
 benchpress.patches.seed_public_site
 benchpress.patches.drop_page_content_doctypes
+benchpress.patches.claim_host_name

--- a/benchpress/patches.txt
+++ b/benchpress/patches.txt
@@ -34,3 +34,4 @@ benchpress.patches.seed_public_site
 benchpress.patches.drop_page_content_doctypes
 benchpress.patches.claim_host_name
 benchpress.patches.refresh_approval_mail
+benchpress.patches.seed_password_reset_template

--- a/benchpress/patches.txt
+++ b/benchpress/patches.txt
@@ -33,3 +33,4 @@ benchpress.patches.seed_route_rate_limits
 benchpress.patches.seed_public_site
 benchpress.patches.drop_page_content_doctypes
 benchpress.patches.claim_host_name
+benchpress.patches.refresh_approval_mail

--- a/benchpress/patches/claim_host_name.py
+++ b/benchpress/patches/claim_host_name.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+import frappe
+
+from benchpress.benchpress.doctype.benchpress_settings.benchpress_settings import claim_host_name
+
+
+def execute():
+	claim_host_name(frappe.db.get_single_value("BenchPress Settings", "base_domain"))

--- a/benchpress/patches/refresh_approval_mail.py
+++ b/benchpress/patches/refresh_approval_mail.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""Re-seed the approval mail while it still promises a welcome mail that never arrives.
+
+Over an operator edit that kept that sentence, deliberately: the sentence is untrue.
+"""
+
+import frappe
+
+from benchpress import emails
+
+DEAD_PROMISE = "separate welcome email"
+
+
+def execute():
+	stored = frappe.db.get_value("Email Template", emails.ACCESS_APPROVED, "response_html")
+	if not stored or DEAD_PROMISE not in stored:
+		return
+	frappe.db.set_value(
+		"Email Template",
+		emails.ACCESS_APPROVED,
+		"response_html",
+		emails.default_body(emails.ACCESS_APPROVED),
+	)
+	frappe.clear_cache(doctype="Email Template")

--- a/benchpress/patches/seed_password_reset_template.py
+++ b/benchpress/patches/seed_password_reset_template.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""Plant the seventh `Email Template` row on a site the first seeding pass predates."""
+
+from benchpress.public_site.seed import seed_public_site
+
+
+def execute():
+	seed_public_site()

--- a/benchpress/templates/emails/access_approved.html
+++ b/benchpress/templates/emails/access_approved.html
@@ -1,10 +1,11 @@
 <!--
-	BenchPress Access Approved — the decision, and never a credential.
+	BenchPress Access Approved — the decision and the way in, in one mail.
 
-	The password-set link travels in Frappe's own welcome mail. This one must read correctly
-	whether that mail was sent or the account already existed, so it points at the login page and
-	names the welcome mail rather than assuming it.
+	`set_password_url` is Frappe's one-time key, and is set only for an account this approval
+	created. An address that already had a login gets the sign-in door instead, so the mail reads
+	correctly either way.
 -->
+{% set action_url = set_password_url or login_url %}
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#F6F8FF;">
 	<tr>
 		<td align="center" style="padding:24px 12px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
@@ -25,7 +26,7 @@
 					<td style="padding:30px 28px 0;">
 						<div style="font-size:12px;font-weight:700;letter-spacing:0.14em;text-transform:uppercase;color:#2FB714;">Approved</div>
 						<h1 style="margin:10px 0 0;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:24px;line-height:32px;font-weight:800;color:#0A1024;">Your account is open, {{ full_name | e }}.</h1>
-						<p style="margin:14px 0 0;font-size:15px;line-height:24px;color:#4E5A7C;">Request {{ reference | e }} is approved. Sign in with {{ email | e }} and deploy your first lab — a template picks the Frappe version and the app set, and the site is usually answering in about ninety seconds.</p>
+						<p style="margin:14px 0 0;font-size:15px;line-height:24px;color:#4E5A7C;">Request {{ reference | e }} is approved. Your login is {{ email | e }} — deploy your first lab — a template picks the Frappe version and the app set, and the site is usually answering in about ninety seconds.</p>
 					</td>
 				</tr>
 
@@ -49,12 +50,16 @@
 						<table role="presentation" cellpadding="0" cellspacing="0" border="0">
 							<tr>
 								<td bgcolor="#1F5CF5" style="border-radius:10px;">
-									<a href="{{ login_url | e }}" style="display:inline-block;padding:13px 22px;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:15px;font-weight:700;color:#FFFFFF;text-decoration:none;">Sign in</a>
+									<a href="{{ action_url | e }}" style="display:inline-block;padding:13px 22px;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:15px;font-weight:700;color:#FFFFFF;text-decoration:none;">{% if set_password_url %}Set your password{% else %}Sign in{% endif %}</a>
 								</td>
 							</tr>
 						</table>
-						<p style="margin:12px 0 0;font-family:'SFMono-Regular',Consolas,Menlo,monospace;font-size:12px;line-height:19px;color:#8B94AE;"><a href="{{ login_url | e }}" style="color:#8B94AE;text-decoration:none;">{{ login_url | e }}</a></p>
-						<p style="margin:10px 0 0;font-size:13px;line-height:20px;color:#8B94AE;">If you have not set a password yet, use the link in the separate welcome email — we never put one in this message.</p>
+						<p style="margin:12px 0 0;font-family:'SFMono-Regular',Consolas,Menlo,monospace;font-size:12px;line-height:19px;color:#8B94AE;"><a href="{{ action_url | e }}" style="color:#8B94AE;text-decoration:none;">{{ action_url | e }}</a></p>
+						{% if set_password_url %}
+						<p style="margin:10px 0 0;font-size:13px;line-height:20px;color:#8B94AE;">The link sets your password once and then expires. If it has, ask for a new one with Forgot Password at <a href="{{ login_url | e }}" style="color:#8B94AE;text-decoration:underline;">{{ login_url | e }}</a>.</p>
+						{% else %}
+						<p style="margin:10px 0 0;font-size:13px;line-height:20px;color:#8B94AE;">This address already has a login. Use Forgot Password on the sign-in page if you need a new one.</p>
+						{% endif %}
 					</td>
 				</tr>
 

--- a/benchpress/templates/emails/password_reset.html
+++ b/benchpress/templates/emails/password_reset.html
@@ -1,0 +1,61 @@
+<!--
+	BenchPress Password Reset — the framework's reset mail, in BenchPress's own chrome.
+
+	`benchpress.user.BenchPressPasswordResetMixin` renders this instead of
+	`frappe/templates/emails/password_reset.html`, which draws a white masthead from
+	`app_logo_url` and signs itself with whoever was logged in.
+-->
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#F6F8FF;">
+	<tr>
+		<td align="center" style="padding:24px 12px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+			<table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="width:100%;max-width:600px;background-color:#FFFFFF;border:1px solid #DFE7FA;border-radius:14px;">
+
+				<tr>
+					<td style="padding:20px 28px;background-color:#0A1024;border-radius:13px 13px 0 0;">
+						<a href="{{ site_url | e }}" style="display:inline-block;text-decoration:none;"><img src="{{ logo_url | e }}" width="140" height="36" alt="BenchPress" style="display:block;width:140px;height:36px;border:0;outline:none;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;text-decoration:none;"></a>
+					</td>
+				</tr>
+
+				<tr>
+					<td style="padding:30px 28px 0;">
+						<div style="font-size:12px;font-weight:700;letter-spacing:0.14em;text-transform:uppercase;color:#8B94AE;">Account security</div>
+						<h1 style="margin:10px 0 0;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:24px;line-height:32px;font-weight:800;color:#0A1024;">Reset your password, {{ full_name | e }}.</h1>
+						<p style="margin:14px 0 0;font-size:15px;line-height:24px;color:#4E5A7C;">Someone asked to reset the password for {{ email | e }}. Use the button below to set a new one.</p>
+					</td>
+				</tr>
+
+				<tr>
+					<td style="padding:26px 28px 0;">
+						<table role="presentation" cellpadding="0" cellspacing="0" border="0">
+							<tr>
+								<td bgcolor="#1F5CF5" style="border-radius:10px;">
+									<a href="{{ reset_url | e }}" style="display:inline-block;padding:13px 22px;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:15px;font-weight:700;color:#FFFFFF;text-decoration:none;">Set a new password</a>
+								</td>
+							</tr>
+						</table>
+						<p style="margin:12px 0 0;font-family:'SFMono-Regular',Consolas,Menlo,monospace;font-size:12px;line-height:19px;color:#8B94AE;"><a href="{{ reset_url | e }}" style="color:#8B94AE;text-decoration:none;">{{ reset_url | e }}</a></p>
+						<p style="margin:10px 0 0;font-size:13px;line-height:20px;color:#8B94AE;">The link is single use and expires. If you did not ask for a reset, ignore this message — your password stays as it is.</p>
+					</td>
+				</tr>
+
+				<tr>
+					<td style="padding:22px 28px 0;">
+						<p style="margin:0;font-size:14px;line-height:22px;color:#4E5A7C;">Thank you,<br>BenchPress</p>
+					</td>
+				</tr>
+
+				<tr>
+					<td style="padding:24px 28px 0;">
+						<div style="height:1px;background-color:#E3EAFB;line-height:1px;font-size:0;">&nbsp;</div>
+					</td>
+				</tr>
+				<tr>
+					<td style="padding:16px 28px 26px;">
+						<p style="margin:0;font-size:12px;line-height:19px;color:#8B94AE;">Sent by <a href="{{ site_url | e }}" style="color:#4E5A7C;text-decoration:underline;">BenchPress</a>. Frappe and ERPNext are trademarks of Frappe Technologies Pvt. Ltd. BenchPress is an independent project, not affiliated with Frappe Technologies.</p>
+					</td>
+				</tr>
+
+			</table>
+		</td>
+	</tr>
+</table>

--- a/benchpress/tests/test_emails.py
+++ b/benchpress/tests/test_emails.py
@@ -4,17 +4,21 @@
 from unittest.mock import patch
 
 import frappe
+from frappe.model.base_document import get_controller
 from frappe.tests import IntegrationTestCase
+from frappe.utils import get_url
 
 from benchpress import contact, emails
 from benchpress.patches.refresh_approval_mail import DEAD_PROMISE
 from benchpress.patches.refresh_approval_mail import execute as refresh_approval_mail
+from benchpress.user import BenchPressPasswordResetMixin
 
 REQUESTER = "emails-requester@example.com"
 SENDER = "emails-sender@example.com"
 ADMIN = "emails-admin@example.com"
 ADMIN_ROLE = "BenchPress Admin"
 SET_PASSWORD_URL = "https://benchpress.example/update-password?key=abc123"
+RESET_USER = "emails-reset@example.com"
 
 # `_message()` files under "Sales"; routing it at the admin pins who the notice reaches.
 ROUTED_TO_ADMIN = ({"label": "Sales", "route_to_email": ADMIN},)
@@ -151,6 +155,36 @@ class TestEmails(IntegrationTestCase):
 
 		self.mailer.assert_not_called()
 
+	# the password reset mail
+
+	def test_the_reset_mail_is_branded_and_signed_as_benchpress(self):
+		emails.send_password_reset(self._reset_user(), SET_PASSWORD_URL)
+
+		self.assertEqual(self.sent["recipients"], [RESET_USER])
+		self.assertEqual(self.sent["subject"], "Reset your BenchPress password")
+		self.assertIn(get_url(emails.LOGO_PATH), self.sent["message"])
+		self.assertIn('alt="BenchPress"', self.sent["message"])
+		self.assertIn("Thank you,<br>BenchPress", self.sent["message"])
+		self.assertIn(SET_PASSWORD_URL, self.sent["message"])
+		self.assertNotIn("Administrator", self.sent["message"])
+
+	def test_the_reset_mail_is_sent_at_once_and_redacted_after(self):
+		emails.send_password_reset(self._reset_user(), SET_PASSWORD_URL)
+
+		self.assertTrue(self.sent["now"], "a queued reset mail waits on the scheduler")
+		self.assertTrue(self.sent["redact_message_after_send"], "the key would stay in Email Queue")
+
+	def test_the_framework_reaches_the_branded_mail(self):
+		user = self._reset_user()
+
+		user._reset_password(send_email=True)
+
+		self.assertIn(RESET_USER, self.sent["recipients"])
+		self.assertEqual(self.sent["subject"], "Reset your BenchPress password")
+
+	def test_the_user_class_carries_the_mixin(self):
+		self.assertTrue(issubclass(get_controller("User"), BenchPressPasswordResetMixin))
+
 	# email templates
 
 	def test_a_deleted_template_row_falls_back_to_the_shipped_body(self):
@@ -255,6 +289,23 @@ class TestEmails(IntegrationTestCase):
 		self.assertNotIn(ADMIN, emails.admin_recipients())
 
 	# helpers
+
+	def _reset_user(self):
+		self.addCleanup(self._drop_reset_user)
+		self._drop_reset_user()
+		return frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": RESET_USER,
+				"first_name": "Reset",
+				"last_name": "Person",
+				"send_welcome_email": 0,
+			}
+		).insert(ignore_permissions=True)
+
+	def _drop_reset_user(self) -> None:
+		if frappe.db.exists("User", RESET_USER):
+			frappe.delete_doc("User", RESET_USER, force=True, ignore_permissions=True)
 
 	def _install_template(self, name: str, subject: str, body: str) -> None:
 		if frappe.db.exists("Email Template", name):

--- a/benchpress/tests/test_emails.py
+++ b/benchpress/tests/test_emails.py
@@ -17,6 +17,7 @@ REQUESTER = "emails-requester@example.com"
 SENDER = "emails-sender@example.com"
 ADMIN = "emails-admin@example.com"
 ADMIN_ROLE = "BenchPress Admin"
+ROLE_HOLDER = "emails-role-holder@example.com"
 SET_PASSWORD_URL = "https://benchpress.example/update-password?key=abc123"
 RESET_USER = "emails-reset@example.com"
 
@@ -92,8 +93,8 @@ class TestEmails(IntegrationTestCase):
 		self.assertEqual(self.sent["subject"], "Your BenchPress access request — REQ-A1B2-C3D4")
 		self.assertIn("REQ-A1B2-C3D4", self.sent["message"])
 
-	def test_the_admin_notice_names_the_requester_and_the_company(self):
-		with patch.object(emails, "admin_recipients", return_value=[ADMIN]):
+	def test_the_operator_notice_names_the_requester_and_the_company(self):
+		with patch.dict(frappe.conf, {contact.NOTIFY_KEY: ADMIN}):
 			emails.notify_admins_of_access_request(_entry())
 
 		self.assertEqual(self.sent["recipients"], [ADMIN])
@@ -150,10 +151,18 @@ class TestEmails(IntegrationTestCase):
 		self.assertEqual(self.sent["recipients"], ["hello@benchpress.example"])
 
 	def test_nothing_is_queued_when_there_is_nobody_to_tell(self):
-		with patch.object(emails, "admin_recipients", return_value=[]):
+		with patch.object(contact, "notify_email", return_value=""):
 			emails.notify_admins_of_access_request(_entry())
 
 		self.mailer.assert_not_called()
+
+	def test_an_admin_role_holder_is_not_a_recipient(self):
+		self._install_role_holder()
+
+		with patch.dict(frappe.conf, {contact.NOTIFY_KEY: ADMIN}):
+			emails.notify_admins_of_access_request(_entry())
+
+		self.assertEqual(self.sent["recipients"], [ADMIN], "a role query is back in the recipient list")
 
 	# the password reset mail
 
@@ -276,18 +285,6 @@ class TestEmails(IntegrationTestCase):
 
 		self.assertEqual(self.sent["message"], "<p>Ampersand &amp; co</p>")
 
-	# admin recipients
-
-	def test_admin_recipients_are_the_enabled_role_holders(self):
-		self._install_admin_user()
-
-		self.assertIn(ADMIN, emails.admin_recipients())
-
-	def test_a_disabled_admin_is_not_a_recipient(self):
-		self._install_admin_user(enabled=0)
-
-		self.assertNotIn(ADMIN, emails.admin_recipients())
-
 	# helpers
 
 	def _reset_user(self):
@@ -335,23 +332,22 @@ class TestEmails(IntegrationTestCase):
 			frappe.delete_doc("Email Template", name, force=True, ignore_permissions=True)
 		frappe.clear_cache(doctype="Email Template")
 
-	def _install_admin_user(self, enabled: int = 1) -> None:
-		self.addCleanup(self._drop_admin_user)
-		self._drop_admin_user()
+	def _install_role_holder(self) -> None:
+		self.addCleanup(self._drop_role_holder)
+		self._drop_role_holder()
 		user = frappe.get_doc(
 			{
 				"doctype": "User",
-				"email": ADMIN,
+				"email": ROLE_HOLDER,
 				"first_name": "Emails",
 				"last_name": "Admin",
 				"user_type": "System User",
-				"enabled": enabled,
 				"send_welcome_email": 0,
 			}
 		)
 		user.append("roles", {"role": ADMIN_ROLE})
 		user.insert(ignore_permissions=True)
 
-	def _drop_admin_user(self) -> None:
-		if frappe.db.exists("User", ADMIN):
-			frappe.delete_doc("User", ADMIN, force=True, ignore_permissions=True)
+	def _drop_role_holder(self) -> None:
+		if frappe.db.exists("User", ROLE_HOLDER):
+			frappe.delete_doc("User", ROLE_HOLDER, force=True, ignore_permissions=True)

--- a/benchpress/tests/test_emails.py
+++ b/benchpress/tests/test_emails.py
@@ -7,11 +7,14 @@ import frappe
 from frappe.tests import IntegrationTestCase
 
 from benchpress import contact, emails
+from benchpress.patches.refresh_approval_mail import DEAD_PROMISE
+from benchpress.patches.refresh_approval_mail import execute as refresh_approval_mail
 
 REQUESTER = "emails-requester@example.com"
 SENDER = "emails-sender@example.com"
 ADMIN = "emails-admin@example.com"
 ADMIN_ROLE = "BenchPress Admin"
+SET_PASSWORD_URL = "https://benchpress.example/update-password?key=abc123"
 
 # `_message()` files under "Sales"; routing it at the admin pins who the notice reaches.
 ROUTED_TO_ADMIN = ({"label": "Sales", "route_to_email": ADMIN},)
@@ -93,12 +96,19 @@ class TestEmails(IntegrationTestCase):
 		self.assertEqual(self.sent["subject"], "Access request from Priya Nair (Kettle Works)")
 		self.assertIn("Two interns<br>starting on Monday", self.sent["message"])
 
-	def test_the_approval_goes_to_the_requester_and_carries_no_password(self):
-		emails.send_access_request_approved(_entry())
+	def test_the_approval_goes_to_the_requester_and_carries_the_way_in(self):
+		emails.send_access_request_approved(_entry(), set_password_url=SET_PASSWORD_URL)
 
 		self.assertEqual(self.sent["recipients"], [REQUESTER])
 		self.assertEqual(self.sent["subject"], "Your BenchPress account is open")
-		self.assertIn("separate welcome email", self.sent["message"])
+		self.assertIn("Set your password", self.sent["message"])
+		self.assertIn(SET_PASSWORD_URL, self.sent["message"])
+
+	def test_the_approval_offers_the_sign_in_door_when_there_is_no_link(self):
+		emails.send_access_request_approved(_entry())
+
+		self.assertNotIn("Set your password", self.sent["message"])
+		self.assertIn("Sign in", self.sent["message"])
 
 	def test_the_decline_carries_the_reason_and_the_self_hosting_door(self):
 		emails.send_access_request_rejected(_entry(rejection_reason="Hosted access is invite-only."))
@@ -162,6 +172,27 @@ class TestEmails(IntegrationTestCase):
 
 		self.assertEqual(self.sent["subject"], "Welcome aboard, Priya Nair")
 		self.assertEqual(self.sent["message"], "<p>REQ-A1B2-C3D4</p>")
+
+	def test_a_row_that_still_promises_a_welcome_mail_is_re_seeded(self):
+		self._install_template(
+			emails.ACCESS_APPROVED, subject="x", body=f"<p>the link in the {DEAD_PROMISE}</p>"
+		)
+
+		refresh_approval_mail()
+
+		body = frappe.db.get_value("Email Template", emails.ACCESS_APPROVED, "response_html")
+		self.assertNotIn(DEAD_PROMISE, body)
+		self.assertIn("Set your password", body)
+
+	def test_a_row_that_no_longer_promises_one_is_left_alone(self):
+		self._install_template(emails.ACCESS_APPROVED, subject="x", body="<p>operator copy</p>")
+
+		refresh_approval_mail()
+
+		self.assertEqual(
+			frappe.db.get_value("Email Template", emails.ACCESS_APPROVED, "response_html"),
+			"<p>operator copy</p>",
+		)
 
 	def test_every_shipped_body_renders_from_an_empty_document(self):
 		bare = frappe._dict({"name": REQUESTER, "email": SENDER, "sender_name": ""})

--- a/benchpress/tests/test_waitlist.py
+++ b/benchpress/tests/test_waitlist.py
@@ -202,6 +202,32 @@ class TestWaitlist(IntegrationTestCase):
 		with self.assertRaises(frappe.PermissionError):
 			waitlist.approve([EMAIL])
 
+	def test_approval_mails_a_set_password_link_for_an_account_it_created(self):
+		waitlist.join(EMAIL)
+
+		with patch(DECISION_SENDER) as sender:
+			waitlist.approve([EMAIL])
+
+		self.assertIn("/update-password?key=", sender.call_args.kwargs["set_password_url"])
+
+	def test_an_address_that_already_has_a_login_is_mailed_no_link(self):
+		frappe.get_doc(
+			{"doctype": "User", "email": EMAIL, "first_name": "Already", "send_welcome_email": 0}
+		).insert(ignore_permissions=True)
+		waitlist.join(EMAIL)
+
+		with patch(DECISION_SENDER) as sender:
+			waitlist.approve([EMAIL])
+
+		self.assertEqual(sender.call_args.kwargs["set_password_url"], "")
+
+	def test_frappes_own_welcome_mail_is_not_asked_for(self):
+		waitlist.join(EMAIL)
+
+		waitlist.approve([EMAIL])
+
+		self.assertEqual(frappe.db.get_value("User", EMAIL, "send_welcome_email"), 0)
+
 	def test_the_approval_notice_follows_the_decision_not_the_call(self):
 		waitlist.join(EMAIL)
 		with patch(DECISION_SENDER) as sender:

--- a/benchpress/user.py
+++ b/benchpress/user.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+import frappe
+
+
+class BenchPressPasswordResetMixin:
+	def password_reset_mail(self, link):
+		# Not the framework's own mail: `send_login_mail` forces `with_container`, which draws a
+		# white masthead from `app_logo_url` and signs the body with whoever was logged in. An
+		# operator who named a template in System Settings still gets theirs.
+		if frappe.db.get_system_setting("reset_password_template"):
+			return super().password_reset_mail(link)
+
+		# Imported here: this mixin is loaded by `get_controller`, which runs before a request has
+		# a reason to pull the mail module's own import chain in.
+		from benchpress import emails
+
+		emails.send_password_reset(self, link)

--- a/docs-bundle/docs/reference/configuration.md
+++ b/docs-bundle/docs/reference/configuration.md
@@ -3,7 +3,7 @@ title: Configuration
 description: Where each BenchPress setting lives — build arguments that need a
   rebuild, runtime environment that needs a restart, and DocType fields that
   apply on save.
-lastModified: "2026-08-31T22:27:49-04:00"
+lastModified: "2026-09-01T13:47:42-04:00"
 lastAuthor: Venkatesh
 ---
 # Configuration
@@ -90,8 +90,8 @@ and an install that runs labs for one team has no use for the marketing pages
 of the hosted service. With the key absent, `/`, `/landing`, `/about`,
 `/contact` and `/signup` are not found, `/login` serves Frappe's own login
 form, the three guest form endpoints refuse, `Website Settings → Home Page` is
-left as the operator set it, and the six transactional email templates are not
-created.
+left as the operator set it, and the seven transactional email templates are
+not created.
 
 Set it only on a deployment that is the public site:
 
@@ -102,7 +102,7 @@ bench --site <site> clear-cache
 docker compose restart backend
 ```
 
-The second command plants the page copy, the six mail templates and the home
+The second command plants the page copy, the seven mail templates and the home
 page. Run it every time you set the key: the seeding patch is marked as run on
 a fresh install whether or not the key was set, so a migrate will not plant
 them later. It never overwrites an edit.

--- a/docs-site/.well-known/llms-full.txt
+++ b/docs-site/.well-known/llms-full.txt
@@ -6938,8 +6938,8 @@ and an install that runs labs for one team has no use for the marketing pages
 of the hosted service. With the key absent, `/`, `/landing`, `/about`,
 `/contact` and `/signup` are not found, `/login` serves Frappe's own login
 form, the three guest form endpoints refuse, `Website Settings → Home Page` is
-left as the operator set it, and the six transactional email templates are not
-created.
+left as the operator set it, and the seven transactional email templates are
+not created.
 
 Set it only on a deployment that is the public site:
 
@@ -6950,7 +6950,7 @@ bench --site <site> clear-cache
 docker compose restart backend
 ```
 
-The second command plants the page copy, the six mail templates and the home
+The second command plants the page copy, the seven mail templates and the home
 page. Run it every time you set the key: the seeding patch is marked as run on
 a fresh install whether or not the key was set, so a migrate will not plant
 them later. It never overwrites an edit.

--- a/docs-site/docs/reference/configuration.md
+++ b/docs-site/docs/reference/configuration.md
@@ -3,7 +3,7 @@ title: Configuration
 description: Where each BenchPress setting lives — build arguments that need a
   rebuild, runtime environment that needs a restart, and DocType fields that
   apply on save.
-lastModified: "2026-08-31T22:27:49-04:00"
+lastModified: "2026-09-01T13:47:42-04:00"
 lastAuthor: Venkatesh
 ---
 # Configuration
@@ -90,8 +90,8 @@ and an install that runs labs for one team has no use for the marketing pages
 of the hosted service. With the key absent, `/`, `/landing`, `/about`,
 `/contact` and `/signup` are not found, `/login` serves Frappe's own login
 form, the three guest form endpoints refuse, `Website Settings → Home Page` is
-left as the operator set it, and the six transactional email templates are not
-created.
+left as the operator set it, and the seven transactional email templates are
+not created.
 
 Set it only on a deployment that is the public site:
 
@@ -102,7 +102,7 @@ bench --site <site> clear-cache
 docker compose restart backend
 ```
 
-The second command plants the page copy, the six mail templates and the home
+The second command plants the page copy, the seven mail templates and the home
 page. Run it every time you set the key: the seeding patch is marked as run on
 a fresh install whether or not the key was set, so a migrate will not plant
 them later. It never overwrites an edit.

--- a/docs-site/llms-full.txt
+++ b/docs-site/llms-full.txt
@@ -6938,8 +6938,8 @@ and an install that runs labs for one team has no use for the marketing pages
 of the hosted service. With the key absent, `/`, `/landing`, `/about`,
 `/contact` and `/signup` are not found, `/login` serves Frappe's own login
 form, the three guest form endpoints refuse, `Website Settings → Home Page` is
-left as the operator set it, and the six transactional email templates are not
-created.
+left as the operator set it, and the seven transactional email templates are
+not created.
 
 Set it only on a deployment that is the public site:
 
@@ -6950,7 +6950,7 @@ bench --site <site> clear-cache
 docker compose restart backend
 ```
 
-The second command plants the page copy, the six mail templates and the home
+The second command plants the page copy, the seven mail templates and the home
 page. Run it every time you set the key: the seeding patch is marked as run on
 a fresh install whether or not the key was set, so a migrate will not plant
 them later. It never overwrites an edit.

--- a/docs-site/sitemap.xml
+++ b/docs-site/sitemap.xml
@@ -146,7 +146,7 @@
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/reference/configuration</loc>
-    <lastmod>2026-09-01T02:27:49.000Z</lastmod>
+    <lastmod>2026-09-01T17:47:42.000Z</lastmod>
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/reference/cli-and-scripts</loc>

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -87,8 +87,8 @@ and an install that runs labs for one team has no use for the marketing pages
 of the hosted service. With the key absent, `/`, `/landing`, `/about`,
 `/contact` and `/signup` are not found, `/login` serves Frappe's own login
 form, the three guest form endpoints refuse, `Website Settings → Home Page` is
-left as the operator set it, and the six transactional email templates are not
-created.
+left as the operator set it, and the seven transactional email templates are
+not created.
 
 Set it only on a deployment that is the public site:
 
@@ -99,7 +99,7 @@ bench --site <site> clear-cache
 docker compose restart backend
 ```
 
-The second command plants the page copy, the six mail templates and the home
+The second command plants the page copy, the seven mail templates and the home
 page. Run it every time you set the key: the seeding patch is marked as run on
 a fresh install whether or not the key was set, so a migrate will not plant
 them later. It never overwrites an edit.


### PR DESCRIPTION
## What

Four verified bugs from the 2026-09-01 manual test pass, all in transactional mail. One commit each.

### 01 — every mailed link pointed at `http://frontend/`

`site_config.json` had no `host_name`, so `frappe.utils.get_url()` fell back to the site name. Email login, password reset, the welcome mail and every notification carried an unresolvable host.

`BenchPress Settings.base_domain` already holds the public zone, so `claim_host_name` writes `https://{base_domain}` into site config — skipping an empty value and `localhost` exactly as `ingress` does, and skipping a site whose key already agrees. Called from the settings controller's `on_update` and from `benchpress.patches.claim_host_name`, so an existing deployment is repaired by `bench migrate`.

### 02 — an approved user could not get in

The approval mail's only action was **Sign in**, and its body pointed at a separate welcome mail for the password. That mail is Frappe's own and is queued, so a stopped scheduler swallows it — the login form was a dead end for a user with no password.

Option B from the ticket: one mail carries both. `WaitlistEntry.approve` takes Frappe's one-time key for an account the approval created and hands it to the mail, which then offers **Set your password**. An address that already had a login is mailed no link and reads correctly. `create_user` stops asking for Frappe's welcome mail, so there is no second mail and no second key invalidating the first. The `decided_now` guard is untouched — re-approving still mails nobody twice. `set_password_url` never raises, so a key that cannot be minted degrades to the sign-in door rather than undoing the decision.

`benchpress.patches.refresh_approval_mail` re-seeds a stored `Email Template` row while it still promises the welcome mail. That overwrites an operator edit which kept the sentence, deliberately: the sentence is untrue.

### 03 — the password reset mail was the framework's

A white masthead drawing the favicon from `app_logo_url`, and a body signed with whoever was logged in.

`BenchPressPasswordResetMixin`, mixed into `User` by `extend_doctype_class`, sends a seventh BenchPress mail instead, with the dark header bar and the `wordmark-on-dark.png` lockup the other six carry, and a BenchPress sign-off. A mixin rather than `override_doctype_class` — that replaces the controller class, so only one app can own a DocType, and the frappe semgrep rules block it (they caught the first attempt in CI). Shadowing `frappe/templates/emails/password_reset.html` would not have been enough: `User.send_login_mail` forces `with_container`, so the white masthead is not reachable from a template and the mail would have carried two brand bars. An operator who named a template in `System Settings.reset_password_template` still gets theirs.

The mail keeps the framework's delivery properties — sent at once rather than queued, and redacted in `Email Queue` once sent, because the body holds a one-time key.

### 12 — operator notices went to a crowd

`admin_recipients()` built the recipient list by query: every enabled System User holding `System Manager` or `BenchPress Admin`. The list grew with the user table, which is how the site's test accounts ended up reading operator mail.

The access-request notice now goes to `benchpress_contact_email` — the same site-config key the contact form reads, with the same fallback. The role query is gone and nothing derives a recipient from the user table. The contact notice already resolved through `contact.route_for`, which ends at the same key.

## Tests

- `test_benchpress_settings.py`: four cases on `claim_host_name` — a zone becomes the URL, empty and `localhost` write nothing, an agreeing key is not rewritten. `update_site_config` is patched, so no test writes the site's real config.
- `test_waitlist.py`: a new account is mailed a `/update-password?key=` link, an address that already has a login is mailed none, and Frappe's welcome mail is not asked for.
- `test_emails.py`: the approval mail's two shapes, the reset mail's lockup / signature / `now` / `redact_message_after_send`, `User._reset_password(send_email=True)` reaching the branded mail, the `extend_doctype_class` wiring, and the two patch cases. `admin_recipients`' two tests are gone, replaced by one asserting an admin role holder is *not* a recipient.

Every test that creates a `User` deletes it on `addCleanup`.

`uvx pre-commit@4.3.0 run --all-files` is clean. `npm run docs:build`, `docs:lint`, `docs:score` and `docs:links` all pass; `docs-site/` and `docs-bundle/` are regenerated in their own commit.

## Not verified from a worktree

The compose stack bind-mounts the main checkout, so the server suite ran in CI rather than locally. Left for a check on the live site:

- `frappe.utils.get_url()` returning `https://benchpress.cloud` — the code fix does not repair a site that is already up. Either `bench migrate` (the patch) or one save of the Settings screen writes it.
- "Login with Email Link" and the approval mail's set-password link resolving end to end.
- The reset mail as a mail client renders it.

## Note for #302

`emails.LOGO_PATH` and the `logo_url` key in `_urls()` are added here byte-identically to #302's version of them, because the new reset template needs the same lockup URL. Nothing else in `emails.py` or in the six existing bodies is touched, so #302 should still rebase; the collisions to expect are the trailing lines of `patches.txt` and, in `test_emails.py`, the import block and the two places that patched `emails.admin_recipients` — which no longer exists.

Closes nothing in the tracker; the four tickets live in `specs/in-progress/testing-round-1/`.
