### PR TITLE
fix(scripts): point the unattended runner at bp_test_site

### DIFF
--- a/.claude/skills/issue-to-phases/SKILL.md
+++ b/.claude/skills/issue-to-phases/SKILL.md
@@ -207,9 +207,10 @@ completed.
   Frappe resolves scheduled and enqueued jobs from strings at run time, so moving
   a function they name breaks them while every import still works. Rewrite every
   string in the same commit, run
-  `docker compose exec backend bench --site frontend migrate`, and restart the
+  `docker compose exec backend bench --site bp_test_site migrate`, and restart the
   workers **after** — the other order leaves a `Scheduled Job Type` row pointing
-  at nothing, and that fails in complete silence. Job ids never change during a
+  at nothing, and that fails in complete silence. That table is per site, so it
+  repairs the test site alone; the deployment's rows wait for the deploy migrate. Job ids never change during a
   move, and a re-export shim is not a fallback: see
   [Moving code that a string names](references/ralph-loop.md#moving-code-that-a-string-names).
 - One subfolder per feature, always inside a status bucket — never loose in

--- a/.claude/skills/issue-to-phases/assets/prompt.md.template
+++ b/.claude/skills/issue-to-phases/assets/prompt.md.template
@@ -227,7 +227,10 @@ End the phase in this order, and do not reorder it:
 1. Rewrite **every** string in the same commit as the move: call sites,
    `hooks.py`, docstrings, tracked `.md`, and the test assertions naming the path.
    `git grep '<old.dotted.path>'` must come back empty.
-2. `docker compose exec backend bench --site frontend migrate`
+2. `docker compose exec backend bench --site bp_test_site migrate` — never
+   `--site frontend`, which is the deployment's own site. `Scheduled Job Type` is
+   per site, so this repairs the test site; the deployment's rows wait for the
+   deploy migrate
 3. `docker compose restart backend queue-long queue-short scheduler websocket`
 
 Before step 3, poll `queue-long` for at most 120 seconds, then go ahead anyway and

--- a/.claude/skills/issue-to-phases/references/ralph-loop.md
+++ b/.claude/skills/issue-to-phases/references/ralph-loop.md
@@ -160,13 +160,22 @@ drops first when it is concentrating on code, and a shipped feature filed under
 `{{TEST_CMD}}` names the test modules the phase touches, one line each:
 
 ```bash
-docker compose exec backend bench --site frontend run-tests --module benchpress.tests.test_deploy_manager
+docker compose exec backend bench --site bp_test_site run-tests --module benchpress.tests.test_deploy_manager
 ```
 
-Two rules, and each one has cost a real run.
+Three rules, and each one has cost a real run.
+
+**Never `--site frontend`.** `frontend` is the deployment's own site, and on a
+public host it is the one the world reads. It carries no `allow_tests`, so the
+runner refuses it, and the refusal comes after the runner has already disabled
+its scheduler from a value it holds in memory and restores only on a clean exit.
+A site with the scheduler off composes mail and never sends it, with nothing in
+any log to say so. An interrupted iteration is normal in a loop, not
+exceptional, which turns a possible failure into a likely one. Name
+`bp_test_site` locally and `test_site` in CI.
 
 **Never `--app benchpress`.** The whole suite is CI's job. It takes 60 seconds
-against the live site and does not repeat. Three runs of the same tree gave
+against `bp_test_site` and does not repeat. Three runs of the same tree gave
 one failure, then four, then one: `test_api` blew a 600 ms budget at 1,473 ms
 under whole-suite load, and `test_credit_guard` got a Docker 404 that it does not
 get on its own. Scoped `--module` runs of the same tests were stable every time.
@@ -229,17 +238,23 @@ stopped.
 1. **Move the code and rewrite every string in the same commit** — call sites,
    `hooks.py`, docstrings, tracked `.md`, and the test assertions that name the
    path. A forgotten test assertion fails loudly, which is the cheapest gate here.
-2. **`docker compose exec backend bench --site frontend migrate`.**
+2. **`docker compose exec backend bench --site bp_test_site migrate`.** Migrating
+   `frontend` is a deploy step a person runs by hand, never part of a loop.
 3. **`docker compose restart backend queue-long queue-short scheduler websocket`.**
 
 Step 2 before step 3 is a rule, not a preference. `migrate` calls `sync_jobs()`
 (`frappe/migrate.py:162`), which inserts the new `Scheduled Job Type` row and then
 deletes the one whose method is no longer in `scheduler_events`. So the stale row
-never outlives the commit, and a scheduler string never needs a `patches.txt`
+never outlives the commit on the site you migrated, and a scheduler string never needs a `patches.txt`
 entry. `migrate` runs inside `backend`, a fresh process reading the bind-mounted
 new code, so it sees the new hooks while the un-restarted workers resolve the new
 path straight from disk. Between steps 2 and 3 both paths work. **Migrating after
 the restart is the order that opens the silent window.**
+
+`Scheduled Job Type` is a per-site table, so step 2 repairs `bp_test_site` and
+nothing else. The deployment's own rows stay stale until a person migrates
+`frontend` on deploy. That is the trade for keeping production out of a loop: a
+moved scheduler string is not live until it ships. Say so in the phase notes.
 
 Before step 3, wait for `queue-long` — **bounded, and not a gate.** Poll for at
 most 120 seconds, then go ahead anyway and log the depth it gave up at. A restart

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,7 @@ surface uses those tokens and never a raw hex value.
 
 ```bash
 docker compose exec backend bench --site frontend migrate
-docker compose exec backend bench --site frontend run-tests --app benchpress
+docker compose exec backend bench --site bp_test_site run-tests --app benchpress
 docker compose exec backend bench build --app benchpress   # after frontend changes, then:
 docker compose restart backend frontend
 

--- a/benchpress/tests/test_runner_targets.py
+++ b/benchpress/tests/test_runner_targets.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+"""What an unattended loop is told to run against, and what it is told to sign in with.
+
+`frontend` is the deployment's own site. It carries no `allow_tests`, so `run-tests` refuses
+it — but only after disabling its scheduler from a value the runner holds in memory and
+restores on a clean exit. A site with the scheduler off composes mail and never sends it,
+silently. An interrupted iteration is normal in a loop, so the refusal is the likely outcome,
+not the exceptional one. The instructions are read fresh every iteration, which is why a scan
+of them is the test.
+
+Each pattern needs whitespace or a line start before `--site`, so the prose that forbids the
+command — which writes it inside backticks — does not read as the command itself.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+# `scripts/ralph.sh` cd's here before invoking `claude`, so CLAUDE.md is loaded every
+# iteration alongside the prompt. It is a runner file, whatever else it is.
+CLAUDE_MD = "CLAUDE.md"
+
+# The loop's own instructions, and the two templates that generate them.
+LOOP_FILES = (
+	"scripts/prompt.md",
+	"scripts/ralph.sh",
+	".claude/skills/issue-to-phases/SKILL.md",
+	".claude/skills/issue-to-phases/assets/prompt.md.template",
+	".claude/skills/issue-to-phases/assets/ralph.sh.template",
+	".claude/skills/issue-to-phases/references/ralph-loop.md",
+)
+
+ON_FRONTEND = r"""(?:^|\s)--site[= ]["']?frontend\b"""
+
+# Testing the deployment site is wrong everywhere. Migrating it is what a person does on
+# deploy, so only the loop is forbidden to name it.
+RUN_TESTS_ON_FRONTEND = re.compile(ON_FRONTEND + r".*\brun-tests\b")
+BENCH_ON_FRONTEND = re.compile(ON_FRONTEND)
+
+# Any value for either name, except the empty `${BP_TEST_URL:-}` the guard reads with.
+CREDENTIAL_DEFAULT = re.compile(r"\b(BP_TEST_URL|BP_TEST_PASSWORD)=(?!\$\{\1:-\}|\s|$)")
+
+
+def _missing(names: tuple[str, ...]) -> list[str]:
+	return [name for name in names if not (REPO / name).exists()]
+
+
+def _hits(pattern: re.Pattern, names: tuple[str, ...]) -> list[str]:
+	found = []
+	for name in names:
+		path = REPO / name
+		if not path.exists():
+			continue
+		for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+			if pattern.search(line):
+				found.append(f"{name}:{number}: {line.strip()}")
+	return found
+
+
+class TestRunnerTargets(unittest.TestCase):
+	def test_every_runner_file_is_where_the_scan_looks(self):
+		"""A renamed file would make every other assertion here vacuous."""
+		self.assertEqual(_missing((*LOOP_FILES, CLAUDE_MD)), [])
+
+	def test_no_runner_instruction_names_the_deployment_site(self):
+		self.assertEqual(_hits(BENCH_ON_FRONTEND, LOOP_FILES), [], "a loop is pointed at `frontend`")
+
+	def test_nothing_an_agent_reads_tests_the_deployment_site(self):
+		self.assertEqual(_hits(RUN_TESTS_ON_FRONTEND, (*LOOP_FILES, CLAUDE_MD)), [])
+
+	def test_the_loop_names_the_test_site_for_both_commands(self):
+		"""`assertIn` would print the whole prompt into a log a loop has to read."""
+		prompt = (REPO / "scripts/prompt.md").read_text(encoding="utf-8")
+		for command in ("run-tests", "migrate"):
+			self.assertTrue(
+				f"--site bp_test_site {command}" in prompt,
+				f"scripts/prompt.md names no test site for `{command}`",
+			)
+
+	def test_every_template_still_names_a_site_to_migrate(self):
+		"""Losing the site name outright would pass every pattern above."""
+		for name in LOOP_FILES:
+			body = (REPO / name).read_text(encoding="utf-8")
+			if "migrate" in body:
+				self.assertIn("--site bp_test_site migrate", body, f"{name} migrates a nameless site")
+
+	def test_the_browser_credentials_carry_no_default(self):
+		self.assertEqual(
+			_hits(CREDENTIAL_DEFAULT, LOOP_FILES), [], "a browser credential still has a default"
+		)

--- a/scripts/prompt.md
+++ b/scripts/prompt.md
@@ -58,13 +58,18 @@ bundle at seam one instead.
 
 - Bench commands run inside the parent compose stack, not a standalone bench. From
   `/home/ubuntu/benchpress_devops` use `docker compose exec -T backend bench ...`.
-- One module while working:
-  `bench --site frontend run-tests --app benchpress --module <module.path>`.
+- The test site is `bp_test_site`. One module while working:
+  `bench --site bp_test_site run-tests --app benchpress --module <module.path>`.
   Whole app suite once before you commit: `... run-tests --app benchpress`.
+- **Never name `frontend` in a `run-tests` command.** It carries no `allow_tests`, so the runner
+  refuses it, and an interrupted run leaves its scheduler off from a value the runner held in
+  memory. A site with the scheduler off composes mail and never sends it, with nothing in any log
+  to say so. An interrupted iteration is normal in this loop, not exceptional.
 - Frontend changes need `bench build --app benchpress`, then restart backend and frontend.
-  Schema changes need `bench --site frontend migrate`.
-- The local site has this branch migrated and seeded, so the schema is real and every seam runs
-  locally.
+  Schema changes need `bench --site bp_test_site migrate`. Migrating `frontend` is a deploy step a
+  person runs by hand; it is not part of this loop.
+- `bp_test_site` has this branch migrated and seeded, and carries `benchpress_public_site`, so the
+  schema is real and every seam runs locally.
 - Query with `frappe.qb`, never raw SQL. Every whitelisted method checks permissions itself.
 - Behaviour lives in doctype controllers and `hooks.py` as often as in the obvious module. Read
   `hooks.py` before assuming a save does the plain thing.
@@ -75,13 +80,20 @@ A rendering test cannot see a broken layout, a header that overflows on a phone,
 stopped submitting. Any issue that changes what a page looks like or how it behaves must be checked
 in a real browser before you commit. Use the `agent-browser` skill.
 
-1. **The local stack, `http://localhost:8080`** — the port is `PORT` in
-   `/home/ubuntu/benchpress_devops/.env`. It runs this branch against real, migrated schema. Sign
-   in as `Administrator` with `ADMIN_PASSWORD` from that same file. **Use this for anything that
-   writes**: submitting a form, signing in or out, creating a user, editing in Desk.
-2. **The deployed branch instance, `$BP_TEST_URL`**, defaulting to
-   `https://b3873df7.benchpress.cloud`, signing in as `Administrator` with `$BP_TEST_PASSWORD`,
-   defaulting to `admin`. Use it to see a change against deployed data.
+Read `PUBLIC_HOSTNAME` in `/home/ubuntu/benchpress_devops/.env` before you open anything. That one
+key turns the checkout into a public deployment, and nginx serves the same `frontend` site on
+loopback that Traefik serves on 443. Where it is set, nothing on this host is writable — nginx
+serves `frontend` alone, so `bp_test_site` has no URL. Use target 2 if it is configured; otherwise
+check read-only and say in the issue comment what you could not exercise.
+
+1. **The local stack, `http://localhost:8080`** — the port is `PORT` in that same file. It runs
+   this branch against real, migrated schema. Sign in as `Administrator` with `ADMIN_PASSWORD`
+   from that file. Use it for anything that writes — submitting a form, signing in or out,
+   creating a user, editing in Desk — **only while `PUBLIC_HOSTNAME` is unset**. Where it is set,
+   this port is production.
+2. **A deployed branch instance, `$BP_TEST_URL`**, signing in as `Administrator` with
+   `$BP_TEST_PASSWORD`. Use it to see a change against deployed data. Both are unset by default;
+   skip this check when they are.
 3. **Production, `https://benchpress.cloud`** — **read-only, always**. Never submit a form there,
    never sign in, never create or edit a record.
 

--- a/scripts/ralph.sh
+++ b/scripts/ralph.sh
@@ -12,9 +12,12 @@ set -e
 
 export IS_SANDBOX=1
 
-# Browser checks. Writes belong on the local stack; production is read-only.
-export BP_TEST_URL=${BP_TEST_URL:-https://b3873df7.benchpress.cloud}
-export BP_TEST_PASSWORD=${BP_TEST_PASSWORD:-admin}
+# Optional browser check against a deployed branch instance. No defaults: the
+# pair used to name a live host and the password `admin`.
+if [[ -n "${BP_TEST_URL:-}" ]]; then
+  : "${BP_TEST_PASSWORD:?BP_TEST_URL is set, so BP_TEST_PASSWORD must be set too}"
+  export BP_TEST_URL BP_TEST_PASSWORD
+fi
 
 ITERATIONS=${1:-20}
 REPO=/home/ubuntu/benchpress_devops/apps/benchpress


### PR DESCRIPTION
Closes #356.

`scripts/prompt.md` told the loop to run tests and to migrate against `frontend`.
On this host `PUBLIC_HOSTNAME=benchpress.cloud` is set, so `frontend` is the site
benchpress.cloud serves.

`frontend` carries no `allow_tests`, so `run-tests` refuses it — but only after the
runner has disabled that site's scheduler, from a value it holds in memory and
restores on a clean exit. A site with the scheduler off composes mail and never
sends it, with nothing in any log to say so. An interrupted iteration is normal in
a loop, which made that likely rather than possible. The `migrate` line ran,
against production.

## What changed

| File | Change |
|---|---|
| `scripts/prompt.md` | `run-tests` and `migrate` name `bp_test_site`. The browser section says to read `PUBLIC_HOSTNAME` first. |
| `scripts/ralph.sh` | `BP_TEST_URL` and `BP_TEST_PASSWORD` lose their defaults. |
| `CLAUDE.md` | The Everyday commands `run-tests` line names `bp_test_site`. |
| `.claude/skills/issue-to-phases/{SKILL.md,assets/prompt.md.template,references/ralph-loop.md}` | The same lines, in the templates that regenerate the loop. |
| `benchpress/tests/test_runner_targets.py` | New. Scans the seven files an agent reads. |

Three things beyond the issue's three bullets, each with a reason:

**`CLAUDE.md` is a runner file.** `scripts/ralph.sh:52` does `cd "$REPO"` before
invoking `claude`, so `apps/benchpress/CLAUDE.md` is auto-loaded every iteration —
the highest-precedence instruction the runner reads. Its Everyday commands carried
the same `run-tests --site frontend` line, contradicting its own
`.agents/prompts/00_app_context.md:97`. The `migrate` line there is unchanged:
migrating your own site is what a person does.

**The browser targets.** The section sent every write to `http://localhost:8080`.
With `PUBLIC_HOSTNAME` set, the prod overlay moves nginx to loopback and Traefik
serves the same site on 443 — `docker compose ps` shows `frontend` on
`127.0.0.1:8080`. That port was production, so "use this for anything that writes"
was the same defect in a second place.

**The skill templates.** `assets/prompt.md.template` carried the `--site frontend`
line and would have written it into the next generated loop.

## Scheduler rows

`Scheduled Job Type` is a per-site table, so migrating `bp_test_site` repairs that
site alone and the deployment's rows wait for the deploy migrate. The three files
explaining the migrate-then-restart order say so now, rather than keeping a
rationale that no longer holds.

## The guard test

`BENCH_ON_FRONTEND` matches a bench invocation, not prose, so the rule can still be
stated in words — the files say "Never `--site frontend`" and the test passes.
Verified against 11 evasions (`--site=frontend`, an intervening flag, quoting,
line continuation) and 9 legitimate strings, and confirmed red against
`origin/version-16`: it catches all eight removed lines.

## Verification

- `uvx pre-commit@4.3.0 run --all-files` — passes.
- New module: 6 tests green, and confirmed discovered by Frappe's own runner.
- No runtime Python changes: the diff is instructions, plus one stdlib-only test.

The whole-suite state is reported in #356 — it is red on `version-16` before this
branch, for reasons unrelated to it.

Left for #357: `docs/reference/cli-and-scripts.mdx:60` carries the same `run-tests`
line and needs `docs-site/` and `docs-bundle/` regenerated with it.
