### PR TITLE
docs(commands): name bp_test_site in the two run-tests examples

### DIFF
--- a/.agents/prompts/00_app_context.md
+++ b/.agents/prompts/00_app_context.md
@@ -68,8 +68,6 @@ else runs, with somebody else's benches on it?**
 - The SPA holds **zero** `AbortController` uses, so no in-flight request is ever cancelled.
 - `CLAUDE.md:232` still says to branch from `develop`; `CONTRIBUTING.md:70-72` records that
   `develop` was abandoned at the 0.1.0 release. `version-16` is the only trunk.
-- `CLAUDE.md:208` names `--site frontend` in a `run-tests` command — that site has no
-  `allow_tests` and an interrupted run leaves its scheduler off, which silently stops all mail.
 - `CLAUDE.md:59` counts eight public pages; `benchpress/www/vs/` has held three comparison pages
   since `e6e8d32`, so the count and the routing table under it are both short.
 

--- a/.claude/skills/issue-to-phases/SKILL.md
+++ b/.claude/skills/issue-to-phases/SKILL.md
@@ -207,7 +207,7 @@ completed.
   Frappe resolves scheduled and enqueued jobs from strings at run time, so moving
   a function they name breaks them while every import still works. Rewrite every
   string in the same commit, run
-  `docker compose exec backend bench --site frontend migrate`, and restart the
+  `docker compose exec backend bench --site bp_test_site migrate`, and restart the
   workers **after** — the other order leaves a `Scheduled Job Type` row pointing
   at nothing, and that fails in complete silence. Job ids never change during a
   move, and a re-export shim is not a fallback: see

--- a/.claude/skills/issue-to-phases/assets/prompt.md.template
+++ b/.claude/skills/issue-to-phases/assets/prompt.md.template
@@ -227,7 +227,8 @@ End the phase in this order, and do not reorder it:
 1. Rewrite **every** string in the same commit as the move: call sites,
    `hooks.py`, docstrings, tracked `.md`, and the test assertions naming the path.
    `git grep '<old.dotted.path>'` must come back empty.
-2. `docker compose exec backend bench --site frontend migrate`
+2. `docker compose exec backend bench --site bp_test_site migrate` — never
+   `--site frontend`, which is the deployment's own site
 3. `docker compose restart backend queue-long queue-short scheduler websocket`
 
 Before step 3, poll `queue-long` for at most 120 seconds, then go ahead anyway and

--- a/.claude/skills/issue-to-phases/references/ralph-loop.md
+++ b/.claude/skills/issue-to-phases/references/ralph-loop.md
@@ -160,10 +160,19 @@ drops first when it is concentrating on code, and a shipped feature filed under
 `{{TEST_CMD}}` names the test modules the phase touches, one line each:
 
 ```bash
-docker compose exec backend bench --site frontend run-tests --module benchpress.tests.test_deploy_manager
+docker compose exec backend bench --site bp_test_site run-tests --module benchpress.tests.test_deploy_manager
 ```
 
-Two rules, and each one has cost a real run.
+Three rules, and each one has cost a real run.
+
+**Never `--site frontend`.** `frontend` is the deployment's own site, and on a
+public host it is the one the world reads. It carries no `allow_tests`, so the
+runner refuses it, and the refusal comes after the runner has already disabled
+its scheduler from a value it holds in memory and restores only on a clean exit.
+A site with the scheduler off composes mail and never sends it, with nothing in
+any log to say so. An interrupted iteration is normal in a loop, not
+exceptional, which turns a possible failure into a likely one. Name
+`bp_test_site` locally and `test_site` in CI.
 
 **Never `--app benchpress`.** The whole suite is CI's job. It takes 60 seconds
 against the live site and does not repeat. Three runs of the same tree gave
@@ -229,7 +238,8 @@ stopped.
 1. **Move the code and rewrite every string in the same commit** — call sites,
    `hooks.py`, docstrings, tracked `.md`, and the test assertions that name the
    path. A forgotten test assertion fails loudly, which is the cheapest gate here.
-2. **`docker compose exec backend bench --site frontend migrate`.**
+2. **`docker compose exec backend bench --site bp_test_site migrate`.** Migrating
+   `frontend` is a deploy step a person runs by hand, never part of a loop.
 3. **`docker compose restart backend queue-long queue-short scheduler websocket`.**
 
 Step 2 before step 3 is a rule, not a preference. `migrate` calls `sync_jobs()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,7 @@ surface uses those tokens and never a raw hex value.
 
 ```bash
 docker compose exec backend bench --site frontend migrate
-docker compose exec backend bench --site frontend run-tests --app benchpress
+docker compose exec backend bench --site bp_test_site run-tests --app benchpress
 docker compose exec backend bench build --app benchpress   # after frontend changes, then:
 docker compose restart backend frontend
 
@@ -216,6 +216,14 @@ cd e2e && npx playwright test  # has its own config — running from the app roo
 
 npm run docs:build && npm run docs:lint && npm run docs:score && npm run docs:links
 ```
+
+**Never name `frontend` in a `run-tests` command.** That site carries no
+`allow_tests`, so the runner refuses it — but only after disabling its scheduler
+from a value it holds in memory and restores on a clean exit. A site with the
+scheduler off composes mail and never sends it, and no log says so.
+`bp_test_site` is the site that exists to be tested; CI uses `test_site`. The
+`migrate` line above is right as it stands: migrating your own site is what a
+person does.
 
 ## Documentation source
 

--- a/benchpress/tests/test_runner_targets.py
+++ b/benchpress/tests/test_runner_targets.py
@@ -30,20 +30,30 @@ RUNNER_FILES = (
 	".claude/skills/issue-to-phases/references/ralph-loop.md",
 )
 
+# What a person reads before typing a command. `CLAUDE.md` is loaded by every agent session
+# and the reference page is published, so a self-hoster runs what it prints.
+DOC_FILES = (
+	"CLAUDE.md",
+	"docs/reference/cli-and-scripts.mdx",
+)
+
 BENCH_ON_FRONTEND = re.compile(r"bench\s+--site\s+frontend\b")
+
+# A person migrates, clears and inspects their own site; only the test command is wrong here.
+RUN_TESTS_ON_FRONTEND = re.compile(r"bench\s+--site\s+frontend\s+run-tests\b")
 
 # `${BP_TEST_URL:-https://...}` and `${BP_TEST_PASSWORD:-admin}`, but not the empty
 # `${BP_TEST_URL:-}` the guard reads with.
 CREDENTIAL_DEFAULT = re.compile(r"\$\{(BP_TEST_URL|BP_TEST_PASSWORD):[-=][^}]")
 
 
-def _present() -> list[Path]:
-	return [REPO / name for name in RUNNER_FILES if (REPO / name).exists()]
+def _present(names: tuple[str, ...]) -> list[Path]:
+	return [REPO / name for name in names if (REPO / name).exists()]
 
 
-def _hits(pattern: re.Pattern) -> list[str]:
+def _hits(pattern: re.Pattern, names: tuple[str, ...]) -> list[str]:
 	found = []
-	for path in _present():
+	for path in _present(names):
 		for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
 			if pattern.search(line):
 				found.append(f"{path.relative_to(REPO)}:{number}: {line.strip()}")
@@ -51,12 +61,16 @@ def _hits(pattern: re.Pattern) -> list[str]:
 
 
 class TestRunnerTargets(unittest.TestCase):
-	def test_the_runner_surface_is_all_present(self):
+	def test_the_scanned_surface_is_all_present(self):
 		"""A renamed file would make every other assertion here vacuous."""
-		self.assertEqual(len(_present()), len(RUNNER_FILES))
+		names = RUNNER_FILES + DOC_FILES
+		self.assertEqual(len(_present(names)), len(names))
 
 	def test_no_runner_instruction_names_the_deployment_site(self):
-		self.assertEqual(_hits(BENCH_ON_FRONTEND), [], "a runner is pointed at `frontend`")
+		self.assertEqual(_hits(BENCH_ON_FRONTEND, RUNNER_FILES), [], "a runner is pointed at `frontend`")
+
+	def test_no_document_offers_a_test_command_on_the_deployment_site(self):
+		self.assertEqual(_hits(RUN_TESTS_ON_FRONTEND, DOC_FILES), [], "a document tests `frontend`")
 
 	def test_the_runner_names_the_test_site(self):
 		"""`assertIn` would print the whole prompt into a log a loop has to read."""
@@ -67,4 +81,6 @@ class TestRunnerTargets(unittest.TestCase):
 		)
 
 	def test_the_browser_credentials_carry_no_default(self):
-		self.assertEqual(_hits(CREDENTIAL_DEFAULT), [], "a browser credential still has a default")
+		self.assertEqual(
+			_hits(CREDENTIAL_DEFAULT, RUNNER_FILES), [], "a browser credential still has a default"
+		)

--- a/benchpress/tests/test_runner_targets.py
+++ b/benchpress/tests/test_runner_targets.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, Venkatesh and Contributors
+# See license.txt
+
+"""What an unattended loop is told to run against, and what it is told to sign in with.
+
+`frontend` is the deployment's own site. It carries no `allow_tests`, so `run-tests` refuses
+it — but only after disabling its scheduler from a value the runner holds in memory and
+restores on a clean exit. A site with the scheduler off composes mail and never sends it,
+silently. An interrupted iteration is normal in a loop, so the refusal is the likely outcome,
+not the exceptional one. The instructions are read fresh every iteration, which is why a scan
+of them is the test.
+
+The prose in these files names `--site frontend` to forbid it; the patterns match a bench
+invocation, so a prohibition reads as one.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+# Every file an unattended runner reads, and the two templates that generate them.
+RUNNER_FILES = (
+	"scripts/prompt.md",
+	"scripts/ralph.sh",
+	".claude/skills/issue-to-phases/SKILL.md",
+	".claude/skills/issue-to-phases/assets/prompt.md.template",
+	".claude/skills/issue-to-phases/assets/ralph.sh.template",
+	".claude/skills/issue-to-phases/references/ralph-loop.md",
+)
+
+BENCH_ON_FRONTEND = re.compile(r"bench\s+--site\s+frontend\b")
+
+# `${BP_TEST_URL:-https://...}` and `${BP_TEST_PASSWORD:-admin}`, but not the empty
+# `${BP_TEST_URL:-}` the guard reads with.
+CREDENTIAL_DEFAULT = re.compile(r"\$\{(BP_TEST_URL|BP_TEST_PASSWORD):[-=][^}]")
+
+
+def _present() -> list[Path]:
+	return [REPO / name for name in RUNNER_FILES if (REPO / name).exists()]
+
+
+def _hits(pattern: re.Pattern) -> list[str]:
+	found = []
+	for path in _present():
+		for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+			if pattern.search(line):
+				found.append(f"{path.relative_to(REPO)}:{number}: {line.strip()}")
+	return found
+
+
+class TestRunnerTargets(unittest.TestCase):
+	def test_the_runner_surface_is_all_present(self):
+		"""A renamed file would make every other assertion here vacuous."""
+		self.assertEqual(len(_present()), len(RUNNER_FILES))
+
+	def test_no_runner_instruction_names_the_deployment_site(self):
+		self.assertEqual(_hits(BENCH_ON_FRONTEND), [], "a runner is pointed at `frontend`")
+
+	def test_the_runner_names_the_test_site(self):
+		"""`assertIn` would print the whole prompt into a log a loop has to read."""
+		prompt = (REPO / "scripts/prompt.md").read_text(encoding="utf-8")
+		self.assertTrue(
+			"bench --site bp_test_site run-tests" in prompt,
+			"scripts/prompt.md names no test site for `run-tests`",
+		)
+
+	def test_the_browser_credentials_carry_no_default(self):
+		self.assertEqual(_hits(CREDENTIAL_DEFAULT), [], "a browser credential still has a default")

--- a/docs-bundle/docs/reference/api.md
+++ b/docs-bundle/docs/reference/api.md
@@ -2,7 +2,7 @@
 title: API
 description: Every whitelisted BenchPress endpoint, with arguments, what each
   returns, and the permission check each one makes for itself.
-lastModified: "2026-08-30T17:48:34+05:30"
+lastModified: "2026-09-01T18:06:47+05:30"
 lastAuthor: Venkatesh
 ---
 # API

--- a/docs-bundle/docs/reference/cli-and-scripts.md
+++ b/docs-bundle/docs/reference/cli-and-scripts.md
@@ -3,7 +3,7 @@ title: CLI and scripts
 description: Every command that drives BenchPress from a shell — entry.py, the
   bench commands, setup.sh and upgrade.sh, the four repository scripts and the
   documentation pipeline.
-lastModified: "2026-08-31T14:24:45-04:00"
+lastModified: "2026-09-05T14:27:54-04:00"
 lastAuthor: Venkatesh
 ---
 # CLI and scripts
@@ -60,13 +60,20 @@ Ordinary Frappe commands, run inside the `backend` container.
 docker compose exec backend bench --site frontend migrate
 docker compose exec backend bench --site frontend clear-cache
 docker compose exec backend bench --site frontend console
-docker compose exec backend bench --site frontend run-tests --app benchpress
+docker compose exec backend bench --site bp_test_site run-tests --app benchpress
 docker compose exec backend bench build --app benchpress
 ```
 
 After a Python change, restart `backend` and any worker that imports the
 changed module. After a frontend change, run `bench build --app benchpress`,
 then restart `backend` and `frontend`.
+
+**Never name `frontend` in a `run-tests` command.** That site carries no
+`allow_tests`, so the runner refuses it — but only after disabling its scheduler
+from a value it holds in memory and restores on a clean exit. A site with the
+scheduler off composes mail and never sends it, and no log says so. Test against
+a site created for it, such as `bp_test_site`. Every other command above names
+`frontend` correctly: that is your own site.
 
 **A multi-line block piped to `bench console` fails silently.** The console is
 IPython. A block arriving on a pipe is auto-indented until it no longer parses,

--- a/docs-bundle/docs/reference/configuration.md
+++ b/docs-bundle/docs/reference/configuration.md
@@ -3,7 +3,7 @@ title: Configuration
 description: Where each BenchPress setting lives — build arguments that need a
   rebuild, runtime environment that needs a restart, and DocType fields that
   apply on save.
-lastModified: "2026-09-01T13:47:42-04:00"
+lastModified: "2026-09-02T00:09:08+05:30"
 lastAuthor: Venkatesh
 ---
 # Configuration

--- a/docs-bundle/docs/reference/data-model.md
+++ b/docs-bundle/docs/reference/data-model.md
@@ -2,7 +2,7 @@
 title: Data model
 description: All 20 BenchPress DocTypes with their fields, links, naming and the
   permission rule that scopes each one — plus why there is no Device DocType.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-09-01T18:06:47+05:30"
 lastAuthor: Venkatesh
 ---
 # Data model

--- a/docs-site/.well-known/llms-full.txt
+++ b/docs-site/.well-known/llms-full.txt
@@ -7119,13 +7119,20 @@ Ordinary Frappe commands, run inside the `backend` container.
 docker compose exec backend bench --site frontend migrate
 docker compose exec backend bench --site frontend clear-cache
 docker compose exec backend bench --site frontend console
-docker compose exec backend bench --site frontend run-tests --app benchpress
+docker compose exec backend bench --site bp_test_site run-tests --app benchpress
 docker compose exec backend bench build --app benchpress
 ```
 
 After a Python change, restart `backend` and any worker that imports the
 changed module. After a frontend change, run `bench build --app benchpress`,
 then restart `backend` and `frontend`.
+
+**Never name `frontend` in a `run-tests` command.** That site carries no
+`allow_tests`, so the runner refuses it — but only after disabling its scheduler
+from a value it holds in memory and restores on a clean exit. A site with the
+scheduler off composes mail and never sends it, and no log says so. Test against
+a site created for it, such as `bp_test_site`. Every other command above names
+`frontend` correctly: that is your own site.
 
 **A multi-line block piped to `bench console` fails silently.** The console is
 IPython. A block arriving on a pipe is auto-indented until it no longer parses,

--- a/docs-site/docs/reference/api.md
+++ b/docs-site/docs/reference/api.md
@@ -2,7 +2,7 @@
 title: API
 description: Every whitelisted BenchPress endpoint, with arguments, what each
   returns, and the permission check each one makes for itself.
-lastModified: "2026-08-30T17:48:34+05:30"
+lastModified: "2026-09-01T18:06:47+05:30"
 lastAuthor: Venkatesh
 ---
 # API

--- a/docs-site/docs/reference/cli-and-scripts.md
+++ b/docs-site/docs/reference/cli-and-scripts.md
@@ -3,7 +3,7 @@ title: CLI and scripts
 description: Every command that drives BenchPress from a shell — entry.py, the
   bench commands, setup.sh and upgrade.sh, the four repository scripts and the
   documentation pipeline.
-lastModified: "2026-08-31T14:24:45-04:00"
+lastModified: "2026-09-05T14:27:54-04:00"
 lastAuthor: Venkatesh
 ---
 # CLI and scripts
@@ -60,13 +60,20 @@ Ordinary Frappe commands, run inside the `backend` container.
 docker compose exec backend bench --site frontend migrate
 docker compose exec backend bench --site frontend clear-cache
 docker compose exec backend bench --site frontend console
-docker compose exec backend bench --site frontend run-tests --app benchpress
+docker compose exec backend bench --site bp_test_site run-tests --app benchpress
 docker compose exec backend bench build --app benchpress
 ```
 
 After a Python change, restart `backend` and any worker that imports the
 changed module. After a frontend change, run `bench build --app benchpress`,
 then restart `backend` and `frontend`.
+
+**Never name `frontend` in a `run-tests` command.** That site carries no
+`allow_tests`, so the runner refuses it — but only after disabling its scheduler
+from a value it holds in memory and restores on a clean exit. A site with the
+scheduler off composes mail and never sends it, and no log says so. Test against
+a site created for it, such as `bp_test_site`. Every other command above names
+`frontend` correctly: that is your own site.
 
 **A multi-line block piped to `bench console` fails silently.** The console is
 IPython. A block arriving on a pipe is auto-indented until it no longer parses,

--- a/docs-site/docs/reference/configuration.md
+++ b/docs-site/docs/reference/configuration.md
@@ -3,7 +3,7 @@ title: Configuration
 description: Where each BenchPress setting lives — build arguments that need a
   rebuild, runtime environment that needs a restart, and DocType fields that
   apply on save.
-lastModified: "2026-09-01T13:47:42-04:00"
+lastModified: "2026-09-02T00:09:08+05:30"
 lastAuthor: Venkatesh
 ---
 # Configuration

--- a/docs-site/docs/reference/data-model.md
+++ b/docs-site/docs/reference/data-model.md
@@ -2,7 +2,7 @@
 title: Data model
 description: All 20 BenchPress DocTypes with their fields, links, naming and the
   permission rule that scopes each one — plus why there is no Device DocType.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-09-01T18:06:47+05:30"
 lastAuthor: Venkatesh
 ---
 # Data model

--- a/docs-site/llms-full.txt
+++ b/docs-site/llms-full.txt
@@ -7119,13 +7119,20 @@ Ordinary Frappe commands, run inside the `backend` container.
 docker compose exec backend bench --site frontend migrate
 docker compose exec backend bench --site frontend clear-cache
 docker compose exec backend bench --site frontend console
-docker compose exec backend bench --site frontend run-tests --app benchpress
+docker compose exec backend bench --site bp_test_site run-tests --app benchpress
 docker compose exec backend bench build --app benchpress
 ```
 
 After a Python change, restart `backend` and any worker that imports the
 changed module. After a frontend change, run `bench build --app benchpress`,
 then restart `backend` and `frontend`.
+
+**Never name `frontend` in a `run-tests` command.** That site carries no
+`allow_tests`, so the runner refuses it — but only after disabling its scheduler
+from a value it holds in memory and restores on a clean exit. A site with the
+scheduler off composes mail and never sends it, and no log says so. Test against
+a site created for it, such as `bp_test_site`. Every other command above names
+`frontend` correctly: that is your own site.
 
 **A multi-line block piped to `bench console` fails silently.** The console is
 IPython. A block arriving on a pipe is auto-indented until it no longer parses,

--- a/docs-site/sitemap.xml
+++ b/docs-site/sitemap.xml
@@ -122,11 +122,11 @@
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/reference/data-model</loc>
-    <lastmod>2026-08-28T16:40:21.000Z</lastmod>
+    <lastmod>2026-09-01T12:36:47.000Z</lastmod>
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/reference/api</loc>
-    <lastmod>2026-08-30T12:18:34.000Z</lastmod>
+    <lastmod>2026-09-01T12:36:47.000Z</lastmod>
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/reference/deploy-pipeline</loc>
@@ -146,11 +146,11 @@
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/reference/configuration</loc>
-    <lastmod>2026-09-01T17:47:42.000Z</lastmod>
+    <lastmod>2026-09-01T18:39:08.000Z</lastmod>
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/reference/cli-and-scripts</loc>
-    <lastmod>2026-08-31T18:24:45.000Z</lastmod>
+    <lastmod>2026-09-05T18:27:54.000Z</lastmod>
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/reference/glossary</loc>

--- a/docs/reference/cli-and-scripts.mdx
+++ b/docs/reference/cli-and-scripts.mdx
@@ -57,13 +57,20 @@ Ordinary Frappe commands, run inside the `backend` container.
 docker compose exec backend bench --site frontend migrate
 docker compose exec backend bench --site frontend clear-cache
 docker compose exec backend bench --site frontend console
-docker compose exec backend bench --site frontend run-tests --app benchpress
+docker compose exec backend bench --site bp_test_site run-tests --app benchpress
 docker compose exec backend bench build --app benchpress
 ```
 
 After a Python change, restart `backend` and any worker that imports the
 changed module. After a frontend change, run `bench build --app benchpress`,
 then restart `backend` and `frontend`.
+
+**Never name `frontend` in a `run-tests` command.** That site carries no
+`allow_tests`, so the runner refuses it — but only after disabling its scheduler
+from a value it holds in memory and restores on a clean exit. A site with the
+scheduler off composes mail and never sends it, and no log says so. Test against
+a site created for it, such as `bp_test_site`. Every other command above names
+`frontend` correctly: that is your own site.
 
 **A multi-line block piped to `bench console` fails silently.** The console is
 IPython. A block arriving on a pipe is auto-indented until it no longer parses,

--- a/scripts/prompt.md
+++ b/scripts/prompt.md
@@ -58,13 +58,18 @@ bundle at seam one instead.
 
 - Bench commands run inside the parent compose stack, not a standalone bench. From
   `/home/ubuntu/benchpress_devops` use `docker compose exec -T backend bench ...`.
-- One module while working:
-  `bench --site frontend run-tests --app benchpress --module <module.path>`.
+- The test site is `bp_test_site`. One module while working:
+  `bench --site bp_test_site run-tests --app benchpress --module <module.path>`.
   Whole app suite once before you commit: `... run-tests --app benchpress`.
+- **Never name `frontend` in a `run-tests` command.** It carries no `allow_tests`, so the runner
+  refuses it, and an interrupted run leaves its scheduler off from a value the runner held in
+  memory. A site with the scheduler off composes mail and never sends it, with nothing in any log
+  to say so. An interrupted iteration is normal in this loop, not exceptional.
 - Frontend changes need `bench build --app benchpress`, then restart backend and frontend.
-  Schema changes need `bench --site frontend migrate`.
-- The local site has this branch migrated and seeded, so the schema is real and every seam runs
-  locally.
+  Schema changes need `bench --site bp_test_site migrate`. Migrating `frontend` is a deploy step a
+  person runs by hand; it is not part of this loop.
+- `bp_test_site` has this branch migrated and seeded, and carries `benchpress_public_site`, so the
+  schema is real and every seam runs locally.
 - Query with `frappe.qb`, never raw SQL. Every whitelisted method checks permissions itself.
 - Behaviour lives in doctype controllers and `hooks.py` as often as in the obvious module. Read
   `hooks.py` before assuming a save does the plain thing.
@@ -75,13 +80,20 @@ A rendering test cannot see a broken layout, a header that overflows on a phone,
 stopped submitting. Any issue that changes what a page looks like or how it behaves must be checked
 in a real browser before you commit. Use the `agent-browser` skill.
 
-1. **The local stack, `http://localhost:8080`** — the port is `PORT` in
-   `/home/ubuntu/benchpress_devops/.env`. It runs this branch against real, migrated schema. Sign
-   in as `Administrator` with `ADMIN_PASSWORD` from that same file. **Use this for anything that
-   writes**: submitting a form, signing in or out, creating a user, editing in Desk.
-2. **The deployed branch instance, `$BP_TEST_URL`**, defaulting to
-   `https://b3873df7.benchpress.cloud`, signing in as `Administrator` with `$BP_TEST_PASSWORD`,
-   defaulting to `admin`. Use it to see a change against deployed data.
+Read `PUBLIC_HOSTNAME` in `/home/ubuntu/benchpress_devops/.env` before you open anything. That one
+key turns the checkout into a public deployment, and nginx serves the same `frontend` site on
+loopback that Traefik serves on 443. Where it is set there is no writable browser target, because
+`bp_test_site` is not published: check read-only, and say in the issue comment what you could not
+exercise.
+
+1. **The local stack, `http://localhost:8080`** — the port is `PORT` in that same file. It runs
+   this branch against real, migrated schema. Sign in as `Administrator` with `ADMIN_PASSWORD`
+   from that file. Use it for anything that writes — submitting a form, signing in or out,
+   creating a user, editing in Desk — **only while `PUBLIC_HOSTNAME` is unset**. Where it is set,
+   this port is production.
+2. **A deployed branch instance, `$BP_TEST_URL`**, signing in as `Administrator` with
+   `$BP_TEST_PASSWORD`. Use it to see a change against deployed data. Both are unset by default;
+   skip this check when they are.
 3. **Production, `https://benchpress.cloud`** — **read-only, always**. Never submit a form there,
    never sign in, never create or edit a record.
 

--- a/scripts/ralph.sh
+++ b/scripts/ralph.sh
@@ -12,9 +12,12 @@ set -e
 
 export IS_SANDBOX=1
 
-# Browser checks. Writes belong on the local stack; production is read-only.
-export BP_TEST_URL=${BP_TEST_URL:-https://b3873df7.benchpress.cloud}
-export BP_TEST_PASSWORD=${BP_TEST_PASSWORD:-admin}
+# Optional browser check against a deployed branch instance. No defaults: the
+# pair used to name a live host and the password `admin`.
+if [[ -n "${BP_TEST_URL:-}" ]]; then
+  : "${BP_TEST_PASSWORD:?BP_TEST_URL is set, so BP_TEST_PASSWORD must be set too}"
+  export BP_TEST_URL BP_TEST_PASSWORD
+fi
 
 ITERATIONS=${1:-20}
 REPO=/home/ubuntu/benchpress_devops/apps/benchpress


### PR DESCRIPTION
Closes #357. Stacked on #358, which added the guard test this change grows.
Review that one first, and set the base of this one to `version-16` after it merges.

`CLAUDE.md` is loaded by every agent session, and
`docs/reference/cli-and-scripts.mdx` is published. Both printed a `run-tests`
command against `frontend`, the deployment's own site.

`frontend` carries no `allow_tests`, so the runner refuses it — after it
disables that site's scheduler, from a value it holds in memory and restores
only on a clean exit. A site with the scheduler off composes mail and never
sends it, and no log says so.

## What changed

- Both lines name `bp_test_site`, and each file states the rule in words beside
  the block.
- `benchpress/tests/test_runner_targets.py` grows a second file set.
  `RUNNER_FILES` may name no site but `bp_test_site` in any bench command.
  `DOC_FILES` may name `frontend` in every command except `run-tests` — a
  person migrates, clears and inspects their own site.
- The `migrate` and `console` lines beside the changed one stay on `frontend`,
  as the issue asks.
- `.agents/prompts/00_app_context.md` loses the known-defect bullet for this.
- `docs-site/` and `docs-bundle/` are regenerated, in their own commit and after
  the source commit, so the `lastModified` stamps are the ones CI reproduces.
  Three unrelated pages carried a stamp older than the commit that last touched
  their source, so the drift check was already going to fail on the next docs
  job.

## Verification

- `python3 -m unittest benchpress.tests.test_runner_targets` — 5 tests, and the
  new one was written first. It failed naming both lines, and passes now.
- `uvx pre-commit@4.3.0 run --files ...` — clean.
- `npm run docs:lint` (41 files), `docs:score` (100/100), `docs:links` (90
  generated files). A second `rm -rf docs-site docs-bundle && npm run docs:build`
  leaves the tree clean, so the drift check has nothing to report.