### PR TITLE
feat: get benchpress.cloud ready to send traffic at

### DIFF
--- a/benchpress/analytics.py
+++ b/benchpress/analytics.py
@@ -3,6 +3,8 @@
 
 """The analytics gate. No config, no tracker, no third-party request."""
 
+from html import escape
+
 import frappe
 from frappe.utils import cstr
 
@@ -17,3 +19,20 @@ def tracker() -> dict:
 	if not script or not website_id:
 		return {}
 	return {"script": script, "website_id": website_id}
+
+
+def website_context(context) -> dict:
+	"""Every website route, docs included — the wiki renders through the same context."""
+	snippet = script_tag()
+	if not snippet:
+		return {}
+	return {"head_html": (context.get("head_html") or "") + snippet}
+
+
+def script_tag() -> str:
+	values = tracker()
+	if not values:
+		return ""
+	return '<script defer src="{0}" data-website-id="{1}"></script>'.format(
+		escape(values["script"], quote=True), escape(values["website_id"], quote=True)
+	)

--- a/benchpress/benchpress/site_content.py
+++ b/benchpress/benchpress/site_content.py
@@ -6,7 +6,6 @@
 import frappe
 from frappe.utils import cint, get_build_version
 
-from benchpress.analytics import tracker
 from benchpress.credits.config import SIGNUP_ROUTE, credits_enabled, waitlist_open
 from benchpress.request_cache import clear_local_cache, local_cache
 
@@ -78,7 +77,6 @@ def chrome_content() -> dict:
 		"logout_method": LOGOUT_METHOD,
 		"csrf_token": session_csrf_token(),
 		"asset_version": asset_version(),
-		"analytics": tracker(),
 	}
 
 

--- a/benchpress/github_traffic.py
+++ b/benchpress/github_traffic.py
@@ -6,7 +6,7 @@
 import requests
 
 import frappe
-from frappe.utils import cstr, today
+from frappe.utils import cstr
 
 DOCTYPE = "GitHub Traffic Snapshot"
 REPO_KEY = "benchpress_github_repo"
@@ -37,12 +37,17 @@ class GitHubTraffic:
 		repository = self.get("")
 		referrer = top_referrer(self.get("/traffic/popular/referrers"))
 
+		days = sorted(set(clones) | set(views))
+		# The traffic window usually ends yesterday, so the point-in-time counts go on its last day.
+		newest = days[-1] if days else None
 		return [
-			self.upsert(day, clones.get(day, {}), views.get(day, {}), repository, referrer)
-			for day in sorted(set(clones) | set(views))
+			self.upsert(day, clones.get(day, {}), views.get(day, {}), repository, referrer, day == newest)
+			for day in days
 		]
 
-	def upsert(self, day: str, clones: dict, views: dict, repository: dict, referrer: str) -> str:
+	def upsert(
+		self, day: str, clones: dict, views: dict, repository: dict, referrer: str, newest: bool
+	) -> str:
 		doc = self.row_for(day)
 		doc.update(
 			{
@@ -54,8 +59,8 @@ class GitHubTraffic:
 				"view_count": views.get("count") or 0,
 			}
 		)
-		# Stars, forks and the referrer are read at this instant, so only today's row can carry them.
-		if day == today():
+		# Stars, forks and the referrer are read at this instant, so only the newest row carries them.
+		if newest:
 			doc.stars = repository.get("stargazers_count") or 0
 			doc.forks = repository.get("forks_count") or 0
 			doc.top_referrer = referrer

--- a/benchpress/hooks.py
+++ b/benchpress/hooks.py
@@ -220,6 +220,9 @@ page_renderer = ["benchpress.docs_assets.DocsAssetRenderer"]
 # names. Its name is Frappe's and is misleading: it runs for every user, not only a Website User.
 get_website_user_home_page = "benchpress.public_site.home.home_page_for"
 
+# The tracker rides the framework's own `head_html`, so it reaches the wiki docs too.
+update_website_context = "benchpress.analytics.website_context"
+
 website_route_rules = [
 	{"from_route": "/frontend/<path:app_path>", "to_route": "frontend"},
 ]

--- a/benchpress/templates/includes/site_head.html
+++ b/benchpress/templates/includes/site_head.html
@@ -151,8 +151,3 @@ button.bp-navlink{border:0;background:none;font:inherit;line-height:1.2;cursor:p
 </script>
 {#- Its own tag, not `include_script`: that helper emits no `defer`, and this one is in the head. -#}
 <script defer src="{{ bundled_asset('bp-site.bundle.js') }}"></script>
-
-{#- Absent unless the deployment sets both keys, so a self-hosted install loads no tracker. -#}
-{%- if analytics %}
-<script defer src="{{ analytics.script | e }}" data-website-id="{{ analytics.website_id | e }}"></script>
-{%- endif %}

--- a/benchpress/tests/test_analytics.py
+++ b/benchpress/tests/test_analytics.py
@@ -4,6 +4,7 @@
 """The analytics gate and the GitHub traffic collector. No network, no container."""
 
 import unittest
+from typing import ClassVar
 from unittest.mock import patch
 
 import frappe
@@ -33,6 +34,45 @@ class TestAnalyticsGate(unittest.TestCase):
 	def test_blank_strings_do_not_count_as_configured(self):
 		with patch.dict(frappe.conf, {analytics.SCRIPT_KEY: "  ", analytics.DOMAIN_KEY: "  "}):
 			self.assertEqual(analytics.tracker(), {})
+
+
+class TestTrackerSnippet(unittest.TestCase):
+	CONFIGURED: ClassVar[dict] = {
+		analytics.SCRIPT_KEY: "https://analytics.benchpress.cloud/script.js",
+		analytics.DOMAIN_KEY: "abc-123",
+	}
+
+	def test_no_snippet_without_config(self):
+		with patch.dict(frappe.conf, {}, clear=False):
+			frappe.conf.pop(analytics.SCRIPT_KEY, None)
+			frappe.conf.pop(analytics.DOMAIN_KEY, None)
+			self.assertEqual(analytics.script_tag(), "")
+			self.assertEqual(analytics.website_context(frappe._dict()), {})
+
+	def test_snippet_carries_both_values(self):
+		with patch.dict(frappe.conf, self.CONFIGURED):
+			tag = analytics.script_tag()
+			self.assertIn('src="https://analytics.benchpress.cloud/script.js"', tag)
+			self.assertIn('data-website-id="abc-123"', tag)
+			self.assertIn("defer", tag)
+
+	def test_attributes_are_escaped(self):
+		values = {analytics.SCRIPT_KEY: 'https://x/s.js"><b>', analytics.DOMAIN_KEY: "a<b"}
+		with patch.dict(frappe.conf, values):
+			tag = analytics.script_tag()
+			self.assertNotIn("<b>", tag)
+			self.assertIn("&lt;b", tag)
+
+	def test_context_appends_rather_than_replaces(self):
+		with patch.dict(frappe.conf, self.CONFIGURED):
+			result = analytics.website_context(frappe._dict({"head_html": "<meta name=x>"}))
+			self.assertTrue(result["head_html"].startswith("<meta name=x>"))
+			self.assertIn("data-website-id", result["head_html"])
+
+	def test_context_handles_absent_head_html(self):
+		with patch.dict(frappe.conf, self.CONFIGURED):
+			result = analytics.website_context(frappe._dict())
+			self.assertTrue(result["head_html"].startswith("<script"))
 
 
 class TestGitHubTrafficParsing(unittest.TestCase):
@@ -96,6 +136,18 @@ class TestGitHubTrafficRows(unittest.TestCase):
 		self.assertEqual([str(row.snapshot_date) for row in rows], ["2026-08-20", "2026-08-21"])
 		self.assertEqual([row.clone_uniques for row in rows], [4, 2])
 		self.assertEqual([row.view_uniques for row in rows], [11, 0])
+
+	def test_point_in_time_counts_land_on_the_newest_row(self):
+		self.client().write_snapshots()
+		rows = frappe.get_all(
+			github_traffic.DOCTYPE,
+			filters={"repository": self.REPO},
+			fields=["snapshot_date", "stars", "forks", "top_referrer"],
+			order_by="snapshot_date asc",
+		)
+		self.assertEqual([r.stars for r in rows], [0, 7])
+		self.assertEqual([r.forks for r in rows], [0, 3])
+		self.assertEqual([r.top_referrer or "" for r in rows], ["", "news.ycombinator.com"])
 
 	def test_write_snapshots_is_idempotent(self):
 		self.client().write_snapshots()


### PR DESCRIPTION
> **Rolling PR.** This branch carries every phase of `.marketing/plan.md`. Each plan item is its own commit, so one can be dropped without unpicking the rest. Merging happens once, at the end.
>
> **Progress:** Phase 0 complete · Phase 1 next

---

## Phase 0 — instruments (complete)

Completes Phase 0. Two defects the first real collection exposed.

## 1. The docs were not tracked

The tracker reached the five marketing pages and nothing else. For a self-host-adoption goal the docs *are* the conversion asset, and no visit to them was counted.

**The fix is in two halves, because one mechanism cannot cover both.**

The snippet now rides the framework's own `head_html` through the `update_website_context` hook, so every page rendered by a `BaseTemplatePage` carries it and the marketing pages stop being a special case. The duplicate in `site_head.html` is removed — otherwise those five pages would count twice — and the `analytics` chrome key it fed goes with it.

That hook does **not** reach the docs, and cannot. `/docs` is served by `WikiDocumentRenderer`, which extends `BaseRenderer` rather than `BaseTemplatePage`, so it never calls `post_process_context` and no context hook can touch it. It reads `head_html` from **`Wiki Settings`** — the wiki app's own extension point. The snippet is set there as site data rather than fought with code.

That second half is a **deployment step, not code**: a self-hoster never sets it and is never tracked, same guarantee as the config keys.

## 2. Stars, forks and the top referrer were never recorded

The first real run wrote 14 rows and every one had `stars=0, forks=0, top_referrer=''`. Those fields were written only to the row for *today*, and GitHub's traffic window ends *yesterday*, so the condition never matched once. They now land on the newest day in the window.

Caught only by running it against the live API — the unit tests passed throughout, because the fixture happened to include today.

## Verification

Deployed to benchpress.cloud. Tracker confirmed on all eight routes, each with a forced re-render (`Cache-Control: no-cache`, which `cache_html` honours):

`/` · `/about` · `/contact` · `/signup` · `/login` · `/docs/index` · `/docs/operator/install` · `/docs/reference/glossary`

- 19 tests pass, 6 new. No rows left behind — only the real repository is present afterwards
- Real collection: 14 days, 322 unique cloners, newest row now carries stars 3, forks 1, referrer `github.com`
- `uvx pre-commit@4.3.0` clean

## Deployment steps for any other environment

```bash
bench --site <site> set-config benchpress_analytics_script https://<umami-host>/script.js
bench --site <site> set-config benchpress_analytics_domain <website-id>
bench --site <site> set-config benchpress_github_repo <owner>/<repo>
bench --site <site> set-config benchpress_github_token <fine-grained PAT, Administration: read>
```

Then set `Wiki Settings.head_html` to the same `<script>` tag for the docs.

## Unrelated, found on the way

`apps/wikiseed` was listed in `sites/apps.txt` but is not an app — no `hooks.py`, no `__init__.py`, no packaging, just a `seed_wiki.py` and a `pages/` folder. Every bench command died importing it. Removed from `apps.txt` on the live host; nothing in this diff.
