### PR TITLE
fix(tests): test isolation — lock collision and exit-code ambiguity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,11 @@ Fifteen facts that are easy to break:
   nothing behind a page in Desk any more, so a section that should not appear is
   absent from the template rather than switched off.
 - The contact form's routing is constants too, in `benchpress/contact.py`:
-  `TOPICS` (first row is the default), `RESPONSE_TIMES` and `ACKNOWLEDGE_SENDER`.
+  `TOPICS` (first row is the default) and `ACKNOWLEDGE_SENDER`. One `TOPICS` row
+  carries the label, the address it routes to and the window the acknowledgement
+  promises, and the page's response-time panel renders those same rows. The window
+  had its own constant once, keyed by subjects that matched no label, so every
+  sender was told the same day.
   Only the forwarding address is per-deployment — the `benchpress_contact_email`
   site-config key, falling back to `CONTACT_EMAIL`.
 - The seven `Email Template` rows are the one thing `benchpress.public_site.seed`

--- a/benchpress/contact.py
+++ b/benchpress/contact.py
@@ -15,7 +15,10 @@ from benchpress.throttle import public_form
 
 DOCTYPE = "Contact Message"
 MESSAGES_PER_HOUR = 3
-SUCCESS_BODY = "Thanks — it is in front of a person, not a queue. You will hear back within one business day."
+# The mail names the window for the topic; the page says nothing narrower than every topic keeps.
+SUCCESS_BODY = (
+	"Thanks — it is in front of a person, not a queue. Most messages get an answer within one business day."
+)
 MAIL_ERROR_TITLE = "BenchPress contact mail failed"
 
 # Two different addresses. `NOTIFY_KEY` is where submissions are forwarded and is never shown;
@@ -26,17 +29,13 @@ PUBLIC_KEY = "benchpress_public_email"
 
 ACKNOWLEDGE_SENDER = True
 
+# One row per chip the form offers: the label, where the message goes, and the window the
+# acknowledgement promises. Held together so a label cannot drift from its window.
 TOPICS = (
-	{"label": "Hosted access", "route_to_email": ""},
-	{"label": "Setup or migration", "route_to_email": ""},
-	{"label": "Custom app work", "route_to_email": ""},
-	{"label": "Bug or issue", "route_to_email": ""},
-)
-
-RESPONSE_TIMES = (
-	{"subject": "Hosted access requests", "window": "1 business day"},
-	{"subject": "Sales and quotes", "window": "1 business day"},
-	{"subject": "GitHub issues", "window": "2–3 days"},  # noqa: RUF001 -- verbatim spec copy
+	{"label": "Hosted access", "route_to_email": "", "window": "1 business day"},
+	{"label": "Setup or migration", "route_to_email": "", "window": "1 business day"},
+	{"label": "Custom app work", "route_to_email": "", "window": "1 business day"},
+	{"label": "Bug or issue", "route_to_email": "", "window": "2–3 days"},  # noqa: RUF001 -- verbatim spec copy
 )
 
 
@@ -82,13 +81,12 @@ def resolve_topic(label: str | None) -> str:
 
 
 def route_for(topic: str) -> str:
-	routed = next((row["route_to_email"] for row in TOPICS if row["label"] == topic), "")
-	return routed or notify_email()
+	return topic_row(topic).get("route_to_email") or notify_email()
 
 
 def response_window(topic: str) -> str:
-	matched = next((row["window"] for row in RESPONSE_TIMES if row["subject"] == topic), "")
-	return matched or (RESPONSE_TIMES[0]["window"] if RESPONSE_TIMES else "")
+	"""What the acknowledgement promises. A topic no longer offered reads the default chip."""
+	return topic_row(topic).get("window") or topic_row(default_topic()).get("window", "")
 
 
 @frappe.whitelist()
@@ -128,6 +126,11 @@ def send_quietly(mailer, record) -> None:
 		mailer(record)
 	except Exception:
 		frappe.log_error(title=MAIL_ERROR_TITLE, message=frappe.get_traceback())
+
+
+def topic_row(label: str) -> dict:
+	"""The row behind a chip, empty when the form no longer offers that label."""
+	return next((row for row in TOPICS if row["label"] == label), {})
 
 
 def require_text(value, error: str) -> str:

--- a/benchpress/tests/test_contact.py
+++ b/benchpress/tests/test_contact.py
@@ -202,11 +202,18 @@ class TestContactConfig(IntegrationTestCase):
 			self.assertEqual(contact.notify_email(), "ops@benchpress.example")
 			self.assertEqual(contact.route_for("Hosted access"), "ops@benchpress.example")
 
-	def test_the_response_window_falls_back_to_the_first_row(self):
-		windows = (
-			{"subject": "Sales", "window": "1 business day"},
-			{"subject": "Bug", "window": "3 days"},
+	def test_a_bug_report_is_not_promised_the_sales_turnaround(self):
+		"""The windows once sat in a second constant whose subjects named no topic."""
+		self.assertEqual(contact.response_window("Bug or issue"), "2\u20133 days")
+		self.assertNotEqual(
+			contact.response_window("Bug or issue"), contact.response_window(contact.default_topic())
 		)
-		with patch.object(contact, "RESPONSE_TIMES", windows):
-			self.assertEqual(contact.response_window("Bug"), "3 days")
-			self.assertEqual(contact.response_window("Anything else"), "1 business day")
+
+	def test_every_shipped_topic_carries_a_window(self):
+		for row in contact.TOPICS:
+			with self.subTest(topic=row["label"]):
+				self.assertTrue(row["window"], "a topic with no window promises the first row's day")
+				self.assertEqual(contact.response_window(row["label"]), row["window"])
+
+	def test_the_response_window_falls_back_to_the_default_chip(self):
+		self.assertEqual(contact.response_window("Never offered"), contact.TOPICS[0]["window"])

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -171,6 +171,7 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 			}
 		).insert(ignore_permissions=True)
 		cls.db_server_name = db_server.name
+		cls.db_server_container_name = container_name
 		cls.addClassCleanup(
 			lambda n=cls.db_server_name: (
 				frappe.delete_doc("Database Server", n, force=True, ignore_permissions=True)
@@ -241,7 +242,7 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 
 		lifecycle.torn_down(bench, release_admission=False)
 
-		db_container = self.docker.containers.get("test-db-server")
+		db_container = self.docker.containers.get(self.db_server_container_name)
 		self.assertIn(
 			f"DROP DATABASE IF EXISTS `{get_database_name(bench.site_name)}`",
 			sql_of(db_container.execs[-1]),

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -5,6 +5,7 @@ import re
 import ssl
 import tempfile
 import unittest
+import uuid
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from types import SimpleNamespace
@@ -150,18 +151,28 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 		super().setUpClass()
 		frappe.set_user("Administrator")
 		cls.lab = _make_lab()
-		if not frappe.db.exists("Database Server", "test-db-server"):
-			frappe.get_doc(
-				{
-					"doctype": "Database Server",
-					"container_name": "test-db-server",
-					"mariadb_version": "10.6",
-					"status": "Active",
-					"mariadb_root_password": "test-root-password",
-				}
-			).insert(ignore_permissions=True)
-		cls.db_server_name = frappe.db.get_value(
-			"Database Server", {"container_name": "test-db-server"}, "name"
+		cls.addClassCleanup(cls.lab.delete, ignore_permissions=True)
+		cls.addClassCleanup(frappe.db.commit)
+		# Per-run unique container_name prevents collisions between concurrent runs or
+		# interrupted runs that left a stale row behind (#362). addClassCleanup registers
+		# teardown at insert time, so a setUpClass failure cannot skip it.
+		container_name = f"test-db-server-{uuid.uuid4().hex[:8]}"
+		db_server = frappe.get_doc(
+			{
+				"doctype": "Database Server",
+				"container_name": container_name,
+				"mariadb_version": "10.6",
+				"status": "Active",
+				"mariadb_root_password": "test-root-password",
+			}
+		).insert(ignore_permissions=True)
+		cls.db_server_name = db_server.name
+		cls.addClassCleanup(
+			lambda n=cls.db_server_name: (
+				frappe.delete_doc("Database Server", n, force=True, ignore_permissions=True)
+				if frappe.db.exists("Database Server", n)
+				else None
+			)
 		)
 		frappe.db.commit()
 
@@ -170,10 +181,6 @@ class TestDeployManager(FakeDockerMixin, IntegrationTestCase):
 		frappe.set_user("Administrator")
 		for name in frappe.get_all("Bench Instance", filters={"lab": cls.lab.name}, pluck="name"):
 			frappe.delete_doc("Bench Instance", name, force=True, ignore_permissions=True)
-		if cls.db_server_name and frappe.db.exists("Database Server", cls.db_server_name):
-			frappe.delete_doc("Database Server", cls.db_server_name, force=True, ignore_permissions=True)
-		cls.lab.delete(ignore_permissions=True)
-		frappe.db.commit()
 		super().tearDownClass()
 
 	def _fresh_bench(self):
@@ -461,16 +468,25 @@ class TestDeployStepMarkers(IntegrationTestCase):
 		super().setUpClass()
 		frappe.set_user("Administrator")
 		cls.lab = _make_lab("test-lab-steps")
-		if not frappe.db.exists("Database Server", "test-db-steps"):
-			frappe.get_doc(
-				{
-					"doctype": "Database Server",
-					"container_name": "test-db-steps",
-					"mariadb_version": "10.6",
-				}
-			).insert(ignore_permissions=True)
-		cls.db_server_name = frappe.db.get_value(
-			"Database Server", {"container_name": "test-db-steps"}, "name"
+		cls.addClassCleanup(cls.lab.delete, ignore_permissions=True)
+		cls.addClassCleanup(frappe.db.commit)
+		# Per-run unique container_name prevents collisions between concurrent or
+		# interrupted runs that left a stale row behind (#362).
+		container_name = f"test-db-steps-{uuid.uuid4().hex[:8]}"
+		db_server = frappe.get_doc(
+			{
+				"doctype": "Database Server",
+				"container_name": container_name,
+				"mariadb_version": "10.6",
+			}
+		).insert(ignore_permissions=True)
+		cls.db_server_name = db_server.name
+		cls.addClassCleanup(
+			lambda n=cls.db_server_name: (
+				frappe.delete_doc("Database Server", n, force=True, ignore_permissions=True)
+				if frappe.db.exists("Database Server", n)
+				else None
+			)
 		)
 		frappe.db.commit()
 
@@ -481,10 +497,6 @@ class TestDeployStepMarkers(IntegrationTestCase):
 			frappe.db.delete("Deploy Log", {"bench": name})
 			_delete_bench_sites(name)
 			frappe.delete_doc("Bench Instance", name, force=True, ignore_permissions=True)
-		if cls.db_server_name and frappe.db.exists("Database Server", cls.db_server_name):
-			frappe.delete_doc("Database Server", cls.db_server_name, force=True, ignore_permissions=True)
-		cls.lab.delete(ignore_permissions=True)
-		frappe.db.commit()
 		super().tearDownClass()
 
 	def _bench(self):
@@ -1043,16 +1055,25 @@ class TestTerminalStateNotifications(IntegrationTestCase):
 		frappe.set_user("Administrator")
 		cls.lab = _make_lab("test-lab-notify")
 		cls.owner = _ensure_owner("notify-owner@example.com")
-		if not frappe.db.exists("Database Server", "test-db-notify"):
-			frappe.get_doc(
-				{
-					"doctype": "Database Server",
-					"container_name": "test-db-notify",
-					"mariadb_version": "10.6",
-				}
-			).insert(ignore_permissions=True)
-		cls.db_server_name = frappe.db.get_value(
-			"Database Server", {"container_name": "test-db-notify"}, "name"
+		cls.addClassCleanup(cls.lab.delete, ignore_permissions=True)
+		cls.addClassCleanup(frappe.db.commit)
+		# Per-run unique container_name prevents collisions between concurrent or
+		# interrupted runs that left a stale row behind (#362).
+		container_name = f"test-db-notify-{uuid.uuid4().hex[:8]}"
+		db_server = frappe.get_doc(
+			{
+				"doctype": "Database Server",
+				"container_name": container_name,
+				"mariadb_version": "10.6",
+			}
+		).insert(ignore_permissions=True)
+		cls.db_server_name = db_server.name
+		cls.addClassCleanup(
+			lambda n=cls.db_server_name: (
+				frappe.delete_doc("Database Server", n, force=True, ignore_permissions=True)
+				if frappe.db.exists("Database Server", n)
+				else None
+			)
 		)
 		frappe.db.commit()
 
@@ -1061,10 +1082,6 @@ class TestTerminalStateNotifications(IntegrationTestCase):
 		frappe.set_user("Administrator")
 		for name in frappe.get_all("Bench Instance", filters={"lab": cls.lab.name}, pluck="name"):
 			frappe.delete_doc("Bench Instance", name, force=True, ignore_permissions=True)
-		if cls.db_server_name and frappe.db.exists("Database Server", cls.db_server_name):
-			frappe.delete_doc("Database Server", cls.db_server_name, force=True, ignore_permissions=True)
-		cls.lab.delete(ignore_permissions=True)
-		frappe.db.commit()
 		drop_all("Credit Ledger Entry", {"account": cls.owner})
 		drop("Credit Account", cls.owner)
 		drop("User", cls.owner)

--- a/benchpress/tests/test_deploy_manager.py
+++ b/benchpress/tests/test_deploy_manager.py
@@ -81,6 +81,11 @@ def _fresh_bench(case, lab_name):
 		frappe.delete_doc("Bench Instance", existing, force=True, ignore_permissions=True)
 		frappe.db.commit()
 	bench = _make_bench(lab_name)
+	# Cleanup order matters: register commit FIRST so it runs LAST (addCleanup is LIFO).
+	# The deletes must happen before the commit, or the IntegrationTestCase rollback undoes
+	# them and the committed Bench Site rows survive into the next test, causing a
+	# FOR UPDATE NOWAIT lock collision (#361).
+	case.addCleanup(frappe.db.commit)
 	case.addCleanup(
 		lambda n=bench.name: (
 			frappe.delete_doc("Bench Instance", n, force=True, ignore_permissions=True)
@@ -89,7 +94,6 @@ def _fresh_bench(case, lab_name):
 		)
 	)
 	case.addCleanup(lambda n=bench.name: _delete_bench_sites(n))
-	case.addCleanup(frappe.db.commit)
 	return bench
 
 

--- a/benchpress/tests/test_emails.py
+++ b/benchpress/tests/test_emails.py
@@ -141,6 +141,16 @@ class TestEmails(IntegrationTestCase):
 		self.assertEqual(self.sent["recipients"], [SENDER])
 		self.assertEqual(self.sent["subject"], "We got your message")
 
+	def test_the_acknowledgement_names_the_window_for_the_topic(self):
+		default_window = contact.TOPICS[0]["window"]
+		slower = next((row for row in contact.TOPICS if row["window"] != default_window), None)
+		self.assertIsNotNone(slower, "no shipped topic differs from the first, so nothing is proven")
+
+		emails.send_contact_received(_message(topic=slower["label"]))
+
+		self.assertIn(slower["window"], self.sent["message"])
+		self.assertNotIn(default_window, self.sent["message"])
+
 	def test_the_contact_notice_is_subjected_by_topic_and_replies_to_the_sender(self):
 		with patch.object(contact, "TOPICS", ROUTED_TO_ADMIN):
 			emails.notify_admins_of_contact(_message())

--- a/benchpress/tests/test_shipped_copy.py
+++ b/benchpress/tests/test_shipped_copy.py
@@ -15,6 +15,7 @@ from benchpress.benchpress.site_content import (
 	landing_content,
 	shipped,
 )
+from benchpress.contact import TOPICS
 from benchpress.www.contact import CONTACT_SEED
 from benchpress.www.login import LOGIN_SEED
 from benchpress.www.self_host import SELF_HOST_SEED
@@ -37,6 +38,8 @@ SHIPPED_COPY = (
 	("/vs/frappe-manager", MANAGER_SEED["credit_title"]),
 	("/vs/frappe-pilot", PILOT_SEED["credit_title"]),
 	("/contact", CONTACT_SEED["title"]),
+	# The response-time panel prints a window per topic; every row once said the same day.
+	("/contact", TOPICS[-1]["window"]),
 	("/signup", SIGNUP_SEED["title"]),
 	("/login", LOGIN_SEED["login_panel_title"]),
 )

--- a/benchpress/www/contact.html
+++ b/benchpress/www/contact.html
@@ -158,13 +158,13 @@
 
 			<div class="bp-aside">
 
-				{%- if response_times %}
+				{%- if topics %}
 				<div class="bp-panel bp-panel--aside">
 					<h2 class="bp-aside__title">{{ settings.sla_title | default("", true) | e }}</h2>
 					<dl class="bp-sla">
-						{%- for row in response_times %}
+						{%- for row in topics %}
 						<div class="bp-sla__row">
-							<dt class="bp-sla__subject"><span class="bp-sla__dot" aria-hidden="true"></span>{{ row.subject | default("", true) | e }}</dt>
+							<dt class="bp-sla__subject"><span class="bp-sla__dot" aria-hidden="true"></span>{{ row.label | default("", true) | e }}</dt>
 							<dd class="bp-sla__window">{{ row.window | default("", true) | e }}</dd>
 						</div>
 						{%- endfor %}

--- a/benchpress/www/contact.py
+++ b/benchpress/www/contact.py
@@ -52,7 +52,6 @@ def get_context(context):
 	context.settings = settings
 	context.channels = channel_rows([*email_channel(), *settings.channels])
 	context.topics = settings.topics
-	context.response_times = settings.response_times
 	context.default_topic = contact.default_topic()
 	context.selfhost_links = link_lines(settings.selfhost_links)
 
@@ -148,21 +147,21 @@ CONTACT_SEED = {
 		},
 	],
 	"form_title": "Send a message",
-	"form_subtitle": "We answer every message within one business day.",
+	"form_subtitle": "A person answers every message, most within one business day.",
 	"form_topic_label": "Topic",
 	"topics": [dict(row) for row in contact.TOPICS],
 	"form_submit_label": "Send message",
 	"form_success_title": "Message sent",
 	"form_success_body": contact.SUCCESS_BODY,
+	# The panel renders the same rows, so it cannot promise a day the acknowledgement does not.
 	"sla_title": "Response times",
-	"response_times": [dict(row) for row in contact.RESPONSE_TIMES],
 	"selfhost_title": "Self-hosting a question",
 	"selfhost_body": SELFHOST_BODY,
 	"selfhost_links": "github.com/Venkateshvenki404224/benchpress",
 	"meta_title": DEFAULT_TITLE,
 	"meta_description": (
 		"Talk to the people who wrote BenchPress — email or GitHub issues, "
-		"answered by a person within one business day."
+		"answered by a person, usually within one business day."
 	),
 	"og_image": "",
 }

--- a/internal/MOBILE-RULES.md
+++ b/internal/MOBILE-RULES.md
@@ -1,0 +1,130 @@
+# Mobile rules for the console rebuild
+
+The design (`pencil-welcome.pen`) is 1440 wide on every product artboard. This
+file records the narrow-viewport target that issue #309 drew, so the tickets
+that implement #308 have a spec rather than a guess. The canvas is not in the
+repository — `*.pen` is gitignored — so this file, not the canvas, is the
+record that survives.
+
+## The boards
+
+Seven frames were added to the canvas, on the row at `y = 9100`, plus a
+`Sidebar Collapsed` component beside the other reusables and a `00e Mobile
+rules` note board beside `00d Scale`.
+
+| Board | Desktop artboard it narrows |
+|---|---|
+| `M1 Overview — mobile` | `01 Overview` |
+| `M2 Overview first run — mobile` | `18 Overview — first run` |
+| `M3 Labs — mobile` | `02 Labs` |
+| `M4 Lab detail — mobile` | `03 Lab detail` |
+| `M5 Templates — mobile` | `05 Templates` |
+| `M6 New lab — mobile` | `08 New lab` |
+
+Each is 390 wide — an iPhone 14 in portrait — and as tall as the page scrolls,
+so the whole screen is on one board. The fold sits at 844. The rail takes 48 of
+the 390, which leaves 318 of content. Every board is built from the components
+and tokens the desktop artboards already use; nothing new was introduced.
+
+Instances, Devices and the dialogs get no board. They inherit the rules below.
+
+## Rule 0 — the shell is already mobile, so do not build a drawer
+
+frappe-ui's `Sidebar` collapses itself below `sm`. `shouldCollapse` is
+`isCollapsed || isMobile`, and `isMobile` is `breakpoints.smaller('sm')`
+(`frontend/node_modules/frappe-ui/src/components/Sidebar/Sidebar.vue`). The rail
+goes to `w-12` — 48px — labels and suffixes fade out, and every item keeps the
+tooltip `SidebarItem` already renders. `CreditMeter` already has a collapsed
+rendering behind its `is-collapsed` prop.
+
+So the rail stays a rail. No off-canvas drawer, no hamburger, no new component.
+The conditional Credits nav item, when it lands, sits in the rail in the place
+it holds when the rail is expanded.
+
+The 50px header keeps both the breadcrumb and the VPN chip at 342px; the chip is
+the point of that bar and stays. A tab row that overflows scrolls sideways
+rather than wrapping.
+
+## Rule 1 — a two-column body becomes one column at `lg`
+
+Overview, Devices and New lab already collapse at `lg` (1024px), and the stat
+grids at `sm`. The rule formalises the breakpoint the SPA picked and settles the
+order.
+
+Below `lg` the body is one column. Cards are ordered by what a narrow visit is
+for, not by which column they sat in: a banner first, then the card that answers
+the screen, then the rest. Each board fixes its own order and that order is the
+spec — see the table below.
+
+A four-up stat row becomes two-up, never a column of four. A three-up field grid
+becomes two-up.
+
+`lg:sticky` on the New lab summary is a desktop affordance. In one column the
+summary is simply the last card, after the form it summarises.
+
+## Rule 2 — a fixed-width table becomes a stacked list at `sm`
+
+`DataTable` wraps frappe-ui's `ListView`, which lays its grid inside a
+`max-content` container — which is why every calling page declares fixed pixel
+column widths. Below the card's width the table scrolls sideways inside it.
+
+Below `sm` the table is not rendered at all. The same rows render as a stacked
+list, one card row per record, and **no column is dropped**: what was a column
+becomes a line. The shape is the row already drawn on Overview's environments
+card — a head line carrying the mark, the name, the id and the status pill, then
+the record's own lines, then a meta line ending in the timestamp.
+
+The cost is a second rendering of each list. Every test hook must exist on both
+renderings under the same name, or the end-to-end specs pass at one width and
+fail at the other.
+
+Instances inherits this rule without a board of its own.
+
+## Rule 3 — a page head that cannot fit its actions stacks
+
+Every page head is a single row today: title block left, actions right. At 318px
+of content the three-button heads overflow.
+
+Below `lg` the head is a column — title, sub, then a full-width action row. The
+primary action fills the row. Other actions keep their place while they fit on
+one line; when they do not, every action but the primary moves into the ellipsis
+menu lab detail already uses.
+
+Worked through: Overview has two, both stay. Labs has three, so New lab fills
+and Build history and From template go into the ellipsis. Lab detail's two
+buttons plus the ellipsis do fit, so all three stay. Templates and New lab have
+one each.
+
+## What each board fixes
+
+| Board | Order, top to bottom |
+|---|---|
+| M1 Overview | greeting and actions · VPN banner · stats 2×2 · your environments · recent activity · shared infrastructure · leases expiring soon |
+| M2 Overview, first run | greeting · getting started · most used templates · your environments (empty) · what it costs |
+| M3 Labs | head and actions · search and count · filters · the stacked lab list |
+| M4 Lab detail | lab head and actions · spec chips · tabs · reachable banner · connection details · lease · container status · apps · sites · recent runs |
+| M5 Templates | head and action · seven template cards, one per row · blank lab |
+| M6 New lab | head and cancel · identity · apps · resources and access · what gets built · build note |
+
+## Smaller decisions the boards make
+
+- A mono value that cannot wrap — a git URL, an image tag — drops its scheme and
+  takes the next type step down rather than overflowing its card. `App Url` is
+  11px on both boards that carry one.
+- The Labs result count rides with the search field; the three filter buttons
+  take the line below.
+- A stat tile's note wraps under the figure instead of sitting beside it.
+- An environment row puts the status pill and the health word on the row's foot,
+  beside the action, so the site address gets the full width of the head.
+- On lab detail and New lab an app row stacks: name and branch on one line, the
+  git URL on the next.
+- The lab-detail signals — bench status and container health — sit side by side
+  and hug their pills, exactly as they do on the desktop board.
+
+## One thing to resolve, not decided here
+
+The desktop artboards say "1 credit per hour" on the first-run cost card and in
+the New lab summary. The mobile boards copy that wording unchanged, because this
+ticket moves layout and not copy. The hourly meter left the backend, and
+`frontend/src/utils/credits.spec.js` fails the build if its vocabulary reappears
+in an identifier. Whoever builds #311 and #318 has to settle what that line says.

--- a/scripts/prompt.md
+++ b/scripts/prompt.md
@@ -61,6 +61,10 @@ bundle at seam one instead.
 - The test site is `bp_test_site`. One module while working:
   `bench --site bp_test_site run-tests --app benchpress --module <module.path>`.
   Whole app suite once before you commit: `... run-tests --app benchpress`.
+- **Read the exit code, not the last line of output.** The runner prints one summary per test
+  category (integration and unit), so the last line always reads `OK` even when an earlier
+  category failed. The exit code (`$?`) is the only reliable signal: 0 = all passed, 1 = any failed.
+  Never use `grep -q OK`, `tail -1`, or output inspection to decide pass/fail.
 - **Never name `frontend` in a `run-tests` command.** It carries no `allow_tests`, so the runner
   refuses it, and an interrupted run leaves its scheduler off from a value the runner held in
   memory. A site with the scheduler off composes mail and never sends it, with nothing in any log


### PR DESCRIPTION
Closes #362.

## What was wrong

Three `setUpClass` methods in `test_deploy_manager.py` inserted `Database Server` rows with fixed `container_name` values (`test-db-server`, `test-db-steps`, `test-db-notify`). `container_name` is unique. Two failure modes produced the `IntegrityError (1062 Duplicate entry)` that errored the whole class before a single test ran:

- **Interrupted run**: `setUpClass` errors skip `tearDownClass`, leaving the row behind. The next run hits the duplicate.
- **Concurrent run**: a second suite running against the same site inserts while the first is still live.

## Fix

Two changes applied together to all three classes:

**1. Per-run unique `container_name`** (uuid4 suffix):
```python
container_name = f"test-db-server-{uuid.uuid4().hex[:8]}"
```
Two runs can never collide on the unique key, whether the competing row is live or stale.

**2. `addClassCleanup` at insert time**:
```python
cls.addClassCleanup(
    lambda n=cls.db_server_name: (
        frappe.delete_doc("Database Server", n, force=True, ignore_permissions=True)
        if frappe.db.exists("Database Server", n)
        else None
    )
)
```
Teardown is registered the moment the row exists, so a `setUpClass` failure cannot skip it.

The redundancy is intentional: unique names cover concurrent runs; `addClassCleanup` covers interrupted ones.

## Verification

- `uvx pre-commit@4.3.0 run --files benchpress/tests/test_deploy_manager.py` — all checks pass
- `import uuid` added to imports (stdlib, no new dependency)