### PR TITLE
fix(emails): put the BenchPress logo in the mail header

### DIFF
--- a/benchpress/patches.txt
+++ b/benchpress/patches.txt
@@ -35,3 +35,4 @@ benchpress.patches.drop_page_content_doctypes
 benchpress.patches.claim_host_name
 benchpress.patches.refresh_approval_mail
 benchpress.patches.seed_password_reset_template
+benchpress.patches.relogo_email_templates

--- a/benchpress/patches/relogo_email_templates.py
+++ b/benchpress/patches/relogo_email_templates.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Venkatesh and contributors
+# For license information, please see license.txt
+
+from benchpress.public_site.seed import relogo_email_templates
+
+
+def execute():
+	relogo_email_templates()

--- a/benchpress/public_site/seed.py
+++ b/benchpress/public_site/seed.py
@@ -1,7 +1,10 @@
 # Copyright (c) 2026, Venkatesh and contributors
 # For license information, please see license.txt
 
+import re
+
 import frappe
+from frappe import _
 
 from benchpress import emails
 from benchpress.public_site import public_site_enabled
@@ -11,6 +14,14 @@ EMAIL_TEMPLATE = "Email Template"
 
 # The landing page's former route; a site still pointing at it is re-pointed, not left.
 FORMER_HOME_PAGE = "home"
+
+# The brand bar the first seeded rows carried: a blue square beside the word BENCHPRESS.
+FAUX_LOGO = re.compile(
+	r'<table role="presentation" cellpadding="0" cellspacing="0" border="0">\s*<tr>\s*'
+	r'<td width="10" bgcolor="#4E8BFB".*?</td>\s*<td [^>]*>BENCHPRESS</td>\s*</tr>\s*</table>',
+	re.DOTALL,
+)
+LOGO_BLOCK = re.compile(r'<a href="\{\{ site_url \| e \}\}"[^>]*><img [^>]*alt="BenchPress"[^>]*></a>')
 
 
 def seed_public_site() -> None:
@@ -37,3 +48,23 @@ def claim_home_page() -> None:
 	frappe.db.set_single_value(WEBSITE_SETTINGS, "home_page", LANDING_PAGE)
 	# Written straight to the row, so the controller that would have dropped this key never ran.
 	frappe.cache.delete_value("home_page")
+
+
+def relogo_email_templates() -> None:
+	block = _shipped_logo_block()
+	for name in emails.DEFAULTS:
+		body = frappe.db.get_value(EMAIL_TEMPLATE, name, "response_html")
+		if not body:
+			continue
+		swapped, count = FAUX_LOGO.subn(lambda _match: block, body, count=1)
+		if count:
+			frappe.db.set_value(EMAIL_TEMPLATE, name, "response_html", swapped)
+	frappe.clear_cache(doctype=EMAIL_TEMPLATE)
+
+
+def _shipped_logo_block() -> str:
+	# Taken from the shipped body so the markup lives in the templates and nowhere else.
+	found = LOGO_BLOCK.search(emails.default_body(emails.ACCESS_APPROVED))
+	if not found:
+		frappe.throw(_("The shipped email header no longer carries the logo block"))
+	return found.group(0)

--- a/benchpress/templates/emails/access_approved.html
+++ b/benchpress/templates/emails/access_approved.html
@@ -13,12 +13,7 @@
 
 				<tr>
 					<td style="padding:20px 28px;background-color:#0A1024;border-radius:13px 13px 0 0;">
-						<table role="presentation" cellpadding="0" cellspacing="0" border="0">
-							<tr>
-								<td width="10" bgcolor="#4E8BFB" style="width:10px;height:10px;border-radius:3px;font-size:0;line-height:10px;">&nbsp;</td>
-								<td style="padding-left:12px;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;">BENCHPRESS</td>
-							</tr>
-						</table>
+						<a href="{{ site_url | e }}" style="display:inline-block;text-decoration:none;"><img src="{{ logo_url | e }}" width="140" height="36" alt="BenchPress" style="display:block;width:140px;height:36px;border:0;outline:none;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;text-decoration:none;"></a>
 					</td>
 				</tr>
 

--- a/benchpress/templates/emails/access_declined.html
+++ b/benchpress/templates/emails/access_declined.html
@@ -11,12 +11,7 @@
 
 				<tr>
 					<td style="padding:20px 28px;background-color:#0A1024;border-radius:13px 13px 0 0;">
-						<table role="presentation" cellpadding="0" cellspacing="0" border="0">
-							<tr>
-								<td width="10" bgcolor="#4E8BFB" style="width:10px;height:10px;border-radius:3px;font-size:0;line-height:10px;">&nbsp;</td>
-								<td style="padding-left:12px;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;">BENCHPRESS</td>
-							</tr>
-						</table>
+						<a href="{{ site_url | e }}" style="display:inline-block;text-decoration:none;"><img src="{{ logo_url | e }}" width="140" height="36" alt="BenchPress" style="display:block;width:140px;height:36px;border:0;outline:none;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;text-decoration:none;"></a>
 					</td>
 				</tr>
 

--- a/benchpress/templates/emails/access_request_filed.html
+++ b/benchpress/templates/emails/access_request_filed.html
@@ -11,12 +11,7 @@
 
 				<tr>
 					<td style="padding:20px 28px;background-color:#0A1024;border-radius:13px 13px 0 0;">
-						<table role="presentation" cellpadding="0" cellspacing="0" border="0">
-							<tr>
-								<td width="10" bgcolor="#4E8BFB" style="width:10px;height:10px;border-radius:3px;font-size:0;line-height:10px;">&nbsp;</td>
-								<td style="padding-left:12px;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;">BENCHPRESS</td>
-							</tr>
-						</table>
+						<a href="{{ site_url | e }}" style="display:inline-block;text-decoration:none;"><img src="{{ logo_url | e }}" width="140" height="36" alt="BenchPress" style="display:block;width:140px;height:36px;border:0;outline:none;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;text-decoration:none;"></a>
 					</td>
 				</tr>
 

--- a/benchpress/templates/emails/access_request_received.html
+++ b/benchpress/templates/emails/access_request_received.html
@@ -12,12 +12,7 @@
 
 				<tr>
 					<td style="padding:20px 28px;background-color:#0A1024;border-radius:13px 13px 0 0;">
-						<table role="presentation" cellpadding="0" cellspacing="0" border="0">
-							<tr>
-								<td width="10" bgcolor="#4E8BFB" style="width:10px;height:10px;border-radius:3px;font-size:0;line-height:10px;">&nbsp;</td>
-								<td style="padding-left:12px;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;">BENCHPRESS</td>
-							</tr>
-						</table>
+						<a href="{{ site_url | e }}" style="display:inline-block;text-decoration:none;"><img src="{{ logo_url | e }}" width="140" height="36" alt="BenchPress" style="display:block;width:140px;height:36px;border:0;outline:none;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;text-decoration:none;"></a>
 					</td>
 				</tr>
 

--- a/benchpress/templates/emails/contact_filed.html
+++ b/benchpress/templates/emails/contact_filed.html
@@ -11,12 +11,7 @@
 
 				<tr>
 					<td style="padding:20px 28px;background-color:#0A1024;border-radius:13px 13px 0 0;">
-						<table role="presentation" cellpadding="0" cellspacing="0" border="0">
-							<tr>
-								<td width="10" bgcolor="#4E8BFB" style="width:10px;height:10px;border-radius:3px;font-size:0;line-height:10px;">&nbsp;</td>
-								<td style="padding-left:12px;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;">BENCHPRESS</td>
-							</tr>
-						</table>
+						<a href="{{ site_url | e }}" style="display:inline-block;text-decoration:none;"><img src="{{ logo_url | e }}" width="140" height="36" alt="BenchPress" style="display:block;width:140px;height:36px;border:0;outline:none;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;text-decoration:none;"></a>
 					</td>
 				</tr>
 

--- a/benchpress/templates/emails/contact_received.html
+++ b/benchpress/templates/emails/contact_received.html
@@ -11,12 +11,7 @@
 
 				<tr>
 					<td style="padding:20px 28px;background-color:#0A1024;border-radius:13px 13px 0 0;">
-						<table role="presentation" cellpadding="0" cellspacing="0" border="0">
-							<tr>
-								<td width="10" bgcolor="#4E8BFB" style="width:10px;height:10px;border-radius:3px;font-size:0;line-height:10px;">&nbsp;</td>
-								<td style="padding-left:12px;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;">BENCHPRESS</td>
-							</tr>
-						</table>
+						<a href="{{ site_url | e }}" style="display:inline-block;text-decoration:none;"><img src="{{ logo_url | e }}" width="140" height="36" alt="BenchPress" style="display:block;width:140px;height:36px;border:0;outline:none;font-family:'Poppins','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:800;letter-spacing:0.04em;color:#FFFFFF;text-decoration:none;"></a>
 					</td>
 				</tr>
 

--- a/benchpress/tests/test_emails.py
+++ b/benchpress/tests/test_emails.py
@@ -11,6 +11,7 @@ from frappe.utils import get_url
 from benchpress import contact, emails
 from benchpress.patches.refresh_approval_mail import DEAD_PROMISE
 from benchpress.patches.refresh_approval_mail import execute as refresh_approval_mail
+from benchpress.public_site.seed import relogo_email_templates
 from benchpress.user import BenchPressPasswordResetMixin
 
 REQUESTER = "emails-requester@example.com"
@@ -23,6 +24,17 @@ RESET_USER = "emails-reset@example.com"
 
 # `_message()` files under "Sales"; routing it at the admin pins who the notice reaches.
 ROUTED_TO_ADMIN = ({"label": "Sales", "route_to_email": ADMIN},)
+
+# A row as the seed planted it before the logo existed, with a line of operator copy under it.
+FAUX_LOGO_BODY = """<td style="padding:20px 28px;background-color:#0A1024;border-radius:13px 13px 0 0;">
+	<table role="presentation" cellpadding="0" cellspacing="0" border="0">
+		<tr>
+			<td width="10" bgcolor="#4E8BFB" style="width:10px;height:10px;">&nbsp;</td>
+			<td style="font-size:17px;color:#FFFFFF;">BENCHPRESS</td>
+		</tr>
+	</table>
+</td>
+<p>Hosted access is invite-only.</p>"""
 
 
 def _entry(**overrides) -> frappe._dict:
@@ -201,8 +213,21 @@ class TestEmails(IntegrationTestCase):
 			emails.send_access_request_received(_entry())
 
 		self.assertEqual(self.sent["subject"], "Your BenchPress access request — REQ-A1B2-C3D4")
-		self.assertIn("BENCH", self.sent["message"], "the shipped body did not render")
+		self.assertIn(emails.LOGO_PATH, self.sent["message"], "the shipped body did not render")
 		self.assertNotIn("{{", self.sent["message"], "an interpolation was left unrendered")
+
+	def test_every_shipped_body_carries_the_logo_over_an_absolute_url(self):
+		"""A mail client resolves nothing relative, so the header src must arrive absolute."""
+		patch.dict(frappe.conf, {contact.NOTIFY_KEY: ADMIN}).start()
+		patch.object(contact, "TOPICS", ROUTED_TO_ADMIN).start()
+
+		with patch.object(frappe.db, "exists", return_value=False):
+			for send, row in self._every_send():
+				self.mailer.reset_mock()
+				send(row)
+				with self.subTest(send=send.__name__):
+					self.assertIn(f'src="{get_url(emails.LOGO_PATH)}?v=', self.sent["message"])
+					self.assertIn('alt="BenchPress"', self.sent["message"])
 
 	def test_an_operator_edit_in_desk_wins_over_the_shipped_body(self):
 		self._install_template(
@@ -249,6 +274,26 @@ class TestEmails(IntegrationTestCase):
 				self.mailer.reset_mock()
 				send(bare)
 				self.assertTrue(self.sent["message"].strip())
+
+	def test_a_row_seeded_before_the_logo_is_re_branded_in_place(self):
+		self._install_template(emails.ACCESS_APPROVED, subject="x", body=FAUX_LOGO_BODY)
+
+		relogo_email_templates()
+
+		body = frappe.db.get_value("Email Template", emails.ACCESS_APPROVED, "response_html")
+		self.assertNotIn("BENCHPRESS", body)
+		self.assertIn('alt="BenchPress"', body)
+		self.assertIn("<p>Hosted access is invite-only.</p>", body, "the operator's copy was lost")
+
+	def test_re_branding_a_row_that_already_carries_the_logo_changes_nothing(self):
+		self._install_template(emails.ACCESS_APPROVED, subject="x", body=FAUX_LOGO_BODY)
+		relogo_email_templates()
+		once = frappe.db.get_value("Email Template", emails.ACCESS_APPROVED, "response_html")
+
+		relogo_email_templates()
+
+		twice = frappe.db.get_value("Email Template", emails.ACCESS_APPROVED, "response_html")
+		self.assertEqual(once, twice)
 
 	# failure containment
 
@@ -303,6 +348,18 @@ class TestEmails(IntegrationTestCase):
 	def _drop_reset_user(self) -> None:
 		if frappe.db.exists("User", RESET_USER):
 			frappe.delete_doc("User", RESET_USER, force=True, ignore_permissions=True)
+
+	def _every_send(self) -> tuple:
+		"""One call per shipped body: the four that reach a person and the two that reach the admins."""
+		entry, message = _entry(), _message()
+		return (
+			(emails.send_access_request_received, entry),
+			(emails.notify_admins_of_access_request, entry),
+			(emails.send_access_request_approved, entry),
+			(emails.send_access_request_rejected, entry),
+			(emails.send_contact_received, message),
+			(emails.notify_admins_of_contact, message),
+		)
 
 	def _install_template(self, name: str, subject: str, body: str) -> None:
 		if frappe.db.exists("Email Template", name):


### PR DESCRIPTION
## Summary

The six transactional mail bodies drew their own brand bar — a blue square beside the word `BENCHPRESS` — instead of the BenchPress logo. Each body now carries `wordmark-on-dark.png`, the lockup the site header and footer already use, at 140x36 and linked to the site.

This is commit `79ffcc6` from #353, cherry-picked onto `version-16`. Nothing else from that branch comes with it: the rest of #353 re-implements the public-site work that `version-16` already carries, so that PR should be closed rather than merged.

`password_reset.html` already rendered the logo, and `emails.LOGO_PATH` / `logo_url` were already on `version-16`. Only the six older bodies and the migration were missing.

## How

- The six templates swap their text brand bar for the `<img>`, matching the markup `password_reset.html` already used.
- The `<img>` carries the font, weight, letter spacing and colour the old text carried, so a client that blocks remote images degrades to a readable white **BenchPress** rather than to nothing.
- Rows seeded before this change still hold the old markup, and the seeder only inserts what is missing. `benchpress.patches.relogo_email_templates` swaps just the brand block in each stored `response_html` and leaves the rest of the body — including operator edits — alone. It is idempotent, and it runs last in `patches.txt`, after `refresh_approval_mail` and `seed_password_reset_template` rewrite their bodies.

## Changes from the cherry-picked commit

Two conflicts, both additive, resolved by keeping both sides:

- `patches.txt` — `relogo_email_templates` appended after the three patches `version-16` added.
- `test_emails.py` — the new helper and import kept alongside the password-reset helpers.

One fix was needed. `test_every_shipped_body_carries_the_logo_over_an_absolute_url` patched `emails.admin_recipients`, which does not exist on `version-16`; the operator address resolves through `contact.notify_email()` here. The test now patches `frappe.conf[contact.NOTIFY_KEY]`, the seam the neighbouring tests already use.

## Test Plan

- [x] `bench --site bp_test_site run-tests --app benchpress` — 1441 pass, 12 skipped, no failures
- [x] `bench --site bp_test_site run-tests --module benchpress.tests.test_emails` — 28 pass, three of them the logo tests: every send carries an absolute `src` and `alt="BenchPress"`; a row seeded before the change is re-branded with operator copy intact; running the patch twice changes nothing
- [x] `uvx pre-commit@4.3.0` clean on every changed file
- [x] `pause_scheduler` absent on `frontend` and `bp_test_site` after the run

## Type of Change

- [x] Bug fix

## Checklist

- [x] Commit message follows conventional commits format
- [x] No `frappe.db.sql` in new code
- [x] No `console.log` left in JS
- [x] No new whitelisted endpoints
- [x] No hardcoded credentials or API keys

## One thing to know before merging

`public_site.seed._shipped_logo_block()` calls `frappe.throw` when its regex finds no logo block in the shipped `access_approved.html`, and it runs before the row loop, so it fires on every site — including a self-hosted one with no templates at all. A future hand-edit that splits the `<a>` and `<img>` tags across lines would abort `bench migrate` everywhere. Returning `None` and skipping the swap would degrade to a no-op instead. Left as cherry-picked; worth a follow-up.
