### PR TITLE
feat(analytics): measure the self-host funnel, gated behind site config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,10 @@ docs-site/docs/search-index.json
 .ralph/
 
 .teach/
+
+# Marketing and commercial strategy. The software is open source; the go-to-market is not.
+.marketing/
+.agents/product-marketing.md
+
+# Agent working directories.
+.claude/worktrees/

--- a/benchpress/analytics.py
+++ b/benchpress/analytics.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""The analytics gate. No config, no tracker, no third-party request."""
+
+import frappe
+from frappe.utils import cstr
+
+SCRIPT_KEY = "benchpress_analytics_script"
+DOMAIN_KEY = "benchpress_analytics_domain"
+
+
+def tracker() -> dict:
+	"""The script URL and site id for this deployment, or empty when none is configured."""
+	script = cstr(frappe.conf.get(SCRIPT_KEY)).strip()
+	website_id = cstr(frappe.conf.get(DOMAIN_KEY)).strip()
+	if not script or not website_id:
+		return {}
+	return {"script": script, "website_id": website_id}

--- a/benchpress/benchpress/doctype/github_traffic_snapshot/github_traffic_snapshot.json
+++ b/benchpress/benchpress/doctype/github_traffic_snapshot/github_traffic_snapshot.json
@@ -1,0 +1,126 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "hash",
+ "creation": "2026-09-01 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 0,
+ "engine": "InnoDB",
+ "field_order": [
+  "repository",
+  "snapshot_date",
+  "column_break_source",
+  "stars",
+  "forks",
+  "section_break_traffic",
+  "clone_uniques",
+  "clone_count",
+  "column_break_traffic",
+  "view_uniques",
+  "view_count",
+  "top_referrer"
+ ],
+ "fields": [
+  {
+   "description": "owner/repo, as GitHub names it.",
+   "fieldname": "repository",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Repository",
+   "reqd": 1
+  },
+  {
+   "description": "The day this row counts. One row per repository per day.",
+   "fieldname": "snapshot_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Snapshot Date",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_source",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "stars",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Stars"
+  },
+  {
+   "fieldname": "forks",
+   "fieldtype": "Int",
+   "label": "Forks"
+  },
+  {
+   "fieldname": "section_break_traffic",
+   "fieldtype": "Section Break",
+   "label": "Traffic"
+  },
+  {
+   "description": "Distinct cloners. The nearest available proxy for an install.",
+   "fieldname": "clone_uniques",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Clone Uniques"
+  },
+  {
+   "fieldname": "clone_count",
+   "fieldtype": "Int",
+   "label": "Clone Count"
+  },
+  {
+   "fieldname": "column_break_traffic",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "view_uniques",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "View Uniques"
+  },
+  {
+   "fieldname": "view_count",
+   "fieldtype": "Int",
+   "label": "View Count"
+  },
+  {
+   "description": "The referrer sending the most traffic on this day.",
+   "fieldname": "top_referrer",
+   "fieldtype": "Data",
+   "label": "Top Referrer"
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-09-01 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Benchpress",
+ "name": "GitHub Traffic Snapshot",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "export": 1,
+   "read": 1,
+   "report": 1,
+   "role": "BenchPress Admin"
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "snapshot_date",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 0
+}

--- a/benchpress/benchpress/doctype/github_traffic_snapshot/github_traffic_snapshot.py
+++ b/benchpress/benchpress/doctype/github_traffic_snapshot/github_traffic_snapshot.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+
+class GitHubTrafficSnapshot(Document):
+	def validate(self):
+		if self.duplicate_name():
+			frappe.throw(_("A snapshot for {0} on {1} already exists.").format(self.repository, self.snapshot_date))
+
+	def duplicate_name(self) -> str | None:
+		table = frappe.qb.DocType("GitHub Traffic Snapshot")
+		rows = (
+			frappe.qb.from_(table)
+			.select(table.name)
+			.where(table.repository == self.repository)
+			.where(table.snapshot_date == self.snapshot_date)
+			.where(table.name != self.name)
+			.limit(1)
+		).run()
+		return rows[0][0] if rows else None

--- a/benchpress/benchpress/site_content.py
+++ b/benchpress/benchpress/site_content.py
@@ -6,6 +6,7 @@
 import frappe
 from frappe.utils import cint, get_build_version
 
+from benchpress.analytics import tracker
 from benchpress.credits.config import SIGNUP_ROUTE, credits_enabled, waitlist_open
 from benchpress.request_cache import clear_local_cache, local_cache
 
@@ -70,6 +71,7 @@ def chrome_content() -> dict:
 		"logout_method": LOGOUT_METHOD,
 		"csrf_token": session_csrf_token(),
 		"asset_version": asset_version(),
+		"analytics": tracker(),
 	}
 
 

--- a/benchpress/github_traffic.py
+++ b/benchpress/github_traffic.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""The GitHub traffic snapshot. GitHub keeps fourteen days; these rows keep the rest."""
+
+import requests
+
+import frappe
+from frappe.utils import cstr, today
+
+DOCTYPE = "GitHub Traffic Snapshot"
+REPO_KEY = "benchpress_github_repo"
+TOKEN_KEY = "benchpress_github_token"
+
+API_ROOT = "https://api.github.com"
+TIMEOUT = 30
+
+
+def snapshot_traffic() -> list[str]:
+	"""Scheduled daily. Writes nothing at all unless a deployment configured a repo and a token."""
+	repository = cstr(frappe.conf.get(REPO_KEY)).strip()
+	token = cstr(frappe.conf.get(TOKEN_KEY)).strip()
+	if not repository or not token:
+		return []
+
+	return GitHubTraffic(repository, token).write_snapshots()
+
+
+class GitHubTraffic:
+	def __init__(self, repository: str, token: str):
+		self.repository = repository
+		self.token = token
+
+	def write_snapshots(self) -> list[str]:
+		clones = self.by_day("/traffic/clones", "clones")
+		views = self.by_day("/traffic/views", "views")
+		repository = self.get("")
+		referrer = top_referrer(self.get("/traffic/popular/referrers"))
+
+		return [
+			self.upsert(day, clones.get(day, {}), views.get(day, {}), repository, referrer)
+			for day in sorted(set(clones) | set(views))
+		]
+
+	def upsert(self, day: str, clones: dict, views: dict, repository: dict, referrer: str) -> str:
+		doc = self.row_for(day)
+		doc.update(
+			{
+				"repository": self.repository,
+				"snapshot_date": day,
+				"clone_uniques": clones.get("uniques") or 0,
+				"clone_count": clones.get("count") or 0,
+				"view_uniques": views.get("uniques") or 0,
+				"view_count": views.get("count") or 0,
+			}
+		)
+		# Stars, forks and the referrer are read at this instant, so only today's row can carry them.
+		if day == today():
+			doc.stars = repository.get("stargazers_count") or 0
+			doc.forks = repository.get("forks_count") or 0
+			doc.top_referrer = referrer
+
+		doc.save(ignore_permissions=True)
+		return doc.name
+
+	def row_for(self, day: str):
+		name = existing_row(self.repository, day)
+		return frappe.get_doc(DOCTYPE, name) if name else frappe.new_doc(DOCTYPE)
+
+	def by_day(self, path: str, key: str) -> dict:
+		rows = self.get(path).get(key) or []
+		return {cstr(row.get("timestamp"))[:10]: row for row in rows if row.get("timestamp")}
+
+	def get(self, path: str) -> dict:
+		response = requests.get(
+			f"{API_ROOT}/repos/{self.repository}{path}",
+			headers={
+				"Accept": "application/vnd.github+json",
+				"Authorization": f"Bearer {self.token}",
+				"X-GitHub-Api-Version": "2022-11-28",
+			},
+			timeout=TIMEOUT,
+		)
+		response.raise_for_status()
+		return response.json()
+
+
+def existing_row(repository: str, day: str) -> str | None:
+	table = frappe.qb.DocType(DOCTYPE)
+	rows = (
+		frappe.qb.from_(table)
+		.select(table.name)
+		.where(table.repository == repository)
+		.where(table.snapshot_date == day)
+		.limit(1)
+	).run()
+	return rows[0][0] if rows else None
+
+
+def top_referrer(payload) -> str:
+	if not payload:
+		return ""
+	return cstr(payload[0].get("referrer"))

--- a/benchpress/hooks.py
+++ b/benchpress/hooks.py
@@ -241,6 +241,8 @@ scheduler_events = {
 	# ],
 	"daily": [
 		"benchpress.credits.reaper.reap_stopped_instances",
+		# GitHub drops traffic data after fourteen days. No repo and token configured, no-op.
+		"benchpress.github_traffic.snapshot_traffic",
 	],
 	# "hourly": [
 	# 	"benchpress.tasks.hourly"

--- a/benchpress/public/css/bp-landing.bundle.css
+++ b/benchpress/public/css/bp-landing.bundle.css
@@ -314,6 +314,51 @@
 	overflow-x: auto;
 }
 
+.bp-code-block {
+	position: relative;
+	margin: 20px 0 0;
+}
+.bp-code-block .bp-code {
+	margin: 0;
+	padding-right: 74px;
+}
+.bp-code__copy {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 6px 8px;
+	border: 1px solid var(--cardb);
+	border-radius: 8px;
+	background: var(--card);
+	color: var(--fg3);
+	font-family: var(--font-mono);
+	font-size: 11px;
+	cursor: pointer;
+	transition: var(--transition-control);
+}
+.bp-code__copy:hover {
+	color: var(--fg);
+}
+.bp-code__copyicon {
+	width: 12px;
+	height: 12px;
+	flex: none;
+}
+
+/* Absolute over a 12px mono block leaves too little room for the command on a phone. */
+@media (max-width: 520px) {
+	.bp-code__copy {
+		position: static;
+		margin-top: 8px;
+	}
+	.bp-code-block .bp-code {
+		padding-right: 16px;
+	}
+}
+
 /* -- Hero -------------------------------------------------------------------------------- */
 
 .bp-hero {

--- a/benchpress/public/js/bp-contact.bundle.js
+++ b/benchpress/public/js/bp-contact.bundle.js
@@ -72,8 +72,12 @@
 
 			busy(form, true);
 			try {
-				const reply = await window.bpSite.postMethod(METHOD, new FormData(form));
+				const data = new FormData(form);
+				const reply = await window.bpSite.postMethod(METHOD, data);
 				showSent(form, sent, reply);
+				window.bpSite.track("contact_submitted", {
+					topic: String(data.get("topic") || ""),
+				});
 			} catch (error) {
 				show(banner, error.message);
 			} finally {

--- a/benchpress/public/js/bp-landing.bundle.js
+++ b/benchpress/public/js/bp-landing.bundle.js
@@ -56,22 +56,37 @@
 	// --- copy ------------------------------------------------------------------------------
 
 	// `navigator.clipboard` is undefined outside a secure context.
-	function bindCopy(root) {
-		const button = root.querySelector("[data-bp-copy]");
-		if (!button) return;
-
+	function bindCopyButton(button, readText) {
 		button.addEventListener("click", async () => {
-			const panel = visiblePanel(root, "[data-bp-api-panel]");
-			if (!panel || !navigator.clipboard) return;
+			const text = readText();
+			if (!text || !navigator.clipboard) return;
 
 			try {
-				await navigator.clipboard.writeText(panel.textContent);
+				await navigator.clipboard.writeText(text);
 			} catch (error) {
 				void error;
 				return;
 			}
 			setCopyLabel(button, COPIED_LABEL);
 			window.setTimeout(() => setCopyLabel(button, COPY_LABEL), COPY_RESET_MS);
+
+			const event = button.dataset.bpCopyEvent;
+			if (event && window.bpSite) window.bpSite.track(event);
+		});
+	}
+
+	function bindCopy(root) {
+		const api = root.querySelector("[data-bp-copy]");
+		if (api) {
+			bindCopyButton(api, () => {
+				const panel = visiblePanel(root, "[data-bp-api-panel]");
+				return panel ? panel.textContent : "";
+			});
+		}
+
+		root.querySelectorAll("[data-bp-copy-target]").forEach((button) => {
+			const source = button.parentElement.querySelector(button.dataset.bpCopyTarget);
+			if (source) bindCopyButton(button, () => source.textContent);
 		});
 	}
 

--- a/benchpress/public/js/bp-signup.bundle.js
+++ b/benchpress/public/js/bp-signup.bundle.js
@@ -107,6 +107,7 @@
 		try {
 			const reply = await window.bpSite.postMethod(METHOD, new FormData(form));
 			showReceipt(root, form, reply, form.elements.email.value.trim());
+			window.bpSite.track("waitlist_submitted");
 		} catch (error) {
 			showAlert(banner, error.message);
 		} finally {

--- a/benchpress/public/js/bp-site.bundle.js
+++ b/benchpress/public/js/bp-site.bundle.js
@@ -1,5 +1,6 @@
-// window.bpSite: the theme toggle, the mobile nav disclosure, and postMethod(method, values,
-// options), which posts to a whitelisted method and resolves with its return value.
+// window.bpSite: the theme toggle, the mobile nav disclosure, postMethod(method, values,
+// options), which posts to a whitelisted method and resolves with its return value, and
+// track(name, properties).
 (function () {
 	const MODES = ["dark", "light"];
 	const DEFAULT_MODE = "dark";
@@ -176,6 +177,35 @@
 			.trim();
 	}
 
+	// --- analytics -------------------------------------------------------------------------
+
+	// No-op when no tracker is configured, or when one is blocked. Tracking is never load-bearing.
+	function track(name, properties) {
+		if (!window.umami) return;
+		try {
+			window.umami.track(name, properties);
+		} catch (error) {
+			void error;
+		}
+	}
+
+	// Every `data-bp-track-*` on the element becomes a property, so a new one needs no JS.
+	function trackProperties(element) {
+		const properties = {};
+		Object.keys(element.dataset).forEach((key) => {
+			if (key.startsWith("bpTrack") && key !== "bpTrack") {
+				properties[key.slice(7).toLowerCase()] = element.dataset[key];
+			}
+		});
+		return Object.keys(properties).length ? properties : undefined;
+	}
+
+	function trackClick(event) {
+		const element = event.target.closest("[data-bp-track]");
+		if (!element) return;
+		track(element.dataset.bpTrack, trackProperties(element));
+	}
+
 	function start() {
 		const saved = storedMode();
 		if (saved) setMode(saved);
@@ -184,9 +214,10 @@
 		wireModeToggles();
 		wireNav();
 		wireSignOut();
+		document.addEventListener("click", trackClick);
 	}
 
-	window.bpSite = { mode, setMode, toggleMode, postMethod };
+	window.bpSite = { mode, setMode, toggleMode, postMethod, track };
 
 	if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", start);
 	else start();

--- a/benchpress/templates/includes/site_footer.html
+++ b/benchpress/templates/includes/site_footer.html
@@ -16,7 +16,7 @@
 			<nav class="bp-footer__col" aria-labelledby="bp-footer-col-{{ loop.index }}">
 				<h2 class="bp-footer__heading" id="bp-footer-col-{{ loop.index }}">{{ column.heading | e }}</h2>
 				{%- for link in column.links %}
-				<a class="bp-footer__link" href="{{ link.url | e }}">{{ link.label | e }}</a>
+				<a class="bp-footer__link" href="{{ link.url | e }}"{% if link.url.startswith("http") %} data-bp-track="outbound_clicked" data-bp-track-location="footer" data-bp-track-destination="{{ link.label | e }}"{% endif %}>{{ link.label | e }}</a>
 				{%- endfor %}
 			</nav>
 			{%- endfor %}

--- a/benchpress/templates/includes/site_head.html
+++ b/benchpress/templates/includes/site_head.html
@@ -151,3 +151,8 @@ button.bp-navlink{border:0;background:none;font:inherit;line-height:1.2;cursor:p
 </script>
 {#- Its own tag, not `include_script`: that helper emits no `defer`, and this one is in the head. -#}
 <script defer src="{{ bundled_asset('bp-site.bundle.js') }}"></script>
+
+{#- Absent unless the deployment sets both keys, so a self-hosted install loads no tracker. -#}
+{%- if analytics %}
+<script defer src="{{ analytics.script | e }}" data-website-id="{{ analytics.website_id | e }}"></script>
+{%- endif %}

--- a/benchpress/templates/includes/site_header.html
+++ b/benchpress/templates/includes/site_header.html
@@ -5,6 +5,8 @@
 {%- set cta = (nav_items | selectattr("is_cta") | first) if nav_items else None -%}
 {%- set cta_label = (cta.label if cta else "") or "Start free" -%}
 {%- set cta_url = (cta.anchor if cta else None) or signup_route or "/signup" -%}
+{#- The CTA flips doors with `credits_enabled`; an external target is the repo, not a signup. -#}
+{%- set cta_event = "selfhost_cta_clicked" if cta_url.startswith("http") else "hosted_cta_clicked" -%}
 
 <a class="bp-skip" href="#bp-content">Skip to content</a>
 
@@ -44,7 +46,7 @@
 		</nav>
 
 		<div class="bp-header__actions">
-			<a class="bp-cta" href="{{ cta_url | e }}"><span class="bp-cta__label">{{ cta_label | e }}</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M5 12h14"></path><path d="m12 5 7 7-7 7"></path></svg></a>
+			<a class="bp-cta" href="{{ cta_url | e }}" data-bp-track="{{ cta_event | e }}" data-bp-track-location="header"><span class="bp-cta__label">{{ cta_label | e }}</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M5 12h14"></path><path d="m12 5 7 7-7 7"></path></svg></a>
 
 			<button type="button" class="bp-menu" data-bp-nav-toggle aria-controls="bp-nav" aria-expanded="false">
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M4 6h16"></path><path d="M4 12h16"></path><path d="M4 18h16"></path></svg>

--- a/benchpress/tests/test_analytics.py
+++ b/benchpress/tests/test_analytics.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+"""The analytics gate and the GitHub traffic collector. No network, no container."""
+
+import unittest
+from unittest.mock import patch
+
+import frappe
+
+from benchpress import analytics, github_traffic
+
+
+class TestAnalyticsGate(unittest.TestCase):
+	def test_tracker_is_empty_without_config(self):
+		with patch.dict(frappe.conf, {}, clear=False):
+			frappe.conf.pop(analytics.SCRIPT_KEY, None)
+			frappe.conf.pop(analytics.DOMAIN_KEY, None)
+			self.assertEqual(analytics.tracker(), {})
+
+	def test_tracker_is_empty_when_only_one_key_is_set(self):
+		with patch.dict(frappe.conf, {analytics.SCRIPT_KEY: "https://u.example/s.js"}):
+			frappe.conf.pop(analytics.DOMAIN_KEY, None)
+			self.assertEqual(analytics.tracker(), {})
+
+	def test_tracker_reads_both_keys(self):
+		values = {analytics.SCRIPT_KEY: "https://u.example/s.js", analytics.DOMAIN_KEY: "abc-123"}
+		with patch.dict(frappe.conf, values):
+			self.assertEqual(
+				analytics.tracker(), {"script": "https://u.example/s.js", "website_id": "abc-123"}
+			)
+
+	def test_blank_strings_do_not_count_as_configured(self):
+		with patch.dict(frappe.conf, {analytics.SCRIPT_KEY: "  ", analytics.DOMAIN_KEY: "  "}):
+			self.assertEqual(analytics.tracker(), {})
+
+
+class TestGitHubTrafficParsing(unittest.TestCase):
+	def test_snapshot_does_nothing_without_config(self):
+		with patch.dict(frappe.conf, {}, clear=False):
+			frappe.conf.pop(github_traffic.REPO_KEY, None)
+			frappe.conf.pop(github_traffic.TOKEN_KEY, None)
+			self.assertEqual(github_traffic.snapshot_traffic(), [])
+
+	def test_by_day_keys_on_the_date_part_of_the_timestamp(self):
+		client = github_traffic.GitHubTraffic("owner/repo", "token")
+		payload = {
+			"clones": [
+				{"timestamp": "2026-08-20T00:00:00Z", "count": 9, "uniques": 4},
+				{"timestamp": "2026-08-21T00:00:00Z", "count": 2, "uniques": 2},
+			]
+		}
+		with patch.object(client, "get", return_value=payload):
+			self.assertEqual(sorted(client.by_day("/traffic/clones", "clones")), ["2026-08-20", "2026-08-21"])
+
+	def test_by_day_skips_rows_with_no_timestamp(self):
+		client = github_traffic.GitHubTraffic("owner/repo", "token")
+		with patch.object(client, "get", return_value={"clones": [{"count": 1}]}):
+			self.assertEqual(client.by_day("/traffic/clones", "clones"), {})
+
+	def test_by_day_is_empty_when_the_key_is_absent(self):
+		client = github_traffic.GitHubTraffic("owner/repo", "token")
+		with patch.object(client, "get", return_value={}):
+			self.assertEqual(client.by_day("/traffic/views", "views"), {})
+
+	def test_top_referrer_reads_the_first_row(self):
+		self.assertEqual(
+			github_traffic.top_referrer([{"referrer": "news.ycombinator.com"}]), "news.ycombinator.com"
+		)
+
+	def test_top_referrer_is_blank_when_there_are_none(self):
+		self.assertEqual(github_traffic.top_referrer([]), "")
+		self.assertEqual(github_traffic.top_referrer(None), "")
+
+
+class TestGitHubTrafficRows(unittest.TestCase):
+	REPO = "owner/test-repo"
+
+	def tearDown(self):
+		# Every row this class writes is removed here; nothing survives the run.
+		for name in frappe.get_all(github_traffic.DOCTYPE, filters={"repository": self.REPO}, pluck="name"):
+			frappe.delete_doc(github_traffic.DOCTYPE, name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def test_write_snapshots_creates_one_row_per_day(self):
+		client = self.client()
+		names = client.write_snapshots()
+
+		self.assertEqual(len(names), 2)
+		rows = frappe.get_all(
+			github_traffic.DOCTYPE,
+			filters={"repository": self.REPO},
+			fields=["snapshot_date", "clone_uniques", "view_uniques"],
+			order_by="snapshot_date asc",
+		)
+		self.assertEqual([str(row.snapshot_date) for row in rows], ["2026-08-20", "2026-08-21"])
+		self.assertEqual([row.clone_uniques for row in rows], [4, 2])
+		self.assertEqual([row.view_uniques for row in rows], [11, 0])
+
+	def test_write_snapshots_is_idempotent(self):
+		self.client().write_snapshots()
+		self.client().write_snapshots()
+
+		self.assertEqual(frappe.db.count(github_traffic.DOCTYPE, {"repository": self.REPO}), 2)
+
+	def test_duplicate_rows_are_refused(self):
+		doc = frappe.get_doc(
+			{
+				"doctype": github_traffic.DOCTYPE,
+				"repository": self.REPO,
+				"snapshot_date": "2026-08-20",
+			}
+		).insert(ignore_permissions=True)
+		self.assertTrue(doc.name)
+
+		duplicate = frappe.get_doc(
+			{
+				"doctype": github_traffic.DOCTYPE,
+				"repository": self.REPO,
+				"snapshot_date": "2026-08-20",
+			}
+		)
+		self.assertRaises(frappe.ValidationError, duplicate.insert, ignore_permissions=True)
+
+	def client(self) -> github_traffic.GitHubTraffic:
+		client = github_traffic.GitHubTraffic(self.REPO, "token")
+		responses = {
+			"/traffic/clones": {
+				"clones": [
+					{"timestamp": "2026-08-20T00:00:00Z", "count": 9, "uniques": 4},
+					{"timestamp": "2026-08-21T00:00:00Z", "count": 2, "uniques": 2},
+				]
+			},
+			"/traffic/views": {"views": [{"timestamp": "2026-08-20T00:00:00Z", "count": 40, "uniques": 11}]},
+			"/traffic/popular/referrers": [{"referrer": "news.ycombinator.com"}],
+			"": {"stargazers_count": 7, "forks_count": 3},
+		}
+		client.get = lambda path: responses[path]
+		return client

--- a/benchpress/www/index.html
+++ b/benchpress/www/index.html
@@ -116,11 +116,11 @@
 
 				<div class="bp-hero__actions">
 					{%- if credits_enabled %}
-					<a class="bp-btn bp-btn--lg bp-btn--primary" href="{{ signup_route | e }}">
+					<a class="bp-btn bp-btn--lg bp-btn--primary" href="{{ signup_route | e }}" data-bp-track="hosted_cta_clicked" data-bp-track-location="hero">
 						{{ settings.hero_cta_primary_label | default("", true) | e }}{{ arrow_right("bp-btn__icon") }}
 					</a>
 					{%- endif %}
-					<a class="bp-btn bp-btn--lg {{ 'bp-btn--ghost' if credits_enabled else 'bp-btn--primary' }}" href="{{ settings.hero_cta_secondary_url | default('#paths', true) | e }}">
+					<a class="bp-btn bp-btn--lg {{ 'bp-btn--ghost' if credits_enabled else 'bp-btn--primary' }}" href="{{ settings.hero_cta_secondary_url | default('#paths', true) | e }}" data-bp-track="selfhost_cta_clicked" data-bp-track-location="hero">
 						{{ github("bp-btn__icon") }}{{ settings.hero_cta_secondary_label | default("", true) | e }}
 					</a>
 				</div>
@@ -218,11 +218,11 @@
 					{%- endif %}
 
 					<div class="bp-path__actions">
-						<a class="bp-btn bp-btn--lg bp-btn--primary" href="{{ signup_route | e }}">
+						<a class="bp-btn bp-btn--lg bp-btn--primary" href="{{ signup_route | e }}" data-bp-track="hosted_cta_clicked" data-bp-track-location="paths">
 							{{ settings.paths_hosted_cta_label | default("", true) | e }}{{ arrow_right("bp-btn__icon") }}
 						</a>
 						{%- if settings.paths_hosted_cta2_label %}
-						<a class="bp-btn bp-btn--lg bp-btn--outline" href="{{ settings.paths_hosted_cta2_url | default('/contact', true) | e }}">{{ settings.paths_hosted_cta2_label | e }}</a>
+						<a class="bp-btn bp-btn--lg bp-btn--outline" href="{{ settings.paths_hosted_cta2_url | default('/contact', true) | e }}" data-bp-track="contact_cta_clicked" data-bp-track-location="paths_hosted">{{ settings.paths_hosted_cta2_label | e }}</a>
 						{%- endif %}
 					</div>
 				</div>
@@ -235,7 +235,10 @@
 				<p class="bp-path__body">{{ settings.paths_self_body | default("", true) | e }}</p>
 
 				{%- if settings.paths_self_terminal %}
-				<pre class="bp-code" data-ondark>{{ settings.paths_self_terminal | e }}</pre>
+				<div class="bp-code-block" data-ondark>
+					<pre class="bp-code">{{ settings.paths_self_terminal | e }}</pre>
+					<button type="button" class="bp-code__copy" data-bp-copy-target=".bp-code" data-bp-copy-event="clone_command_copied" aria-label="Copy the install commands">{{ copy("bp-code__copyicon") }}<span data-bp-copy-label aria-live="polite">copy</span></button>
+				</div>
 				{%- endif %}
 
 				{%- if self_points %}
@@ -248,10 +251,10 @@
 
 				<div class="bp-path__actions">
 					{%- if settings.paths_self_cta_label %}
-					<a class="bp-btn bp-btn--lg bp-btn--ghost" href="{{ settings.paths_self_cta_url | default(repo_url, true) | e }}">{{ github("bp-btn__icon") }}{{ settings.paths_self_cta_label | e }}</a>
+					<a class="bp-btn bp-btn--lg bp-btn--ghost" href="{{ settings.paths_self_cta_url | default(repo_url, true) | e }}" data-bp-track="selfhost_cta_clicked" data-bp-track-location="paths">{{ github("bp-btn__icon") }}{{ settings.paths_self_cta_label | e }}</a>
 					{%- endif %}
 					{%- if settings.paths_self_cta2_label %}
-					<a class="bp-btn bp-btn--lg bp-btn--quiet" href="{{ settings.paths_self_cta2_url | default('#services', true) | e }}">{{ hammer("bp-btn__icon") }}{{ settings.paths_self_cta2_label | e }}</a>
+					<a class="bp-btn bp-btn--lg bp-btn--quiet" href="{{ settings.paths_self_cta2_url | default('#services', true) | e }}" data-bp-track="contact_cta_clicked" data-bp-track-location="paths_self">{{ hammer("bp-btn__icon") }}{{ settings.paths_self_cta2_label | e }}</a>
 					{%- endif %}
 				</div>
 			</div>
@@ -628,7 +631,7 @@ Built js/erpnext.bundle.js in 12.4s</pre>
 		<div class="bp-services__cta">
 			<p class="bp-services__pitch"><b>{{ settings.services_cta_title | default("", true) | e }}</b> {{ settings.services_cta_body | default("", true) | e }}</p>
 			{%- if settings.services_cta_label %}
-			<a class="bp-btn bp-btn--lg bp-btn--primary" href="{{ settings.services_cta_url | default('/contact', true) | e }}">{{ settings.services_cta_label | e }}{{ arrow_right("bp-btn__icon") }}</a>
+			<a class="bp-btn bp-btn--lg bp-btn--primary" href="{{ settings.services_cta_url | default('/contact', true) | e }}" data-bp-track="contact_cta_clicked" data-bp-track-location="services">{{ settings.services_cta_label | e }}{{ arrow_right("bp-btn__icon") }}</a>
 			{%- endif %}
 		</div>
 		{%- endif %}


### PR DESCRIPTION
## What

The public site had no tracking of any kind. This adds it for the one conversion that matters — a self-hosted install — and keeps it off every install that did not ask for it.

## Why the install is triangulated, not measured

BenchPress ships no telemetry, and instrumenting the installed product would break the promise the product is sold on. So the install is never observed directly:

| Source | What it sees |
|---|---|
| Site events | Reach and intent on benchpress.cloud |
| GitHub traffic API | Unique cloners, referrers, stars |

Neither is the number. Together they are a funnel with a believable shape.

## Why not GA4

Three reasons, in order of weight. The audience is the population most likely to block it, so the numbers would be understated in a biased way — the more technical the visitor, the more invisible. A consent banner would sit on top of the page whose job is to convert. And a landing page that says "no telemetry, your data, your host" while loading Google argues against itself.

The tracker is Umami, self-hosted.

## The gate

Nothing is collected unless a deployment sets `benchpress_analytics_script` and `benchpress_analytics_domain`, the same way the public site sits behind `benchpress_public_site`. Absent, no snippet renders and no third-party request is made.

`benchpress_github_repo` and `benchpress_github_token` gate the daily job identically. **No committed file names a tracker, a domain or an account.** A self-hoster who installs this app is tracked by nobody.

## Events

Eight, each answering a question that changes what gets built next: `selfhost_cta_clicked`, `clone_command_copied`, `hosted_cta_clicked`, `contact_cta_clicked`, `outbound_clicked`, `contact_submitted`, `waitlist_submitted`, and `docs_install_viewed` (not yet wired — `docs-site` is generated by leadtype and does not share `site_head.html`).

Deliberately not tracked: scroll depth, time on page, theme toggle, nav hovers. None would change a decision.

One delegated click listener reads `data-bp-track` and turns every `data-bp-track-*` attribute into a property, so a new tracked element needs no JavaScript.

## Two things worth a reviewer's eye

**The copy button.** `clone_command_copied` needed one. The landing page already had a copy button for the API panel, so `bindCopy` was generalised to serve both rather than growing a second implementation. The API button's behaviour is unchanged and was re-tested.

**The fourteen-day trapdoor.** GitHub deletes traffic data after 14 days. `snapshot_traffic` writes one row per day and backfills the whole window, so a missed run costs nothing until the fourteenth.

## Verification

Deployed to benchpress.cloud: migrated, `bench build --app benchpress`, backend and frontend restarted.

- 13 unit tests pass. `tearDown` deletes every row they write; zero rows left on the site afterwards.
- Nine tracked elements render on `/`, and no `data-website-id` appears in the markup because the keys are unset. The gate holds.
- Checked in Chromium at 390, 768 and 1440 px: copy button visible at all three, no text collision, no horizontal page scroll, drops below the block under 520px.
- Clipboard writes the two-line command, the label flips to "copied", the event fires.
- `uvx pre-commit@4.3.0` clean (ruff, prettier, eslint).

## Before this does anything

1. Stand up Umami and set the two analytics keys in `site_config.json`.
2. Set the two GitHub keys. The traffic API needs a fine-grained token with **Administration: read**, not just Contents.
3. **Enable the scheduler.** `System Settings.enable_scheduler` is `0` on the live site. The daily job is registered and not stopped, but nothing will run it, and each day it does not run is a day of clone data GitHub deletes.