### PR TITLE
docs(commands): stop the published CLI page testing the deployment site

### DIFF
--- a/.agents/prompts/00_app_context.md
+++ b/.agents/prompts/00_app_context.md
@@ -66,10 +66,8 @@ else runs, with somebody else's benches on it?**
 - 56 `frappe.get_all(` / `frappe.get_list(` call sites declare no `limit`; a few are deliberate and
   say so, as at `api.py:485-487`, and the rest are simply unbounded.
 - The SPA holds **zero** `AbortController` uses, so no in-flight request is ever cancelled.
-- `CLAUDE.md:232` still says to branch from `develop`; `CONTRIBUTING.md:70-72` records that
+- `CLAUDE.md:241` still says to branch from `develop`; `CONTRIBUTING.md:70-72` records that
   `develop` was abandoned at the 0.1.0 release. `version-16` is the only trunk.
-- `CLAUDE.md:208` names `--site frontend` in a `run-tests` command — that site has no
-  `allow_tests` and an interrupted run leaves its scheduler off, which silently stops all mail.
 - `CLAUDE.md:59` counts eight public pages; `benchpress/www/vs/` has held three comparison pages
   since `e6e8d32`, so the count and the routing table under it are both short.
 

--- a/.agents/prompts/05_verification_gates.md
+++ b/.agents/prompts/05_verification_gates.md
@@ -75,7 +75,7 @@ actually run that one?**
 
 - `version-16` is the only trunk. Benchpress branches from it and targets it — `main` and `develop`
   were abandoned at the 0.1.0 release, as `CONTRIBUTING.md:70-72` records, whatever
-  `CLAUDE.md:232` still says.
+  `CLAUDE.md:241` still says.
 - A branch takes its commit type as a prefix: `feat/<name>`, `fix/<name>`, `docs/<name>`,
   `refactor/<name>`, `test/<name>`, `chore/<name>`.
 - Conventional Commits are the rule and nothing enforces them — 51 of the last 200 non-merge

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,15 @@ cd e2e && npx playwright test  # has its own config — running from the app roo
 npm run docs:build && npm run docs:lint && npm run docs:score && npm run docs:links
 ```
 
+**Never name `frontend` in a `run-tests` command.** That site carries no
+`allow_tests`, so the runner refuses it. It refuses after it disables that
+site's scheduler. The runner holds the old value in memory and puts it back only
+on a clean exit. A site with the scheduler off composes mail and never sends it,
+and no log says so.
+`bp_test_site` is the site that exists to be tested. CI uses `test_site`. The
+`migrate` line above is right as it stands. Migrating your own site is what a
+person does.
+
 ## Documentation source
 
 `docs/**/*.mdx` is the source; `docs-site/` and `docs-bundle/` are generated and

--- a/benchpress/tests/test_runner_targets.py
+++ b/benchpress/tests/test_runner_targets.py
@@ -34,11 +34,23 @@ LOOP_FILES = (
 	".claude/skills/issue-to-phases/references/ralph-loop.md",
 )
 
+# What a person reads before typing a command. `docs/reference/cli-and-scripts.mdx` is
+# published, so a self-hoster runs what it prints.
+DOC_FILES = (
+	CLAUDE_MD,
+	"docs/reference/cli-and-scripts.mdx",
+	"README.md",
+	"CONTRIBUTING.md",
+)
+
 ON_FRONTEND = r"""(?:^|\s)--site[= ]["']?frontend\b"""
+
+# `run-parallel-tests` and `run-ui-tests` disable the scheduler the same way `run-tests` does.
+ANY_TEST_COMMAND = r".*\brun-[\w-]*tests\b"
 
 # Testing the deployment site is wrong everywhere. Migrating it is what a person does on
 # deploy, so only the loop is forbidden to name it.
-RUN_TESTS_ON_FRONTEND = re.compile(ON_FRONTEND + r".*\brun-tests\b")
+RUN_TESTS_ON_FRONTEND = re.compile(ON_FRONTEND + ANY_TEST_COMMAND)
 BENCH_ON_FRONTEND = re.compile(ON_FRONTEND)
 
 # Any value for either name, except the empty `${BP_TEST_URL:-}` the guard reads with.
@@ -49,13 +61,25 @@ def _missing(names: tuple[str, ...]) -> list[str]:
 	return [name for name in names if not (REPO / name).exists()]
 
 
+def _commands(text: str) -> list[tuple[int, str]]:
+	"""A command wrapped over a backslash is one line to a shell, so it is one line here."""
+	lines = []
+	for number, line in enumerate(text.splitlines(), 1):
+		if lines and lines[-1][1].endswith("\\"):
+			start, held = lines[-1]
+			lines[-1] = (start, f"{held[:-1]} {line.strip()}")
+		else:
+			lines.append((number, line))
+	return lines
+
+
 def _hits(pattern: re.Pattern, names: tuple[str, ...]) -> list[str]:
 	found = []
 	for name in names:
 		path = REPO / name
 		if not path.exists():
 			continue
-		for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+		for number, line in _commands(path.read_text(encoding="utf-8")):
 			if pattern.search(line):
 				found.append(f"{name}:{number}: {line.strip()}")
 	return found
@@ -64,13 +88,13 @@ def _hits(pattern: re.Pattern, names: tuple[str, ...]) -> list[str]:
 class TestRunnerTargets(unittest.TestCase):
 	def test_every_runner_file_is_where_the_scan_looks(self):
 		"""A renamed file would make every other assertion here vacuous."""
-		self.assertEqual(_missing((*LOOP_FILES, CLAUDE_MD)), [])
+		self.assertEqual(_missing((*LOOP_FILES, *DOC_FILES)), [])
 
 	def test_no_runner_instruction_names_the_deployment_site(self):
 		self.assertEqual(_hits(BENCH_ON_FRONTEND, LOOP_FILES), [], "a loop is pointed at `frontend`")
 
 	def test_nothing_an_agent_reads_tests_the_deployment_site(self):
-		self.assertEqual(_hits(RUN_TESTS_ON_FRONTEND, (*LOOP_FILES, CLAUDE_MD)), [])
+		self.assertEqual(_hits(RUN_TESTS_ON_FRONTEND, (*LOOP_FILES, *DOC_FILES)), [])
 
 	def test_the_loop_names_the_test_site_for_both_commands(self):
 		"""`assertIn` would print the whole prompt into a log a loop has to read."""

--- a/docs-bundle/docs/reference/api.md
+++ b/docs-bundle/docs/reference/api.md
@@ -2,7 +2,7 @@
 title: API
 description: Every whitelisted BenchPress endpoint, with arguments, what each
   returns, and the permission check each one makes for itself.
-lastModified: "2026-08-30T17:48:34+05:30"
+lastModified: "2026-09-01T18:06:47+05:30"
 lastAuthor: Venkatesh
 ---
 # API

--- a/docs-bundle/docs/reference/cli-and-scripts.md
+++ b/docs-bundle/docs/reference/cli-and-scripts.md
@@ -3,7 +3,7 @@ title: CLI and scripts
 description: Every command that drives BenchPress from a shell — entry.py, the
   bench commands, setup.sh and upgrade.sh, the four repository scripts and the
   documentation pipeline.
-lastModified: "2026-08-31T14:24:45-04:00"
+lastModified: "2026-09-05T14:27:54-04:00"
 lastAuthor: Venkatesh
 ---
 # CLI and scripts
@@ -60,13 +60,24 @@ Ordinary Frappe commands, run inside the `backend` container.
 docker compose exec backend bench --site frontend migrate
 docker compose exec backend bench --site frontend clear-cache
 docker compose exec backend bench --site frontend console
-docker compose exec backend bench --site frontend run-tests --app benchpress
+docker compose exec backend bench --site bp_test_site run-tests --app benchpress
 docker compose exec backend bench build --app benchpress
 ```
 
 After a Python change, restart `backend` and any worker that imports the
 changed module. After a frontend change, run `bench build --app benchpress`,
 then restart `backend` and `frontend`.
+
+**Never name `frontend` in a `run-tests` command.** That site carries no
+`allow_tests`, so the runner refuses it. It refuses after it disables that
+site's scheduler. The runner holds the old value in memory and puts it back only
+on a clean exit. A site with the scheduler off composes mail and never sends it,
+and no log says so.
+
+Test against a site made for it, such as `bp_test_site`. Create one with
+`bench new-site`, then set `allow_tests` in its site config. The `migrate`,
+`clear-cache` and `console` lines above name `frontend` correctly. That is your
+own site.
 
 **A multi-line block piped to `bench console` fails silently.** The console is
 IPython. A block arriving on a pipe is auto-indented until it no longer parses,

--- a/docs-bundle/docs/reference/configuration.md
+++ b/docs-bundle/docs/reference/configuration.md
@@ -3,7 +3,7 @@ title: Configuration
 description: Where each BenchPress setting lives — build arguments that need a
   rebuild, runtime environment that needs a restart, and DocType fields that
   apply on save.
-lastModified: "2026-09-01T13:47:42-04:00"
+lastModified: "2026-09-02T00:09:08+05:30"
 lastAuthor: Venkatesh
 ---
 # Configuration

--- a/docs-bundle/docs/reference/data-model.md
+++ b/docs-bundle/docs/reference/data-model.md
@@ -2,7 +2,7 @@
 title: Data model
 description: All 20 BenchPress DocTypes with their fields, links, naming and the
   permission rule that scopes each one — plus why there is no Device DocType.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-09-01T18:06:47+05:30"
 lastAuthor: Venkatesh
 ---
 # Data model

--- a/docs-site/.well-known/llms-full.txt
+++ b/docs-site/.well-known/llms-full.txt
@@ -7119,13 +7119,24 @@ Ordinary Frappe commands, run inside the `backend` container.
 docker compose exec backend bench --site frontend migrate
 docker compose exec backend bench --site frontend clear-cache
 docker compose exec backend bench --site frontend console
-docker compose exec backend bench --site frontend run-tests --app benchpress
+docker compose exec backend bench --site bp_test_site run-tests --app benchpress
 docker compose exec backend bench build --app benchpress
 ```
 
 After a Python change, restart `backend` and any worker that imports the
 changed module. After a frontend change, run `bench build --app benchpress`,
 then restart `backend` and `frontend`.
+
+**Never name `frontend` in a `run-tests` command.** That site carries no
+`allow_tests`, so the runner refuses it. It refuses after it disables that
+site's scheduler. The runner holds the old value in memory and puts it back only
+on a clean exit. A site with the scheduler off composes mail and never sends it,
+and no log says so.
+
+Test against a site made for it, such as `bp_test_site`. Create one with
+`bench new-site`, then set `allow_tests` in its site config. The `migrate`,
+`clear-cache` and `console` lines above name `frontend` correctly. That is your
+own site.
 
 **A multi-line block piped to `bench console` fails silently.** The console is
 IPython. A block arriving on a pipe is auto-indented until it no longer parses,

--- a/docs-site/docs/reference/api.md
+++ b/docs-site/docs/reference/api.md
@@ -2,7 +2,7 @@
 title: API
 description: Every whitelisted BenchPress endpoint, with arguments, what each
   returns, and the permission check each one makes for itself.
-lastModified: "2026-08-30T17:48:34+05:30"
+lastModified: "2026-09-01T18:06:47+05:30"
 lastAuthor: Venkatesh
 ---
 # API

--- a/docs-site/docs/reference/cli-and-scripts.md
+++ b/docs-site/docs/reference/cli-and-scripts.md
@@ -3,7 +3,7 @@ title: CLI and scripts
 description: Every command that drives BenchPress from a shell — entry.py, the
   bench commands, setup.sh and upgrade.sh, the four repository scripts and the
   documentation pipeline.
-lastModified: "2026-08-31T14:24:45-04:00"
+lastModified: "2026-09-05T14:27:54-04:00"
 lastAuthor: Venkatesh
 ---
 # CLI and scripts
@@ -60,13 +60,24 @@ Ordinary Frappe commands, run inside the `backend` container.
 docker compose exec backend bench --site frontend migrate
 docker compose exec backend bench --site frontend clear-cache
 docker compose exec backend bench --site frontend console
-docker compose exec backend bench --site frontend run-tests --app benchpress
+docker compose exec backend bench --site bp_test_site run-tests --app benchpress
 docker compose exec backend bench build --app benchpress
 ```
 
 After a Python change, restart `backend` and any worker that imports the
 changed module. After a frontend change, run `bench build --app benchpress`,
 then restart `backend` and `frontend`.
+
+**Never name `frontend` in a `run-tests` command.** That site carries no
+`allow_tests`, so the runner refuses it. It refuses after it disables that
+site's scheduler. The runner holds the old value in memory and puts it back only
+on a clean exit. A site with the scheduler off composes mail and never sends it,
+and no log says so.
+
+Test against a site made for it, such as `bp_test_site`. Create one with
+`bench new-site`, then set `allow_tests` in its site config. The `migrate`,
+`clear-cache` and `console` lines above name `frontend` correctly. That is your
+own site.
 
 **A multi-line block piped to `bench console` fails silently.** The console is
 IPython. A block arriving on a pipe is auto-indented until it no longer parses,

--- a/docs-site/docs/reference/configuration.md
+++ b/docs-site/docs/reference/configuration.md
@@ -3,7 +3,7 @@ title: Configuration
 description: Where each BenchPress setting lives — build arguments that need a
   rebuild, runtime environment that needs a restart, and DocType fields that
   apply on save.
-lastModified: "2026-09-01T13:47:42-04:00"
+lastModified: "2026-09-02T00:09:08+05:30"
 lastAuthor: Venkatesh
 ---
 # Configuration

--- a/docs-site/docs/reference/data-model.md
+++ b/docs-site/docs/reference/data-model.md
@@ -2,7 +2,7 @@
 title: Data model
 description: All 20 BenchPress DocTypes with their fields, links, naming and the
   permission rule that scopes each one — plus why there is no Device DocType.
-lastModified: "2026-08-28T22:10:21+05:30"
+lastModified: "2026-09-01T18:06:47+05:30"
 lastAuthor: Venkatesh
 ---
 # Data model

--- a/docs-site/llms-full.txt
+++ b/docs-site/llms-full.txt
@@ -7119,13 +7119,24 @@ Ordinary Frappe commands, run inside the `backend` container.
 docker compose exec backend bench --site frontend migrate
 docker compose exec backend bench --site frontend clear-cache
 docker compose exec backend bench --site frontend console
-docker compose exec backend bench --site frontend run-tests --app benchpress
+docker compose exec backend bench --site bp_test_site run-tests --app benchpress
 docker compose exec backend bench build --app benchpress
 ```
 
 After a Python change, restart `backend` and any worker that imports the
 changed module. After a frontend change, run `bench build --app benchpress`,
 then restart `backend` and `frontend`.
+
+**Never name `frontend` in a `run-tests` command.** That site carries no
+`allow_tests`, so the runner refuses it. It refuses after it disables that
+site's scheduler. The runner holds the old value in memory and puts it back only
+on a clean exit. A site with the scheduler off composes mail and never sends it,
+and no log says so.
+
+Test against a site made for it, such as `bp_test_site`. Create one with
+`bench new-site`, then set `allow_tests` in its site config. The `migrate`,
+`clear-cache` and `console` lines above name `frontend` correctly. That is your
+own site.
 
 **A multi-line block piped to `bench console` fails silently.** The console is
 IPython. A block arriving on a pipe is auto-indented until it no longer parses,

--- a/docs-site/sitemap.xml
+++ b/docs-site/sitemap.xml
@@ -122,11 +122,11 @@
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/reference/data-model</loc>
-    <lastmod>2026-08-28T16:40:21.000Z</lastmod>
+    <lastmod>2026-09-01T12:36:47.000Z</lastmod>
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/reference/api</loc>
-    <lastmod>2026-08-30T12:18:34.000Z</lastmod>
+    <lastmod>2026-09-01T12:36:47.000Z</lastmod>
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/reference/deploy-pipeline</loc>
@@ -146,11 +146,11 @@
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/reference/configuration</loc>
-    <lastmod>2026-09-01T17:47:42.000Z</lastmod>
+    <lastmod>2026-09-01T18:39:08.000Z</lastmod>
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/reference/cli-and-scripts</loc>
-    <lastmod>2026-08-31T18:24:45.000Z</lastmod>
+    <lastmod>2026-09-05T18:27:54.000Z</lastmod>
   </url>
   <url>
     <loc>https://benchpress.cloud/docs/reference/glossary</loc>

--- a/docs/reference/cli-and-scripts.mdx
+++ b/docs/reference/cli-and-scripts.mdx
@@ -57,13 +57,24 @@ Ordinary Frappe commands, run inside the `backend` container.
 docker compose exec backend bench --site frontend migrate
 docker compose exec backend bench --site frontend clear-cache
 docker compose exec backend bench --site frontend console
-docker compose exec backend bench --site frontend run-tests --app benchpress
+docker compose exec backend bench --site bp_test_site run-tests --app benchpress
 docker compose exec backend bench build --app benchpress
 ```
 
 After a Python change, restart `backend` and any worker that imports the
 changed module. After a frontend change, run `bench build --app benchpress`,
 then restart `backend` and `frontend`.
+
+**Never name `frontend` in a `run-tests` command.** That site carries no
+`allow_tests`, so the runner refuses it. It refuses after it disables that
+site's scheduler. The runner holds the old value in memory and puts it back only
+on a clean exit. A site with the scheduler off composes mail and never sends it,
+and no log says so.
+
+Test against a site made for it, such as `bp_test_site`. Create one with
+`bench new-site`, then set `allow_tests` in its site config. The `migrate`,
+`clear-cache` and `console` lines above name `frontend` correctly. That is your
+own site.
 
 **A multi-line block piped to `bench console` fails silently.** The console is
 IPython. A block arriving on a pipe is auto-indented until it no longer parses,


### PR DESCRIPTION
Closes #357. Replaces #359, which GitHub closed when #358 merged and its base branch was deleted.

#358 fixed `CLAUDE.md:208` on its way in, so what is left of #357 is the published
half. `docs/reference/cli-and-scripts.mdx` told a self-hoster to run `run-tests`
against `frontend`, which on their host is their own live site.

`frontend` carries no `allow_tests`, so the runner refuses it. It refuses after it
disables that site's scheduler. The runner holds the old value in memory and puts
it back only on a clean exit. A site with the scheduler off composes mail and never
sends it, and no log says so.

## What changed

- `docs/reference/cli-and-scripts.mdx:60` names `bp_test_site`, and the page now
  says how to make such a site. The `migrate`, `clear-cache` and `console` lines
  beside it stay on `frontend`, as the issue asks.
- `CLAUDE.md` states the rule in words under the command block. #358 corrected the
  command itself.
- `benchpress/tests/test_runner_targets.py` grows `DOC_FILES`: `CLAUDE.md` moves
  into it, and the reference page, `README.md` and `CONTRIBUTING.md` join it. Two
  hardenings came out of review, both with a live bypass behind them:
  - `_commands()` joins a command wrapped over a backslash before matching. Wrapping
    the example to fit an 80-column block would otherwise have hidden it from a
    line-by-line scan.
  - The pattern matches `run-parallel-tests` and `run-ui-tests`, which disable the
    scheduler the same way `run-tests` does.
- `.agents/prompts/00_app_context.md` loses the known-defect bullet for this. Two
  prompts cited `CLAUDE.md:232` for the `develop` line, which the new paragraph
  moves to 241.
- `docs-site/` and `docs-bundle/` are regenerated, in their own commit and after the
  source commit, so the `lastModified` stamps are the ones CI reproduces. Three
  unrelated pages carried a stamp older than the commit that last touched their
  source, so the drift check was already going to fail on the next docs job.

## Verification

- `python3 -m unittest benchpress.tests.test_runner_targets` — 6 pass. The doc
  assertion was written first and failed naming the line before it was fixed.
- Every bypass found in review is now caught: `--site=frontend`, `--site 'frontend'`,
  `--site "frontend"`, a flag between `--site frontend` and `run-tests`, a
  backslash-wrapped command, `run-parallel-tests` and `run-ui-tests`. Prose that
  writes the command inside backticks to forbid it still passes.
- `uvx pre-commit@4.3.0 run --files ...` clean. `docs:lint` 41 files, `docs:score`
  100/100, `docs:links` 90 files. A second `rm -rf docs-site docs-bundle &&
  npm run docs:build` leaves the tree clean.
- `bench --site bp_test_site run-tests --app benchpress` on the pre-merge tree: 352
  pass.